### PR TITLE
Enable source maps

### DIFF
--- a/.changeset/honest-birds-pull.md
+++ b/.changeset/honest-birds-pull.md
@@ -1,0 +1,8 @@
+---
+"postgraphile": patch
+"@dataplan/json": patch
+"@dataplan/pg": patch
+"grafast": patch
+---
+
+Enable source maps in modules where it was disabled.

--- a/grafast/dataplan-json/tsconfig.json
+++ b/grafast/dataplan-json/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "sourceMap": false,
     "rootDir": "src",
     "declarationDir": "./dist",
     "outDir": "./dist"

--- a/grafast/dataplan-pg/tsconfig.json
+++ b/grafast/dataplan-pg/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "sourceMap": false,
     "rootDir": "src",
     "declarationDir": "./dist",
     "outDir": "./dist",

--- a/grafast/grafast/tsconfig.json
+++ b/grafast/grafast/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "sourceMap": false,
     "rootDir": "src",
     "declarationDir": "./dist",
     "outDir": "./dist"


### PR DESCRIPTION
Should have been enabled once we launched the beta; oops.