### PR TITLE
Add 'pgIdentifiers' setting to allow _not_ fully qualifying table/function names

### DIFF
--- a/.changeset/violet-adults-confess.md
+++ b/.changeset/violet-adults-confess.md
@@ -1,0 +1,9 @@
+---
+"graphile-build-pg": patch
+"postgraphile": patch
+---
+
+Add `preset.gather.pgIdentifiers` setting (values: 'qualified' or
+'unqualified'); if set to 'unqualified' then we will not add the schema name to
+table or function identifiers - it's up to you to ensure they're present in the
+`search_path` (which you can set via `pgSettings` on a per-request basis).

--- a/graphile-build/graphile-build-pg/src/plugins/PgBasicsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgBasicsPlugin.ts
@@ -1,4 +1,3 @@
-import "graphile-build";
 import "./PgTablesPlugin.js";
 import "../interfaces.js";
 import "graphile-config";
@@ -14,13 +13,14 @@ import type {
 } from "@dataplan/pg";
 import * as dataplanPg from "@dataplan/pg";
 import type { GraphQLType } from "grafast/graphql";
-import sql, { SQL } from "pg-sql2";
+import { EXPORTABLE, gatherConfig } from "graphile-build";
+import type { SQL } from "pg-sql2";
+import sql from "pg-sql2";
 
 import { getBehavior } from "../behavior.js";
 import type { PgCodecMetaLookup } from "../inputUtils.js";
 import { getCodecMetaLookupFromInput, makePgCodecMeta } from "../inputUtils.js";
 import { version } from "../version.js";
