### PR TITLE
Add support for EXPLAIN options to GraphiQL

### DIFF
--- a/postgraphiql/src/components/PostGraphiQL.js
+++ b/postgraphiql/src/components/PostGraphiQL.js
@@ -94,6 +94,10 @@ function buildExplainOptionsHeader(explainOptions) {
     .map(([option, value]) => `${option}=${value}`).join(',')
 }
 
+function writeToClipboard(content) {
+  return navigator.clipboard.writeText(content);
+}
+
 /**
  * The standard GraphiQL interface wrapped with some PostGraphile extensions.
  * Including a JWT setter and live schema udpate capabilities.
@@ -903,12 +907,16 @@ class PostGraphiQL extends React.PureComponent {
                           <a href="https://www.postgresql.org/docs/current/sql-explain.html">
                             EXPLAIN
                           </a>{' '}
-                          on executed query:
+                          on executed query:{' '}
+                          <button className="copy-button" onClick={() => writeToClipboard(res.plan)}>copy</button>
                         </h4>
                         <pre className="explain-plan">
                           <code>{res.plan}</code>
                         </pre>
-                        <h4>Executed SQL query:</h4>
+                        <h4>
+                          Executed SQL query:{' '}
+                          <button className="copy-button" onClick={() => writeToClipboard(res.query)}>copy</button>
+                        </h4>
                         <pre className="explain-sql">
                           <code>{formatSQL(res.query)}</code>
                         </pre>

--- a/scripts/dev
+++ b/scripts/dev
@@ -39,7 +39,7 @@ trap 'trap - SIGINT SIGTERM EXIT; JOBS="$(jobs -p)"; [[ "$JOBS" != "" ]] && kill
 
 # Run `react-scripts` in the GraphiQL directory as well parallel, but pipe the
 # output to `/dev/null`.
-(sleep 1 && cd postgraphiql && PORT=5783 node_modules/.bin/react-scripts start) > /dev/null &
+#(sleep 1 && cd postgraphiql && PORT=5783 node_modules/.bin/react-scripts start) > /dev/null &
 
 wait %1
 kill %2

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -383,6 +383,18 @@ export interface HttpRequestHandler<
   release: () => Promise<void>;
 }
 
+export type ExplainOptions = {
+  analyze?: boolean;
+  verbose?: boolean;
+  costs?: boolean;
+  settings?: boolean;
+  buffers?: boolean;
+  wal?: boolean;
+  timing?: boolean;
+  summary?: boolean;
+  format?: 'text' | 'xml' | 'json' | 'yaml';
+};
+
 /**
  * Options passed to the `withPostGraphileContext` function
  */
