### PR TITLE
feat(interface): add usePartitionedParent (#1160)

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -318,6 +318,10 @@ export interface PostGraphileOptions<
   // disable.
   /* @middlewareOnly */
   queryCacheMaxSize?: number;
+  // By default, partitioned tables' partitions are exposed and parents
+  // are hidden in the generated GraphQL schema. You can use this flag to
+  // expose parents and hide partitions, instead.
+  usePartitionedParent?: boolean;
 }
 
 export interface CreateRequestHandlerOptions extends PostGraphileOptions {

--- a/src/postgraphile/cli.ts
+++ b/src/postgraphile/cli.ts
@@ -187,7 +187,12 @@ program
   .option(
     '--include-extension-resources',
     'by default, tables and functions that come from extensions are excluded; use this flag to include them (not recommended)',
-  );
+  )
+  .option(
+    '--use-partitioned-parent',
+    'by default, partitioned table partitions are exposed and their parents are hidden; use this flag to hide partitions and expose their parents',
+  )
+;
 
 pluginHook('cli:flags:add:schema', addFlag);
 
@@ -498,6 +503,7 @@ const {
   simpleCollections,
   legacyFunctionsOnly,
   ignoreIndexes,
+  usePartitionedParent = false,
   // tslint:disable-next-line no-any
 } = { ...config['options'], ...program, ...overridesFromOptions } as typeof program;
 
@@ -753,6 +759,7 @@ const postgraphileOptions = pluginHook(
     legacyFunctionsOnly,
     ignoreIndexes,
     ownerConnectionString,
+    usePartitionedParent,
   },
   { config, cliOptions: program },
 );


### PR DESCRIPTION
## Description

This adds the ability to set `usePartitionedParent` from https://github.com/graphile/graphile-engine/pull/801
It depends on that PR being merged.
<!-- If this PR adds a feature, what does it add and what was the motivation for it? -->
<!-- If this PR fixes an issue, what is the issue? -->
<!-- Please link to the relevant GitHub issues/Discord discussion/etc as appropriate -->

## Performance impact

None
<!-- Detail any impact on performance of this PR, or put 'unknown' if not known -->

## Security impact

None
<!-- Detail any impact on security of this PR, or put 'unknown' if not known -->

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~~I've added tests for the new feature, and `yarn test` passes.~~
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [ ] ~~I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).~~
- [ ] ~~If this is a breaking change I've explained why.~~

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
