### PR TITLE
Fix koa middleware going to next middleware

### DIFF
--- a/src/postgraphile/http/frameworks.ts
+++ b/src/postgraphile/http/frameworks.ts
@@ -295,7 +295,6 @@ export class PostGraphileResponseKoa extends PostGraphileResponse {
 
   setBody(body: Stream | Buffer | string | undefined) {
     this._ctx.body = body || '';
-    this._next();
   }
 }
 


### PR DESCRIPTION
## Description

Currently the koa middleware will always go to the next middleware in the line. so if you have
```
app.use(postgraphile(...);
app.use(async (ctx) => {
    ctx.redirect('http://somewhere');
});
```
the request will always get redirected, even if the request was for /graphql and postgraphile actually set a response.

This PR fixes this issue, making /graphql not redirect, while everything not used in the postgraphile middleware will be redirected.

Also I noticed the koa middleware doesn't use async/await, despite koa heavily relying on it, any particular reason why?

<!-- If this PR adds a feature, what does it add and what was the motivation for it? -->
<!-- If this PR fixes an issue, what is the issue? -->
<!-- Please link to the relevant GitHub issues/Discord discussion/etc as appropriate -->

## Performance impact
None
<!-- Detail any impact on performance of this PR, or put 'unknown' if not known -->

## Security impact
None
<!-- Detail any impact on security of this PR, or put 'unknown' if not known -->

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes. *I didn't have the time to setup a dev env, so I used githubs interface, it should pass everything though*
- [x] I've added tests for the new feature, and `yarn test` passes. *does it need tests?*
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why. *NOT BREAKING*

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