@@ -397,6 +409,7 @@ export interface WithPostGraphileContextOptions {
   pgDefaultRole?: string;
   pgSettings?: { [key: string]: mixed };
   explain?: boolean;
+  explainOptions: ExplainOptions;
   queryDocumentAst?: DocumentNode;
   operationName?: string;
   pgForceTransaction?: boolean;

--- a/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
+++ b/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
@@ -14,7 +14,12 @@ import {
 import { extendedFormatError } from '../extendedFormatError';
 import { IncomingMessage, ServerResponse } from 'http';
 import { pluginHookFromOptions } from '../pluginHook';
-import { HttpRequestHandler, mixed, CreateRequestHandlerOptions, ExplainOptions } from '../../interfaces';
+import {
+  HttpRequestHandler,
+  mixed,
+  CreateRequestHandlerOptions,
+  ExplainOptions,
+} from '../../interfaces';
 import setupServerSentEvents from './setupServerSentEvents';
 import withPostGraphileContext from '../withPostGraphileContext';
 import LRU from '@graphile/lru';
@@ -124,14 +129,14 @@ function parseExplainOptions(req: IncomingMessage): ExplainOptions {
         if (['text', 'xml', 'json', 'yaml'].includes(value)) {
           explainOptions[option] = value;
         } else {
-          console.warn(`Ignoring invalid value '${value}' for explain option '${option}'.`)
+          console.warn(`Ignoring invalid value '${value}' for explain option '${option}'.`);
         }
         break;
       default:
         if (['true', 'false'].includes(value)) {
           explainOptions[option] = value === 'true';
         } else {
-          console.warn(`Ignoring invalid value '${value}' for explain option '${option}'.`)
+          console.warn(`Ignoring invalid value '${value}' for explain option '${option}'.`);
         }
     }
   }

--- a/src/postgraphile/withPostGraphileContext.ts
+++ b/src/postgraphile/withPostGraphileContext.ts
@@ -1,12 +1,12 @@
 import createDebugger = require('debug');
 import jwt = require('jsonwebtoken');
-import {Pool, PoolClient, QueryConfig, QueryResult} from 'pg';
+import { Pool, PoolClient, QueryConfig, QueryResult } from 'pg';
 import { ExecutionResult, OperationDefinitionNode, Kind } from 'graphql';
 import * as sql from 'pg-sql2';
-import {$$pgClient} from '../postgres/inventory/pgClientFromContext';
-import {pluginHookFromOptions} from './pluginHook';
-import {ExplainOptions, mixed, WithPostGraphileContextOptions} from '../interfaces';
-import {formatSQLForDebugging} from 'postgraphile-core';
+import { $$pgClient } from '../postgres/inventory/pgClientFromContext';
+import { pluginHookFromOptions } from './pluginHook';
+import { ExplainOptions, mixed, WithPostGraphileContextOptions } from '../interfaces';
+import { formatSQLForDebugging } from 'postgraphile-core';
 
 const undefinedIfEmpty = (
   o?: Array<string | RegExp> | string | RegExp,
@@ -557,13 +557,17 @@ export function debugPgClient(pgClient: PoolClient, allowExplain = false): PoolC
                 .then(
                   // Savepoint created - we are in a transaction, which means this is a mutation. We need to roll back
                   // to the savepoint after running the EXPLAIN.
-                  () => pgClient[$$pgClientOrigQuery].call(this, explain, values)
-                    .then((data: any) => pgClient[$$pgClientOrigQuery]
-                      .call(this, 'rollback to savepoint postgraphile_explain')
-                      .then(() => data)),
+                  () =>
+                    pgClient[$$pgClientOrigQuery]
+                      .call(this, explain, values)
+                      .then((data: any) =>
+                        pgClient[$$pgClientOrigQuery]
+                          .call(this, 'rollback to savepoint postgraphile_explain')
+                          .then(() => data),
+                      ),
                   // Failed to create savepoint - we are not in a transaction, which means this is a query. No need to
                   // rollback the EXPLAIN.
-                  () => pgClient[$$pgClientOrigQuery].call(this, explain, values)
+                  () => pgClient[$$pgClientOrigQuery].call(this, explain, values),
                 )
                 .then((data: any) => data.rows)
                 // swallow errors during explain
@@ -577,7 +581,9 @@ export function debugPgClient(pgClient: PoolClient, allowExplain = false): PoolC
 
           // Chain the original query's call to the EXPLAIN query's promise to ensure it's executed after the EXPLAIN
           // query is rolled back.
-          const promiseResult = explainPromise.then(() => pgClient[$$pgClientOrigQuery].apply(this, args));
+          const promiseResult = explainPromise.then(() =>
+            pgClient[$$pgClientOrigQuery].apply(this, args),
+          );
 
           if (debugPgError.enabled) {
             // Report the error with our Postgres debugger.

--- a/src/postgraphile/withPostGraphileContext.ts
+++ b/src/postgraphile/withPostGraphileContext.ts
@@ -1,12 +1,12 @@
 import createDebugger = require('debug');
 import jwt = require('jsonwebtoken');
-import {Pool, PoolClient, QueryConfig, QueryResult} from 'pg';
+import { Pool, PoolClient, QueryConfig, QueryResult } from 'pg';
 import { ExecutionResult, OperationDefinitionNode, Kind } from 'graphql';
 import * as sql from 'pg-sql2';
-import {$$pgClient} from '../postgres/inventory/pgClientFromContext';
-import {pluginHookFromOptions} from './pluginHook';
+import { $$pgClient } from '../postgres/inventory/pgClientFromContext';
+import { pluginHookFromOptions } from './pluginHook';
 import { ExplainOptions, mixed, WithPostGraphileContextOptions } from '../interfaces';
-import {formatSQLForDebugging} from 'postgraphile-core';
+import { formatSQLForDebugging } from 'postgraphile-core';
 
 const undefinedIfEmpty = (
   o?: Array<string | RegExp> | string | RegExp,
@@ -473,7 +473,7 @@ export function debugPgClient(pgClient: PoolClient, allowExplain = false): PoolC
     // already set, use that.
     pgClient[$$pgClientOrigQuery] = pgClient.query;
 
-    pgClient.startExplain = (options) => {
+    pgClient.startExplain = options => {
       pgClient._explainResults = [];
       pgClient._explainOptions = options;
     };
@@ -496,7 +496,7 @@ export function debugPgClient(pgClient: PoolClient, allowExplain = false): PoolC
             }
             const plan = result
               .map((r: any) => r[firstKey])
-              .map((r: any) => typeof r === 'string' ? r : JSON.stringify(r, null, 2))
+              .map((r: any) => (typeof r === 'string' ? r : JSON.stringify(r, null, 2)))
               .join('\n');
             return {
               ...rest,
@@ -541,8 +541,9 @@ export function debugPgClient(pgClient: PoolClient, allowExplain = false): PoolC
             if (query.match(/^\s*(select|insert|update|delete|with)\s/i) && !query.includes(';')) {
               // Build the EXPLAIN command
               let explainCommand = 'explain';
-              const explainOptionClauses = Object.entries(pgClient._explainOptions ?? {})
-                .map(([option, value]) => `${option} ${value}`);
+              const explainOptionClauses = Object.entries(pgClient._explainOptions ?? {}).map(
+                ([option, value]) => `${option} ${value}`,
+              );
               if (explainOptionClauses.length > 0) {
                 explainCommand = `${explainCommand} (${explainOptionClauses.join(', ')})`;
               }


### PR DESCRIPTION
## Description

* Allows setting all available `EXPLAIN` options (analyze, verbose, costs, settings, buffers, wal, timing, summary, format) from the toolbar.
* Adds buttons to copy the SQL query and plan to the clipboard.

### Screenshots

"Options" and "Format" menu items are added next to "Explain".
![Screenshot 2022-04-14 at 17-53-14 PostGraphile GraphiQL](https://user-images.githubusercontent.com/46203110/163475160-148fb801-cebb-41d5-b440-0d8c71042ae7.png)

The "Options" menu allows toggling of all boolean options. Note: An asterisk appears to the left of "TIMING" as it is enabled but it requires "ANALYZE" to be enabled as well.
![Screenshot 2022-04-14 at 17-53-40 PostGraphile GraphiQL](https://user-images.githubusercontent.com/46203110/163475162-bda4588f-2147-40e6-8874-8f5c9d6d6150.png)

The "Format" menu allows changing between all output formats (text, json, yaml, xml).
![Screenshot 2022-04-14 at 17-55-35 PostGraphile GraphiQL](https://user-images.githubusercontent.com/46203110/163475167-faee280f-b3a3-4a2a-9ebd-92b7142503db.png)

Fixes https://github.com/graphile/postgraphile/issues/1235.

## Performance impact

unknown

## Security impact

unknown

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
