### PR TITLE
Make `defaultBehavior: "-*"` work as expected

### DIFF
--- a/graphile-build/graphile-build-pg/src/plugins/PgMutationCreatePlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgMutationCreatePlugin.ts
@@ -76,7 +76,7 @@ export const PgMutationCreatePlugin: GraphileConfig.Plugin = {
         provides: ["default"],
         before: ["inferred", "override"],
         callback(behavior, resource) {
-          const newBehavior = [behavior, "+insert:resource:select"];
+          const newBehavior = ["+insert:resource:select"];
           if (
             !resource.parameters &&
             !!resource.codec.attributes &&
@@ -86,6 +86,7 @@ export const PgMutationCreatePlugin: GraphileConfig.Plugin = {
             newBehavior.unshift("insert");
             newBehavior.unshift("record");
           }
+          newBehavior.push(behavior);
           return newBehavior;
         },
       },

--- a/graphile-build/graphile-build-pg/src/plugins/PgTableNodePlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgTableNodePlugin.ts
@@ -35,7 +35,7 @@ export const PgTableNodePlugin: GraphileConfig.Plugin = {
         provides: ["default"],
         before: ["inferred", "override"],
         callback(behavior, codec, build) {
-          const newBehavior = [behavior];
+          const newBehavior = [];
           if (
             !codec.isAnonymous &&
             !!codec.attributes &&
@@ -50,12 +50,14 @@ export const PgTableNodePlugin: GraphileConfig.Plugin = {
               if (codec.polymorphism) {
                 newBehavior.push("interface:node");
               } else {
+                console.log(`${resource.name} is type:node`);
                 newBehavior.push("type:node");
               }
             } else {
               // Meh
             }
           }
+          newBehavior.push(behavior);
           return newBehavior;
         },
       },

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.graphql
@@ -504,6 +504,7 @@ enum CompoundKeysOrderBy {
 """Awesome feature!"""
 type CompoundType {
   a: Int
+  arrayQuery: [CompoundType]
   b: String
   c: Color
   computedField: Int
@@ -512,6 +513,8 @@ type CompoundType {
   f: EnumWithEmptyString
   fooBar: Int
   g: Interval
+  query: CompoundType
+  queryCompoundTypeArray: [CompoundType]
 }
 
 """All input for the `compoundTypeArrayMutation` mutation."""
@@ -7143,6 +7146,7 @@ type Query implements Node {
   """Get a single `CompoundKey`."""
   compoundKeyByPersonId1AndPersonId2(personId1: Int!, personId2: Int!): CompoundKey
   compoundTypeArrayQuery(object: CompoundTypeInput): [CompoundType]
+  compoundTypeComputedField(compoundType: CompoundTypeInput): Int
   compoundTypeQuery(object: CompoundTypeInput): CompoundType
 
   """Reads and enables pagination through a set of `CompoundType`."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.graphql
@@ -504,6 +504,7 @@ enum CompoundKeysOrderBy {
 """Awesome feature!"""
 type CompoundType {
   a: Int
+  arrayQuery: [CompoundType]
   b: String
   c: Color
   computedField: Int
@@ -512,6 +513,8 @@ type CompoundType {
   f: EnumWithEmptyString
   fooBar: Int
   g: Interval
+  query: CompoundType
+  queryCompoundTypeArray: [CompoundType]
 }
 
 """All input for the `compoundTypeArrayMutation` mutation."""
@@ -7143,6 +7146,7 @@ type Query implements Node {
   """Get a single `CompoundKey`."""
   compoundKeyByPersonId1AndPersonId2(personId1: Int!, personId2: Int!): CompoundKey
   compoundTypeArrayQuery(object: CompoundTypeInput): [CompoundType]
+  compoundTypeComputedField(compoundType: CompoundTypeInput): Int
   compoundTypeQuery(object: CompoundTypeInput): CompoundType
 
   """Reads and enables pagination through a set of `CompoundType`."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.graphql
@@ -184,6 +184,18 @@ type CompoundType {
   g: Interval
 }
 
+"""An input for mutations affecting `CompoundType`"""
+input CompoundTypeInput {
+  a: Int
+  b: String
+  c: Color
+  d: UUID
+  e: EnumCaps
+  f: EnumWithEmptyString
+  fooBar: Int
+  g: IntervalInput
+}
+
 """A connection to a list of `CompoundType` values."""
 type CompoundTypesConnection {
   """
@@ -1253,6 +1265,33 @@ scalar InternetAddress
 An interval of time that has passed where the smallest distinct unit is a second.
 """
 type Interval {
+  """A quantity of days."""
+  days: Int
+
+  """A quantity of hours."""
+  hours: Int
+
+  """A quantity of minutes."""
+  minutes: Int
+
+  """A quantity of months."""
+  months: Int
+
+  """
+  A quantity of seconds. This is the only non-integer field, as all the other
+  fields will dump their overflow into a smaller unit of time. Intervals don’t
+  have a smaller unit than seconds.
+  """
+  seconds: Float
+
+  """A quantity of years."""
+  years: Int
+}
+
+"""
+An interval of time that has passed where the smallest distinct unit is a second.
+"""
+input IntervalInput {
   """A quantity of days."""
   days: Int
 
@@ -3509,6 +3548,7 @@ type Query implements Node {
 
   """Get a single `CompoundKey`."""
   compoundKeyByPersonId1AndPersonId2(personId1: Int!, personId2: Int!): CompoundKey
+  compoundTypeComputedField(compoundType: CompoundTypeInput): Int
 
   """Reads and enables pagination through a set of `CompoundType`."""
   compoundTypeSetQuery(

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-good.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-good.1.graphql
@@ -184,6 +184,18 @@ type CompoundType {
   g: Interval
 }
 
+"""An input for mutations affecting `CompoundType`"""
+input CompoundTypeInput {
+  a: Int
+  b: String
+  c: Color
+  d: UUID
+  e: EnumCaps
+  f: EnumWithEmptyString
+  fooBar: Int
+  g: IntervalInput
+}
+
 """A connection to a list of `CompoundType` values."""
 type CompoundTypesConnection {
   """
@@ -1264,6 +1276,33 @@ scalar InternetAddress
 An interval of time that has passed where the smallest distinct unit is a second.
 """
 type Interval {
+  """A quantity of days."""
+  days: Int
+
+  """A quantity of hours."""
+  hours: Int
+
+  """A quantity of minutes."""
+  minutes: Int
+
+  """A quantity of months."""
+  months: Int
+
+  """
+  A quantity of seconds. This is the only non-integer field, as all the other
+  fields will dump their overflow into a smaller unit of time. Intervals don’t
+  have a smaller unit than seconds.
+  """
+  seconds: Float
+
+  """A quantity of years."""
+  years: Int
+}
+
+"""
+An interval of time that has passed where the smallest distinct unit is a second.
+"""
+input IntervalInput {
   """A quantity of days."""
   days: Int
 
@@ -3536,6 +3575,7 @@ type Query implements Node {
 
   """Get a single `CompoundKey`."""
   compoundKeyByPersonId1AndPersonId2(personId1: Int!, personId2: Int!): CompoundKey
+  compoundTypeComputedField(compoundType: CompoundTypeInput): Int
 
   """Reads and enables pagination through a set of `CompoundType`."""
   compoundTypeSetQuery(

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.graphql
@@ -504,6 +504,7 @@ enum CompoundKeysOrderBy {
 """Awesome feature!"""
 type CompoundType {
   a: Int
+  arrayQuery: [CompoundType]
   b: String
   c: Color
   computedField: Int
@@ -512,6 +513,8 @@ type CompoundType {
   f: EnumWithEmptyString
   fooBar: Int
   g: Interval
+  query: CompoundType
+  queryCompoundTypeArray: [CompoundType]
 }
 
 """All input for the `compoundTypeArrayMutation` mutation."""
@@ -7055,6 +7058,7 @@ type Query implements Node {
   """Get a single `CompoundKey`."""
   compoundKeyByPersonId1AndPersonId2(personId1: Int!, personId2: Int!): CompoundKey
   compoundTypeArrayQuery(object: CompoundTypeInput): [CompoundType]
+  compoundTypeComputedField(compoundType: CompoundTypeInput): Int
   compoundTypeQuery(object: CompoundTypeInput): CompoundType
 
   """Reads and enables pagination through a set of `CompoundType`."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.graphql
@@ -504,6 +504,7 @@ enum CompoundKeysOrderBy {
 """Awesome feature!"""
 type CompoundType {
   a: Int
+  arrayQuery: [CompoundType]
   b: String
   c: Color
   computedField: Int
@@ -512,6 +513,8 @@ type CompoundType {
   f: EnumWithEmptyString
   fooBar: Int
   g: Interval
+  query: CompoundType
+  queryCompoundTypeArray: [CompoundType]
 }
 
 """All input for the `compoundTypeArrayMutation` mutation."""
@@ -7143,6 +7146,7 @@ type Query implements Node {
   """Get a single `CompoundKey`."""
   compoundKeyByPersonId1AndPersonId2(personId1: Int!, personId2: Int!): CompoundKey
   compoundTypeArrayQuery(object: CompoundTypeInput): [CompoundType]
+  compoundTypeComputedField(compoundType: CompoundTypeInput): Int
   compoundTypeQuery(object: CompoundTypeInput): CompoundType
 
   """Reads and enables pagination through a set of `CompoundType`."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.graphql
@@ -465,6 +465,7 @@ enum CompoundKeysOrderBy {
 """Awesome feature!"""
 type CompoundType {
   a: Int
+  arrayQuery: [CompoundType]
   b: String
   c: Color
   computedField: Int
@@ -473,6 +474,8 @@ type CompoundType {
   f: EnumWithEmptyString
   fooBar: Int
   g: Interval
+  query: CompoundType
+  queryCompoundTypeArray: [CompoundType]
 }
 
 """All input for the `compoundTypeArrayMutation` mutation."""
@@ -6859,6 +6862,7 @@ type Query implements Node {
   """Get a single `CompoundKey`."""
   compoundKeyByPersonId1AndPersonId2(personId1: Int!, personId2: Int!): CompoundKey
   compoundTypeArrayQuery(object: CompoundTypeInput): [CompoundType]
+  compoundTypeComputedField(compoundType: CompoundTypeInput): Int
   compoundTypeQuery(object: CompoundTypeInput): CompoundType
 
   """Reads and enables pagination through a set of `CompoundType`."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.graphql
@@ -509,6 +509,7 @@ enum CompoundKeysOrderBy {
 """Awesome feature!"""
 type CompoundType {
   a: Int
+  arrayQuery: [CompoundType]
   b: String
   c: Color
   computedField: Int
@@ -517,6 +518,8 @@ type CompoundType {
   f: EnumWithEmptyString
   fooBar: Int
   g: I
+  query: CompoundType
+  queryCompoundTypeArray: [CompoundType]
 }
 
 """All input for the `compoundTypeArrayMutation` mutation."""
@@ -7148,6 +7151,7 @@ type Q implements N {
   """Get a single `CompoundKey`."""
   compoundKeyByPersonId1AndPersonId2(personId1: Int!, personId2: Int!): CompoundKey
   compoundTypeArrayQuery(object: CompoundTypeInput): [CompoundType]
+  compoundTypeComputedField(compoundType: CompoundTypeInput): Int
   compoundTypeQuery(object: CompoundTypeInput): CompoundType
 
   """Reads and enables pagination through a set of `CompoundType`."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/jwt.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/jwt.1.graphql
@@ -221,6 +221,7 @@ enum Color {
 """Awesome feature!"""
 type CompoundType {
   a: Int
+  arrayQuery: [CompoundType]
   b: String
   c: Color
   d: UUID
@@ -228,6 +229,7 @@ type CompoundType {
   f: EnumWithEmptyString
   fooBar: Int
   g: Interval
+  query: CompoundType
 }
 
 """All input for the `compoundTypeArrayMutation` mutation."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.graphql
@@ -168,6 +168,18 @@ type CompoundType {
   g: Interval
 }
 
+"""An input for mutations affecting `CompoundType`"""
+input CompoundTypeInput {
+  a: Int
+  b: String
+  c: Color
+  d: UUID
+  e: EnumCaps
+  f: EnumWithEmptyString
+  fooBar: Int
+  g: IntervalInput
+}
+
 """A connection to a list of `CompoundType` values."""
 type CompoundTypesConnection {
   """
@@ -567,6 +579,33 @@ scalar InternetAddress
 An interval of time that has passed where the smallest distinct unit is a second.
 """
 type Interval {
+  """A quantity of days."""
+  days: Int
+
+  """A quantity of hours."""
+  hours: Int
+
+  """A quantity of minutes."""
+  minutes: Int
+
+  """A quantity of months."""
+  months: Int
+
+  """
+  A quantity of seconds. This is the only non-integer field, as all the other
+  fields will dump their overflow into a smaller unit of time. Intervals don’t
+  have a smaller unit than seconds.
+  """
+  seconds: Float
+
+  """A quantity of years."""
+  years: Int
+}
+
+"""
+An interval of time that has passed where the smallest distinct unit is a second.
+"""
+input IntervalInput {
   """A quantity of days."""
   days: Int
 
@@ -2344,6 +2383,7 @@ type Query implements Node {
 
   """Get a single `CompoundKey`."""
   compoundKeyByPersonId1AndPersonId2(personId1: Int!, personId2: Int!): CompoundKey
+  compoundTypeComputedField(compoundType: CompoundTypeInput): Int
 
   """Reads and enables pagination through a set of `CompoundType`."""
   compoundTypeSetQuery(

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.1.graphql
@@ -1021,7 +1021,6 @@ type Person implements Node {
   firstName: String
   id: Int!
   lastName: String
-  name: String
 
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.1.graphql
@@ -1021,7 +1021,6 @@ type Person implements Node {
   firstName: String
   id: Int!
   lastName: String
-  name: String
 
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.loads-title.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.loads-title.1.graphql
@@ -1021,7 +1021,6 @@ type Person implements Node {
   firstName: String
   id: Int!
   lastName: String
-  name: String
 
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.shows-title-asterisk.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.shows-title-asterisk.1.graphql
@@ -1021,7 +1021,6 @@ type Person implements Node {
   firstName: String
   id: Int!
   lastName: String
-  name: String
 
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.title-order.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.title-order.1.graphql
@@ -1021,7 +1021,6 @@ type Person implements Node {
   firstName: String
   id: Int!
   lastName: String
-  name: String
 
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.update-title.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.update-title.1.graphql
@@ -1021,7 +1021,6 @@ type Person implements Node {
   firstName: String
   id: Int!
   lastName: String
-  name: String
 
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.1.graphql
@@ -886,7 +886,6 @@ type Person implements Node {
   firstName: String
   id: Int!
   lastName: String
-  name: String
 
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.constraints.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.constraints.1.graphql
@@ -1021,7 +1021,6 @@ type Person implements Node {
   firstName: String
   id: Int!
   lastName: String
-  name: String
 
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-asterisk.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-asterisk.1.graphql
@@ -693,7 +693,6 @@ type Person implements Node {
   firstName: String
   id: Int!
   lastName: String
-  name: String
 
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-create.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-create.1.graphql
@@ -972,7 +972,6 @@ type Person implements Node {
   firstName: String
   id: Int!
   lastName: String
-  name: String
 
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-delete.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-delete.1.graphql
@@ -957,7 +957,6 @@ type Person implements Node {
   firstName: String
   id: Int!
   lastName: String
-  name: String
 
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-loads.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-loads.1.graphql
@@ -828,7 +828,6 @@ type Person implements Node {
   firstName: String
   id: Int!
   lastName: String
-  name: String
 
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-update.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-update.1.graphql
@@ -999,7 +999,6 @@ type Person implements Node {
   firstName: String
   id: Int!
   lastName: String
-  name: String
 
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.shows-order.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.shows-order.1.graphql
@@ -1009,7 +1009,6 @@ type Person implements Node {
   firstName: String
   id: Int!
   lastName: String
-  name: String
 
   """
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.

--- a/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.graphql
@@ -504,6 +504,7 @@ enum CompoundKeysOrderBy {
 """Awesome feature!"""
 type CompoundType {
   a: Int
+  arrayQuery: [CompoundType]
   b: String
   c: Color
   computedField: Int
@@ -512,6 +513,8 @@ type CompoundType {
   f: EnumWithEmptyString
   fooBar: Int
   g: Interval
+  query: CompoundType
+  queryCompoundTypeArray: [CompoundType]
 }
 
 """All input for the `compoundTypeArrayMutation` mutation."""
@@ -7143,6 +7146,7 @@ type Query implements Node {
   """Get a single `CompoundKey`."""
   compoundKeyByPersonId1AndPersonId2(personId1: Int!, personId2: Int!): CompoundKey
   compoundTypeArrayQuery(object: CompoundTypeInput): [CompoundType]
+  compoundTypeComputedField(compoundType: CompoundTypeInput): Int
   compoundTypeQuery(object: CompoundTypeInput): CompoundType
 
   """Reads and enables pagination through a set of `CompoundType`."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/relay.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/relay.1.graphql
@@ -841,7 +841,6 @@ type Person implements Node {
   """
   id: ID!
   lastName: String
-  name: String
 
   """Reads and enables pagination through a set of `Post`."""
   posts(

--- a/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.graphql
@@ -184,6 +184,18 @@ type CompoundType {
   g: Interval
 }
 
+"""An input for mutations affecting `CompoundType`"""
+input CompoundTypeInput {
+  a: Int
+  b: String
+  c: Color
+  d: UUID
+  e: EnumCaps
+  f: EnumWithEmptyString
+  fooBar: Int
+  g: IntervalInput
+}
+
 """A connection to a list of `CompoundType` values."""
 type CompoundTypesConnection {
   """
@@ -1247,6 +1259,33 @@ scalar InternetAddress
 An interval of time that has passed where the smallest distinct unit is a second.
 """
 type Interval {
+  """A quantity of days."""
+  days: Int
+
+  """A quantity of hours."""
+  hours: Int
+
+  """A quantity of minutes."""
+  minutes: Int
+
+  """A quantity of months."""
+  months: Int
+
+  """
+  A quantity of seconds. This is the only non-integer field, as all the other
+  fields will dump their overflow into a smaller unit of time. Intervals don’t
+  have a smaller unit than seconds.
+  """
+  seconds: Float
+
+  """A quantity of years."""
+  years: Int
+}
+
+"""
+An interval of time that has passed where the smallest distinct unit is a second.
+"""
+input IntervalInput {
   """A quantity of days."""
   days: Int
 
@@ -3467,6 +3506,7 @@ type Query implements Node {
 
   """Get a single `CompoundKey`."""
   compoundKeyByPersonId1AndPersonId2(personId1: Int!, personId2: Int!): CompoundKey
+  compoundTypeComputedField(compoundType: CompoundTypeInput): Int
 
   """Reads and enables pagination through a set of `CompoundType`."""
   compoundTypeSetQuery(

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.graphql
@@ -184,6 +184,18 @@ type CompoundType {
   g: Interval
 }
 
+"""An input for mutations affecting `CompoundType`"""
+input CompoundTypeInput {
+  a: Int
+  b: String
+  c: Color
+  d: UUID
+  e: EnumCaps
+  f: EnumWithEmptyString
+  fooBar: Int
+  g: IntervalInput
+}
+
 """A connection to a list of `CompoundType` values."""
 type CompoundTypesConnection {
   """
@@ -1247,6 +1259,33 @@ scalar InternetAddress
 An interval of time that has passed where the smallest distinct unit is a second.
 """
 type Interval {
+  """A quantity of days."""
+  days: Int
+
+  """A quantity of hours."""
+  hours: Int
+
+  """A quantity of minutes."""
+  minutes: Int
+
+  """A quantity of months."""
+  months: Int
+
+  """
+  A quantity of seconds. This is the only non-integer field, as all the other
+  fields will dump their overflow into a smaller unit of time. Intervals don’t
+  have a smaller unit than seconds.
+  """
+  seconds: Float
+
+  """A quantity of years."""
+  years: Int
+}
+
+"""
+An interval of time that has passed where the smallest distinct unit is a second.
+"""
+input IntervalInput {
   """A quantity of days."""
   days: Int
 
@@ -3665,6 +3704,7 @@ type Query implements Node {
 
   """Get a single `CompoundKey`."""
   compoundKeyByPersonId1AndPersonId2(personId1: Int!, personId2: Int!): CompoundKey
+  compoundTypeComputedField(compoundType: CompoundTypeInput): Int
 
   """Reads and enables pagination through a set of `CompoundType`."""
   compoundTypeSetQuery(

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only.1.graphql
@@ -158,6 +158,18 @@ type CompoundType {
   g: Interval
 }
 
+"""An input for mutations affecting `CompoundType`"""
+input CompoundTypeInput {
+  a: Int
+  b: String
+  c: Color
+  d: UUID
+  e: EnumCaps
+  f: EnumWithEmptyString
+  fooBar: Int
+  g: IntervalInput
+}
+
 type Comptype {
   isOptimised: Boolean
   schedule: Datetime
@@ -920,6 +932,33 @@ scalar InternetAddress
 An interval of time that has passed where the smallest distinct unit is a second.
 """
 type Interval {
+  """A quantity of days."""
+  days: Int
+
+  """A quantity of hours."""
+  hours: Int
+
+  """A quantity of minutes."""
+  minutes: Int
+
+  """A quantity of months."""
+  months: Int
+
+  """
+  A quantity of seconds. This is the only non-integer field, as all the other
+  fields will dump their overflow into a smaller unit of time. Intervals don’t
+  have a smaller unit than seconds.
+  """
+  seconds: Float
+
+  """A quantity of years."""
+  years: Int
+}
+
+"""
+An interval of time that has passed where the smallest distinct unit is a second.
+"""
+input IntervalInput {
   """A quantity of days."""
   days: Int
 
@@ -2793,6 +2832,7 @@ type Query implements Node {
 
   """Get a single `CompoundKey`."""
   compoundKeyByPersonId1AndPersonId2(personId1: Int!, personId2: Int!): CompoundKey
+  compoundTypeComputedField(compoundType: CompoundTypeInput): Int
   compoundTypeSetQueryList(
     """Only read the first `n` values of the set."""
     first: Int

--- a/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.graphql
@@ -278,6 +278,7 @@ type Query implements Node {
   queryTextArray: [String]
   returnTableWithoutGrants: CompoundKey
   typesQuery(a: BigInt!, b: Boolean!, c: String!, d: [Int]!, e: JSON!, f: FloatRangeInput!): Boolean
+  compoundTypeComputedField(compoundType: CompoundTypeInput): Int
   funcOutOutCompoundType(i1: Int): FuncOutOutCompoundTypeRecord
 
   """Reads and enables pagination through a set of `CompoundType`."""
@@ -1628,6 +1629,9 @@ type PersonComputedComplexRecord {
 """Awesome feature!"""
 type CompoundType {
   computedField: Int
+  query: CompoundType
+  queryCompoundTypeArray: [CompoundType]
+  arrayQuery: [CompoundType]
   a: Int
   b: String
   c: Color

--- a/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.1.graphql
@@ -499,6 +499,7 @@ enum CompoundKeysOrderBy {
 """Awesome feature!"""
 type CompoundType {
   a: Int
+  arrayQuery: [CompoundType]
   b: String
   c: Color
   computedField: Int
@@ -507,6 +508,8 @@ type CompoundType {
   f: EnumWithEmptyString
   fooBar: Int
   g: Interval
+  query: CompoundType
+  queryCompoundTypeArray: [CompoundType]
 }
 
 """All input for the `compoundTypeArrayMutation` mutation."""
@@ -6498,6 +6501,7 @@ type Query {
   """Get a single `CompoundKey`."""
   compoundKeyByPersonId1AndPersonId2(personId1: Int!, personId2: Int!): CompoundKey
   compoundTypeArrayQuery(object: CompoundTypeInput): [CompoundType]
+  compoundTypeComputedField(compoundType: CompoundTypeInput): Int
   compoundTypeQuery(object: CompoundTypeInput): CompoundType
 
   """Reads and enables pagination through a set of `CompoundType`."""

--- a/postgraphile/postgraphile/graphile.config.ts
+++ b/postgraphile/postgraphile/graphile.config.ts
@@ -15,7 +15,9 @@ import { PgRelayPreset } from "postgraphile/presets/relay";
 import { makeV4Preset } from "postgraphile/presets/v4";
 
 // import { PgManyToManyPreset } from "../../contrib/pg-many-to-many/dist/index.js";
+// import { PgOmitArchivedPlugin } from "../../contrib/pg-omit-archived/dist/index.js";
 // import { PostGraphileConnectionFilterPreset } from "../../contrib/postgraphile-plugin-connection-filter/dist/index.js";
+// import { PgAggregatesPreset } from "../../contrib/postgraphile-plugin-connection-filter/contrib/pg-aggregates/dist/index.js";
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -196,11 +198,12 @@ const preset: GraphileConfig.Preset = {
     makeRuruTitlePlugin("<New title text here!>"),
     ExportSchemaPlugin,
     NonNullRelationsPlugin,
+    // PgOmitArchivedPlugin,
   ],
   extends: [
     PostGraphileAmberPreset,
     makeV4Preset({
-      simpleCollections: "both",
+      //simpleCollections: "both",
       jwtPgTypeIdentifier: '"b"."jwt_token"',
       dynamicJson: true,
       graphiql: true,
@@ -208,6 +211,7 @@ const preset: GraphileConfig.Preset = {
     }),
     // PgManyToManyPreset,
     // PostGraphileConnectionFilterPreset,
+    // PgAggregatesPreset,
     PgRelayPreset,
     PgLazyJWTPreset,
   ],
@@ -226,6 +230,7 @@ const preset: GraphileConfig.Preset = {
     exportSchemaIntrospectionResultPath: `${__dirname}/latestSchema.json`,
     sortExport: true,
     pgJwtSecret: "FROGS",
+    // defaultBehavior: "-query:*:* -queryField:*:* -queryField -*",
   },
   grafserv: {
     port: 5678,

--- a/postgraphile/postgraphile/src/plugins/PgV4BehaviorPlugin.ts
+++ b/postgraphile/postgraphile/src/plugins/PgV4BehaviorPlugin.ts
@@ -1,7 +1,7 @@
 import "graphile-config";
 import "graphile-build-pg";
 
-import type { PgResourceOptions } from "@dataplan/pg";
+import type { PgResource, PgResourceOptions } from "@dataplan/pg";
 import type { PgProc } from "graphile-build-pg/pg-introspection";
 import { inspect } from "util";
 
@@ -13,20 +13,28 @@ declare global {
   }
 }
 
-const v4ComputedAttributeChecks = (
-  _s: PgResourceOptions,
-  pgProc: PgProc,
-): boolean => {
-  const args = pgProc.getArguments();
-  const firstArg = args[0];
+const v4ComputedAttributeChecks = (s: PgResource): boolean => {
+  const firstArg = s.parameters![0];
 
   // Has to be in same schema
-  if (firstArg.type.typnamespace !== pgProc.pronamespace) {
+  if (
+    firstArg.codec.extensions?.pg?.schemaName !== s.extensions?.pg?.schemaName
+  ) {
+    console.log(
+      `v4compcheck1 ${s.name} (${s.extensions?.pg?.schemaName}.${s.extensions?.pg?.name}) -- ${firstArg.codec.extensions?.pg?.schemaName} !== ${s.extensions?.pg?.schemaName}`,
+    );
     return false;
   }
 
   // Has to start with the name prefix
-  if (!pgProc.proname.startsWith(firstArg.type.typname + "_")) {
+  if (
+    !s.extensions?.pg?.name.startsWith(
+      firstArg.codec.extensions?.pg?.name + "_",
+    )
+  ) {
+    console.log(
+      `v4compcheck2 ${s.extensions?.pg?.name} doesn't start with ${firstArg.codec.extensions?.pg?.name}`,
+    );
     return false;
   }
 
@@ -39,52 +47,44 @@ export const PgV4BehaviorPlugin: GraphileConfig.Plugin = {
     "For compatibility with PostGraphile v4 schemas, this plugin updates the default behaviors of certain things.",
   version: "0.0.0",
 
-  gather: {
-    hooks: {
-      pgProcedures_PgResourceOptions(info, event) {
-        const { resourceOptions: s } = event;
-        // Apply default behavior
-        const behavior = [];
-        const firstParameter = s.parameters![0];
-        if (s.isMutation && s.parameters) {
-          behavior.push("-queryField mutationField -typeField");
-        } else if (
-          s.parameters &&
-          s.parameters?.[0]?.codec?.attributes &&
-          !s.isMutation &&
-          v4ComputedAttributeChecks(s, event.pgProc)
-        ) {
-          behavior.push("-queryField -mutationField typeField");
-        } else if (
-          !s.isMutation &&
-          s.parameters &&
-          // Don't default to this being a queryField if it looks like a computed attribute function
-          (!firstParameter?.codec?.attributes ||
-            firstParameter?.codec?.extensions?.isTableLike === false)
-        ) {
-          behavior.push("queryField -mutationField -typeField");
-        } else {
-          behavior.push("-queryField -mutationField -typeField");
-        }
+  schema: {
+    entityBehavior: {
+      pgResource: {
+        provides: ["inferred"],
+        after: ["default"],
+        before: ["overrides", "PgCustomTypeFieldPlugin"],
+        callback(behavior, s, build) {
+          if (!s.parameters) {
+            return behavior;
+          }
+          // Apply default behavior
+          const newBehavior = [];
+          const firstParameter = s.parameters![0];
+          if (s.isMutation && s.parameters) {
+            newBehavior.push("-queryField mutationField -typeField");
+          } else if (
+            s.parameters &&
+            s.parameters?.[0]?.codec?.attributes &&
+            !s.isMutation &&
+            v4ComputedAttributeChecks(s)
+          ) {
+            newBehavior.push("-queryField -mutationField typeField");
+          } else if (
+            !s.isMutation &&
+            s.parameters &&
+            // Don't default to this being a queryField if it looks like a computed attribute function
+            (!firstParameter?.codec?.attributes ||
+              firstParameter?.codec?.extensions?.isTableLike === false)
+          ) {
+            // console.log(s.name);
+            newBehavior.push("queryField -mutationField -typeField");
+          } else {
+            newBehavior.push("-queryField -mutationField -typeField");
+          }
 
-        if (!s.extensions) {
-          s.extensions = Object.create(null);
-        }
-        if (!s.extensions!.tags) {
-          s.extensions!.tags = Object.create(null);
-        }
-        const b = s.extensions!.tags!.behavior;
-        if (!b) {
-          s.extensions!.tags!.behavior = behavior;
-        } else if (typeof b === "string") {
-          s.extensions!.tags!.behavior = [...behavior, b];
-        } else if (Array.isArray(b)) {
-          s.extensions!.tags!.behavior = [...behavior, ...b];
-        } else {
-          throw new Error(
-            `${s}.extensions.tags.behavior has unknown shape '${inspect(b)}'`,
-          );
-        }
+          newBehavior.push(behavior);
+          return newBehavior;
+        },
       },
     },
   },

--- a/postgraphile/postgraphile/src/presets/relay.ts
+++ b/postgraphile/postgraphile/src/presets/relay.ts
@@ -38,7 +38,6 @@ export const PgRelayPlugin: GraphileConfig.Plugin = {
 
   schema: {
     globalBehavior: `\
-+node \
 +connection -list \
 -query:resource:single \
 +nodeId:filterBy \

--- a/publish.sh
+++ b/publish.sh
@@ -5,54 +5,54 @@ BUILD_DIR=crystal/builds
 TAG=beta
 
 cd ..
-tar tzf $BUILD_DIR/graphile__lru.tgz
-tar tzf $BUILD_DIR/tamedevil.tgz
-tar tzf $BUILD_DIR/graphile-config.tgz
+#tar tzf $BUILD_DIR/graphile__lru.tgz
+#tar tzf $BUILD_DIR/tamedevil.tgz
+#tar tzf $BUILD_DIR/graphile-config.tgz
 tar tzf $BUILD_DIR/ruru-components.tgz
 tar tzf $BUILD_DIR/ruru.tgz
 tar tzf $BUILD_DIR/grafast.tgz
 tar tzf $BUILD_DIR/grafserv.tgz
 tar tzf $BUILD_DIR/dataplan__json.tgz
-tar tzf $BUILD_DIR/eslint-plugin-graphile-export.tgz
+#tar tzf $BUILD_DIR/eslint-plugin-graphile-export.tgz
 tar tzf $BUILD_DIR/graphile-utils.tgz
-tar tzf $BUILD_DIR/graphile-export.tgz
-tar tzf $BUILD_DIR/jest-serializer-graphql-schema.tgz
-tar tzf $BUILD_DIR/jest-serializer-simple.tgz
+#tar tzf $BUILD_DIR/graphile-export.tgz
+#tar tzf $BUILD_DIR/jest-serializer-graphql-schema.tgz
+#tar tzf $BUILD_DIR/jest-serializer-simple.tgz
 tar tzf $BUILD_DIR/graphile-build.tgz
-tar tzf $BUILD_DIR/pg-introspection.tgz
-tar tzf $BUILD_DIR/pg-sql2.tgz
+#tar tzf $BUILD_DIR/pg-introspection.tgz
+#tar tzf $BUILD_DIR/pg-sql2.tgz
 tar tzf $BUILD_DIR/dataplan__pg.tgz
 tar tzf $BUILD_DIR/graphile-build-pg.tgz
 tar tzf $BUILD_DIR/postgraphile.tgz
 tar tzf $BUILD_DIR/pgl.tgz
-tar tzf $BUILD_DIR/graphile__simplify-inflection.tgz
+#tar tzf $BUILD_DIR/graphile__simplify-inflection.tgz
 tar tzf $BUILD_DIR/grafserv__persisted.tgz
 tar tzf $BUILD_DIR/graphile.tgz
 
 read -n1 -p "Publish? [y,n]" doit
 case $doit in
   y|Y)
-    npm publish --access=public --tag="$TAG" "$BUILD_DIR/graphile__lru.tgz"
-    npm publish --access=public --tag="$TAG" "$BUILD_DIR/tamedevil.tgz"
-    npm publish --access=public --tag="$TAG" "$BUILD_DIR/graphile-config.tgz"
+    #npm publish --access=public --tag="$TAG" "$BUILD_DIR/graphile__lru.tgz"
+    #npm publish --access=public --tag="$TAG" "$BUILD_DIR/tamedevil.tgz"
+    #npm publish --access=public --tag="$TAG" "$BUILD_DIR/graphile-config.tgz"
     npm publish --access=public --tag="$TAG" "$BUILD_DIR/ruru-components.tgz"
     npm publish --access=public --tag="$TAG" "$BUILD_DIR/ruru.tgz"
     npm publish --access=public --tag="$TAG" "$BUILD_DIR/grafast.tgz"
     npm publish --access=public --tag="$TAG" "$BUILD_DIR/grafserv.tgz"
     npm publish --access=public --tag="$TAG" "$BUILD_DIR/dataplan__json.tgz"
-    npm publish --access=public --tag="$TAG" "$BUILD_DIR/eslint-plugin-graphile-export.tgz"
+    #npm publish --access=public --tag="$TAG" "$BUILD_DIR/eslint-plugin-graphile-export.tgz"
     npm publish --access=public --tag="$TAG" "$BUILD_DIR/graphile-utils.tgz"
-    npm publish --access=public --tag="$TAG" "$BUILD_DIR/graphile-export.tgz"
-    npm publish --access=public --tag="$TAG" "$BUILD_DIR/jest-serializer-graphql-schema.tgz"
-    npm publish --access=public --tag="$TAG" "$BUILD_DIR/jest-serializer-simple.tgz"
+    #npm publish --access=public --tag="$TAG" "$BUILD_DIR/graphile-export.tgz"
+    #npm publish --access=public --tag="$TAG" "$BUILD_DIR/jest-serializer-graphql-schema.tgz"
+    #npm publish --access=public --tag="$TAG" "$BUILD_DIR/jest-serializer-simple.tgz"
     npm publish --access=public --tag="$TAG" "$BUILD_DIR/graphile-build.tgz"
-    npm publish --access=public --tag="$TAG" "$BUILD_DIR/pg-introspection.tgz"
-    npm publish --access=public --tag="$TAG" "$BUILD_DIR/pg-sql2.tgz"
+    #npm publish --access=public --tag="$TAG" "$BUILD_DIR/pg-introspection.tgz"
+    #npm publish --access=public --tag="$TAG" "$BUILD_DIR/pg-sql2.tgz"
     npm publish --access=public --tag="$TAG" "$BUILD_DIR/dataplan__pg.tgz"
     npm publish --access=public --tag="$TAG" "$BUILD_DIR/graphile-build-pg.tgz"
     npm publish --access=public --tag="$TAG" "$BUILD_DIR/postgraphile.tgz"
     npm publish --access=public --tag="$TAG" "$BUILD_DIR/pgl.tgz"
-    npm publish --access=public --tag="$TAG" "$BUILD_DIR/graphile__simplify-inflection.tgz"
+    #npm publish --access=public --tag="$TAG" "$BUILD_DIR/graphile__simplify-inflection.tgz"
     npm publish --access=public --tag="$TAG" "$BUILD_DIR/grafserv__persisted.tgz"
     npm publish --access=public --tag="$TAG" "$BUILD_DIR/graphile.tgz"
     ;;


### PR DESCRIPTION
## Description

It would make sense that `defaultBehavior: "-*"` would disable all behaviors; but currently it doesn't. This is due to the order that behaviors are added and to some legacy approaches for adding behaviors (e.g. adding directly to tags). This PR sets out to address this problem, but is a work in progress.

## Performance impact

Unknown.

## Security impact

None known.