### PR TITLE
Add passthrough `onEdit` callbacks to the Ruru config with a plugin to update URL query params

### DIFF
--- a/.changeset/healthy-kiwis-notice.md
+++ b/.changeset/healthy-kiwis-notice.md
@@ -5,4 +5,4 @@
 ---
 
 Can now pass onEdit callbacks through the Ruru config via the plugin system;
-e.g. to update the url search params with the current editor state.
+e.g. to update the URL search params with the current editor state.

--- a/.changeset/healthy-kiwis-notice.md
+++ b/.changeset/healthy-kiwis-notice.md
@@ -1,0 +1,8 @@
+---
+"postgraphile": patch
+"ruru-components": patch
+"ruru": patch
+---
+
+Can now pass onEdit callbacks through the Ruru config via the plugin system;
+e.g. to update the url search params with the current editor state.

--- a/grafast/ruru-components/src/interfaces.ts
+++ b/grafast/ruru-components/src/interfaces.ts
@@ -35,12 +35,12 @@ export interface RuruProps {
   defaultQuery?: string;
 
   /**
-   * DEPRECATED: use `query` instead
+   * @deprecated Use `query` instead
    */
   initialQuery?: string;
 
   /**
-   * DEPRECATED: use `variables` instead
+   * @deprecated Use `variables` instead
    */
   initialVariables?: string;
 

--- a/grafast/ruru-components/src/interfaces.ts
+++ b/grafast/ruru-components/src/interfaces.ts
@@ -44,7 +44,6 @@ export interface RuruProps {
    */
   initialVariables?: string;
 
-
   /**
    * The query to prepopulate the editor with.
    */
@@ -59,7 +58,6 @@ export interface RuruProps {
    * Callback executed when the current query changes.
    */
   onEditQuery?: GraphiQLProps["onEditQuery"];
-
 
   /**
    * Callback executed when the variables change.

--- a/grafast/ruru-components/src/interfaces.ts
+++ b/grafast/ruru-components/src/interfaces.ts
@@ -35,12 +35,34 @@ export interface RuruProps {
   defaultQuery?: string;
 
   /**
-   * The query to prepopulate the editor with.
+   * DEPRECATED: use `query` instead
    */
   initialQuery?: string;
 
   /**
-   * The variables to prepopulate the editor with.
+   * DEPRECATED: use `variables` instead
    */
   initialVariables?: string;
+
+
+  /**
+   * The query to prepopulate the editor with.
+   */
+  query?: string;
+
+  /**
+   * The variables to prepopulate the editor with.
+   */
+  variables?: string;
+
+  /**
+   * Callback executed when the current query changes.
+   */
+  onEditQuery?: GraphiQLProps["onEditQuery"];
+
+
+  /**
+   * Callback executed when the variables change.
+   */
+  onEditVariables?: GraphiQLProps["onEditVariables"];
 }

--- a/grafast/ruru-components/src/ruru.tsx
+++ b/grafast/ruru-components/src/ruru.tsx
@@ -101,7 +101,14 @@ export const RuruInner: FC<{
   onEditQuery?: GraphiQLProps["onEditQuery"];
   onEditVariables?: GraphiQLProps["onEditVariables"];
 }> = (props) => {
-  const { storage, editorTheme, error, setError, onEditQuery, onEditVariables } = props;
+  const {
+    storage,
+    editorTheme,
+    error,
+    setError,
+    onEditQuery,
+    onEditVariables,
+  } = props;
   const prettify = usePrettify();
   const mergeQuery = useMergeQuery();
   const copyQuery = useCopyQuery();

--- a/grafast/ruru-components/src/ruru.tsx
+++ b/grafast/ruru-components/src/ruru.tsx
@@ -75,8 +75,8 @@ export const Ruru: FC<RuruProps> = (props) => {
         fetcher={fetcher}
         schema={schema}
         defaultQuery={defaultQuery}
-        query={props.initialQuery}
-        variables={props.initialVariables}
+        query={props.query ?? props.initialQuery}
+        variables={props.variables ?? props.initialVariables}
         plugins={plugins}
         shouldPersistHeaders={saveHeaders}
       >
@@ -85,6 +85,8 @@ export const Ruru: FC<RuruProps> = (props) => {
           editorTheme={props.editorTheme}
           error={error}
           setError={setError}
+          onEditQuery={props.onEditQuery}
+          onEditVariables={props.onEditVariables}
         />
       </GraphiQLProvider>
     </ExplainContext.Provider>
@@ -97,8 +99,9 @@ export const RuruInner: FC<{
   error: Error | null;
   setError: React.Dispatch<React.SetStateAction<Error | null>>;
   onEditQuery?: GraphiQLProps["onEditQuery"];
+  onEditVariables?: GraphiQLProps["onEditVariables"];
 }> = (props) => {
-  const { storage, editorTheme, error, setError, onEditQuery } = props;
+  const { storage, editorTheme, error, setError, onEditQuery, onEditVariables } = props;
   const prettify = usePrettify();
   const mergeQuery = useMergeQuery();
   const copyQuery = useCopyQuery();
@@ -126,6 +129,7 @@ export const RuruInner: FC<{
         <GraphiQLInterface
           editorTheme={editorTheme ?? "graphiql"}
           onEditQuery={onEditQuery}
+          onEditVariables={onEditVariables}
         >
           <GraphiQL.Logo>
             <a

--- a/postgraphile/postgraphile/graphile.config.ts
+++ b/postgraphile/postgraphile/graphile.config.ts
@@ -95,12 +95,12 @@ const RuruQueryParamsPlugin: GraphileConfig.Plugin = {
       ruruHTMLParts(_info, parts, _extra) {
         parts.headerScripts += `
 <script>
-const currentUrl = new URL(document.URL);
-const query = currentUrl.searchParams.get("query");
-const variables = currentUrl.searchParams.get("variables");
-if (query) {
-  RURU_CONFIG.query = query;
-  RURU_CONFIG.variables = variables;
+const ruruQueryParamsUrl = new URL(document.URL);
+const ruruQueryParamsQuery = ruruQueryParamsUrl.searchParams.get("query");
+const ruruQueryParamsVariables = ruruQueryParamsUrl.searchParams.get("variables");
+if (ruruQueryParamsQuery) {
+  RURU_CONFIG.query = ruruQueryParamsQuery;
+  RURU_CONFIG.variables = ruruQueryParamsVariables;
 }
 </script>
 `;
@@ -122,13 +122,13 @@ const RuruQueryParamsUpdatePlugin: GraphileConfig.Plugin = {
         parts.headerScripts += `
 <script>
 const ruruQueryParamsUpdateUrl = new URL(document.URL);
-const search = ruruQueryParamsUpdateUrl.searchParams;
+const ruruQueryParamsUpdateSearch = ruruQueryParamsUpdateUrl.searchParams;
 RURU_CONFIG.onEditQuery = (query) => {
-  search.set("query", query);
+  ruruQueryParamsUpdateSearch.set("query", query);
   window.history.replaceState(null, "", ruruQueryParamsUpdateUrl);
 }
 RURU_CONFIG.onEditVariables = (variables) => {
-  search.set("variables", variables);
+  ruruQueryParamsUpdateSearch.set("variables", variables);
   window.history.replaceState(null, "", ruruQueryParamsUpdateUrl);
 }
 </script>

--- a/postgraphile/postgraphile/graphile.config.ts
+++ b/postgraphile/postgraphile/graphile.config.ts
@@ -95,12 +95,14 @@ const RuruQueryParamsPlugin: GraphileConfig.Plugin = {
       ruruHTMLParts(_info, parts, _extra) {
         parts.headerScripts += `
 <script>
-const ruruQueryParamsUrl = new URL(document.URL);
-const ruruQueryParamsQuery = ruruQueryParamsUrl.searchParams.get("query");
-const ruruQueryParamsVariables = ruruQueryParamsUrl.searchParams.get("variables");
-if (ruruQueryParamsQuery) {
-  RURU_CONFIG.query = ruruQueryParamsQuery;
-  RURU_CONFIG.variables = ruruQueryParamsVariables;
+{
+  const currentUrl = new URL(document.URL);
+  const query = currentUrl.searchParams.get("query");
+  const variables = currentUrl.searchParams.get("variables");
+  if (query) {
+    RURU_CONFIG.query = query;
+    RURU_CONFIG.variables = variables;
+  }
 }
 </script>
 `;
@@ -121,15 +123,16 @@ const RuruQueryParamsUpdatePlugin: GraphileConfig.Plugin = {
       ruruHTMLParts(_info, parts, _extra) {
         parts.headerScripts += `
 <script>
-const ruruQueryParamsUpdateUrl = new URL(document.URL);
-const ruruQueryParamsUpdateSearch = ruruQueryParamsUpdateUrl.searchParams;
-RURU_CONFIG.onEditQuery = (query) => {
-  ruruQueryParamsUpdateSearch.set("query", query);
-  window.history.replaceState(null, "", ruruQueryParamsUpdateUrl);
-}
-RURU_CONFIG.onEditVariables = (variables) => {
-  ruruQueryParamsUpdateSearch.set("variables", variables);
-  window.history.replaceState(null, "", ruruQueryParamsUpdateUrl);
+{
+  const currentUrl = new URL(document.URL);
+  RURU_CONFIG.onEditQuery = (query) => {
+    currentUrl.searchParams.set("query", query);
+    window.history.replaceState(null, "", currentUrl);
+  }
+  RURU_CONFIG.onEditVariables = (variables) => {
+    currentUrl.searchParams.set("variables", variables);
+    window.history.replaceState(null, "", currentUrl);
+  }
 }
 </script>
 `;

--- a/postgraphile/postgraphile/graphile.config.ts
+++ b/postgraphile/postgraphile/graphile.config.ts
@@ -99,8 +99,37 @@ const currentUrl = new URL(document.URL);
 const query = currentUrl.searchParams.get("query");
 const variables = currentUrl.searchParams.get("variables");
 if (query) {
-  RURU_CONFIG.initialQuery = query;
-  RURU_CONFIG.initialVariables = variables;
+  RURU_CONFIG.query = query;
+  RURU_CONFIG.variables = variables;
+}
+</script>
+`;
+      },
+    },
+  },
+};
+
+/**
+ * Update the URL search params with the current query and variables
+ */
+const RuruQueryParamsUpdatePlugin: GraphileConfig.Plugin = {
+  name: "RuruQueryParamsUpdatePlugin",
+  version: "0.0.0",
+
+  grafserv: {
+    hooks: {
+      ruruHTMLParts(_info, parts, _extra) {
+        parts.headerScripts += `
+<script>
+const ruruQueryParamsUpdateUrl = new URL(document.URL);
+const search = ruruQueryParamsUpdateUrl.searchParams;
+RURU_CONFIG.onEditQuery = (query) => {
+  search.set("query", query);
+  window.history.replaceState(null, "", ruruQueryParamsUpdateUrl);
+}
+RURU_CONFIG.onEditVariables = (variables) => {
+  search.set("variables", variables);
+  window.history.replaceState(null, "", ruruQueryParamsUpdateUrl);
 }
 </script>
 `;
@@ -220,6 +249,7 @@ const preset: GraphileConfig.Preset = {
     ExportSchemaPlugin,
     NonNullRelationsPlugin,
     RuruQueryParamsPlugin,
+    RuruQueryParamsUpdatePlugin,
   ],
   extends: [
     PostGraphileAmberPreset,

--- a/postgraphile/postgraphile/graphile.config.ts
+++ b/postgraphile/postgraphile/graphile.config.ts
@@ -128,11 +128,11 @@ const RuruQueryParamsUpdatePlugin: GraphileConfig.Plugin = {
   RURU_CONFIG.onEditQuery = (query) => {
     currentUrl.searchParams.set("query", query);
     window.history.replaceState(null, "", currentUrl);
-  }
+  };
   RURU_CONFIG.onEditVariables = (variables) => {
     currentUrl.searchParams.set("variables", variables);
     window.history.replaceState(null, "", currentUrl);
-  }
+  };
 }
 </script>
 `;


### PR DESCRIPTION
Fixes [#1798](https://github.com/graphile/crystal/issues/1798)

Adds `onEditQuery` and `onEditVariables` props to the ruru config that are passed through
to the underlying `GraphiQLInterface`. 

Adds a plugin that updates the URL `query` and `variables` query params on edits.

Also deprecates the `initialQuery` and `initialVariables` props in favor of `query` and `variables`.
