### PR TITLE
Enum table fixes

### DIFF
--- a/.changeset/mean-trainers-try.md
+++ b/.changeset/mean-trainers-try.md
@@ -1,0 +1,9 @@
+---
+"graphile-build-pg": patch
+"postgraphile": patch
+"@dataplan/pg": patch
+---
+
+Fix issues around enum tables: indicate when an enum table codec replaces a
+regular attribute codec, expose helpers for working with enum tables, and don't
+exclude enum table references when using the Relay preset.

--- a/grafast/dataplan-pg/src/interfaces.ts
+++ b/grafast/dataplan-pg/src/interfaces.ts
@@ -476,6 +476,7 @@ declare global {
         name: string;
       };
       listItemNonNull?: boolean;
+      isEnumTableEnum?: boolean;
     }
 
     /**

--- a/graphile-build/graphile-build-pg/src/plugins/PgEnumTablesPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgEnumTablesPlugin.ts
@@ -320,6 +320,7 @@ Original error: ${e.message}
 
               const extensions: PgCodecExtensions = {
                 // ENHANCE: more extensions/tags?
+                isEnumTableEnum: true,
                 tags: {
                   name: info.inflection.enumTableEnum({
                     serviceName,


### PR DESCRIPTION
Fix issues around enum tables: indicate when an enum table codec replaces a regular attribute codec, expose helpers for working with enum tables, and don't exclude enum table references when using the Relay preset.