### PR TITLE
fix misspell in help

### DIFF
--- a/graphile-build/graphile-build-pg/src/plugins/PgFakeConstraintsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgFakeConstraintsPlugin.ts
@@ -378,7 +378,7 @@ or use a '@unique ${foreignKeyAttibutes
             ",",
           )}' smart tag to emulate this. (Original spec: ${JSON.stringify(
           rawSpec,
-        )}).\nTo temporarily fix this you can set 'preset.gather.pgFaceConstraintsAutofixForeignKeyUniqueness' to 'true', but we strongly recommend against using this long term.'`,
+        )}).\nTo temporarily fix this you can set 'preset.gather.pgFakeConstraintsAutofixForeignKeyUniqueness' to 'true', but we strongly recommend against using this long term.'`,
       );
     }
   }

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-bad.test.ts
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-bad.test.ts
@@ -25,6 +25,6 @@ test("raises an error when a foreignKey tries to reference a non-unique combinat
       ADD UNIQUE ("about");
 
     or use a '@unique about' smart tag to emulate this. (Original spec: "(sekrit) references c.person (about)").
-    To temporarily fix this you can set 'preset.gather.pgFaceConstraintsAutofixForeignKeyUniqueness' to 'true', but we strongly recommend against using this long term.'"
+    To temporarily fix this you can set 'preset.gather.pgFakeConstraintsAutofixForeignKeyUniqueness' to 'true', but we strongly recommend against using this long term.'"
   `);
 });


### PR DESCRIPTION
## Description

pgFakeConstraintsAutofixForeignKeyUniqueness is mispelled as pgFaceConstraintsAutofixForeignKeyUniqueness

<!-- If this PR adds a feature, what does it add and what was the motivation for it? -->
<!-- If this PR fixes an issue, what is the issue? -->
<!-- Please link to the relevant GitHub issues/Discord discussion/etc as appropriate -->

## Performance impact

<!-- Detail any impact on performance of this PR, or put 'unknown' if not known -->
None

## Security impact

<!-- Detail any impact on security of this PR, or put 'unknown' if not known -->
None

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [ ] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
