### PR TITLE
Enable a Ruru plugin to populate query and variables from query string

### DIFF
--- a/.changeset/fresh-hats-knock.md
+++ b/.changeset/fresh-hats-knock.md
@@ -1,0 +1,8 @@
+---
+"postgraphile": patch
+"ruru-components": patch
+"ruru": patch
+---
+
+Can now set initial query and variables in Ruru via the plugin system; e.g. to
+set query/variables based on query string.

--- a/grafast/ruru-components/src/interfaces.ts
+++ b/grafast/ruru-components/src/interfaces.ts
@@ -29,5 +29,18 @@ export interface RuruProps {
    */
   debugTools?: Array<"explain" | "plan">;
 
+  /**
+   * The query to use when the user has never visited the page before (unless `initialQuery` is set).
+   */
   defaultQuery?: string;
+
+  /**
+   * The query to prepopulate the editor with.
+   */
+  initialQuery?: string;
+
+  /**
+   * The variables to prepopulate the editor with.
+   */
+  initialVariables?: string;
 }

--- a/grafast/ruru-components/src/ruru.tsx
+++ b/grafast/ruru-components/src/ruru.tsx
@@ -75,6 +75,8 @@ export const Ruru: FC<RuruProps> = (props) => {
         fetcher={fetcher}
         schema={schema}
         defaultQuery={defaultQuery}
+        query={props.initialQuery}
+        variables={props.initialVariables}
         plugins={plugins}
         shouldPersistHeaders={saveHeaders}
       >

--- a/postgraphile/postgraphile/graphile.config.ts
+++ b/postgraphile/postgraphile/graphile.config.ts
@@ -92,7 +92,7 @@ const RuruQueryParamsPlugin: GraphileConfig.Plugin = {
 
   grafserv: {
     hooks: {
-      ruruHTMLParts(_info, parts, extra) {
+      ruruHTMLParts(_info, parts, _extra) {
         parts.headerScripts += `
 <script>
 const currentUrl = new URL(document.URL);

--- a/postgraphile/postgraphile/graphile.config.ts
+++ b/postgraphile/postgraphile/graphile.config.ts
@@ -86,6 +86,29 @@ function makeRuruTitlePlugin(title: string): GraphileConfig.Plugin {
   };
 }
 
+const RuruQueryParamsPlugin: GraphileConfig.Plugin = {
+  name: "RuruQueryParamsPlugin",
+  version: "0.0.0",
+
+  grafserv: {
+    hooks: {
+      ruruHTMLParts(_info, parts, extra) {
+        parts.headerScripts += `
+<script>
+const currentUrl = new URL(document.URL);
+const query = currentUrl.searchParams.get("query");
+const variables = currentUrl.searchParams.get("variables");
+if (query) {
+  RURU_CONFIG.initialQuery = query;
+  RURU_CONFIG.initialVariables = variables;
+}
+</script>
+`;
+      },
+    },
+  },
+};
+
 const ExportSchemaPlugin: GraphileConfig.Plugin = {
   name: "ExportSchemaPlugin",
   version: "0.0.0",
@@ -196,6 +219,7 @@ const preset: GraphileConfig.Preset = {
     makeRuruTitlePlugin("<New title text here!>"),
     ExportSchemaPlugin,
     NonNullRelationsPlugin,
+    RuruQueryParamsPlugin,
   ],
   extends: [
     PostGraphileAmberPreset,


### PR DESCRIPTION
Fixes https://github.com/graphile/crystal/issues/1794

Example plugin:

```ts
const RuruQueryParamsPlugin: GraphileConfig.Plugin = {
  name: "RuruQueryParamsPlugin",
  version: "0.0.0",

  grafserv: {
    hooks: {
      ruruHTMLParts(_info, parts, extra) {
        parts.headerScripts += `
<script>
const currentUrl = new URL(document.URL);
const query = currentUrl.searchParams.get("query");
const variables = currentUrl.searchParams.get("variables");
if (query) {
  RURU_CONFIG.initialQuery = query;
  RURU_CONFIG.initialVariables = variables;
}
</script>
`;
      },
    },
  },
};
```