### PR TITLE
Fix docs for configuring list behavior in preset

### DIFF
--- a/postgraphile/website/postgraphile/connections.md
+++ b/postgraphile/website/postgraphile/connections.md
@@ -42,7 +42,7 @@ like this to your preset:
 ```js title="graphile.config.mjs"
 const preset = {
   schema: {
-    globalBehavior: "-connection +list",
+    defaultBehavior: "-connection +list",
   },
 };
 ```
@@ -55,7 +55,7 @@ on a per-entity basis with [smart tags](./smart-tags.md#behavior) if you like!
 If you're comparing the performance of two GraphQL servers be sure to make sure
 the comparison is fair by using either lists on both or connections on both.
 You can have PostGraphile generate lists rather than connections by using the
-`globalBehavior` setting detailed in the advice above.
+`defaultBehavior` setting detailed in the advice above.
 
 If you read a research paper comparing performance of different GraphQL servers
 and they don't ensure basic equivalence by using either lists on both or


### PR DESCRIPTION
## Description

The field to use in the preset file for configuring list behaviour is `defaultBehavior` instead of `globalBehavior`,
as described here https://postgraphile.org/postgraphile/next/behavior#global-default-behavior

## Performance impact
None 

## Security impact
None

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [ ] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