-import { gatherConfig } from "graphile-build";
 
 declare global {
   namespace GraphileBuild {
@@ -148,11 +148,18 @@ export const PgBasicsPlugin: GraphileConfig.Plugin = {
           case "unqualified": {
             // strip the schema
             const [, ...partsWithoutSchema] = parts;
-            return sql.identifier(...partsWithoutSchema);
+            return EXPORTABLE(
+              (partsWithoutSchema, sql) =>
+                sql.identifier(...partsWithoutSchema),
+              [partsWithoutSchema, sql],
+            );
           }
           case "qualified":
           case undefined: {
-            return sql.identifier(...parts);
+            return EXPORTABLE(
+              (parts, sql) => sql.identifier(...parts),
+              [parts, sql],
+            );
           }
           default: {
             throw new Error(

--- a/graphile-build/graphile-build-pg/src/plugins/PgCodecsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgCodecsPlugin.ts
@@ -418,7 +418,7 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
               sql,
             ) => ({
               name: codecName,
-              identifier: sql.identifier(nspName, className),
+              identifier: info.helpers.pgBasics.identifier(nspName, className),
               attributes,
               description,
               extensions,
@@ -576,7 +576,10 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
                 ) =>
                   enumCodec({
                     name: codecName,
-                    identifier: sql.identifier(namespaceName, typeName),
+                    identifier: info.helpers.pgBasics.identifier(
+                      namespaceName,
+                      typeName,
+                    ),
                     values: enumLabels,
                     extensions,
                   }),
@@ -654,7 +657,7 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
                   rangeOfCodec(
                     innerCodec,
                     codecName,
-                    sql.identifier(namespaceName, typeName),
+                    info.helpers.pgBasics.identifier(namespaceName, typeName),
                     {
                       description,
                       extensions,
@@ -728,7 +731,7 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
                     domainOfCodec(
                       innerCodec,
                       codecName,
-                      sql.identifier(namespaceName, typeName),
+                      info.helpers.pgBasics.identifier(namespaceName, typeName),
                       {
                         description,
                         extensions,

--- a/graphile-build/graphile-build-pg/src/plugins/PgCodecsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgCodecsPlugin.ts
@@ -20,7 +20,6 @@ import {
 } from "@dataplan/pg";
 import { EXPORTABLE, gatherConfig } from "graphile-build";
 import type { PgAttribute, PgClass, PgType } from "pg-introspection";
-import sql from "pg-sql2";
 
 import { addBehaviorToTags } from "../utils.js";
 import { version } from "../version.js";
@@ -406,19 +405,18 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
           };
           const executor =
             info.helpers.pgIntrospection.getExecutorForService(serviceName);
+          const sqlIdent = info.helpers.pgBasics.identifier(nspName, className);
           const spec: PgRecordTypeCodecSpec<any, any> = EXPORTABLE(
             (
               attributes,
-              className,
               codecName,
               description,
               executor,
               extensions,
-              nspName,
-              sql,
+              sqlIdent,
             ) => ({
               name: codecName,
-              identifier: info.helpers.pgBasics.identifier(nspName, className),
+              identifier: sqlIdent,
               attributes,
               description,
               extensions,
@@ -426,13 +424,11 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
             }),
             [
               attributes,
-              className,
               codecName,
               description,
               executor,
               extensions,
-              nspName,
-              sql,
+              sqlIdent,
             ],
           );
           await info.process("pgCodecs_recordType_spec", {
@@ -564,34 +560,19 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
                 pgType: type,
                 extensions,
               });
+              const sqlIdent = info.helpers.pgBasics.identifier(
+                namespaceName,
+                typeName,
+              );
               return EXPORTABLE(
-                (
-                  codecName,
-                  enumCodec,
-                  enumLabels,
-                  extensions,
-                  namespaceName,
-                  sql,
-                  typeName,
-                ) =>
+                (codecName, enumCodec, enumLabels, extensions, sqlIdent) =>
                   enumCodec({
                     name: codecName,
-                    identifier: info.helpers.pgBasics.identifier(
-                      namespaceName,
-                      typeName,
-                    ),
+                    identifier: sqlIdent,
                     values: enumLabels,
                     extensions,
                   }),
-                [
-                  codecName,
-                  enumCodec,
-                  enumLabels,
-                  extensions,
-                  namespaceName,
-                  sql,
-                  typeName,
-                ],
+                [codecName, enumCodec, enumLabels, extensions, sqlIdent],
               );
             }
 
@@ -643,35 +624,30 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
                 extensions,
               });
 
+              const sqlIdent = info.helpers.pgBasics.identifier(
+                namespaceName,
+                typeName,
+              );
               return EXPORTABLE(
                 (
                   codecName,
                   description,
                   extensions,
                   innerCodec,
-                  namespaceName,
                   rangeOfCodec,
-                  sql,
-                  typeName,
+                  sqlIdent,
                 ) =>
-                  rangeOfCodec(
-                    innerCodec,
-                    codecName,
-                    info.helpers.pgBasics.identifier(namespaceName, typeName),
-                    {
-                      description,
-                      extensions,
-                    },
-                  ),
+                  rangeOfCodec(innerCodec, codecName, sqlIdent, {
+                    description,
+                    extensions,
+                  }),
                 [
                   codecName,
                   description,
                   extensions,
                   innerCodec,
-                  namespaceName,
                   rangeOfCodec,
-                  sql,
-                  typeName,
+                  sqlIdent,
                 ],
               );
             }
@@ -716,6 +692,10 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
                   pgType: type,
                   serviceName,
                 });
+                const sqlIdent = info.helpers.pgBasics.identifier(
+                  namespaceName,
+                  typeName,
+                );
                 return EXPORTABLE(
                   (
                     codecName,
@@ -723,31 +703,22 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
                     domainOfCodec,
                     extensions,
                     innerCodec,
-                    namespaceName,
                     notNull,
-                    sql,
-                    typeName,
+                    sqlIdent,
                   ) =>
-                    domainOfCodec(
-                      innerCodec,
-                      codecName,
-                      info.helpers.pgBasics.identifier(namespaceName, typeName),
-                      {
-                        description,
-                        extensions,
-                        notNull,
-                      },
-                    ) as PgCodec,
+                    domainOfCodec(innerCodec, codecName, sqlIdent, {
+                      description,
+                      extensions,
+                      notNull,
+                    }) as PgCodec,
                   [
                     codecName,
                     description,
                     domainOfCodec,
                     extensions,
                     innerCodec,
-                    namespaceName,
                     notNull,
-                    sql,
-                    typeName,
+                    sqlIdent,
                   ],
                 );
               }

--- a/graphile-build/graphile-build-pg/src/plugins/PgEnumTablesPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgEnumTablesPlugin.ts
@@ -171,10 +171,11 @@ export const PgEnumTablesPlugin: GraphileConfig.Plugin = {
           sql.fragment`select ${sql.join(
             attributes.map((col) => sql.identifier(col.attname)),
             ", ",
-          )} from ${sql.identifier(
-            pgClass.getNamespace()!.nspname,
-            pgClass.relname,
-          )};`,
+          )} from ${
+            // NOTE: Even in the case of unqualified pgIdentifiers, we still want
+            // to read _this_ enums values from _this_ schema.
+            sql.identifier(pgClass.getNamespace()!.nspname, pgClass.relname)
+          };`,
         );
 
         const pgService = info.resolvedPreset.pgServices!.find(

--- a/graphile-build/graphile-build-pg/src/plugins/PgProceduresPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgProceduresPlugin.ts
@@ -409,7 +409,7 @@ export const PgProceduresPlugin: GraphileConfig.Plugin = {
           const fromCallback = EXPORTABLE(
             (namespaceName, procName, sql, sqlFromArgDigests) =>
               (...args: PgSelectArgumentDigest[]) =>
-                sql`${sql.identifier(
+                sql`${info.helpers.pgBasics.identifier(
                   namespaceName,
                   procName,
                 )}(${sqlFromArgDigests(args)})`,

--- a/graphile-build/graphile-build-pg/src/plugins/PgProceduresPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgProceduresPlugin.ts
@@ -406,14 +406,15 @@ export const PgProceduresPlugin: GraphileConfig.Plugin = {
           const namespaceName = namespace.nspname;
           const procName = pgProc.proname;
 
+          const sqlIdent = info.helpers.pgBasics.identifier(
+            namespaceName,
+            procName,
+          );
           const fromCallback = EXPORTABLE(
-            (namespaceName, procName, sql, sqlFromArgDigests) =>
+            (sql, sqlFromArgDigests, sqlIdent) =>
               (...args: PgSelectArgumentDigest[]) =>
-                sql`${info.helpers.pgBasics.identifier(
-                  namespaceName,
-                  procName,
-                )}(${sqlFromArgDigests(args)})`,
-            [namespaceName, procName, sql, sqlFromArgDigests],
+                sql`${sqlIdent}(${sqlFromArgDigests(args)})`,
+            [sql, sqlFromArgDigests, sqlIdent],
           );
 
           addBehaviorToTags(tags, "-filter -order", true);

--- a/postgraphile/postgraphile/__tests__/helpers.ts
+++ b/postgraphile/postgraphile/__tests__/helpers.ts
@@ -174,6 +174,8 @@ export async function runTestQuery(
     setupSql?: string;
     cleanupSql?: string;
     extends?: string | string[];
+    pgIdentifiers?: "qualified" | "unqualified";
+    search_path?: string;
   },
   options: {
     callback?: (
@@ -194,7 +196,14 @@ export async function runTestQuery(
   queries: PgClientQuery[];
   extensions?: any;
 }> {
-  const { variableValues, graphileBuildOptions, setupSql, cleanupSql } = config;
+  const {
+    variableValues,
+    graphileBuildOptions,
+    setupSql,
+    cleanupSql,
+    pgIdentifiers,
+    search_path,
+  } = config;
   const { path } = options;
 
   const queries: PgClientQuery[] = [];
@@ -243,7 +252,12 @@ export async function runTestQuery(
             ? () => ({
                 role: "postgraphile_test_visitor",
                 "jwt.claims.user_id": "3",
+                search_path,
               })
+            : search_path
+            ? {
+                search_path,
+              }
             : undefined,
         schemas: schemas,
         adaptorSettings: {
@@ -255,6 +269,9 @@ export async function runTestQuery(
       pgForbidSetofFunctionsToReturnNull:
         config.setofFunctionsContainNulls === false,
       ...graphileBuildOptions,
+    },
+    gather: {
+      pgIdentifiers,
     },
     grafast: {
       explain: ["plan"],

--- a/postgraphile/postgraphile/__tests__/mutations/v4/partitions.unqualified.json5
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/partitions.unqualified.json5
@@ -1,0 +1,24 @@
+{
+  createMeasurement: {
+    measurement: {
+      timestamp: "2023-05-24T03:43:00.000000-04:00",
+      key: "temp",
+      value: 12.7,
+      userByUserId: {
+        id: 4,
+        name: "Dave",
+      },
+    },
+  },
+  updateMeasurementByTimestampAndKey: {
+    measurement: {
+      timestamp: "2023-05-24T03:43:00.000000-04:00",
+      key: "temp",
+      value: 13,
+      userByUserId: {
+        id: 4,
+        name: "Dave",
+      },
+    },
+  },
+}

--- a/postgraphile/postgraphile/__tests__/mutations/v4/partitions.unqualified.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/partitions.unqualified.mermaid
@@ -1,0 +1,114 @@
+%%{init: {'themeVariables': { 'fontSize': '12px'}}}%%
+graph TD
+    classDef path fill:#eee,stroke:#000,color:#000
+    classDef plan fill:#fff,stroke-width:1px,color:#000
+    classDef itemplan fill:#fff,stroke-width:2px,color:#000
+    classDef unbatchedplan fill:#dff,stroke-width:1px,color:#000
+    classDef sideeffectplan fill:#fcc,stroke-width:2px,color:#000
+    classDef bucket fill:#f6f6f6,color:#000,stroke-width:2px,text-align:left
+
+
+    %% plan dependencies
+    Object17{{"Object[17∈0]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access15{{"Access[15∈0]<br />ᐸ3.pgSettingsᐳ"}}:::plan
+    Access16{{"Access[16∈0]<br />ᐸ3.withPgClientᐳ"}}:::plan
+    Access15 & Access16 --> Object17
+    __Value3["__Value[3∈0]<br />ᐸcontextᐳ"]:::plan
+    __Value3 --> Access15
+    __Value3 --> Access16
+    __Value0["__Value[0∈0]"]:::plan
+    __Value5["__Value[5∈0]<br />ᐸrootValueᐳ"]:::plan
+    Constant57{{"Constant[57∈0]<br />ᐸ'2023-05-24T07:43:00Z'ᐳ"}}:::plan
+    Constant58{{"Constant[58∈0]<br />ᐸ'temp'ᐳ"}}:::plan
+    Constant59{{"Constant[59∈0]<br />ᐸ12.7ᐳ"}}:::plan
+    Constant60{{"Constant[60∈0]<br />ᐸ4ᐳ"}}:::plan
+    Constant63{{"Constant[63∈0]<br />ᐸ13ᐳ"}}:::plan
+    PgInsertSingle14[["PgInsertSingle[14∈1]<br />ᐸmeasurements(timestamp,key,value,user_id)ᐳ"]]:::sideeffectplan
+    Object17 & Constant57 & Constant58 & Constant59 & Constant60 --> PgInsertSingle14
+    Object18{{"Object[18∈1]<br />ᐸ{result}ᐳ"}}:::plan
+    PgInsertSingle14 --> Object18
+    PgSelect23[["PgSelect[23∈3]<br />ᐸusersᐳ"]]:::plan
+    PgClassExpression22{{"PgClassExpression[22∈3]<br />ᐸ__measurem....”user_id”ᐳ"}}:::plan
+    Object17 & PgClassExpression22 --> PgSelect23
+    PgClassExpression19{{"PgClassExpression[19∈3]<br />ᐸ__measurem...timestamp”ᐳ"}}:::plan
+    PgInsertSingle14 --> PgClassExpression19
+    PgClassExpression20{{"PgClassExpression[20∈3]<br />ᐸ__measurements__.”key”ᐳ"}}:::plan
+    PgInsertSingle14 --> PgClassExpression20
+    PgClassExpression21{{"PgClassExpression[21∈3]<br />ᐸ__measurem...__.”value”ᐳ"}}:::plan
+    PgInsertSingle14 --> PgClassExpression21
+    PgInsertSingle14 --> PgClassExpression22
+    First27{{"First[27∈3]"}}:::plan
+    PgSelect23 --> First27
+    PgSelectSingle28{{"PgSelectSingle[28∈3]<br />ᐸusersᐳ"}}:::plan
+    First27 --> PgSelectSingle28
+    PgClassExpression29{{"PgClassExpression[29∈4]<br />ᐸ__users__.”id”ᐳ"}}:::plan
+    PgSelectSingle28 --> PgClassExpression29
+    PgClassExpression30{{"PgClassExpression[30∈4]<br />ᐸ__users__.”name”ᐳ"}}:::plan
+    PgSelectSingle28 --> PgClassExpression30
+    PgUpdateSingle40[["PgUpdateSingle[40∈5]<br />ᐸmeasurements(timestamp,key;value)ᐳ"]]:::sideeffectplan
+    Object43{{"Object[43∈5]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Object43 & Constant57 & Constant58 & Constant63 --> PgUpdateSingle40
+    Access41{{"Access[41∈5]<br />ᐸ3.pgSettingsᐳ"}}:::plan
+    Access42{{"Access[42∈5]<br />ᐸ3.withPgClientᐳ"}}:::plan
+    Access41 & Access42 --> Object43
+    __Value3 --> Access41
+    __Value3 --> Access42
+    Object44{{"Object[44∈5]<br />ᐸ{result}ᐳ"}}:::plan
+    PgUpdateSingle40 --> Object44
+    PgSelect49[["PgSelect[49∈7]<br />ᐸusersᐳ"]]:::plan
+    PgClassExpression48{{"PgClassExpression[48∈7]<br />ᐸ__measurem....”user_id”ᐳ"}}:::plan
+    Object43 & PgClassExpression48 --> PgSelect49
+    PgClassExpression45{{"PgClassExpression[45∈7]<br />ᐸ__measurem...timestamp”ᐳ"}}:::plan
+    PgUpdateSingle40 --> PgClassExpression45
+    PgClassExpression46{{"PgClassExpression[46∈7]<br />ᐸ__measurements__.”key”ᐳ"}}:::plan
+    PgUpdateSingle40 --> PgClassExpression46
+    PgClassExpression47{{"PgClassExpression[47∈7]<br />ᐸ__measurem...__.”value”ᐳ"}}:::plan
+    PgUpdateSingle40 --> PgClassExpression47
+    PgUpdateSingle40 --> PgClassExpression48
+    First53{{"First[53∈7]"}}:::plan
+    PgSelect49 --> First53
+    PgSelectSingle54{{"PgSelectSingle[54∈7]<br />ᐸusersᐳ"}}:::plan
+    First53 --> PgSelectSingle54
+    PgClassExpression55{{"PgClassExpression[55∈8]<br />ᐸ__users__.”id”ᐳ"}}:::plan
+    PgSelectSingle54 --> PgClassExpression55
+    PgClassExpression56{{"PgClassExpression[56∈8]<br />ᐸ__users__.”name”ᐳ"}}:::plan
+    PgSelectSingle54 --> PgClassExpression56
+
+    %% define steps
+
+    subgraph "Buckets for mutations/v4/partitions.unqualified"
+    Bucket0("Bucket 0 (root)"):::bucket
+    classDef bucket0 stroke:#696969
+    class Bucket0,__Value0,__Value3,__Value5,Access15,Access16,Object17,Constant57,Constant58,Constant59,Constant60,Constant63 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 17, 57, 58, 59, 60<br /><br />1: PgInsertSingle[14]<br />2: <br />ᐳ: Object[18]"):::bucket
+    classDef bucket1 stroke:#00bfff
+    class Bucket1,PgInsertSingle14,Object18 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 18, 14, 17<br /><br />ROOT Object{1}ᐸ{result}ᐳ[18]"):::bucket
+    classDef bucket2 stroke:#7f007f
+    class Bucket2 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 14, 17<br /><br />ROOT PgInsertSingle{1}ᐸmeasurements(timestamp,key,value,user_id)ᐳ[14]<br />1: <br />ᐳ: 19, 20, 21, 22<br />2: PgSelect[23]<br />ᐳ: First[27], PgSelectSingle[28]"):::bucket
+    classDef bucket3 stroke:#ffa500
+    class Bucket3,PgClassExpression19,PgClassExpression20,PgClassExpression21,PgClassExpression22,PgSelect23,First27,PgSelectSingle28 bucket3
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 28<br /><br />ROOT PgSelectSingle{3}ᐸusersᐳ[28]"):::bucket
+    classDef bucket4 stroke:#0000ff
+    class Bucket4,PgClassExpression29,PgClassExpression30 bucket4
+    Bucket5("Bucket 5 (mutationField)<br />Deps: 57, 58, 63, 3<br /><br />1: Access[41]<br />2: Access[42]<br />3: Object[43]<br />4: PgUpdateSingle[40]<br />5: <br />ᐳ: Object[44]"):::bucket
+    classDef bucket5 stroke:#7fff00
+    class Bucket5,PgUpdateSingle40,Access41,Access42,Object43,Object44 bucket5
+    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 44, 40, 43<br /><br />ROOT Object{5}ᐸ{result}ᐳ[44]"):::bucket
+    classDef bucket6 stroke:#ff1493
+    class Bucket6 bucket6
+    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 40, 43<br /><br />ROOT PgUpdateSingle{5}ᐸmeasurements(timestamp,key;value)ᐳ[40]<br />1: <br />ᐳ: 45, 46, 47, 48<br />2: PgSelect[49]<br />ᐳ: First[53], PgSelectSingle[54]"):::bucket
+    classDef bucket7 stroke:#808000
+    class Bucket7,PgClassExpression45,PgClassExpression46,PgClassExpression47,PgClassExpression48,PgSelect49,First53,PgSelectSingle54 bucket7
+    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 54<br /><br />ROOT PgSelectSingle{7}ᐸusersᐳ[54]"):::bucket
+    classDef bucket8 stroke:#dda0dd
+    class Bucket8,PgClassExpression55,PgClassExpression56 bucket8
+    Bucket0 --> Bucket1 & Bucket5
+    Bucket1 --> Bucket2
+    Bucket2 --> Bucket3
+    Bucket3 --> Bucket4
+    Bucket5 --> Bucket6
+    Bucket6 --> Bucket7
+    Bucket7 --> Bucket8
+    end

--- a/postgraphile/postgraphile/__tests__/mutations/v4/partitions.unqualified.sql
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/partitions.unqualified.sql
@@ -1,0 +1,61 @@
+begin; /*fake*/
+
+select set_config(el->>0, el->>1, true) from json_array_elements($1::json) el
+
+insert into "measurements" as __measurements__ ("timestamp", "key", "value", "user_id") values ($1::"timestamptz", $2::"text", $3::"float8", $4::"int4") returning
+  to_char(__measurements__."timestamp", 'YYYY-MM-DD"T"HH24:MI:SS.USTZH:TZM'::text) as "0",
+  __measurements__."key" as "1",
+  __measurements__."value"::text as "2",
+  __measurements__."user_id"::text as "3";
+
+commit; /*fake*/
+
+begin; /*fake*/
+
+select set_config(el->>0, el->>1, true) from json_array_elements($1::json) el
+
+select __users_result__.*
+from (select 0 as idx, $1::"int4" as "id0") as __users_identifiers__,
+lateral (
+  select
+    __users__."id"::text as "0",
+    __users__."name" as "1",
+    __users_identifiers__.idx as "2"
+  from "users" as __users__
+  where (
+    __users__."id" = __users_identifiers__."id0"
+  )
+) as __users_result__;
+
+commit; /*fake*/
+
+begin; /*fake*/
+
+select set_config(el->>0, el->>1, true) from json_array_elements($1::json) el
+
+update "measurements" as __measurements__ set "value" = $1::"float8" where ((__measurements__."timestamp" = $2::"timestamptz") and (__measurements__."key" = $3::"text")) returning
+  to_char(__measurements__."timestamp", 'YYYY-MM-DD"T"HH24:MI:SS.USTZH:TZM'::text) as "0",
+  __measurements__."key" as "1",
+  __measurements__."value"::text as "2",
+  __measurements__."user_id"::text as "3";
+
+commit; /*fake*/
+
+begin; /*fake*/
+
+select set_config(el->>0, el->>1, true) from json_array_elements($1::json) el
+
+select __users_result__.*
+from (select 0 as idx, $1::"int4" as "id0") as __users_identifiers__,
+lateral (
+  select
+    __users__."id"::text as "0",
+    __users__."name" as "1",
+    __users_identifiers__.idx as "2"
+  from "users" as __users__
+  where (
+    __users__."id" = __users_identifiers__."id0"
+  )
+) as __users_result__;
+
+commit; /*fake*/

--- a/postgraphile/postgraphile/__tests__/mutations/v4/partitions.unqualified.test.graphql
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/partitions.unqualified.test.graphql
@@ -2,6 +2,7 @@
 #> schema: ["partitions"]
 #> search_path: "partitions"
 #> pgIdentifiers: 'unqualified'
+## expect(queries.map(q => q.text).join("\n")).not.toMatch(/"partitions"/);
 #> subscriptions: true
 mutation {
   createMeasurement(

--- a/postgraphile/postgraphile/__tests__/mutations/v4/partitions.unqualified.test.graphql
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/partitions.unqualified.test.graphql
@@ -1,5 +1,7 @@
 ## expect(errors).toBeFalsy();
 #> schema: ["partitions"]
+#> search_path: "partitions"
+#> pgIdentifiers: 'unqualified'
 #> subscriptions: true
 mutation {
   createMeasurement(

--- a/utils/pg-sql2/src/index.ts
+++ b/utils/pg-sql2/src/index.ts
@@ -201,7 +201,8 @@ function makeRawNode(text: string, exportName?: string): SQLRawNode {
   if (exportName) {
     exportAs(newNode, exportName);
   }
-  Object.freeze(newNode);
+  // Cannot freeze here, otherwise the SQL node cannot be marked EXPORTABLE later. Maybe wait a tick?
+  // Object.freeze(newNode);
   CACHE_RAW_NODES.set(text, newNode);
   return newNode;
 }


### PR DESCRIPTION
Fixes https://github.com/graphile/crystal/issues/191

Needs tests and documentation before this becomes an "officially supported" interface. GET INVOLVED!

Add `preset.gather.pgIdentifiers` setting (values: 'qualified' or 'unqualified'); if set to 'unqualified' then we will not add the schema name to table or function identifiers - it's up to you to ensure they're present in the `search_path` (which you can set via `pgSettings` on a per-request basis).
