### PR TITLE
Enable limiting polymorphic relations to only certain types

### DIFF
--- a/.changeset/khaki-fans-kiss.md
+++ b/.changeset/khaki-fans-kiss.md
@@ -1,0 +1,11 @@
+---
+"graphile-build-pg": patch
+"postgraphile": patch
+"@dataplan/pg": patch
+---
+
+Add support for limiting polymorphic plans (only some of them, specifically
+`pgUnionAll()` right now) to limit the types of their results; exposed via an
+experimental 'only' argument on fields, for example
+`allApplications(only: [GcpApplication, AwsApplication])` would limit the type
+of applications returned to only be the two specified.

--- a/.changeset/swift-cows-beam.md
+++ b/.changeset/swift-cows-beam.md
@@ -1,0 +1,5 @@
+---
+"graphile-build": patch
+---
+
+Enable detecting "empty" enums (enums with no values).

--- a/grafast/website/docusaurus.config.js
+++ b/grafast/website/docusaurus.config.js
@@ -51,8 +51,7 @@ const config = {
         },
         pages: {
           remarkPlugins: [
-            require("@docusaurus/remark-plugin-npm2yarn"),
-            { sync: true },
+            [require("@docusaurus/remark-plugin-npm2yarn"), { sync: true }],
           ],
         },
         blog: false,

--- a/graphile-build/graphile-build-pg/src/plugins/PgInterfaceModeUnionAllRowsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgInterfaceModeUnionAllRowsPlugin.ts
@@ -7,7 +7,7 @@ import type {
   PgUnionAllStepMember,
 } from "@dataplan/pg";
 import { pgUnionAll } from "@dataplan/pg";
-import { FieldArgs, connection } from "grafast";
+import { connection } from "grafast";
 import type { GraphQLInterfaceType, GraphQLObjectType } from "grafast/graphql";
 import { EXPORTABLE } from "graphile-build";
 

--- a/graphile-build/graphile-build-pg/src/plugins/PgInterfaceModeUnionAllRowsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgInterfaceModeUnionAllRowsPlugin.ts
@@ -175,6 +175,7 @@ export const PgInterfaceModeUnionAllRowsPlugin: GraphileConfig.Plugin = {
                                 ),
                                 description:
                                   "Filter results to only those of the given types",
+                                deprecationReason: "EXPERIMENTAL",
                               },
                             }
                           : null),

--- a/graphile-build/graphile-build-pg/src/plugins/PgInterfaceModeUnionAllRowsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgInterfaceModeUnionAllRowsPlugin.ts
@@ -2,7 +2,6 @@ import "graphile-config";
 
 import type {
   PgCodec,
-  PgRegistry,
   PgResource,
   PgUnionAllStepConfigAttributes,
   PgUnionAllStepMember,
@@ -79,8 +78,9 @@ export const PgInterfaceModeUnionAllRowsPlugin: GraphileConfig.Plugin = {
       GraphQLObjectType_fields(fields, build, context) {
         const {
           inflection,
-          input,
           graphql: { GraphQLList, GraphQLNonNull },
+          pgResourcesByPolymorphicTypeName,
+          pgCodecByPolymorphicUnionModeTypeName,
         } = build;
         const {
           scope: { isRootQuery },
@@ -90,96 +90,16 @@ export const PgInterfaceModeUnionAllRowsPlugin: GraphileConfig.Plugin = {
           return fields;
         }
 
-        const pgRegistry = input.pgRegistry as PgRegistry;
-
-        const resourcesByPolymorphicTypeName: {
-          [polymorphicTypeName: string]: {
-            resources: PgResource[];
-            type: "union" | "interface";
-          };
-        } = Object.create(null);
-
-        const allResources = Object.values(pgRegistry.pgResources);
-        for (const resource of allResources) {
-          if (resource.parameters) continue;
-          if (typeof resource.from === "function") continue;
-          if (!resource.codec.extensions?.tags) continue;
-          const { implements: implementsTag } = resource.codec.extensions.tags;
-          /*
-          const { unionMember } = resource.codec.extensions.tags;
-          if (unionMember) {
-            const unions = Array.isArray(unionMember)
-              ? unionMember
-              : [unionMember];
-            for (const union of unions) {
-              if (!resourcesByPolymorphicTypeName[union]) {
-                resourcesByPolymorphicTypeName[union] = {
-                  resources: [resource as PgResource],
-                  type: "union",
-                };
-              } else {
-                if (resourcesByPolymorphicTypeName[union].type !== "union") {
-                  throw new Error(`Inconsistent polymorphism`);
-                }
-                resourcesByPolymorphicTypeName[union].resources.push(
-                  resource as PgResource,
-                );
-              }
-            }
-          }
-          */
-          if (implementsTag) {
-            const interfaces = Array.isArray(implementsTag)
-              ? implementsTag
-              : [implementsTag];
-            for (const interfaceName of interfaces) {
-              if (!resourcesByPolymorphicTypeName[interfaceName]) {
-                resourcesByPolymorphicTypeName[interfaceName] = {
-                  resources: [resource as PgResource],
-                  type: "interface",
-                };
-              } else {
-                if (
-                  resourcesByPolymorphicTypeName[interfaceName].type !==
-                  "interface"
-                ) {
-                  throw new Error(`Inconsistent polymorphism`);
-                }
-                resourcesByPolymorphicTypeName[interfaceName].resources.push(
-                  resource as PgResource,
-                );
-              }
-            }
-          }
-        }
-
-        const interfaceCodecs: { [polymorphicTypeName: string]: PgCodec } =
-          Object.create(null);
-        for (const codec of Object.values(pgRegistry.pgCodecs)) {
-          if (!codec.polymorphism) continue;
-          if (codec.polymorphism.mode !== "union") continue;
-
-          const interfaceTypeName = inflection.tableType(codec);
-          interfaceCodecs[interfaceTypeName] = codec;
-
-          // Explicitly allow zero implementations.
-          if (!resourcesByPolymorphicTypeName[interfaceTypeName]) {
-            resourcesByPolymorphicTypeName[interfaceTypeName] = {
-              resources: [],
-              type: "interface",
-            };
-          }
-        }
-
         for (const [polymorphicTypeName, spec] of Object.entries(
-          resourcesByPolymorphicTypeName,
+          pgResourcesByPolymorphicTypeName,
         )) {
           if (spec.type === "union") {
             // We can't add a root field for a basic union because there's
             // nothing to order it by - we wouldn't be able to reliably
             // paginate.
           } else if (spec.type === "interface") {
-            const interfaceCodec = interfaceCodecs[polymorphicTypeName];
+            const interfaceCodec =
+              pgCodecByPolymorphicUnionModeTypeName[polymorphicTypeName];
             if (!interfaceCodec) {
               console.warn(
                 `A number of resources claim to implement '${polymorphicTypeName}', but we couldn't find the definition for that type so we won't add a root field for it. (Perhaps you implemented it in makeExtendSchemaPlugin?) Affected resources: ${spec.resources

--- a/graphile-build/graphile-build-pg/src/plugins/PgInterfaceModeUnionAllRowsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgInterfaceModeUnionAllRowsPlugin.ts
@@ -77,6 +77,7 @@ export const PgInterfaceModeUnionAllRowsPlugin: GraphileConfig.Plugin = {
     hooks: {
       GraphQLObjectType_fields(fields, build, context) {
         const {
+          getTypeByName,
           inflection,
           graphql: { GraphQLList, GraphQLNonNull },
           pgResourcesByPolymorphicTypeName,
@@ -116,14 +117,14 @@ export const PgInterfaceModeUnionAllRowsPlugin: GraphileConfig.Plugin = {
             const makeField = (useConnection: boolean): void => {
               if (!interfaceCodec.polymorphism) return;
 
-              const type = build.getTypeByName(
-                build.inflection.tableType(interfaceCodec),
+              const type = getTypeByName(
+                inflection.tableType(interfaceCodec),
               ) as GraphQLInterfaceType | undefined;
               if (!type) return;
 
               const fieldType = useConnection
-                ? (build.getTypeByName(
-                    build.inflection.tableConnectionType(interfaceCodec),
+                ? (getTypeByName(
+                    inflection.tableConnectionType(interfaceCodec),
                   ) as GraphQLObjectType | undefined)
                 : // TODO: nullability.
                   new GraphQLList(new GraphQLNonNull(type));

--- a/graphile-build/graphile-build-pg/src/plugins/PgPolymorphismOnlyArgumentPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgPolymorphismOnlyArgumentPlugin.ts
@@ -1,20 +1,18 @@
-import { GraphileConfig, PluginHook } from "graphile-config";
-import { version } from "../version.js";
-import {
+import type {
   PgCodec,
   PgCodecPolymorphismRelationalTypeSpec,
   PgUnionAllStep,
 } from "@dataplan/pg";
-import {
-  GraphQLEnumValueConfigMap,
-  GraphQLFieldConfigArgumentMap,
-} from "graphql";
-import { EXPORTABLE } from "graphile-build";
-import {
+import type {
   ConnectionStep,
   FieldArgs,
   GrafastFieldConfigArgumentMap,
 } from "grafast";
+import { EXPORTABLE } from "graphile-build";
+import type { GraphileConfig } from "graphile-config";
+import type { GraphQLFieldConfigArgumentMap } from "graphql";
+
+import { version } from "../version.js";
 
 declare global {
   namespace GraphileBuild {
@@ -47,7 +45,7 @@ export const PgPolymorphismOnlyArgumentPlugin: GraphileConfig.Plugin = {
       pgPolymorphismEnumType(options, pgCodec) {
         return this.upperCamelCase(`${this._codecName(pgCodec)}-type`);
       },
-      pgPolymorphismOnlyArgument(options, pgCodec) {
+      pgPolymorphismOnlyArgument(_options, _pgCodec) {
         return "only";
       },
     },

--- a/graphile-build/graphile-build-pg/src/plugins/PgPolymorphismOnlyArgumentPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgPolymorphismOnlyArgumentPlugin.ts
@@ -1,0 +1,138 @@
+import { GraphileConfig } from "graphile-config";
+import { version } from "../version.js";
+import { PgCodec, PgCodecPolymorphismRelationalTypeSpec } from "@dataplan/pg";
+import { GraphQLEnumValueConfigMap } from "graphql";
+
+declare global {
+  namespace GraphileBuild {
+    interface Inflection {
+      pgPolymorphismEnumType(pgCodec: PgCodec): string;
+      pgPolymorphismOnlyArgument(pgCodec: PgCodec): string;
+    }
+    interface ScopeEnum {
+      pgPolymorphismEnumForInterfaceSpec?: Build["pgResourcesByPolymorphicTypeName"] extends Record<
+        any,
+        infer U
+      >
+        ? U
+        : never;
+      pgPolymorphismEnumForRelationalTypes?: {
+        [typeKey: string]: PgCodecPolymorphismRelationalTypeSpec;
+      };
+    }
+  }
+}
+
+export const PgPolymorphismOnlyArgumentPlugin: GraphileConfig.Plugin = {
+  name: "PgPolymorphismOnlyArgumentPlugin",
+  description:
+    "Adds the 'only' argument to polymorphic relations to limit to only the given types",
+  version,
+
+  inflection: {
+    add: {
+      pgPolymorphismEnumType(options, pgCodec) {
+        return this.upperCamelCase(`${this._codecName(pgCodec)}-type`);
+      },
+      pgPolymorphismOnlyArgument(options, pgCodec) {
+        return "only";
+      },
+    },
+  },
+
+  schema: {
+    hooks: {
+      init(_, build) {
+        const {
+          inflection,
+          pgResourcesByPolymorphicTypeName,
+          pgCodecByPolymorphicUnionModeTypeName,
+        } = build;
+        // Register the types
+        for (const [polymorphicTypeName, spec] of Object.entries(
+          pgResourcesByPolymorphicTypeName,
+        )) {
+          if (spec.type === "interface") {
+            const codec =
+              pgCodecByPolymorphicUnionModeTypeName[polymorphicTypeName];
+            const enumTypeName = inflection.pgPolymorphismEnumType(codec);
+            build.registerEnumType(
+              enumTypeName,
+              {
+                pgCodec: codec,
+                pgPolymorphismEnumForInterfaceSpec: spec,
+              },
+              () => ({ values: Object.create(null) }),
+              'Adding enum type for union-mode interface type "' +
+                codec.name +
+                '" in PgPolymorphismOnlyArgumentPlugin',
+            );
+          }
+        }
+        for (const codec of build.allPgCodecs) {
+          if (codec.polymorphism) {
+            const enumTypeName = inflection.pgPolymorphismEnumType(codec);
+            switch (codec.polymorphism.mode) {
+              case "single": {
+                break;
+              }
+              case "relational": {
+                const { types } = codec.polymorphism;
+                build.registerEnumType(
+                  enumTypeName,
+                  {
+                    pgCodec: codec,
+                    pgPolymorphismEnumForRelationalTypes: types,
+                  },
+                  () => ({ values: Object.create(null) }),
+                  'Adding enum type for relational polymorphic type "' +
+                    codec.name +
+                    '" in PgPolymorphismOnlyArgumentPlugin',
+                );
+                break;
+              }
+              case "union": {
+                break;
+              }
+              default: {
+                break;
+              }
+            }
+          }
+        }
+        return _;
+      },
+
+      GraphQLEnumType_values(values, build, context) {
+        const { inflection } = build;
+        const {
+          scope: {
+            pgPolymorphismEnumForInterfaceSpec: spec,
+            pgPolymorphismEnumForRelationalTypes: types,
+          },
+        } = context;
+
+        // ENHANCE: Currently GraphQL.js doesn't allow `values` to be a callback,
+        // so we can't be sure that we only add types that will exist at runtime.
+        if (spec) {
+          for (const resource of spec.resources) {
+            const typeName = inflection.tableType(resource.codec);
+            const type = true; // getTypeByName(typeName);
+            if (type) {
+              values[typeName] = { value: typeName };
+            }
+          }
+        }
+        if (types) {
+          for (const { name: typeName } of Object.values(types)) {
+            const type = true; // getTypeByName(typeName);
+            if (type) {
+              values[typeName] = { value: typeName };
+            }
+          }
+        }
+        return values;
+      },
+    },
+  },
+};

--- a/graphile-build/graphile-build-pg/src/preset.ts
+++ b/graphile-build/graphile-build-pg/src/preset.ts
@@ -28,6 +28,7 @@ import { PgNodeIdAttributesPlugin } from "./plugins/PgNodeIdAttributesPlugin.js"
 import { PgOrderAllAttributesPlugin } from "./plugins/PgOrderAllAttributesPlugin.js";
 import { PgOrderByPrimaryKeyPlugin } from "./plugins/PgOrderByPrimaryKeyPlugin.js";
 import { PgOrderCustomFieldsPlugin } from "./plugins/PgOrderCustomFieldsPlugin.js";
+import { PgPolymorphismOnlyArgumentPlugin } from "./plugins/PgPolymorphismOnlyArgumentPlugin.js";
 import { PgPolymorphismPlugin } from "./plugins/PgPolymorphismPlugin.js";
 import { PgProceduresPlugin } from "./plugins/PgProceduresPlugin.js";
 import { PgRefsPlugin } from "./plugins/PgRefsPlugin.js";
@@ -38,7 +39,6 @@ import { PgRowByUniquePlugin } from "./plugins/PgRowByUniquePlugin.js";
 import { PgTableNodePlugin } from "./plugins/PgTableNodePlugin.js";
 import { PgTablesPlugin } from "./plugins/PgTablesPlugin.js";
 import { PgTypesPlugin } from "./plugins/PgTypesPlugin.js";
-import { PgPolymorphismOnlyArgumentPlugin } from "./plugins/PgPolymorphismOnlyArgumentPlugin.js";
 
 // TODO: version this.
 export const defaultPreset: GraphileConfig.Preset = {

--- a/graphile-build/graphile-build-pg/src/preset.ts
+++ b/graphile-build/graphile-build-pg/src/preset.ts
@@ -38,6 +38,7 @@ import { PgRowByUniquePlugin } from "./plugins/PgRowByUniquePlugin.js";
 import { PgTableNodePlugin } from "./plugins/PgTableNodePlugin.js";
 import { PgTablesPlugin } from "./plugins/PgTablesPlugin.js";
 import { PgTypesPlugin } from "./plugins/PgTypesPlugin.js";
+import { PgPolymorphismOnlyArgumentPlugin } from "./plugins/PgPolymorphismOnlyArgumentPlugin.js";
 
 // TODO: version this.
 export const defaultPreset: GraphileConfig.Preset = {
@@ -79,5 +80,6 @@ export const defaultPreset: GraphileConfig.Preset = {
     PgRBACPlugin,
     PgIndexBehaviorsPlugin,
     PgRegistryPlugin,
+    PgPolymorphismOnlyArgumentPlugin,
   ],
 };

--- a/graphile-build/graphile-build/src/makeNewBuild.ts
+++ b/graphile-build/graphile-build/src/makeNewBuild.ts
@@ -412,6 +412,13 @@ style for these configuration options (e.g. change \`interfaces: \
                 return null;
               }
             }
+            if (klass === GraphQLEnumType) {
+              // Perform values check.
+              if (Object.keys(type.getValues()).length === 0) {
+                allTypes[typeName] = null;
+                return null;
+              }
+            }
 
             return type;
           } else {

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/only.json5
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/only.json5
@@ -1,0 +1,283 @@
+{
+  allApplications: {
+    nodes: [
+      {
+        __typename: "AwsApplication",
+        awsId: "AWS-0001",
+        vulnerabilities: {
+          nodes: [
+            {
+              __typename: "ThirdPartyVulnerability",
+              id: 1,
+              name: "CSRF",
+              vendorName: "98-Factor-Login",
+            },
+            {
+              __typename: "ThirdPartyVulnerability",
+              id: 2,
+              name: "XSS",
+              vendorName: "Frog-Render-Lib",
+            },
+            {
+              __typename: "ThirdPartyVulnerability",
+              id: 4,
+              name: "Malware",
+              vendorName: "Frog-Render-Lib",
+            },
+            {
+              __typename: "ThirdPartyVulnerability",
+              id: 5,
+              name: "License",
+              vendorName: "Frog-Render-Lib",
+            },
+          ],
+        },
+      },
+      {
+        __typename: "AwsApplication",
+        awsId: "AWS-0002",
+        vulnerabilities: {
+          nodes: [],
+        },
+      },
+      {
+        __typename: "AwsApplication",
+        awsId: "AWS-0003",
+        vulnerabilities: {
+          nodes: [
+            {
+              __typename: "ThirdPartyVulnerability",
+              id: 1,
+              name: "CSRF",
+              vendorName: "98-Factor-Login",
+            },
+            {
+              __typename: "ThirdPartyVulnerability",
+              id: 4,
+              name: "Malware",
+              vendorName: "Frog-Render-Lib",
+            },
+          ],
+        },
+      },
+      {
+        __typename: "AwsApplication",
+        awsId: "AWS-0004",
+        vulnerabilities: {
+          nodes: [
+            {
+              __typename: "ThirdPartyVulnerability",
+              id: 1,
+              name: "CSRF",
+              vendorName: "98-Factor-Login",
+            },
+          ],
+        },
+      },
+      {
+        __typename: "AwsApplication",
+        awsId: "AWS-0005",
+        vulnerabilities: {
+          nodes: [
+            {
+              __typename: "ThirdPartyVulnerability",
+              id: 4,
+              name: "Malware",
+              vendorName: "Frog-Render-Lib",
+            },
+          ],
+        },
+      },
+      {
+        __typename: "AwsApplication",
+        awsId: "AWS-0006",
+        vulnerabilities: {
+          nodes: [
+            {
+              __typename: "ThirdPartyVulnerability",
+              id: 2,
+              name: "XSS",
+              vendorName: "Frog-Render-Lib",
+            },
+            {
+              __typename: "ThirdPartyVulnerability",
+              id: 4,
+              name: "Malware",
+              vendorName: "Frog-Render-Lib",
+            },
+            {
+              __typename: "ThirdPartyVulnerability",
+              id: 5,
+              name: "License",
+              vendorName: "Frog-Render-Lib",
+            },
+          ],
+        },
+      },
+      {
+        __typename: "AwsApplication",
+        awsId: "AWSKYNET",
+        vulnerabilities: {
+          nodes: [
+            {
+              __typename: "ThirdPartyVulnerability",
+              id: 2,
+              name: "XSS",
+              vendorName: "Frog-Render-Lib",
+            },
+            {
+              __typename: "ThirdPartyVulnerability",
+              id: 4,
+              name: "Malware",
+              vendorName: "Frog-Render-Lib",
+            },
+          ],
+        },
+      },
+      {
+        __typename: "AwsApplication",
+        awsId: "AWS-0008",
+        vulnerabilities: {
+          nodes: [
+            {
+              __typename: "ThirdPartyVulnerability",
+              id: 1,
+              name: "CSRF",
+              vendorName: "98-Factor-Login",
+            },
+            {
+              __typename: "ThirdPartyVulnerability",
+              id: 2,
+              name: "XSS",
+              vendorName: "Frog-Render-Lib",
+            },
+            {
+              __typename: "ThirdPartyVulnerability",
+              id: 4,
+              name: "Malware",
+              vendorName: "Frog-Render-Lib",
+            },
+            {
+              __typename: "ThirdPartyVulnerability",
+              id: 5,
+              name: "License",
+              vendorName: "Frog-Render-Lib",
+            },
+          ],
+        },
+      },
+      {
+        __typename: "GcpApplication",
+        gcpId: "GCP_0_1",
+        vulnerabilities: {
+          nodes: [
+            {
+              __typename: "ThirdPartyVulnerability",
+              id: 3,
+              name: "SQL injection",
+              vendorName: "Eval-Sequel-Corp",
+            },
+            {
+              __typename: "ThirdPartyVulnerability",
+              id: 4,
+              name: "Malware",
+              vendorName: "Frog-Render-Lib",
+            },
+            {
+              __typename: "ThirdPartyVulnerability",
+              id: 5,
+              name: "License",
+              vendorName: "Frog-Render-Lib",
+            },
+          ],
+        },
+      },
+      {
+        __typename: "GcpApplication",
+        gcpId: "GCP_0_2",
+        vulnerabilities: {
+          nodes: [
+            {
+              __typename: "ThirdPartyVulnerability",
+              id: 1,
+              name: "CSRF",
+              vendorName: "98-Factor-Login",
+            },
+            {
+              __typename: "ThirdPartyVulnerability",
+              id: 3,
+              name: "SQL injection",
+              vendorName: "Eval-Sequel-Corp",
+            },
+            {
+              __typename: "ThirdPartyVulnerability",
+              id: 4,
+              name: "Malware",
+              vendorName: "Frog-Render-Lib",
+            },
+            {
+              __typename: "ThirdPartyVulnerability",
+              id: 5,
+              name: "License",
+              vendorName: "Frog-Render-Lib",
+            },
+          ],
+        },
+      },
+      {
+        __typename: "GcpApplication",
+        gcpId: "GCP_0_3",
+        vulnerabilities: {
+          nodes: [
+            {
+              __typename: "ThirdPartyVulnerability",
+              id: 1,
+              name: "CSRF",
+              vendorName: "98-Factor-Login",
+            },
+            {
+              __typename: "ThirdPartyVulnerability",
+              id: 3,
+              name: "SQL injection",
+              vendorName: "Eval-Sequel-Corp",
+            },
+          ],
+        },
+      },
+      {
+        __typename: "GcpApplication",
+        gcpId: "GCP_0_4",
+        vulnerabilities: {
+          nodes: [
+            {
+              __typename: "ThirdPartyVulnerability",
+              id: 2,
+              name: "XSS",
+              vendorName: "Frog-Render-Lib",
+            },
+          ],
+        },
+      },
+      {
+        __typename: "GcpApplication",
+        gcpId: "GCP_0_5",
+        vulnerabilities: {
+          nodes: [
+            {
+              __typename: "ThirdPartyVulnerability",
+              id: 4,
+              name: "Malware",
+              vendorName: "Frog-Render-Lib",
+            },
+            {
+              __typename: "ThirdPartyVulnerability",
+              id: 5,
+              name: "License",
+              vendorName: "Frog-Render-Lib",
+            },
+          ],
+        },
+      },
+    ],
+  },
+}

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/only.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/only.mermaid
@@ -1,0 +1,174 @@
+%%{init: {'themeVariables': { 'fontSize': '12px'}}}%%
+graph TD
+    classDef path fill:#eee,stroke:#000,color:#000
+    classDef plan fill:#fff,stroke-width:1px,color:#000
+    classDef itemplan fill:#fff,stroke-width:2px,color:#000
+    classDef unbatchedplan fill:#dff,stroke-width:1px,color:#000
+    classDef sideeffectplan fill:#fcc,stroke-width:2px,color:#000
+    classDef bucket fill:#f6f6f6,color:#000,stroke-width:2px,text-align:left
+
+
+    %% plan dependencies
+    Object20{{"Object[20∈0]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access18{{"Access[18∈0]<br />ᐸ3.pgSettingsᐳ"}}:::plan
+    Access19{{"Access[19∈0]<br />ᐸ3.withPgClientᐳ"}}:::plan
+    Access18 & Access19 --> Object20
+    __Value3["__Value[3∈0]<br />ᐸcontextᐳ"]:::plan
+    __Value3 --> Access18
+    __Value3 --> Access19
+    __Value0["__Value[0∈0]"]:::plan
+    __Value5["__Value[5∈0]<br />ᐸrootValueᐳ"]:::plan
+    Connection21{{"Connection[21∈0]<br />ᐸ17ᐳ"}}:::plan
+    PgUnionAll22[["PgUnionAll[22∈1]"]]:::plan
+    Object20 & Connection21 --> PgUnionAll22
+    __Item23[/"__Item[23∈2]<br />ᐸ22ᐳ"\]:::itemplan
+    PgUnionAll22 ==> __Item23
+    PgUnionAllSingle24["PgUnionAllSingle[24∈2]"]:::plan
+    __Item23 --> PgUnionAllSingle24
+    Access25{{"Access[25∈2]<br />ᐸ24.1ᐳ"}}:::plan
+    PgUnionAllSingle24 --> Access25
+    PgUnionAll51[["PgUnionAll[51∈3]<br />ᐳAwsApplication"]]:::plan
+    PgClassExpression44{{"PgClassExpression[44∈3]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
+    Connection50{{"Connection[50∈3]<br />ᐸ46ᐳ<br />ᐳAwsApplication"}}:::plan
+    Object20 & PgClassExpression44 & PgClassExpression44 & Connection50 --> PgUnionAll51
+    PgUnionAll104[["PgUnionAll[104∈3]<br />ᐳGcpApplication"]]:::plan
+    PgClassExpression97{{"PgClassExpression[97∈3]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
+    Connection103{{"Connection[103∈3]<br />ᐸ99ᐳ<br />ᐳGcpApplication"}}:::plan
+    Object20 & PgClassExpression97 & PgClassExpression97 & Connection103 --> PgUnionAll104
+    PgSelect28[["PgSelect[28∈3]<br />ᐸaws_applicationsᐳ<br />ᐳAwsApplication"]]:::plan
+    Access27{{"Access[27∈3]<br />ᐸ26.0ᐳ"}}:::plan
+    Object20 & Access27 --> PgSelect28
+    PgSelect81[["PgSelect[81∈3]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
+    Access80{{"Access[80∈3]<br />ᐸ79.0ᐳ"}}:::plan
+    Object20 & Access80 --> PgSelect81
+    JSONParse26[["JSONParse[26∈3]<br />ᐸ25ᐳ<br />ᐳAwsApplication"]]:::plan
+    Access25 --> JSONParse26
+    JSONParse26 --> Access27
+    First32{{"First[32∈3]"}}:::plan
+    PgSelect28 --> First32
+    PgSelectSingle33{{"PgSelectSingle[33∈3]<br />ᐸaws_applicationsᐳ"}}:::plan
+    First32 --> PgSelectSingle33
+    PgClassExpression34{{"PgClassExpression[34∈3]<br />ᐸ__aws_appl..._.”aws_id”ᐳ"}}:::plan
+    PgSelectSingle33 --> PgClassExpression34
+    PgSelectSingle33 --> PgClassExpression44
+    JSONParse79[["JSONParse[79∈3]<br />ᐸ25ᐳ<br />ᐳGcpApplication"]]:::plan
+    Access25 --> JSONParse79
+    JSONParse79 --> Access80
+    First85{{"First[85∈3]"}}:::plan
+    PgSelect81 --> First85
+    PgSelectSingle86{{"PgSelectSingle[86∈3]<br />ᐸgcp_applicationsᐳ"}}:::plan
+    First85 --> PgSelectSingle86
+    PgClassExpression87{{"PgClassExpression[87∈3]<br />ᐸ__gcp_appl..._.”gcp_id”ᐳ"}}:::plan
+    PgSelectSingle86 --> PgClassExpression87
+    PgSelectSingle86 --> PgClassExpression97
+    __Item52[/"__Item[52∈4]<br />ᐸ51ᐳ"\]:::itemplan
+    PgUnionAll51 ==> __Item52
+    PgUnionAllSingle53["PgUnionAllSingle[53∈4]"]:::plan
+    __Item52 --> PgUnionAllSingle53
+    Access54{{"Access[54∈4]<br />ᐸ53.1ᐳ"}}:::plan
+    PgUnionAllSingle53 --> Access54
+    PgSelect57[["PgSelect[57∈5]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"]]:::plan
+    Access56{{"Access[56∈5]<br />ᐸ55.0ᐳ"}}:::plan
+    Object20 & Access56 --> PgSelect57
+    PgSelect69[["PgSelect[69∈5]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳAwsApplicationᐳThirdPartyVulnerability"]]:::plan
+    Access68{{"Access[68∈5]<br />ᐸ67.0ᐳ"}}:::plan
+    Object20 & Access68 --> PgSelect69
+    JSONParse55[["JSONParse[55∈5]<br />ᐸ54ᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"]]:::plan
+    Access54 --> JSONParse55
+    JSONParse55 --> Access56
+    First61{{"First[61∈5]"}}:::plan
+    PgSelect57 --> First61
+    PgSelectSingle62{{"PgSelectSingle[62∈5]<br />ᐸfirst_party_vulnerabilitiesᐳ"}}:::plan
+    First61 --> PgSelectSingle62
+    PgClassExpression63{{"PgClassExpression[63∈5]<br />ᐸ__first_pa...ies__.”id”ᐳ"}}:::plan
+    PgSelectSingle62 --> PgClassExpression63
+    PgClassExpression64{{"PgClassExpression[64∈5]<br />ᐸ__first_pa...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle62 --> PgClassExpression64
+    PgClassExpression65{{"PgClassExpression[65∈5]<br />ᐸ__first_pa...team_name”ᐳ"}}:::plan
+    PgSelectSingle62 --> PgClassExpression65
+    JSONParse67[["JSONParse[67∈5]<br />ᐸ54ᐳ<br />ᐳAwsApplicationᐳThirdPartyVulnerability"]]:::plan
+    Access54 --> JSONParse67
+    JSONParse67 --> Access68
+    First73{{"First[73∈5]"}}:::plan
+    PgSelect69 --> First73
+    PgSelectSingle74{{"PgSelectSingle[74∈5]<br />ᐸthird_party_vulnerabilitiesᐳ"}}:::plan
+    First73 --> PgSelectSingle74
+    PgClassExpression75{{"PgClassExpression[75∈5]<br />ᐸ__third_pa...ies__.”id”ᐳ"}}:::plan
+    PgSelectSingle74 --> PgClassExpression75
+    PgClassExpression76{{"PgClassExpression[76∈5]<br />ᐸ__third_pa...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle74 --> PgClassExpression76
+    PgClassExpression77{{"PgClassExpression[77∈5]<br />ᐸ__third_pa...ndor_name”ᐳ"}}:::plan
+    PgSelectSingle74 --> PgClassExpression77
+    __Item105[/"__Item[105∈6]<br />ᐸ104ᐳ"\]:::itemplan
+    PgUnionAll104 ==> __Item105
+    PgUnionAllSingle106["PgUnionAllSingle[106∈6]"]:::plan
+    __Item105 --> PgUnionAllSingle106
+    Access107{{"Access[107∈6]<br />ᐸ106.1ᐳ"}}:::plan
+    PgUnionAllSingle106 --> Access107
+    PgSelect110[["PgSelect[110∈7]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"]]:::plan
+    Access109{{"Access[109∈7]<br />ᐸ108.0ᐳ"}}:::plan
+    Object20 & Access109 --> PgSelect110
+    PgSelect122[["PgSelect[122∈7]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳGcpApplicationᐳThirdPartyVulnerability"]]:::plan
+    Access121{{"Access[121∈7]<br />ᐸ120.0ᐳ"}}:::plan
+    Object20 & Access121 --> PgSelect122
+    JSONParse108[["JSONParse[108∈7]<br />ᐸ107ᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"]]:::plan
+    Access107 --> JSONParse108
+    JSONParse108 --> Access109
+    First114{{"First[114∈7]"}}:::plan
+    PgSelect110 --> First114
+    PgSelectSingle115{{"PgSelectSingle[115∈7]<br />ᐸfirst_party_vulnerabilitiesᐳ"}}:::plan
+    First114 --> PgSelectSingle115
+    PgClassExpression116{{"PgClassExpression[116∈7]<br />ᐸ__first_pa...ies__.”id”ᐳ"}}:::plan
+    PgSelectSingle115 --> PgClassExpression116
+    PgClassExpression117{{"PgClassExpression[117∈7]<br />ᐸ__first_pa...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle115 --> PgClassExpression117
+    PgClassExpression118{{"PgClassExpression[118∈7]<br />ᐸ__first_pa...team_name”ᐳ"}}:::plan
+    PgSelectSingle115 --> PgClassExpression118
+    JSONParse120[["JSONParse[120∈7]<br />ᐸ107ᐳ<br />ᐳGcpApplicationᐳThirdPartyVulnerability"]]:::plan
+    Access107 --> JSONParse120
+    JSONParse120 --> Access121
+    First126{{"First[126∈7]"}}:::plan
+    PgSelect122 --> First126
+    PgSelectSingle127{{"PgSelectSingle[127∈7]<br />ᐸthird_party_vulnerabilitiesᐳ"}}:::plan
+    First126 --> PgSelectSingle127
+    PgClassExpression128{{"PgClassExpression[128∈7]<br />ᐸ__third_pa...ies__.”id”ᐳ"}}:::plan
+    PgSelectSingle127 --> PgClassExpression128
+    PgClassExpression129{{"PgClassExpression[129∈7]<br />ᐸ__third_pa...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle127 --> PgClassExpression129
+    PgClassExpression130{{"PgClassExpression[130∈7]<br />ᐸ__third_pa...ndor_name”ᐳ"}}:::plan
+    PgSelectSingle127 --> PgClassExpression130
+
+    %% define steps
+
+    subgraph "Buckets for queries/polymorphic/only"
+    Bucket0("Bucket 0 (root)"):::bucket
+    classDef bucket0 stroke:#696969
+    class Bucket0,__Value0,__Value3,__Value5,Access18,Access19,Object20,Connection21 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 20, 21<br /><br />ROOT Connectionᐸ17ᐳ[21]"):::bucket
+    classDef bucket1 stroke:#00bfff
+    class Bucket1,PgUnionAll22 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 20<br /><br />ROOT __Item{2}ᐸ22ᐳ[23]"):::bucket
+    classDef bucket2 stroke:#7f007f
+    class Bucket2,__Item23,PgUnionAllSingle24,Access25 bucket2
+    Bucket3("Bucket 3 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 25, 20, 24<br />ᐳAwsApplication<br />ᐳGcpApplication<br />1: JSONParse[26], JSONParse[79]<br />ᐳ: 50, 103, 27, 80<br />2: PgSelect[28], PgSelect[81]<br />ᐳ: 32, 33, 34, 44, 85, 86, 87, 97<br />3: PgUnionAll[51], PgUnionAll[104]"):::bucket
+    classDef bucket3 stroke:#ffa500
+    class Bucket3,JSONParse26,Access27,PgSelect28,First32,PgSelectSingle33,PgClassExpression34,PgClassExpression44,Connection50,PgUnionAll51,JSONParse79,Access80,PgSelect81,First85,PgSelectSingle86,PgClassExpression87,PgClassExpression97,Connection103,PgUnionAll104 bucket3
+    Bucket4("Bucket 4 (listItem)<br />Deps: 20<br /><br />ROOT __Item{4}ᐸ51ᐳ[52]"):::bucket
+    classDef bucket4 stroke:#0000ff
+    class Bucket4,__Item52,PgUnionAllSingle53,Access54 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 54, 20, 53<br />ᐳAwsApplicationᐳFirstPartyVulnerability<br />ᐳAwsApplicationᐳThirdPartyVulnerability<br />1: JSONParse[55], JSONParse[67]<br />ᐳ: Access[56], Access[68]<br />2: PgSelect[57], PgSelect[69]<br />ᐳ: 61, 62, 63, 64, 65, 73, 74, 75, 76, 77"):::bucket
+    classDef bucket5 stroke:#7fff00
+    class Bucket5,JSONParse55,Access56,PgSelect57,First61,PgSelectSingle62,PgClassExpression63,PgClassExpression64,PgClassExpression65,JSONParse67,Access68,PgSelect69,First73,PgSelectSingle74,PgClassExpression75,PgClassExpression76,PgClassExpression77 bucket5
+    Bucket6("Bucket 6 (listItem)<br />Deps: 20<br /><br />ROOT __Item{6}ᐸ104ᐳ[105]"):::bucket
+    classDef bucket6 stroke:#ff1493
+    class Bucket6,__Item105,PgUnionAllSingle106,Access107 bucket6
+    Bucket7("Bucket 7 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 107, 20, 106<br />ᐳGcpApplicationᐳFirstPartyVulnerability<br />ᐳGcpApplicationᐳThirdPartyVulnerability<br />1: JSONParse[108], JSONParse[120]<br />ᐳ: Access[109], Access[121]<br />2: PgSelect[110], PgSelect[122]<br />ᐳ: 114, 115, 116, 117, 118, 126, 127, 128, 129, 130"):::bucket
+    classDef bucket7 stroke:#808000
+    class Bucket7,JSONParse108,Access109,PgSelect110,First114,PgSelectSingle115,PgClassExpression116,PgClassExpression117,PgClassExpression118,JSONParse120,Access121,PgSelect122,First126,PgSelectSingle127,PgClassExpression128,PgClassExpression129,PgClassExpression130 bucket7
+    Bucket0 --> Bucket1
+    Bucket1 --> Bucket2
+    Bucket2 --> Bucket3
+    Bucket3 --> Bucket4 & Bucket6
+    Bucket4 --> Bucket5
+    Bucket6 --> Bucket7
+    end

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/only.sql
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/only.sql
@@ -1,0 +1,166 @@
+select
+  __application__."0" as "0",
+  __application__."1"::text as "1"
+from (
+    select
+      __aws_applications__."0",
+      __aws_applications__."1",
+      "n"
+    from (
+      select
+        'AwsApplication' as "0",
+        json_build_array((__aws_applications__."id")::text) as "1",
+        row_number() over (
+          order by
+            __aws_applications__."id" asc
+        ) as "n"
+      from "polymorphic"."aws_applications" as __aws_applications__
+      order by
+        __aws_applications__."id" asc
+    ) as __aws_applications__
+  union all
+    select
+      __gcp_applications__."0",
+      __gcp_applications__."1",
+      "n"
+    from (
+      select
+        'GcpApplication' as "0",
+        json_build_array((__gcp_applications__."id")::text) as "1",
+        row_number() over (
+          order by
+            __gcp_applications__."id" asc
+        ) as "n"
+      from "polymorphic"."gcp_applications" as __gcp_applications__
+      order by
+        __gcp_applications__."id" asc
+    ) as __gcp_applications__
+  order by
+    "0" asc,
+    "n" asc
+) __application__
+
+
+select __aws_applications_result__.*
+from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __aws_applications_identifiers__,
+lateral (
+  select
+    __aws_applications__."aws_id" as "0",
+    __aws_applications__."id"::text as "1",
+    __aws_applications_identifiers__.idx as "2"
+  from "polymorphic"."aws_applications" as __aws_applications__
+  where (
+    __aws_applications__."id" = __aws_applications_identifiers__."id0"
+  )
+) as __aws_applications_result__;
+
+select __gcp_applications_result__.*
+from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __gcp_applications_identifiers__,
+lateral (
+  select
+    __gcp_applications__."gcp_id" as "0",
+    __gcp_applications__."id"::text as "1",
+    __gcp_applications_identifiers__.idx as "2"
+  from "polymorphic"."gcp_applications" as __gcp_applications__
+  where (
+    __gcp_applications__."id" = __gcp_applications_identifiers__."id0"
+  )
+) as __gcp_applications_result__;
+
+select __union_result__.*
+from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0", (ids.value->>1)::"int4" as "id1" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+lateral (
+  select
+    __vulnerabilities__."0" as "0",
+    __vulnerabilities__."1"::text as "1",
+    __union_identifiers__.idx as "2"
+  from (
+      select
+        __third_party_vulnerabilities__."0",
+        __third_party_vulnerabilities__."1",
+        "n"
+      from (
+        select
+          'ThirdPartyVulnerability' as "0",
+          json_build_array((__third_party_vulnerabilities__."id")::text) as "1",
+          row_number() over (
+            order by
+              __third_party_vulnerabilities__."id" asc
+          ) as "n"
+        from "polymorphic"."aws_application_third_party_vulnerabilities" as __aws_application_third_party_vulnerabilities__
+        inner join "polymorphic"."third_party_vulnerabilities" as __third_party_vulnerabilities__
+        on (
+          __third_party_vulnerabilities__."id" = __aws_application_third_party_vulnerabilities__."third_party_vulnerability_id"
+        )
+        where __aws_application_third_party_vulnerabilities__."aws_application_id" = __union_identifiers__."id1"
+        order by
+          __third_party_vulnerabilities__."id" asc
+      ) as __third_party_vulnerabilities__
+    order by
+      "0" asc,
+      "n" asc
+  ) __vulnerabilities__
+) as __union_result__;
+
+select __union_result__.*
+from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0", (ids.value->>1)::"int4" as "id1" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+lateral (
+  select
+    __vulnerabilities__."0" as "0",
+    __vulnerabilities__."1"::text as "1",
+    __union_identifiers__.idx as "2"
+  from (
+      select
+        __third_party_vulnerabilities__."0",
+        __third_party_vulnerabilities__."1",
+        "n"
+      from (
+        select
+          'ThirdPartyVulnerability' as "0",
+          json_build_array((__third_party_vulnerabilities__."id")::text) as "1",
+          row_number() over (
+            order by
+              __third_party_vulnerabilities__."id" asc
+          ) as "n"
+        from "polymorphic"."gcp_application_third_party_vulnerabilities" as __gcp_application_third_party_vulnerabilities__
+        inner join "polymorphic"."third_party_vulnerabilities" as __third_party_vulnerabilities__
+        on (
+          __third_party_vulnerabilities__."id" = __gcp_application_third_party_vulnerabilities__."third_party_vulnerability_id"
+        )
+        where __gcp_application_third_party_vulnerabilities__."gcp_application_id" = __union_identifiers__."id1"
+        order by
+          __third_party_vulnerabilities__."id" asc
+      ) as __third_party_vulnerabilities__
+    order by
+      "0" asc,
+      "n" asc
+  ) __vulnerabilities__
+) as __union_result__;
+
+select __third_party_vulnerabilities_result__.*
+from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __third_party_vulnerabilities_identifiers__,
+lateral (
+  select
+    __third_party_vulnerabilities__."id"::text as "0",
+    __third_party_vulnerabilities__."name" as "1",
+    __third_party_vulnerabilities__."vendor_name" as "2",
+    __third_party_vulnerabilities_identifiers__.idx as "3"
+  from "polymorphic"."third_party_vulnerabilities" as __third_party_vulnerabilities__
+  where (
+    __third_party_vulnerabilities__."id" = __third_party_vulnerabilities_identifiers__."id0"
+  )
+) as __third_party_vulnerabilities_result__;
+
+select __third_party_vulnerabilities_result__.*
+from (select 0 as idx, $1::"int4" as "id0") as __third_party_vulnerabilities_identifiers__,
+lateral (
+  select
+    __third_party_vulnerabilities__."id"::text as "0",
+    __third_party_vulnerabilities__."name" as "1",
+    __third_party_vulnerabilities__."vendor_name" as "2",
+    __third_party_vulnerabilities_identifiers__.idx as "3"
+  from "polymorphic"."third_party_vulnerabilities" as __third_party_vulnerabilities__
+  where (
+    __third_party_vulnerabilities__."id" = __third_party_vulnerabilities_identifiers__."id0"
+  )
+) as __third_party_vulnerabilities_result__;

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/only.test.graphql
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/only.test.graphql
@@ -1,0 +1,29 @@
+## expect(errors).toBeFalsy()
+#> schema: ["polymorphic"]
+
+{
+  allApplications(only: [GcpApplication, AwsApplication]) {
+    nodes {
+      __typename
+      ... on AwsApplication {
+        awsId
+      }
+      ... on GcpApplication {
+        gcpId
+      }
+      vulnerabilities(only: [ThirdPartyVulnerability]) {
+        nodes {
+          __typename
+          id
+          name
+          ... on FirstPartyVulnerability {
+            teamName
+          }
+          ... on ThirdPartyVulnerability {
+            vendorName
+          }
+        }
+      }
+    }
+  }
+}

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-condition.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-condition.mermaid
@@ -17,102 +17,102 @@ graph TD
     __Value3 --> Access16
     __Value3 --> Access17
     Connection19{{"Connection[19∈0]<br />ᐸ15ᐳ"}}:::plan
-    Constant76{{"Constant[76∈0]<br />ᐸ4ᐳ"}}:::plan
-    Constant76 --> Connection19
-    Lambda42{{"Lambda[42∈0]<br />ᐸparseCursorᐳ"}}:::plan
-    Constant78{{"Constant[78∈0]<br />ᐸ'WyJjMDM4YzQzNTYwIiwiQXdzQXBwbGljYXRpb24iLCJbXCI0XCJdIl0='ᐳ"}}:::plan
-    Constant78 --> Lambda42
+    Constant77{{"Constant[77∈0]<br />ᐸ4ᐳ"}}:::plan
+    Constant77 --> Connection19
+    Lambda43{{"Lambda[43∈0]<br />ᐸparseCursorᐳ"}}:::plan
+    Constant79{{"Constant[79∈0]<br />ᐸ'WyJjMDM4YzQzNTYwIiwiQXdzQXBwbGljYXRpb24iLCJbXCI0XCJdIl0='ᐳ"}}:::plan
+    Constant79 --> Lambda43
     __Value0["__Value[0∈0]"]:::plan
     __Value5["__Value[5∈0]<br />ᐸrootValueᐳ"]:::plan
-    Connection41{{"Connection[41∈1]<br />ᐸ37ᐳ"}}:::plan
-    Constant77{{"Constant[77∈1]<br />ᐸ1ᐳ"}}:::plan
-    PgValidateParsedCursor47["PgValidateParsedCursor[47∈1]"]:::plan
-    Constant77 & Lambda42 & PgValidateParsedCursor47 --> Connection41
+    Connection42{{"Connection[42∈1]<br />ᐸ38ᐳ"}}:::plan
+    Constant78{{"Constant[78∈1]<br />ᐸ1ᐳ"}}:::plan
+    PgValidateParsedCursor48["PgValidateParsedCursor[48∈1]"]:::plan
+    Constant78 & Lambda43 & PgValidateParsedCursor48 --> Connection42
     PgSelect20[["PgSelect[20∈1]<br />ᐸpeopleᐳ"]]:::plan
     Object18 & Connection19 --> PgSelect20
-    Lambda42 --> PgValidateParsedCursor47
-    Access48{{"Access[48∈1]<br />ᐸ42.1ᐳ"}}:::plan
-    Lambda42 --> Access48
-    ToPg49{{"ToPg[49∈1]"}}:::plan
-    Access48 --> ToPg49
-    Access50{{"Access[50∈1]<br />ᐸ42.2ᐳ"}}:::plan
-    Lambda42 --> Access50
-    Constant79{{"Constant[79∈1]<br />ᐸ'AWfulS'ᐳ"}}:::plan
+    Lambda43 --> PgValidateParsedCursor48
+    Access49{{"Access[49∈1]<br />ᐸ43.1ᐳ"}}:::plan
+    Lambda43 --> Access49
+    ToPg50{{"ToPg[50∈1]"}}:::plan
+    Access49 --> ToPg50
+    Access51{{"Access[51∈1]<br />ᐸ43.2ᐳ"}}:::plan
+    Lambda43 --> Access51
+    Constant80{{"Constant[80∈1]<br />ᐸ'AWfulS'ᐳ"}}:::plan
     __Item21[/"__Item[21∈2]<br />ᐸ20ᐳ"\]:::itemplan
     PgSelect20 ==> __Item21
     PgSelectSingle22{{"PgSelectSingle[22∈2]<br />ᐸpeopleᐳ"}}:::plan
     __Item21 --> PgSelectSingle22
-    PgUnionAll43[["PgUnionAll[43∈3]"]]:::plan
+    PgUnionAll44[["PgUnionAll[44∈3]"]]:::plan
     PgClassExpression23{{"PgClassExpression[23∈3]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Object18 & PgClassExpression23 & PgClassExpression23 & Constant79 & Connection41 & Lambda42 & ToPg49 & Access50 --> PgUnionAll43
+    Object18 & PgClassExpression23 & PgClassExpression23 & Constant80 & Connection42 & Lambda43 & ToPg50 & Access51 --> PgUnionAll44
     PgSelectSingle22 --> PgClassExpression23
     PgClassExpression24{{"PgClassExpression[24∈3]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle22 --> PgClassExpression24
-    __Item44[/"__Item[44∈4]<br />ᐸ43ᐳ"\]:::itemplan
-    PgUnionAll43 ==> __Item44
-    PgUnionAllSingle45["PgUnionAllSingle[45∈4]"]:::plan
-    __Item44 --> PgUnionAllSingle45
-    List53{{"List[53∈5]<br />ᐸ51,52ᐳ"}}:::plan
-    Access51{{"Access[51∈5]<br />ᐸ45.0ᐳ"}}:::plan
-    Access52{{"Access[52∈5]<br />ᐸ45.1ᐳ"}}:::plan
-    Access51 & Access52 --> List53
-    PgCursor46{{"PgCursor[46∈5]"}}:::plan
-    List53 --> PgCursor46
-    PgUnionAllSingle45 --> Access51
-    PgUnionAllSingle45 --> Access52
-    PgSelect57[["PgSelect[57∈6]<br />ᐸaws_applicationsᐳ<br />ᐳAwsApplication"]]:::plan
-    Access56{{"Access[56∈6]<br />ᐸ55.0ᐳ"}}:::plan
-    Object18 & Access56 --> PgSelect57
-    PgSelect68[["PgSelect[68∈6]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
-    Access67{{"Access[67∈6]<br />ᐸ66.0ᐳ"}}:::plan
-    Object18 & Access67 --> PgSelect68
-    JSONParse55[["JSONParse[55∈6]<br />ᐸ52ᐳ<br />ᐳAwsApplication"]]:::plan
-    Access52 --> JSONParse55
-    JSONParse55 --> Access56
-    First61{{"First[61∈6]"}}:::plan
-    PgSelect57 --> First61
-    PgSelectSingle62{{"PgSelectSingle[62∈6]<br />ᐸaws_applicationsᐳ"}}:::plan
-    First61 --> PgSelectSingle62
-    PgClassExpression63{{"PgClassExpression[63∈6]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
-    PgSelectSingle62 --> PgClassExpression63
-    PgClassExpression64{{"PgClassExpression[64∈6]<br />ᐸ__aws_appl...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle62 --> PgClassExpression64
-    JSONParse66[["JSONParse[66∈6]<br />ᐸ52ᐳ<br />ᐳGcpApplication"]]:::plan
-    Access52 --> JSONParse66
-    JSONParse66 --> Access67
-    First72{{"First[72∈6]"}}:::plan
-    PgSelect68 --> First72
-    PgSelectSingle73{{"PgSelectSingle[73∈6]<br />ᐸgcp_applicationsᐳ"}}:::plan
-    First72 --> PgSelectSingle73
-    PgClassExpression74{{"PgClassExpression[74∈6]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
-    PgSelectSingle73 --> PgClassExpression74
-    PgClassExpression75{{"PgClassExpression[75∈6]<br />ᐸ__gcp_appl...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle73 --> PgClassExpression75
+    __Item45[/"__Item[45∈4]<br />ᐸ44ᐳ"\]:::itemplan
+    PgUnionAll44 ==> __Item45
+    PgUnionAllSingle46["PgUnionAllSingle[46∈4]"]:::plan
+    __Item45 --> PgUnionAllSingle46
+    List54{{"List[54∈5]<br />ᐸ52,53ᐳ"}}:::plan
+    Access52{{"Access[52∈5]<br />ᐸ46.0ᐳ"}}:::plan
+    Access53{{"Access[53∈5]<br />ᐸ46.1ᐳ"}}:::plan
+    Access52 & Access53 --> List54
+    PgCursor47{{"PgCursor[47∈5]"}}:::plan
+    List54 --> PgCursor47
+    PgUnionAllSingle46 --> Access52
+    PgUnionAllSingle46 --> Access53
+    PgSelect58[["PgSelect[58∈6]<br />ᐸaws_applicationsᐳ<br />ᐳAwsApplication"]]:::plan
+    Access57{{"Access[57∈6]<br />ᐸ56.0ᐳ"}}:::plan
+    Object18 & Access57 --> PgSelect58
+    PgSelect69[["PgSelect[69∈6]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
+    Access68{{"Access[68∈6]<br />ᐸ67.0ᐳ"}}:::plan
+    Object18 & Access68 --> PgSelect69
+    JSONParse56[["JSONParse[56∈6]<br />ᐸ53ᐳ<br />ᐳAwsApplication"]]:::plan
+    Access53 --> JSONParse56
+    JSONParse56 --> Access57
+    First62{{"First[62∈6]"}}:::plan
+    PgSelect58 --> First62
+    PgSelectSingle63{{"PgSelectSingle[63∈6]<br />ᐸaws_applicationsᐳ"}}:::plan
+    First62 --> PgSelectSingle63
+    PgClassExpression64{{"PgClassExpression[64∈6]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
+    PgSelectSingle63 --> PgClassExpression64
+    PgClassExpression65{{"PgClassExpression[65∈6]<br />ᐸ__aws_appl...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle63 --> PgClassExpression65
+    JSONParse67[["JSONParse[67∈6]<br />ᐸ53ᐳ<br />ᐳGcpApplication"]]:::plan
+    Access53 --> JSONParse67
+    JSONParse67 --> Access68
+    First73{{"First[73∈6]"}}:::plan
+    PgSelect69 --> First73
+    PgSelectSingle74{{"PgSelectSingle[74∈6]<br />ᐸgcp_applicationsᐳ"}}:::plan
+    First73 --> PgSelectSingle74
+    PgClassExpression75{{"PgClassExpression[75∈6]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
+    PgSelectSingle74 --> PgClassExpression75
+    PgClassExpression76{{"PgClassExpression[76∈6]<br />ᐸ__gcp_appl...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle74 --> PgClassExpression76
 
     %% define steps
 
     subgraph "Buckets for queries/polymorphic/person-app-vulns.app-condition"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value3,__Value5,Access16,Access17,Object18,Connection19,Lambda42,Constant76,Constant78 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 18, 19, 42<br /><br />ROOT Connectionᐸ15ᐳ[19]"):::bucket
+    class Bucket0,__Value0,__Value3,__Value5,Access16,Access17,Object18,Connection19,Lambda43,Constant77,Constant79 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 18, 19, 43<br /><br />ROOT Connectionᐸ15ᐳ[19]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect20,Connection41,PgValidateParsedCursor47,Access48,ToPg49,Access50,Constant77,Constant79 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 18, 79, 41, 42, 49, 50<br /><br />ROOT __Item{2}ᐸ20ᐳ[21]"):::bucket
+    class Bucket1,PgSelect20,Connection42,PgValidateParsedCursor48,Access49,ToPg50,Access51,Constant78,Constant80 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 18, 80, 42, 43, 50, 51<br /><br />ROOT __Item{2}ᐸ20ᐳ[21]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item21,PgSelectSingle22 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 22, 18, 79, 41, 42, 49, 50<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[22]<br />1: <br />ᐳ: 23, 24<br />2: PgUnionAll[43]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 22, 18, 80, 42, 43, 50, 51<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[22]<br />1: <br />ᐳ: 23, 24<br />2: PgUnionAll[44]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression23,PgClassExpression24,PgUnionAll43 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 18<br /><br />ROOT __Item{4}ᐸ43ᐳ[44]"):::bucket
+    class Bucket3,PgClassExpression23,PgClassExpression24,PgUnionAll44 bucket3
+    Bucket4("Bucket 4 (listItem)<br />Deps: 18<br /><br />ROOT __Item{4}ᐸ44ᐳ[45]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item44,PgUnionAllSingle45 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 45, 18<br /><br />ROOT PgUnionAllSingle{4}[45]"):::bucket
+    class Bucket4,__Item45,PgUnionAllSingle46 bucket4
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 46, 18<br /><br />ROOT PgUnionAllSingle{4}[46]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgCursor46,Access51,Access52,List53 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 52, 18, 45<br />ᐳAwsApplication<br />ᐳGcpApplication<br />1: JSONParse[55], JSONParse[66]<br />ᐳ: Access[56], Access[67]<br />2: PgSelect[57], PgSelect[68]<br />ᐳ: 61, 62, 63, 64, 72, 73, 74, 75"):::bucket
+    class Bucket5,PgCursor47,Access52,Access53,List54 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 53, 18, 46<br />ᐳAwsApplication<br />ᐳGcpApplication<br />1: JSONParse[56], JSONParse[67]<br />ᐳ: Access[57], Access[68]<br />2: PgSelect[58], PgSelect[69]<br />ᐳ: 62, 63, 64, 65, 73, 74, 75, 76"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,JSONParse55,Access56,PgSelect57,First61,PgSelectSingle62,PgClassExpression63,PgClassExpression64,JSONParse66,Access67,PgSelect68,First72,PgSelectSingle73,PgClassExpression74,PgClassExpression75 bucket6
+    class Bucket6,JSONParse56,Access57,PgSelect58,First62,PgSelectSingle63,PgClassExpression64,PgClassExpression65,JSONParse67,Access68,PgSelect69,First73,PgSelectSingle74,PgClassExpression75,PgClassExpression76 bucket6
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-order.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-order.mermaid
@@ -17,96 +17,96 @@ graph TD
     __Value3 --> Access16
     __Value3 --> Access17
     Connection19{{"Connection[19∈0]<br />ᐸ15ᐳ"}}:::plan
-    Constant74{{"Constant[74∈0]<br />ᐸ4ᐳ"}}:::plan
-    Constant74 --> Connection19
+    Constant75{{"Constant[75∈0]<br />ᐸ4ᐳ"}}:::plan
+    Constant75 --> Connection19
     __Value0["__Value[0∈0]"]:::plan
     __Value5["__Value[5∈0]<br />ᐸrootValueᐳ"]:::plan
     PgSelect20[["PgSelect[20∈1]<br />ᐸpeopleᐳ"]]:::plan
     Object18 & Connection19 --> PgSelect20
-    Connection40{{"Connection[40∈1]<br />ᐸ36ᐳ"}}:::plan
+    Connection41{{"Connection[41∈1]<br />ᐸ37ᐳ"}}:::plan
     __Item21[/"__Item[21∈2]<br />ᐸ20ᐳ"\]:::itemplan
     PgSelect20 ==> __Item21
     PgSelectSingle22{{"PgSelectSingle[22∈2]<br />ᐸpeopleᐳ"}}:::plan
     __Item21 --> PgSelectSingle22
-    PgUnionAll41[["PgUnionAll[41∈3]"]]:::plan
+    PgUnionAll42[["PgUnionAll[42∈3]"]]:::plan
     PgClassExpression23{{"PgClassExpression[23∈3]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Object18 & PgClassExpression23 & PgClassExpression23 & Connection40 --> PgUnionAll41
+    Object18 & PgClassExpression23 & PgClassExpression23 & Connection41 --> PgUnionAll42
     PgSelectSingle22 --> PgClassExpression23
     PgClassExpression24{{"PgClassExpression[24∈3]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle22 --> PgClassExpression24
-    __Item42[/"__Item[42∈4]<br />ᐸ41ᐳ"\]:::itemplan
-    PgUnionAll41 ==> __Item42
-    PgUnionAllSingle43["PgUnionAllSingle[43∈4]"]:::plan
-    __Item42 --> PgUnionAllSingle43
-    List49{{"List[49∈5]<br />ᐸ45,46,47,48ᐳ"}}:::plan
-    Access45{{"Access[45∈5]<br />ᐸ43.0ᐳ"}}:::plan
-    Access46{{"Access[46∈5]<br />ᐸ43.1ᐳ"}}:::plan
-    Access47{{"Access[47∈5]<br />ᐸ43.2ᐳ"}}:::plan
-    Access48{{"Access[48∈5]<br />ᐸ43.3ᐳ"}}:::plan
-    Access45 & Access46 & Access47 & Access48 --> List49
-    PgCursor44{{"PgCursor[44∈5]"}}:::plan
-    List49 --> PgCursor44
-    PgUnionAllSingle43 --> Access45
-    PgUnionAllSingle43 --> Access46
-    PgUnionAllSingle43 --> Access47
-    PgUnionAllSingle43 --> Access48
-    PgSelect53[["PgSelect[53∈6]<br />ᐸaws_applicationsᐳ<br />ᐳAwsApplication"]]:::plan
-    Access52{{"Access[52∈6]<br />ᐸ51.0ᐳ"}}:::plan
-    Object18 & Access52 --> PgSelect53
-    PgSelect65[["PgSelect[65∈6]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
-    Access64{{"Access[64∈6]<br />ᐸ63.0ᐳ"}}:::plan
-    Object18 & Access64 --> PgSelect65
-    JSONParse51[["JSONParse[51∈6]<br />ᐸ48ᐳ<br />ᐳAwsApplication"]]:::plan
-    Access48 --> JSONParse51
-    JSONParse51 --> Access52
-    First57{{"First[57∈6]"}}:::plan
-    PgSelect53 --> First57
-    PgSelectSingle58{{"PgSelectSingle[58∈6]<br />ᐸaws_applicationsᐳ"}}:::plan
-    First57 --> PgSelectSingle58
-    PgClassExpression59{{"PgClassExpression[59∈6]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
-    PgSelectSingle58 --> PgClassExpression59
-    PgClassExpression60{{"PgClassExpression[60∈6]<br />ᐸ__aws_appl...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle58 --> PgClassExpression60
-    PgClassExpression61{{"PgClassExpression[61∈6]<br />ᐸ__aws_appl..._deployed”ᐳ"}}:::plan
-    PgSelectSingle58 --> PgClassExpression61
-    JSONParse63[["JSONParse[63∈6]<br />ᐸ48ᐳ<br />ᐳGcpApplication"]]:::plan
-    Access48 --> JSONParse63
-    JSONParse63 --> Access64
-    First69{{"First[69∈6]"}}:::plan
-    PgSelect65 --> First69
-    PgSelectSingle70{{"PgSelectSingle[70∈6]<br />ᐸgcp_applicationsᐳ"}}:::plan
-    First69 --> PgSelectSingle70
-    PgClassExpression71{{"PgClassExpression[71∈6]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
-    PgSelectSingle70 --> PgClassExpression71
-    PgClassExpression72{{"PgClassExpression[72∈6]<br />ᐸ__gcp_appl...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle70 --> PgClassExpression72
-    PgClassExpression73{{"PgClassExpression[73∈6]<br />ᐸ__gcp_appl..._deployed”ᐳ"}}:::plan
-    PgSelectSingle70 --> PgClassExpression73
+    __Item43[/"__Item[43∈4]<br />ᐸ42ᐳ"\]:::itemplan
+    PgUnionAll42 ==> __Item43
+    PgUnionAllSingle44["PgUnionAllSingle[44∈4]"]:::plan
+    __Item43 --> PgUnionAllSingle44
+    List50{{"List[50∈5]<br />ᐸ46,47,48,49ᐳ"}}:::plan
+    Access46{{"Access[46∈5]<br />ᐸ44.0ᐳ"}}:::plan
+    Access47{{"Access[47∈5]<br />ᐸ44.1ᐳ"}}:::plan
+    Access48{{"Access[48∈5]<br />ᐸ44.2ᐳ"}}:::plan
+    Access49{{"Access[49∈5]<br />ᐸ44.3ᐳ"}}:::plan
+    Access46 & Access47 & Access48 & Access49 --> List50
+    PgCursor45{{"PgCursor[45∈5]"}}:::plan
+    List50 --> PgCursor45
+    PgUnionAllSingle44 --> Access46
+    PgUnionAllSingle44 --> Access47
+    PgUnionAllSingle44 --> Access48
+    PgUnionAllSingle44 --> Access49
+    PgSelect54[["PgSelect[54∈6]<br />ᐸaws_applicationsᐳ<br />ᐳAwsApplication"]]:::plan
+    Access53{{"Access[53∈6]<br />ᐸ52.0ᐳ"}}:::plan
+    Object18 & Access53 --> PgSelect54
+    PgSelect66[["PgSelect[66∈6]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
+    Access65{{"Access[65∈6]<br />ᐸ64.0ᐳ"}}:::plan
+    Object18 & Access65 --> PgSelect66
+    JSONParse52[["JSONParse[52∈6]<br />ᐸ49ᐳ<br />ᐳAwsApplication"]]:::plan
+    Access49 --> JSONParse52
+    JSONParse52 --> Access53
+    First58{{"First[58∈6]"}}:::plan
+    PgSelect54 --> First58
+    PgSelectSingle59{{"PgSelectSingle[59∈6]<br />ᐸaws_applicationsᐳ"}}:::plan
+    First58 --> PgSelectSingle59
+    PgClassExpression60{{"PgClassExpression[60∈6]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
+    PgSelectSingle59 --> PgClassExpression60
+    PgClassExpression61{{"PgClassExpression[61∈6]<br />ᐸ__aws_appl...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle59 --> PgClassExpression61
+    PgClassExpression62{{"PgClassExpression[62∈6]<br />ᐸ__aws_appl..._deployed”ᐳ"}}:::plan
+    PgSelectSingle59 --> PgClassExpression62
+    JSONParse64[["JSONParse[64∈6]<br />ᐸ49ᐳ<br />ᐳGcpApplication"]]:::plan
+    Access49 --> JSONParse64
+    JSONParse64 --> Access65
+    First70{{"First[70∈6]"}}:::plan
+    PgSelect66 --> First70
+    PgSelectSingle71{{"PgSelectSingle[71∈6]<br />ᐸgcp_applicationsᐳ"}}:::plan
+    First70 --> PgSelectSingle71
+    PgClassExpression72{{"PgClassExpression[72∈6]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
+    PgSelectSingle71 --> PgClassExpression72
+    PgClassExpression73{{"PgClassExpression[73∈6]<br />ᐸ__gcp_appl...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle71 --> PgClassExpression73
+    PgClassExpression74{{"PgClassExpression[74∈6]<br />ᐸ__gcp_appl..._deployed”ᐳ"}}:::plan
+    PgSelectSingle71 --> PgClassExpression74
 
     %% define steps
 
     subgraph "Buckets for queries/polymorphic/person-app-vulns.app-order"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value3,__Value5,Access16,Access17,Object18,Connection19,Constant74 bucket0
+    class Bucket0,__Value0,__Value3,__Value5,Access16,Access17,Object18,Connection19,Constant75 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 18, 19<br /><br />ROOT Connectionᐸ15ᐳ[19]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect20,Connection40 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 18, 40<br /><br />ROOT __Item{2}ᐸ20ᐳ[21]"):::bucket
+    class Bucket1,PgSelect20,Connection41 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 18, 41<br /><br />ROOT __Item{2}ᐸ20ᐳ[21]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item21,PgSelectSingle22 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 22, 18, 40<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[22]<br />1: <br />ᐳ: 23, 24<br />2: PgUnionAll[41]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 22, 18, 41<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[22]<br />1: <br />ᐳ: 23, 24<br />2: PgUnionAll[42]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression23,PgClassExpression24,PgUnionAll41 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 18<br /><br />ROOT __Item{4}ᐸ41ᐳ[42]"):::bucket
+    class Bucket3,PgClassExpression23,PgClassExpression24,PgUnionAll42 bucket3
+    Bucket4("Bucket 4 (listItem)<br />Deps: 18<br /><br />ROOT __Item{4}ᐸ42ᐳ[43]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item42,PgUnionAllSingle43 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 43, 18<br /><br />ROOT PgUnionAllSingle{4}[43]"):::bucket
+    class Bucket4,__Item43,PgUnionAllSingle44 bucket4
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 44, 18<br /><br />ROOT PgUnionAllSingle{4}[44]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgCursor44,Access45,Access46,Access47,Access48,List49 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 48, 18, 43<br />ᐳAwsApplication<br />ᐳGcpApplication<br />1: JSONParse[51], JSONParse[63]<br />ᐳ: Access[52], Access[64]<br />2: PgSelect[53], PgSelect[65]<br />ᐳ: 57, 58, 59, 60, 61, 69, 70, 71, 72, 73"):::bucket
+    class Bucket5,PgCursor45,Access46,Access47,Access48,Access49,List50 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 49, 18, 44<br />ᐳAwsApplication<br />ᐳGcpApplication<br />1: JSONParse[52], JSONParse[64]<br />ᐳ: Access[53], Access[65]<br />2: PgSelect[54], PgSelect[66]<br />ᐳ: 58, 59, 60, 61, 62, 70, 71, 72, 73, 74"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,JSONParse51,Access52,PgSelect53,First57,PgSelectSingle58,PgClassExpression59,PgClassExpression60,PgClassExpression61,JSONParse63,Access64,PgSelect65,First69,PgSelectSingle70,PgClassExpression71,PgClassExpression72,PgClassExpression73 bucket6
+    class Bucket6,JSONParse52,Access53,PgSelect54,First58,PgSelectSingle59,PgClassExpression60,PgClassExpression61,PgClassExpression62,JSONParse64,Access65,PgSelect66,First70,PgSelectSingle71,PgClassExpression72,PgClassExpression73,PgClassExpression74 bucket6
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-page-2.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-page-2.mermaid
@@ -17,195 +17,195 @@ graph TD
     __Value3 --> Access16
     __Value3 --> Access17
     Connection19{{"Connection[19∈0]<br />ᐸ15ᐳ"}}:::plan
-    Constant153{{"Constant[153∈0]<br />ᐸ4ᐳ"}}:::plan
-    Constant153 --> Connection19
-    Lambda39{{"Lambda[39∈0]<br />ᐸparseCursorᐳ"}}:::plan
-    Constant155{{"Constant[155∈0]<br />ᐸ'WyJjMDM4YzQzNTYwIiwiQXdzQXBwbGljYXRpb24iLCJbXCI0XCJdIl0='ᐳ"}}:::plan
-    Constant155 --> Lambda39
+    Constant156{{"Constant[156∈0]<br />ᐸ4ᐳ"}}:::plan
+    Constant156 --> Connection19
+    Lambda40{{"Lambda[40∈0]<br />ᐸparseCursorᐳ"}}:::plan
+    Constant158{{"Constant[158∈0]<br />ᐸ'WyJjMDM4YzQzNTYwIiwiQXdzQXBwbGljYXRpb24iLCJbXCI0XCJdIl0='ᐳ"}}:::plan
+    Constant158 --> Lambda40
     __Value0["__Value[0∈0]"]:::plan
     __Value5["__Value[5∈0]<br />ᐸrootValueᐳ"]:::plan
-    Constant154{{"Constant[154∈0]<br />ᐸ1ᐳ"}}:::plan
-    Connection38{{"Connection[38∈1]<br />ᐸ34ᐳ"}}:::plan
-    PgValidateParsedCursor44["PgValidateParsedCursor[44∈1]"]:::plan
-    Constant154 & Lambda39 & PgValidateParsedCursor44 --> Connection38
+    Constant157{{"Constant[157∈0]<br />ᐸ1ᐳ"}}:::plan
+    Connection39{{"Connection[39∈1]<br />ᐸ35ᐳ"}}:::plan
+    PgValidateParsedCursor45["PgValidateParsedCursor[45∈1]"]:::plan
+    Constant157 & Lambda40 & PgValidateParsedCursor45 --> Connection39
     PgSelect20[["PgSelect[20∈1]<br />ᐸpeopleᐳ"]]:::plan
     Object18 & Connection19 --> PgSelect20
-    Lambda39 --> PgValidateParsedCursor44
-    Access45{{"Access[45∈1]<br />ᐸ39.1ᐳ"}}:::plan
-    Lambda39 --> Access45
-    ToPg46{{"ToPg[46∈1]"}}:::plan
-    Access45 --> ToPg46
-    Access47{{"Access[47∈1]<br />ᐸ39.2ᐳ"}}:::plan
-    Lambda39 --> Access47
+    Lambda40 --> PgValidateParsedCursor45
+    Access46{{"Access[46∈1]<br />ᐸ40.1ᐳ"}}:::plan
+    Lambda40 --> Access46
+    ToPg47{{"ToPg[47∈1]"}}:::plan
+    Access46 --> ToPg47
+    Access48{{"Access[48∈1]<br />ᐸ40.2ᐳ"}}:::plan
+    Lambda40 --> Access48
     __Item21[/"__Item[21∈2]<br />ᐸ20ᐳ"\]:::itemplan
     PgSelect20 ==> __Item21
     PgSelectSingle22{{"PgSelectSingle[22∈2]<br />ᐸpeopleᐳ"}}:::plan
     __Item21 --> PgSelectSingle22
-    PgUnionAll40[["PgUnionAll[40∈3]"]]:::plan
+    PgUnionAll41[["PgUnionAll[41∈3]"]]:::plan
     PgClassExpression23{{"PgClassExpression[23∈3]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Object18 & PgClassExpression23 & PgClassExpression23 & Connection38 & Lambda39 & ToPg46 & Access47 --> PgUnionAll40
+    Object18 & PgClassExpression23 & PgClassExpression23 & Connection39 & Lambda40 & ToPg47 & Access48 --> PgUnionAll41
     PgSelectSingle22 --> PgClassExpression23
     PgClassExpression24{{"PgClassExpression[24∈3]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle22 --> PgClassExpression24
-    __Item41[/"__Item[41∈4]<br />ᐸ40ᐳ"\]:::itemplan
-    PgUnionAll40 ==> __Item41
-    PgUnionAllSingle42["PgUnionAllSingle[42∈4]"]:::plan
-    __Item41 --> PgUnionAllSingle42
-    List50{{"List[50∈5]<br />ᐸ48,49ᐳ"}}:::plan
-    Access48{{"Access[48∈5]<br />ᐸ42.0ᐳ"}}:::plan
-    Access49{{"Access[49∈5]<br />ᐸ42.1ᐳ"}}:::plan
-    Access48 & Access49 --> List50
-    PgCursor43{{"PgCursor[43∈5]"}}:::plan
-    List50 --> PgCursor43
-    PgUnionAllSingle42 --> Access48
-    PgUnionAllSingle42 --> Access49
-    PgUnionAll75[["PgUnionAll[75∈6]<br />ᐳAwsApplication"]]:::plan
-    PgClassExpression60{{"PgClassExpression[60∈6]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
-    Connection74{{"Connection[74∈6]<br />ᐸ70ᐳ<br />ᐳAwsApplication"}}:::plan
-    Object18 & PgClassExpression60 & PgClassExpression60 & Connection74 --> PgUnionAll75
-    PgUnionAll126[["PgUnionAll[126∈6]<br />ᐳGcpApplication"]]:::plan
-    PgClassExpression111{{"PgClassExpression[111∈6]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
-    Connection125{{"Connection[125∈6]<br />ᐸ121ᐳ<br />ᐳGcpApplication"}}:::plan
-    Object18 & PgClassExpression111 & PgClassExpression111 & Connection125 --> PgUnionAll126
-    PgSelect54[["PgSelect[54∈6]<br />ᐸaws_applicationsᐳ<br />ᐳAwsApplication"]]:::plan
-    Access53{{"Access[53∈6]<br />ᐸ52.0ᐳ"}}:::plan
-    Object18 & Access53 --> PgSelect54
-    PgSelect105[["PgSelect[105∈6]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
-    Access104{{"Access[104∈6]<br />ᐸ103.0ᐳ"}}:::plan
-    Object18 & Access104 --> PgSelect105
-    JSONParse52[["JSONParse[52∈6]<br />ᐸ49ᐳ<br />ᐳAwsApplication"]]:::plan
-    Access49 --> JSONParse52
-    JSONParse52 --> Access53
-    First58{{"First[58∈6]"}}:::plan
-    PgSelect54 --> First58
-    PgSelectSingle59{{"PgSelectSingle[59∈6]<br />ᐸaws_applicationsᐳ"}}:::plan
-    First58 --> PgSelectSingle59
-    PgSelectSingle59 --> PgClassExpression60
-    Constant154 --> Connection74
-    JSONParse103[["JSONParse[103∈6]<br />ᐸ49ᐳ<br />ᐳGcpApplication"]]:::plan
-    Access49 --> JSONParse103
-    JSONParse103 --> Access104
-    First109{{"First[109∈6]"}}:::plan
-    PgSelect105 --> First109
-    PgSelectSingle110{{"PgSelectSingle[110∈6]<br />ᐸgcp_applicationsᐳ"}}:::plan
-    First109 --> PgSelectSingle110
-    PgSelectSingle110 --> PgClassExpression111
-    Constant154 --> Connection125
-    __Item76[/"__Item[76∈7]<br />ᐸ75ᐳ"\]:::itemplan
-    PgUnionAll75 ==> __Item76
-    PgUnionAllSingle77["PgUnionAllSingle[77∈7]"]:::plan
-    __Item76 --> PgUnionAllSingle77
-    List81{{"List[81∈8]<br />ᐸ79,80ᐳ<br />ᐳAwsApplication"}}:::plan
-    Access79{{"Access[79∈8]<br />ᐸ77.0ᐳ"}}:::plan
-    Access80{{"Access[80∈8]<br />ᐸ77.1ᐳ"}}:::plan
-    Access79 & Access80 --> List81
-    PgCursor78{{"PgCursor[78∈8]"}}:::plan
-    List81 --> PgCursor78
-    PgUnionAllSingle77 --> Access79
-    PgUnionAllSingle77 --> Access80
-    PgSelect85[["PgSelect[85∈9]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"]]:::plan
-    Access84{{"Access[84∈9]<br />ᐸ83.0ᐳ"}}:::plan
-    Object18 & Access84 --> PgSelect85
-    PgSelect95[["PgSelect[95∈9]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳAwsApplicationᐳThirdPartyVulnerability"]]:::plan
-    Access94{{"Access[94∈9]<br />ᐸ93.0ᐳ"}}:::plan
-    Object18 & Access94 --> PgSelect95
-    JSONParse83[["JSONParse[83∈9]<br />ᐸ80ᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"]]:::plan
-    Access80 --> JSONParse83
-    JSONParse83 --> Access84
-    First89{{"First[89∈9]"}}:::plan
-    PgSelect85 --> First89
-    PgSelectSingle90{{"PgSelectSingle[90∈9]<br />ᐸfirst_party_vulnerabilitiesᐳ"}}:::plan
-    First89 --> PgSelectSingle90
-    PgClassExpression91{{"PgClassExpression[91∈9]<br />ᐸ__first_pa...ies__.”id”ᐳ"}}:::plan
-    PgSelectSingle90 --> PgClassExpression91
-    JSONParse93[["JSONParse[93∈9]<br />ᐸ80ᐳ<br />ᐳAwsApplicationᐳThirdPartyVulnerability"]]:::plan
-    Access80 --> JSONParse93
-    JSONParse93 --> Access94
-    First99{{"First[99∈9]"}}:::plan
-    PgSelect95 --> First99
-    PgSelectSingle100{{"PgSelectSingle[100∈9]<br />ᐸthird_party_vulnerabilitiesᐳ"}}:::plan
-    First99 --> PgSelectSingle100
-    PgClassExpression101{{"PgClassExpression[101∈9]<br />ᐸ__third_pa...ies__.”id”ᐳ"}}:::plan
-    PgSelectSingle100 --> PgClassExpression101
-    __Item127[/"__Item[127∈10]<br />ᐸ126ᐳ"\]:::itemplan
-    PgUnionAll126 ==> __Item127
-    PgUnionAllSingle128["PgUnionAllSingle[128∈10]"]:::plan
-    __Item127 --> PgUnionAllSingle128
-    List132{{"List[132∈11]<br />ᐸ130,131ᐳ<br />ᐳGcpApplication"}}:::plan
-    Access130{{"Access[130∈11]<br />ᐸ128.0ᐳ"}}:::plan
-    Access131{{"Access[131∈11]<br />ᐸ128.1ᐳ"}}:::plan
-    Access130 & Access131 --> List132
-    PgCursor129{{"PgCursor[129∈11]"}}:::plan
-    List132 --> PgCursor129
-    PgUnionAllSingle128 --> Access130
-    PgUnionAllSingle128 --> Access131
-    PgSelect136[["PgSelect[136∈12]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"]]:::plan
-    Access135{{"Access[135∈12]<br />ᐸ134.0ᐳ"}}:::plan
-    Object18 & Access135 --> PgSelect136
-    PgSelect146[["PgSelect[146∈12]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳGcpApplicationᐳThirdPartyVulnerability"]]:::plan
-    Access145{{"Access[145∈12]<br />ᐸ144.0ᐳ"}}:::plan
-    Object18 & Access145 --> PgSelect146
-    JSONParse134[["JSONParse[134∈12]<br />ᐸ131ᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"]]:::plan
-    Access131 --> JSONParse134
-    JSONParse134 --> Access135
-    First140{{"First[140∈12]"}}:::plan
-    PgSelect136 --> First140
-    PgSelectSingle141{{"PgSelectSingle[141∈12]<br />ᐸfirst_party_vulnerabilitiesᐳ"}}:::plan
-    First140 --> PgSelectSingle141
-    PgClassExpression142{{"PgClassExpression[142∈12]<br />ᐸ__first_pa...ies__.”id”ᐳ"}}:::plan
-    PgSelectSingle141 --> PgClassExpression142
-    JSONParse144[["JSONParse[144∈12]<br />ᐸ131ᐳ<br />ᐳGcpApplicationᐳThirdPartyVulnerability"]]:::plan
-    Access131 --> JSONParse144
-    JSONParse144 --> Access145
-    First150{{"First[150∈12]"}}:::plan
-    PgSelect146 --> First150
-    PgSelectSingle151{{"PgSelectSingle[151∈12]<br />ᐸthird_party_vulnerabilitiesᐳ"}}:::plan
-    First150 --> PgSelectSingle151
-    PgClassExpression152{{"PgClassExpression[152∈12]<br />ᐸ__third_pa...ies__.”id”ᐳ"}}:::plan
-    PgSelectSingle151 --> PgClassExpression152
+    __Item42[/"__Item[42∈4]<br />ᐸ41ᐳ"\]:::itemplan
+    PgUnionAll41 ==> __Item42
+    PgUnionAllSingle43["PgUnionAllSingle[43∈4]"]:::plan
+    __Item42 --> PgUnionAllSingle43
+    List51{{"List[51∈5]<br />ᐸ49,50ᐳ"}}:::plan
+    Access49{{"Access[49∈5]<br />ᐸ43.0ᐳ"}}:::plan
+    Access50{{"Access[50∈5]<br />ᐸ43.1ᐳ"}}:::plan
+    Access49 & Access50 --> List51
+    PgCursor44{{"PgCursor[44∈5]"}}:::plan
+    List51 --> PgCursor44
+    PgUnionAllSingle43 --> Access49
+    PgUnionAllSingle43 --> Access50
+    PgUnionAll77[["PgUnionAll[77∈6]<br />ᐳAwsApplication"]]:::plan
+    PgClassExpression61{{"PgClassExpression[61∈6]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
+    Connection76{{"Connection[76∈6]<br />ᐸ72ᐳ<br />ᐳAwsApplication"}}:::plan
+    Object18 & PgClassExpression61 & PgClassExpression61 & Connection76 --> PgUnionAll77
+    PgUnionAll129[["PgUnionAll[129∈6]<br />ᐳGcpApplication"]]:::plan
+    PgClassExpression113{{"PgClassExpression[113∈6]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
+    Connection128{{"Connection[128∈6]<br />ᐸ124ᐳ<br />ᐳGcpApplication"}}:::plan
+    Object18 & PgClassExpression113 & PgClassExpression113 & Connection128 --> PgUnionAll129
+    PgSelect55[["PgSelect[55∈6]<br />ᐸaws_applicationsᐳ<br />ᐳAwsApplication"]]:::plan
+    Access54{{"Access[54∈6]<br />ᐸ53.0ᐳ"}}:::plan
+    Object18 & Access54 --> PgSelect55
+    PgSelect107[["PgSelect[107∈6]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
+    Access106{{"Access[106∈6]<br />ᐸ105.0ᐳ"}}:::plan
+    Object18 & Access106 --> PgSelect107
+    JSONParse53[["JSONParse[53∈6]<br />ᐸ50ᐳ<br />ᐳAwsApplication"]]:::plan
+    Access50 --> JSONParse53
+    JSONParse53 --> Access54
+    First59{{"First[59∈6]"}}:::plan
+    PgSelect55 --> First59
+    PgSelectSingle60{{"PgSelectSingle[60∈6]<br />ᐸaws_applicationsᐳ"}}:::plan
+    First59 --> PgSelectSingle60
+    PgSelectSingle60 --> PgClassExpression61
+    Constant157 --> Connection76
+    JSONParse105[["JSONParse[105∈6]<br />ᐸ50ᐳ<br />ᐳGcpApplication"]]:::plan
+    Access50 --> JSONParse105
+    JSONParse105 --> Access106
+    First111{{"First[111∈6]"}}:::plan
+    PgSelect107 --> First111
+    PgSelectSingle112{{"PgSelectSingle[112∈6]<br />ᐸgcp_applicationsᐳ"}}:::plan
+    First111 --> PgSelectSingle112
+    PgSelectSingle112 --> PgClassExpression113
+    Constant157 --> Connection128
+    __Item78[/"__Item[78∈7]<br />ᐸ77ᐳ"\]:::itemplan
+    PgUnionAll77 ==> __Item78
+    PgUnionAllSingle79["PgUnionAllSingle[79∈7]"]:::plan
+    __Item78 --> PgUnionAllSingle79
+    List83{{"List[83∈8]<br />ᐸ81,82ᐳ<br />ᐳAwsApplication"}}:::plan
+    Access81{{"Access[81∈8]<br />ᐸ79.0ᐳ"}}:::plan
+    Access82{{"Access[82∈8]<br />ᐸ79.1ᐳ"}}:::plan
+    Access81 & Access82 --> List83
+    PgCursor80{{"PgCursor[80∈8]"}}:::plan
+    List83 --> PgCursor80
+    PgUnionAllSingle79 --> Access81
+    PgUnionAllSingle79 --> Access82
+    PgSelect87[["PgSelect[87∈9]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"]]:::plan
+    Access86{{"Access[86∈9]<br />ᐸ85.0ᐳ"}}:::plan
+    Object18 & Access86 --> PgSelect87
+    PgSelect97[["PgSelect[97∈9]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳAwsApplicationᐳThirdPartyVulnerability"]]:::plan
+    Access96{{"Access[96∈9]<br />ᐸ95.0ᐳ"}}:::plan
+    Object18 & Access96 --> PgSelect97
+    JSONParse85[["JSONParse[85∈9]<br />ᐸ82ᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"]]:::plan
+    Access82 --> JSONParse85
+    JSONParse85 --> Access86
+    First91{{"First[91∈9]"}}:::plan
+    PgSelect87 --> First91
+    PgSelectSingle92{{"PgSelectSingle[92∈9]<br />ᐸfirst_party_vulnerabilitiesᐳ"}}:::plan
+    First91 --> PgSelectSingle92
+    PgClassExpression93{{"PgClassExpression[93∈9]<br />ᐸ__first_pa...ies__.”id”ᐳ"}}:::plan
+    PgSelectSingle92 --> PgClassExpression93
+    JSONParse95[["JSONParse[95∈9]<br />ᐸ82ᐳ<br />ᐳAwsApplicationᐳThirdPartyVulnerability"]]:::plan
+    Access82 --> JSONParse95
+    JSONParse95 --> Access96
+    First101{{"First[101∈9]"}}:::plan
+    PgSelect97 --> First101
+    PgSelectSingle102{{"PgSelectSingle[102∈9]<br />ᐸthird_party_vulnerabilitiesᐳ"}}:::plan
+    First101 --> PgSelectSingle102
+    PgClassExpression103{{"PgClassExpression[103∈9]<br />ᐸ__third_pa...ies__.”id”ᐳ"}}:::plan
+    PgSelectSingle102 --> PgClassExpression103
+    __Item130[/"__Item[130∈10]<br />ᐸ129ᐳ"\]:::itemplan
+    PgUnionAll129 ==> __Item130
+    PgUnionAllSingle131["PgUnionAllSingle[131∈10]"]:::plan
+    __Item130 --> PgUnionAllSingle131
+    List135{{"List[135∈11]<br />ᐸ133,134ᐳ<br />ᐳGcpApplication"}}:::plan
+    Access133{{"Access[133∈11]<br />ᐸ131.0ᐳ"}}:::plan
+    Access134{{"Access[134∈11]<br />ᐸ131.1ᐳ"}}:::plan
+    Access133 & Access134 --> List135
+    PgCursor132{{"PgCursor[132∈11]"}}:::plan
+    List135 --> PgCursor132
+    PgUnionAllSingle131 --> Access133
+    PgUnionAllSingle131 --> Access134
+    PgSelect139[["PgSelect[139∈12]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"]]:::plan
+    Access138{{"Access[138∈12]<br />ᐸ137.0ᐳ"}}:::plan
+    Object18 & Access138 --> PgSelect139
+    PgSelect149[["PgSelect[149∈12]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳGcpApplicationᐳThirdPartyVulnerability"]]:::plan
+    Access148{{"Access[148∈12]<br />ᐸ147.0ᐳ"}}:::plan
+    Object18 & Access148 --> PgSelect149
+    JSONParse137[["JSONParse[137∈12]<br />ᐸ134ᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"]]:::plan
+    Access134 --> JSONParse137
+    JSONParse137 --> Access138
+    First143{{"First[143∈12]"}}:::plan
+    PgSelect139 --> First143
+    PgSelectSingle144{{"PgSelectSingle[144∈12]<br />ᐸfirst_party_vulnerabilitiesᐳ"}}:::plan
+    First143 --> PgSelectSingle144
+    PgClassExpression145{{"PgClassExpression[145∈12]<br />ᐸ__first_pa...ies__.”id”ᐳ"}}:::plan
+    PgSelectSingle144 --> PgClassExpression145
+    JSONParse147[["JSONParse[147∈12]<br />ᐸ134ᐳ<br />ᐳGcpApplicationᐳThirdPartyVulnerability"]]:::plan
+    Access134 --> JSONParse147
+    JSONParse147 --> Access148
+    First153{{"First[153∈12]"}}:::plan
+    PgSelect149 --> First153
+    PgSelectSingle154{{"PgSelectSingle[154∈12]<br />ᐸthird_party_vulnerabilitiesᐳ"}}:::plan
+    First153 --> PgSelectSingle154
+    PgClassExpression155{{"PgClassExpression[155∈12]<br />ᐸ__third_pa...ies__.”id”ᐳ"}}:::plan
+    PgSelectSingle154 --> PgClassExpression155
 
     %% define steps
 
     subgraph "Buckets for queries/polymorphic/person-app-vulns.app-page-2"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value3,__Value5,Access16,Access17,Object18,Connection19,Lambda39,Constant153,Constant154,Constant155 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 18, 19, 154, 39<br /><br />ROOT Connectionᐸ15ᐳ[19]"):::bucket
+    class Bucket0,__Value0,__Value3,__Value5,Access16,Access17,Object18,Connection19,Lambda40,Constant156,Constant157,Constant158 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 18, 19, 157, 40<br /><br />ROOT Connectionᐸ15ᐳ[19]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect20,Connection38,PgValidateParsedCursor44,Access45,ToPg46,Access47 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 18, 38, 39, 46, 47, 154<br /><br />ROOT __Item{2}ᐸ20ᐳ[21]"):::bucket
+    class Bucket1,PgSelect20,Connection39,PgValidateParsedCursor45,Access46,ToPg47,Access48 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 18, 39, 40, 47, 48, 157<br /><br />ROOT __Item{2}ᐸ20ᐳ[21]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item21,PgSelectSingle22 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 22, 18, 38, 39, 46, 47, 154<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[22]<br />1: <br />ᐳ: 23, 24<br />2: PgUnionAll[40]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 22, 18, 39, 40, 47, 48, 157<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[22]<br />1: <br />ᐳ: 23, 24<br />2: PgUnionAll[41]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression23,PgClassExpression24,PgUnionAll40 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 18, 154<br /><br />ROOT __Item{4}ᐸ40ᐳ[41]"):::bucket
+    class Bucket3,PgClassExpression23,PgClassExpression24,PgUnionAll41 bucket3
+    Bucket4("Bucket 4 (listItem)<br />Deps: 18, 157<br /><br />ROOT __Item{4}ᐸ41ᐳ[42]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item41,PgUnionAllSingle42 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 42, 18, 154<br /><br />ROOT PgUnionAllSingle{4}[42]"):::bucket
+    class Bucket4,__Item42,PgUnionAllSingle43 bucket4
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 43, 18, 157<br /><br />ROOT PgUnionAllSingle{4}[43]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgCursor43,Access48,Access49,List50 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 49, 18, 154, 42<br />ᐳAwsApplication<br />ᐳGcpApplication<br />1: JSONParse[52], JSONParse[103]<br />ᐳ: 74, 125, 53, 104<br />2: PgSelect[54], PgSelect[105]<br />ᐳ: 58, 59, 60, 109, 110, 111<br />3: PgUnionAll[75], PgUnionAll[126]"):::bucket
+    class Bucket5,PgCursor44,Access49,Access50,List51 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 50, 18, 157, 43<br />ᐳAwsApplication<br />ᐳGcpApplication<br />1: JSONParse[53], JSONParse[105]<br />ᐳ: 76, 128, 54, 106<br />2: PgSelect[55], PgSelect[107]<br />ᐳ: 59, 60, 61, 111, 112, 113<br />3: PgUnionAll[77], PgUnionAll[129]"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,JSONParse52,Access53,PgSelect54,First58,PgSelectSingle59,PgClassExpression60,Connection74,PgUnionAll75,JSONParse103,Access104,PgSelect105,First109,PgSelectSingle110,PgClassExpression111,Connection125,PgUnionAll126 bucket6
-    Bucket7("Bucket 7 (listItem)<br />Deps: 18<br /><br />ROOT __Item{7}ᐸ75ᐳ[76]"):::bucket
+    class Bucket6,JSONParse53,Access54,PgSelect55,First59,PgSelectSingle60,PgClassExpression61,Connection76,PgUnionAll77,JSONParse105,Access106,PgSelect107,First111,PgSelectSingle112,PgClassExpression113,Connection128,PgUnionAll129 bucket6
+    Bucket7("Bucket 7 (listItem)<br />Deps: 18<br /><br />ROOT __Item{7}ᐸ77ᐳ[78]"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,__Item76,PgUnionAllSingle77 bucket7
-    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 77, 18<br /><br />ROOT PgUnionAllSingle{7}[77]"):::bucket
+    class Bucket7,__Item78,PgUnionAllSingle79 bucket7
+    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 79, 18<br /><br />ROOT PgUnionAllSingle{7}[79]"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,PgCursor78,Access79,Access80,List81 bucket8
-    Bucket9("Bucket 9 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 80, 18, 77<br />ᐳAwsApplicationᐳFirstPartyVulnerability<br />ᐳAwsApplicationᐳThirdPartyVulnerability<br />1: JSONParse[83], JSONParse[93]<br />ᐳ: Access[84], Access[94]<br />2: PgSelect[85], PgSelect[95]<br />ᐳ: 89, 90, 91, 99, 100, 101"):::bucket
+    class Bucket8,PgCursor80,Access81,Access82,List83 bucket8
+    Bucket9("Bucket 9 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 82, 18, 79<br />ᐳAwsApplicationᐳFirstPartyVulnerability<br />ᐳAwsApplicationᐳThirdPartyVulnerability<br />1: JSONParse[85], JSONParse[95]<br />ᐳ: Access[86], Access[96]<br />2: PgSelect[87], PgSelect[97]<br />ᐳ: 91, 92, 93, 101, 102, 103"):::bucket
     classDef bucket9 stroke:#ff0000
-    class Bucket9,JSONParse83,Access84,PgSelect85,First89,PgSelectSingle90,PgClassExpression91,JSONParse93,Access94,PgSelect95,First99,PgSelectSingle100,PgClassExpression101 bucket9
-    Bucket10("Bucket 10 (listItem)<br />Deps: 18<br /><br />ROOT __Item{10}ᐸ126ᐳ[127]"):::bucket
+    class Bucket9,JSONParse85,Access86,PgSelect87,First91,PgSelectSingle92,PgClassExpression93,JSONParse95,Access96,PgSelect97,First101,PgSelectSingle102,PgClassExpression103 bucket9
+    Bucket10("Bucket 10 (listItem)<br />Deps: 18<br /><br />ROOT __Item{10}ᐸ129ᐳ[130]"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,__Item127,PgUnionAllSingle128 bucket10
-    Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 128, 18<br /><br />ROOT PgUnionAllSingle{10}[128]"):::bucket
+    class Bucket10,__Item130,PgUnionAllSingle131 bucket10
+    Bucket11("Bucket 11 (nullableBoundary)<br />Deps: 131, 18<br /><br />ROOT PgUnionAllSingle{10}[131]"):::bucket
     classDef bucket11 stroke:#00ffff
-    class Bucket11,PgCursor129,Access130,Access131,List132 bucket11
-    Bucket12("Bucket 12 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 131, 18, 128<br />ᐳGcpApplicationᐳFirstPartyVulnerability<br />ᐳGcpApplicationᐳThirdPartyVulnerability<br />1: JSONParse[134], JSONParse[144]<br />ᐳ: Access[135], Access[145]<br />2: PgSelect[136], PgSelect[146]<br />ᐳ: 140, 141, 142, 150, 151, 152"):::bucket
+    class Bucket11,PgCursor132,Access133,Access134,List135 bucket11
+    Bucket12("Bucket 12 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 134, 18, 131<br />ᐳGcpApplicationᐳFirstPartyVulnerability<br />ᐳGcpApplicationᐳThirdPartyVulnerability<br />1: JSONParse[137], JSONParse[147]<br />ᐳ: Access[138], Access[148]<br />2: PgSelect[139], PgSelect[149]<br />ᐳ: 143, 144, 145, 153, 154, 155"):::bucket
     classDef bucket12 stroke:#4169e1
-    class Bucket12,JSONParse134,Access135,PgSelect136,First140,PgSelectSingle141,PgClassExpression142,JSONParse144,Access145,PgSelect146,First150,PgSelectSingle151,PgClassExpression152 bucket12
+    class Bucket12,JSONParse137,Access138,PgSelect139,First143,PgSelectSingle144,PgClassExpression145,JSONParse147,Access148,PgSelect149,First153,PgSelectSingle154,PgClassExpression155 bucket12
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-totalCount.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-totalCount.mermaid
@@ -17,45 +17,45 @@ graph TD
     __Value3 --> Access16
     __Value3 --> Access17
     Connection19{{"Connection[19∈0]<br />ᐸ15ᐳ"}}:::plan
-    Constant43{{"Constant[43∈0]<br />ᐸ4ᐳ"}}:::plan
-    Constant43 --> Connection19
+    Constant44{{"Constant[44∈0]<br />ᐸ4ᐳ"}}:::plan
+    Constant44 --> Connection19
     __Value0["__Value[0∈0]"]:::plan
     __Value5["__Value[5∈0]<br />ᐸrootValueᐳ"]:::plan
     PgSelect20[["PgSelect[20∈1]<br />ᐸpeopleᐳ"]]:::plan
     Object18 & Connection19 --> PgSelect20
-    Connection38{{"Connection[38∈1]<br />ᐸ34ᐳ"}}:::plan
+    Connection39{{"Connection[39∈1]<br />ᐸ35ᐳ"}}:::plan
     __Item21[/"__Item[21∈2]<br />ᐸ20ᐳ"\]:::itemplan
     PgSelect20 ==> __Item21
     PgSelectSingle22{{"PgSelectSingle[22∈2]<br />ᐸpeopleᐳ"}}:::plan
     __Item21 --> PgSelectSingle22
-    PgUnionAll39[["PgUnionAll[39∈3]"]]:::plan
+    PgUnionAll40[["PgUnionAll[40∈3]"]]:::plan
     PgClassExpression23{{"PgClassExpression[23∈3]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Object18 & PgClassExpression23 & PgClassExpression23 & Connection38 --> PgUnionAll39
+    Object18 & PgClassExpression23 & PgClassExpression23 & Connection39 --> PgUnionAll40
     PgSelectSingle22 --> PgClassExpression23
     PgClassExpression24{{"PgClassExpression[24∈3]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle22 --> PgClassExpression24
-    First40{{"First[40∈3]"}}:::plan
-    PgUnionAll39 --> First40
-    PgUnionAllSingle41["PgUnionAllSingle[41∈3]"]:::plan
-    First40 --> PgUnionAllSingle41
-    PgClassExpression42{{"PgClassExpression[42∈3]<br />ᐸcount(*)ᐳ"}}:::plan
-    PgUnionAllSingle41 --> PgClassExpression42
+    First41{{"First[41∈3]"}}:::plan
+    PgUnionAll40 --> First41
+    PgUnionAllSingle42["PgUnionAllSingle[42∈3]"]:::plan
+    First41 --> PgUnionAllSingle42
+    PgClassExpression43{{"PgClassExpression[43∈3]<br />ᐸcount(*)ᐳ"}}:::plan
+    PgUnionAllSingle42 --> PgClassExpression43
 
     %% define steps
 
     subgraph "Buckets for queries/polymorphic/person-app-vulns.app-totalCount"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value3,__Value5,Access16,Access17,Object18,Connection19,Constant43 bucket0
+    class Bucket0,__Value0,__Value3,__Value5,Access16,Access17,Object18,Connection19,Constant44 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 18, 19<br /><br />ROOT Connectionᐸ15ᐳ[19]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect20,Connection38 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 18, 38<br /><br />ROOT __Item{2}ᐸ20ᐳ[21]"):::bucket
+    class Bucket1,PgSelect20,Connection39 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 18, 39<br /><br />ROOT __Item{2}ᐸ20ᐳ[21]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item21,PgSelectSingle22 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 22, 18, 38<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[22]<br />1: <br />ᐳ: 23, 24<br />2: PgUnionAll[39]<br />ᐳ: First[40]<br />3: PgUnionAllSingle[41]<br />ᐳ: PgClassExpression[42]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 22, 18, 39<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[22]<br />1: <br />ᐳ: 23, 24<br />2: PgUnionAll[40]<br />ᐳ: First[41]<br />3: PgUnionAllSingle[42]<br />ᐳ: PgClassExpression[43]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression23,PgClassExpression24,PgUnionAll39,First40,PgUnionAllSingle41,PgClassExpression42 bucket3
+    class Bucket3,PgClassExpression23,PgClassExpression24,PgUnionAll40,First41,PgUnionAllSingle42,PgClassExpression43 bucket3
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-vuln-totalCount.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.app-vuln-totalCount.mermaid
@@ -17,93 +17,93 @@ graph TD
     __Value3 --> Access16
     __Value3 --> Access17
     Connection19{{"Connection[19∈0]<br />ᐸ15ᐳ"}}:::plan
-    Constant96{{"Constant[96∈0]<br />ᐸ4ᐳ"}}:::plan
-    Constant96 --> Connection19
+    Constant99{{"Constant[99∈0]<br />ᐸ4ᐳ"}}:::plan
+    Constant99 --> Connection19
     __Value0["__Value[0∈0]"]:::plan
     __Value5["__Value[5∈0]<br />ᐸrootValueᐳ"]:::plan
     PgSelect20[["PgSelect[20∈1]<br />ᐸpeopleᐳ"]]:::plan
     Object18 & Connection19 --> PgSelect20
-    Connection38{{"Connection[38∈1]<br />ᐸ34ᐳ"}}:::plan
+    Connection39{{"Connection[39∈1]<br />ᐸ35ᐳ"}}:::plan
     __Item21[/"__Item[21∈2]<br />ᐸ20ᐳ"\]:::itemplan
     PgSelect20 ==> __Item21
     PgSelectSingle22{{"PgSelectSingle[22∈2]<br />ᐸpeopleᐳ"}}:::plan
     __Item21 --> PgSelectSingle22
-    PgUnionAll39[["PgUnionAll[39∈3]"]]:::plan
+    PgUnionAll40[["PgUnionAll[40∈3]"]]:::plan
     PgClassExpression23{{"PgClassExpression[23∈3]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Object18 & PgClassExpression23 & PgClassExpression23 & Connection38 --> PgUnionAll39
+    Object18 & PgClassExpression23 & PgClassExpression23 & Connection39 --> PgUnionAll40
     PgSelectSingle22 --> PgClassExpression23
     PgClassExpression24{{"PgClassExpression[24∈3]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle22 --> PgClassExpression24
-    __Item40[/"__Item[40∈4]<br />ᐸ39ᐳ"\]:::itemplan
-    PgUnionAll39 ==> __Item40
-    PgUnionAllSingle41["PgUnionAllSingle[41∈4]"]:::plan
-    __Item40 --> PgUnionAllSingle41
-    Access42{{"Access[42∈4]<br />ᐸ41.1ᐳ"}}:::plan
-    PgUnionAllSingle41 --> Access42
-    PgUnionAll65[["PgUnionAll[65∈5]<br />ᐳAwsApplication"]]:::plan
-    PgClassExpression58{{"PgClassExpression[58∈5]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
-    Connection64{{"Connection[64∈5]<br />ᐸ60ᐳ<br />ᐳAwsApplication"}}:::plan
-    Object18 & PgClassExpression58 & PgClassExpression58 & Connection64 --> PgUnionAll65
-    PgUnionAll92[["PgUnionAll[92∈5]<br />ᐳGcpApplication"]]:::plan
-    PgClassExpression85{{"PgClassExpression[85∈5]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
-    Connection91{{"Connection[91∈5]<br />ᐸ87ᐳ<br />ᐳGcpApplication"}}:::plan
-    Object18 & PgClassExpression85 & PgClassExpression85 & Connection91 --> PgUnionAll92
-    PgSelect45[["PgSelect[45∈5]<br />ᐸaws_applicationsᐳ<br />ᐳAwsApplication"]]:::plan
-    Access44{{"Access[44∈5]<br />ᐸ43.0ᐳ"}}:::plan
-    Object18 & Access44 --> PgSelect45
-    PgSelect72[["PgSelect[72∈5]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
-    Access71{{"Access[71∈5]<br />ᐸ70.0ᐳ"}}:::plan
-    Object18 & Access71 --> PgSelect72
-    JSONParse43[["JSONParse[43∈5]<br />ᐸ42ᐳ<br />ᐳAwsApplication"]]:::plan
-    Access42 --> JSONParse43
-    JSONParse43 --> Access44
-    First49{{"First[49∈5]"}}:::plan
-    PgSelect45 --> First49
-    PgSelectSingle50{{"PgSelectSingle[50∈5]<br />ᐸaws_applicationsᐳ"}}:::plan
-    First49 --> PgSelectSingle50
-    PgSelectSingle50 --> PgClassExpression58
-    First66{{"First[66∈5]"}}:::plan
-    PgUnionAll65 --> First66
-    PgUnionAllSingle67["PgUnionAllSingle[67∈5]"]:::plan
-    First66 --> PgUnionAllSingle67
-    PgClassExpression68{{"PgClassExpression[68∈5]<br />ᐸcount(*)ᐳ"}}:::plan
-    PgUnionAllSingle67 --> PgClassExpression68
-    JSONParse70[["JSONParse[70∈5]<br />ᐸ42ᐳ<br />ᐳGcpApplication"]]:::plan
-    Access42 --> JSONParse70
-    JSONParse70 --> Access71
-    First76{{"First[76∈5]"}}:::plan
-    PgSelect72 --> First76
-    PgSelectSingle77{{"PgSelectSingle[77∈5]<br />ᐸgcp_applicationsᐳ"}}:::plan
-    First76 --> PgSelectSingle77
-    PgSelectSingle77 --> PgClassExpression85
-    First93{{"First[93∈5]"}}:::plan
-    PgUnionAll92 --> First93
-    PgUnionAllSingle94["PgUnionAllSingle[94∈5]"]:::plan
-    First93 --> PgUnionAllSingle94
-    PgClassExpression95{{"PgClassExpression[95∈5]<br />ᐸcount(*)ᐳ"}}:::plan
-    PgUnionAllSingle94 --> PgClassExpression95
+    __Item41[/"__Item[41∈4]<br />ᐸ40ᐳ"\]:::itemplan
+    PgUnionAll40 ==> __Item41
+    PgUnionAllSingle42["PgUnionAllSingle[42∈4]"]:::plan
+    __Item41 --> PgUnionAllSingle42
+    Access43{{"Access[43∈4]<br />ᐸ42.1ᐳ"}}:::plan
+    PgUnionAllSingle42 --> Access43
+    PgUnionAll67[["PgUnionAll[67∈5]<br />ᐳAwsApplication"]]:::plan
+    PgClassExpression60{{"PgClassExpression[60∈5]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
+    Connection66{{"Connection[66∈5]<br />ᐸ62ᐳ<br />ᐳAwsApplication"}}:::plan
+    Object18 & PgClassExpression60 & PgClassExpression60 & Connection66 --> PgUnionAll67
+    PgUnionAll95[["PgUnionAll[95∈5]<br />ᐳGcpApplication"]]:::plan
+    PgClassExpression88{{"PgClassExpression[88∈5]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
+    Connection94{{"Connection[94∈5]<br />ᐸ90ᐳ<br />ᐳGcpApplication"}}:::plan
+    Object18 & PgClassExpression88 & PgClassExpression88 & Connection94 --> PgUnionAll95
+    PgSelect46[["PgSelect[46∈5]<br />ᐸaws_applicationsᐳ<br />ᐳAwsApplication"]]:::plan
+    Access45{{"Access[45∈5]<br />ᐸ44.0ᐳ"}}:::plan
+    Object18 & Access45 --> PgSelect46
+    PgSelect74[["PgSelect[74∈5]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
+    Access73{{"Access[73∈5]<br />ᐸ72.0ᐳ"}}:::plan
+    Object18 & Access73 --> PgSelect74
+    JSONParse44[["JSONParse[44∈5]<br />ᐸ43ᐳ<br />ᐳAwsApplication"]]:::plan
+    Access43 --> JSONParse44
+    JSONParse44 --> Access45
+    First50{{"First[50∈5]"}}:::plan
+    PgSelect46 --> First50
+    PgSelectSingle51{{"PgSelectSingle[51∈5]<br />ᐸaws_applicationsᐳ"}}:::plan
+    First50 --> PgSelectSingle51
+    PgSelectSingle51 --> PgClassExpression60
+    First68{{"First[68∈5]"}}:::plan
+    PgUnionAll67 --> First68
+    PgUnionAllSingle69["PgUnionAllSingle[69∈5]"]:::plan
+    First68 --> PgUnionAllSingle69
+    PgClassExpression70{{"PgClassExpression[70∈5]<br />ᐸcount(*)ᐳ"}}:::plan
+    PgUnionAllSingle69 --> PgClassExpression70
+    JSONParse72[["JSONParse[72∈5]<br />ᐸ43ᐳ<br />ᐳGcpApplication"]]:::plan
+    Access43 --> JSONParse72
+    JSONParse72 --> Access73
+    First78{{"First[78∈5]"}}:::plan
+    PgSelect74 --> First78
+    PgSelectSingle79{{"PgSelectSingle[79∈5]<br />ᐸgcp_applicationsᐳ"}}:::plan
+    First78 --> PgSelectSingle79
+    PgSelectSingle79 --> PgClassExpression88
+    First96{{"First[96∈5]"}}:::plan
+    PgUnionAll95 --> First96
+    PgUnionAllSingle97["PgUnionAllSingle[97∈5]"]:::plan
+    First96 --> PgUnionAllSingle97
+    PgClassExpression98{{"PgClassExpression[98∈5]<br />ᐸcount(*)ᐳ"}}:::plan
+    PgUnionAllSingle97 --> PgClassExpression98
 
     %% define steps
 
     subgraph "Buckets for queries/polymorphic/person-app-vulns.app-vuln-totalCount"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value3,__Value5,Access16,Access17,Object18,Connection19,Constant96 bucket0
+    class Bucket0,__Value0,__Value3,__Value5,Access16,Access17,Object18,Connection19,Constant99 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 18, 19<br /><br />ROOT Connectionᐸ15ᐳ[19]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect20,Connection38 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 18, 38<br /><br />ROOT __Item{2}ᐸ20ᐳ[21]"):::bucket
+    class Bucket1,PgSelect20,Connection39 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 18, 39<br /><br />ROOT __Item{2}ᐸ20ᐳ[21]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item21,PgSelectSingle22 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 22, 18, 38<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[22]<br />1: <br />ᐳ: 23, 24<br />2: PgUnionAll[39]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 22, 18, 39<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[22]<br />1: <br />ᐳ: 23, 24<br />2: PgUnionAll[40]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression23,PgClassExpression24,PgUnionAll39 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 18<br /><br />ROOT __Item{4}ᐸ39ᐳ[40]"):::bucket
+    class Bucket3,PgClassExpression23,PgClassExpression24,PgUnionAll40 bucket3
+    Bucket4("Bucket 4 (listItem)<br />Deps: 18<br /><br />ROOT __Item{4}ᐸ40ᐳ[41]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item40,PgUnionAllSingle41,Access42 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 42, 18, 41<br />ᐳAwsApplication<br />ᐳGcpApplication<br />1: JSONParse[43], JSONParse[70]<br />ᐳ: 64, 91, 44, 71<br />2: PgSelect[45], PgSelect[72]<br />ᐳ: 49, 50, 58, 76, 77, 85<br />3: PgUnionAll[65], PgUnionAll[92]<br />ᐳ: First[66], First[93]<br />4: 67, 94<br />ᐳ: 68, 95"):::bucket
+    class Bucket4,__Item41,PgUnionAllSingle42,Access43 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 43, 18, 42<br />ᐳAwsApplication<br />ᐳGcpApplication<br />1: JSONParse[44], JSONParse[72]<br />ᐳ: 66, 94, 45, 73<br />2: PgSelect[46], PgSelect[74]<br />ᐳ: 50, 51, 60, 78, 79, 88<br />3: PgUnionAll[67], PgUnionAll[95]<br />ᐳ: First[68], First[96]<br />4: 69, 97<br />ᐳ: 70, 98"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,JSONParse43,Access44,PgSelect45,First49,PgSelectSingle50,PgClassExpression58,Connection64,PgUnionAll65,First66,PgUnionAllSingle67,PgClassExpression68,JSONParse70,Access71,PgSelect72,First76,PgSelectSingle77,PgClassExpression85,Connection91,PgUnionAll92,First93,PgUnionAllSingle94,PgClassExpression95 bucket5
+    class Bucket5,JSONParse44,Access45,PgSelect46,First50,PgSelectSingle51,PgClassExpression60,Connection66,PgUnionAll67,First68,PgUnionAllSingle69,PgClassExpression70,JSONParse72,Access73,PgSelect74,First78,PgSelectSingle79,PgClassExpression88,Connection94,PgUnionAll95,First96,PgUnionAllSingle97,PgClassExpression98 bucket5
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/person-app-vulns.mermaid
@@ -17,452 +17,452 @@ graph TD
     __Value3 --> Access16
     __Value3 --> Access17
     Connection19{{"Connection[19∈0]<br />ᐸ15ᐳ"}}:::plan
-    Constant331{{"Constant[331∈0]<br />ᐸ4ᐳ"}}:::plan
-    Constant331 --> Connection19
+    Constant336{{"Constant[336∈0]<br />ᐸ4ᐳ"}}:::plan
+    Constant336 --> Connection19
     __Value0["__Value[0∈0]"]:::plan
     __Value5["__Value[5∈0]<br />ᐸrootValueᐳ"]:::plan
     PgSelect20[["PgSelect[20∈1]<br />ᐸpeopleᐳ"]]:::plan
     Object18 & Connection19 --> PgSelect20
-    Connection38{{"Connection[38∈1]<br />ᐸ34ᐳ"}}:::plan
+    Connection39{{"Connection[39∈1]<br />ᐸ35ᐳ"}}:::plan
     __Item21[/"__Item[21∈2]<br />ᐸ20ᐳ"\]:::itemplan
     PgSelect20 ==> __Item21
     PgSelectSingle22{{"PgSelectSingle[22∈2]<br />ᐸpeopleᐳ"}}:::plan
     __Item21 --> PgSelectSingle22
-    PgUnionAll39[["PgUnionAll[39∈3]"]]:::plan
+    PgUnionAll40[["PgUnionAll[40∈3]"]]:::plan
     PgClassExpression23{{"PgClassExpression[23∈3]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Object18 & PgClassExpression23 & PgClassExpression23 & Connection38 --> PgUnionAll39
-    PgUnionAll43[["PgUnionAll[43∈3]"]]:::plan
-    Object18 & PgClassExpression23 & PgClassExpression23 & Connection38 --> PgUnionAll43
-    PgUnionAll70[["PgUnionAll[70∈3]"]]:::plan
-    Object18 & PgClassExpression23 & PgClassExpression23 & Connection38 --> PgUnionAll70
+    Object18 & PgClassExpression23 & PgClassExpression23 & Connection39 --> PgUnionAll40
+    PgUnionAll44[["PgUnionAll[44∈3]"]]:::plan
+    Object18 & PgClassExpression23 & PgClassExpression23 & Connection39 --> PgUnionAll44
+    PgUnionAll71[["PgUnionAll[71∈3]"]]:::plan
+    Object18 & PgClassExpression23 & PgClassExpression23 & Connection39 --> PgUnionAll71
     PgSelectSingle22 --> PgClassExpression23
     PgClassExpression24{{"PgClassExpression[24∈3]<br />ᐸ__people__.”username”ᐳ"}}:::plan
     PgSelectSingle22 --> PgClassExpression24
-    First40{{"First[40∈3]"}}:::plan
-    PgUnionAll39 --> First40
-    PgUnionAllSingle41["PgUnionAllSingle[41∈3]"]:::plan
-    First40 --> PgUnionAllSingle41
-    PgClassExpression42{{"PgClassExpression[42∈3]<br />ᐸcount(*)ᐳ"}}:::plan
-    PgUnionAllSingle41 --> PgClassExpression42
-    __Item44[/"__Item[44∈4]<br />ᐸ43ᐳ"\]:::itemplan
-    PgUnionAll43 ==> __Item44
-    PgUnionAllSingle45["PgUnionAllSingle[45∈4]"]:::plan
-    __Item44 --> PgUnionAllSingle45
-    List49{{"List[49∈5]<br />ᐸ47,48ᐳ"}}:::plan
-    Access47{{"Access[47∈5]<br />ᐸ45.0ᐳ"}}:::plan
-    Access48{{"Access[48∈5]<br />ᐸ45.1ᐳ"}}:::plan
-    Access47 & Access48 --> List49
-    PgCursor46{{"PgCursor[46∈5]"}}:::plan
-    List49 --> PgCursor46
-    PgUnionAllSingle45 --> Access47
-    PgUnionAllSingle45 --> Access48
-    PgSelect53[["PgSelect[53∈6]<br />ᐸaws_applicationsᐳ<br />ᐳAwsApplication"]]:::plan
-    Access52{{"Access[52∈6]<br />ᐸ51.0ᐳ"}}:::plan
-    Object18 & Access52 --> PgSelect53
-    PgSelect63[["PgSelect[63∈6]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
-    Access62{{"Access[62∈6]<br />ᐸ61.0ᐳ"}}:::plan
-    Object18 & Access62 --> PgSelect63
-    JSONParse51[["JSONParse[51∈6]<br />ᐸ48ᐳ<br />ᐳAwsApplication"]]:::plan
-    Access48 --> JSONParse51
-    JSONParse51 --> Access52
-    First57{{"First[57∈6]"}}:::plan
-    PgSelect53 --> First57
-    PgSelectSingle58{{"PgSelectSingle[58∈6]<br />ᐸaws_applicationsᐳ"}}:::plan
-    First57 --> PgSelectSingle58
-    PgClassExpression59{{"PgClassExpression[59∈6]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
-    PgSelectSingle58 --> PgClassExpression59
-    JSONParse61[["JSONParse[61∈6]<br />ᐸ48ᐳ<br />ᐳGcpApplication"]]:::plan
-    Access48 --> JSONParse61
-    JSONParse61 --> Access62
-    First67{{"First[67∈6]"}}:::plan
-    PgSelect63 --> First67
-    PgSelectSingle68{{"PgSelectSingle[68∈6]<br />ᐸgcp_applicationsᐳ"}}:::plan
-    First67 --> PgSelectSingle68
-    PgClassExpression69{{"PgClassExpression[69∈6]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
-    PgSelectSingle68 --> PgClassExpression69
-    __Item71[/"__Item[71∈7]<br />ᐸ70ᐳ"\]:::itemplan
-    PgUnionAll70 ==> __Item71
-    PgUnionAllSingle72["PgUnionAllSingle[72∈7]"]:::plan
-    __Item71 --> PgUnionAllSingle72
-    Access73{{"Access[73∈7]<br />ᐸ72.1ᐳ"}}:::plan
-    PgUnionAllSingle72 --> Access73
-    PgUnionAll167[["PgUnionAll[167∈8]<br />ᐳAwsApplication"]]:::plan
-    PgClassExpression83{{"PgClassExpression[83∈8]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
-    Connection166{{"Connection[166∈8]<br />ᐸ162ᐳ<br />ᐳAwsApplication"}}:::plan
-    Object18 & PgClassExpression83 & PgClassExpression83 & Connection166 --> PgUnionAll167
-    PgUnionAll171[["PgUnionAll[171∈8]<br />ᐳAwsApplication"]]:::plan
-    Object18 & PgClassExpression83 & PgClassExpression83 & Connection166 --> PgUnionAll171
-    PgUnionAll296[["PgUnionAll[296∈8]<br />ᐳGcpApplication"]]:::plan
-    PgClassExpression212{{"PgClassExpression[212∈8]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
-    Connection295{{"Connection[295∈8]<br />ᐸ291ᐳ<br />ᐳGcpApplication"}}:::plan
-    Object18 & PgClassExpression212 & PgClassExpression212 & Connection295 --> PgUnionAll296
-    PgUnionAll300[["PgUnionAll[300∈8]<br />ᐳGcpApplication"]]:::plan
-    Object18 & PgClassExpression212 & PgClassExpression212 & Connection295 --> PgUnionAll300
-    PgUnionAll87[["PgUnionAll[87∈8]<br />ᐳAwsApplication"]]:::plan
-    PgClassExpression85{{"PgClassExpression[85∈8]<br />ᐸ__aws_appl...person_id”ᐳ"}}:::plan
-    PgClassExpression86{{"PgClassExpression[86∈8]<br />ᐸ__aws_appl...zation_id”ᐳ"}}:::plan
-    Object18 & PgClassExpression85 & PgClassExpression86 --> PgUnionAll87
-    PgUnionAll121[["PgUnionAll[121∈8]<br />ᐳAwsApplication"]]:::plan
-    Object18 & PgClassExpression83 & PgClassExpression83 --> PgUnionAll121
-    PgUnionAll216[["PgUnionAll[216∈8]<br />ᐳGcpApplication"]]:::plan
-    PgClassExpression214{{"PgClassExpression[214∈8]<br />ᐸ__gcp_appl...person_id”ᐳ"}}:::plan
-    PgClassExpression215{{"PgClassExpression[215∈8]<br />ᐸ__gcp_appl...zation_id”ᐳ"}}:::plan
-    Object18 & PgClassExpression214 & PgClassExpression215 --> PgUnionAll216
-    PgUnionAll250[["PgUnionAll[250∈8]<br />ᐳGcpApplication"]]:::plan
-    Object18 & PgClassExpression212 & PgClassExpression212 --> PgUnionAll250
-    PgSelect76[["PgSelect[76∈8]<br />ᐸaws_applicationsᐳ<br />ᐳAwsApplication"]]:::plan
-    Access75{{"Access[75∈8]<br />ᐸ74.0ᐳ"}}:::plan
-    Object18 & Access75 --> PgSelect76
-    PgSelect205[["PgSelect[205∈8]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
-    Access204{{"Access[204∈8]<br />ᐸ203.0ᐳ"}}:::plan
-    Object18 & Access204 --> PgSelect205
-    JSONParse74[["JSONParse[74∈8]<br />ᐸ73ᐳ<br />ᐳAwsApplication"]]:::plan
-    Access73 --> JSONParse74
-    JSONParse74 --> Access75
-    First80{{"First[80∈8]"}}:::plan
-    PgSelect76 --> First80
-    PgSelectSingle81{{"PgSelectSingle[81∈8]<br />ᐸaws_applicationsᐳ"}}:::plan
-    First80 --> PgSelectSingle81
-    PgClassExpression82{{"PgClassExpression[82∈8]<br />ᐸ__aws_appl..._.”aws_id”ᐳ"}}:::plan
-    PgSelectSingle81 --> PgClassExpression82
-    PgSelectSingle81 --> PgClassExpression83
-    PgClassExpression84{{"PgClassExpression[84∈8]<br />ᐸ__aws_appl...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle81 --> PgClassExpression84
-    PgSelectSingle81 --> PgClassExpression85
-    PgSelectSingle81 --> PgClassExpression86
-    First91{{"First[91∈8]"}}:::plan
-    PgUnionAll87 --> First91
-    PgUnionAllSingle92["PgUnionAllSingle[92∈8]"]:::plan
-    First91 --> PgUnionAllSingle92
-    Access93{{"Access[93∈8]<br />ᐸ92.1ᐳ"}}:::plan
-    PgUnionAllSingle92 --> Access93
-    First168{{"First[168∈8]"}}:::plan
-    PgUnionAll167 --> First168
-    PgUnionAllSingle169["PgUnionAllSingle[169∈8]"]:::plan
-    First168 --> PgUnionAllSingle169
-    PgClassExpression170{{"PgClassExpression[170∈8]<br />ᐸcount(*)ᐳ"}}:::plan
-    PgUnionAllSingle169 --> PgClassExpression170
-    JSONParse203[["JSONParse[203∈8]<br />ᐸ73ᐳ<br />ᐳGcpApplication"]]:::plan
-    Access73 --> JSONParse203
-    JSONParse203 --> Access204
-    First209{{"First[209∈8]"}}:::plan
-    PgSelect205 --> First209
-    PgSelectSingle210{{"PgSelectSingle[210∈8]<br />ᐸgcp_applicationsᐳ"}}:::plan
-    First209 --> PgSelectSingle210
-    PgClassExpression211{{"PgClassExpression[211∈8]<br />ᐸ__gcp_appl..._.”gcp_id”ᐳ"}}:::plan
-    PgSelectSingle210 --> PgClassExpression211
-    PgSelectSingle210 --> PgClassExpression212
-    PgClassExpression213{{"PgClassExpression[213∈8]<br />ᐸ__gcp_appl...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle210 --> PgClassExpression213
-    PgSelectSingle210 --> PgClassExpression214
-    PgSelectSingle210 --> PgClassExpression215
-    First220{{"First[220∈8]"}}:::plan
-    PgUnionAll216 --> First220
-    PgUnionAllSingle221["PgUnionAllSingle[221∈8]"]:::plan
-    First220 --> PgUnionAllSingle221
-    Access222{{"Access[222∈8]<br />ᐸ221.1ᐳ"}}:::plan
-    PgUnionAllSingle221 --> Access222
-    First297{{"First[297∈8]"}}:::plan
-    PgUnionAll296 --> First297
-    PgUnionAllSingle298["PgUnionAllSingle[298∈8]"]:::plan
-    First297 --> PgUnionAllSingle298
-    PgClassExpression299{{"PgClassExpression[299∈8]<br />ᐸcount(*)ᐳ"}}:::plan
-    PgUnionAllSingle298 --> PgClassExpression299
-    PgSelect96[["PgSelect[96∈9]<br />ᐸorganizationsᐳ<br />ᐳAwsApplicationᐳOrganization"]]:::plan
-    Access95{{"Access[95∈9]<br />ᐸ94.0ᐳ"}}:::plan
-    Object18 & Access95 --> PgSelect96
-    PgSelect107[["PgSelect[107∈9]<br />ᐸpeopleᐳ<br />ᐳAwsApplicationᐳPerson"]]:::plan
-    Access106{{"Access[106∈9]<br />ᐸ105.0ᐳ"}}:::plan
-    Object18 & Access106 --> PgSelect107
-    JSONParse94[["JSONParse[94∈9]<br />ᐸ93ᐳ<br />ᐳAwsApplicationᐳOrganization"]]:::plan
-    Access93 --> JSONParse94
-    JSONParse94 --> Access95
-    First100{{"First[100∈9]"}}:::plan
-    PgSelect96 --> First100
-    PgSelectSingle101{{"PgSelectSingle[101∈9]<br />ᐸorganizationsᐳ"}}:::plan
-    First100 --> PgSelectSingle101
-    PgClassExpression102{{"PgClassExpression[102∈9]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
-    PgSelectSingle101 --> PgClassExpression102
-    PgClassExpression103{{"PgClassExpression[103∈9]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle101 --> PgClassExpression103
-    JSONParse105[["JSONParse[105∈9]<br />ᐸ93ᐳ<br />ᐳAwsApplicationᐳPerson"]]:::plan
-    Access93 --> JSONParse105
-    JSONParse105 --> Access106
-    First111{{"First[111∈9]"}}:::plan
-    PgSelect107 --> First111
-    PgSelectSingle112{{"PgSelectSingle[112∈9]<br />ᐸpeopleᐳ"}}:::plan
-    First111 --> PgSelectSingle112
-    PgClassExpression113{{"PgClassExpression[113∈9]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    PgSelectSingle112 --> PgClassExpression113
-    PgClassExpression114{{"PgClassExpression[114∈9]<br />ᐸ__people__.”username”ᐳ"}}:::plan
-    PgSelectSingle112 --> PgClassExpression114
-    __Item125[/"__Item[125∈10]<br />ᐸ121ᐳ"\]:::itemplan
-    PgUnionAll121 ==> __Item125
-    PgUnionAllSingle126["PgUnionAllSingle[126∈10]"]:::plan
-    __Item125 --> PgUnionAllSingle126
-    Access127{{"Access[127∈10]<br />ᐸ126.1ᐳ"}}:::plan
-    PgUnionAllSingle126 --> Access127
-    PgSelect130[["PgSelect[130∈11]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"]]:::plan
-    Access129{{"Access[129∈11]<br />ᐸ128.0ᐳ"}}:::plan
-    Object18 & Access129 --> PgSelect130
-    PgSelect143[["PgSelect[143∈11]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳAwsApplicationᐳThirdPartyVulnerability"]]:::plan
-    Access142{{"Access[142∈11]<br />ᐸ141.0ᐳ"}}:::plan
-    Object18 & Access142 --> PgSelect143
-    JSONParse128[["JSONParse[128∈11]<br />ᐸ127ᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"]]:::plan
-    Access127 --> JSONParse128
-    JSONParse128 --> Access129
-    First134{{"First[134∈11]"}}:::plan
-    PgSelect130 --> First134
-    PgSelectSingle135{{"PgSelectSingle[135∈11]<br />ᐸfirst_party_vulnerabilitiesᐳ"}}:::plan
-    First134 --> PgSelectSingle135
-    PgClassExpression136{{"PgClassExpression[136∈11]<br />ᐸ__first_pa...team_name”ᐳ"}}:::plan
-    PgSelectSingle135 --> PgClassExpression136
-    PgClassExpression137{{"PgClassExpression[137∈11]<br />ᐸ__first_pa...ies__.”id”ᐳ"}}:::plan
-    PgSelectSingle135 --> PgClassExpression137
-    PgClassExpression138{{"PgClassExpression[138∈11]<br />ᐸ__first_pa...vss_score”ᐳ"}}:::plan
-    PgSelectSingle135 --> PgClassExpression138
-    PgClassExpression139{{"PgClassExpression[139∈11]<br />ᐸ__first_pa...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle135 --> PgClassExpression139
-    JSONParse141[["JSONParse[141∈11]<br />ᐸ127ᐳ<br />ᐳAwsApplicationᐳThirdPartyVulnerability"]]:::plan
-    Access127 --> JSONParse141
-    JSONParse141 --> Access142
-    First147{{"First[147∈11]"}}:::plan
-    PgSelect143 --> First147
-    PgSelectSingle148{{"PgSelectSingle[148∈11]<br />ᐸthird_party_vulnerabilitiesᐳ"}}:::plan
-    First147 --> PgSelectSingle148
-    PgClassExpression149{{"PgClassExpression[149∈11]<br />ᐸ__third_pa...ndor_name”ᐳ"}}:::plan
-    PgSelectSingle148 --> PgClassExpression149
-    PgClassExpression150{{"PgClassExpression[150∈11]<br />ᐸ__third_pa...ies__.”id”ᐳ"}}:::plan
-    PgSelectSingle148 --> PgClassExpression150
-    PgClassExpression151{{"PgClassExpression[151∈11]<br />ᐸ__third_pa...vss_score”ᐳ"}}:::plan
-    PgSelectSingle148 --> PgClassExpression151
-    PgClassExpression152{{"PgClassExpression[152∈11]<br />ᐸ__third_pa...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle148 --> PgClassExpression152
-    __Item172[/"__Item[172∈12]<br />ᐸ171ᐳ"\]:::itemplan
-    PgUnionAll171 ==> __Item172
-    PgUnionAllSingle173["PgUnionAllSingle[173∈12]"]:::plan
-    __Item172 --> PgUnionAllSingle173
-    List177{{"List[177∈13]<br />ᐸ175,176ᐳ<br />ᐳAwsApplication"}}:::plan
-    Access175{{"Access[175∈13]<br />ᐸ173.0ᐳ"}}:::plan
-    Access176{{"Access[176∈13]<br />ᐸ173.1ᐳ"}}:::plan
-    Access175 & Access176 --> List177
-    PgCursor174{{"PgCursor[174∈13]"}}:::plan
-    List177 --> PgCursor174
-    PgUnionAllSingle173 --> Access175
-    PgUnionAllSingle173 --> Access176
-    PgSelect181[["PgSelect[181∈14]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"]]:::plan
-    Access180{{"Access[180∈14]<br />ᐸ179.0ᐳ"}}:::plan
-    Object18 & Access180 --> PgSelect181
-    PgSelect193[["PgSelect[193∈14]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳAwsApplicationᐳThirdPartyVulnerability"]]:::plan
-    Access192{{"Access[192∈14]<br />ᐸ191.0ᐳ"}}:::plan
-    Object18 & Access192 --> PgSelect193
-    JSONParse179[["JSONParse[179∈14]<br />ᐸ176ᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"]]:::plan
-    Access176 --> JSONParse179
-    JSONParse179 --> Access180
-    First185{{"First[185∈14]"}}:::plan
-    PgSelect181 --> First185
-    PgSelectSingle186{{"PgSelectSingle[186∈14]<br />ᐸfirst_party_vulnerabilitiesᐳ"}}:::plan
-    First185 --> PgSelectSingle186
-    PgClassExpression187{{"PgClassExpression[187∈14]<br />ᐸ__first_pa...vss_score”ᐳ"}}:::plan
-    PgSelectSingle186 --> PgClassExpression187
-    PgClassExpression188{{"PgClassExpression[188∈14]<br />ᐸ__first_pa...ies__.”id”ᐳ"}}:::plan
-    PgSelectSingle186 --> PgClassExpression188
-    PgClassExpression189{{"PgClassExpression[189∈14]<br />ᐸ__first_pa...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle186 --> PgClassExpression189
-    JSONParse191[["JSONParse[191∈14]<br />ᐸ176ᐳ<br />ᐳAwsApplicationᐳThirdPartyVulnerability"]]:::plan
-    Access176 --> JSONParse191
-    JSONParse191 --> Access192
-    First197{{"First[197∈14]"}}:::plan
-    PgSelect193 --> First197
-    PgSelectSingle198{{"PgSelectSingle[198∈14]<br />ᐸthird_party_vulnerabilitiesᐳ"}}:::plan
-    First197 --> PgSelectSingle198
-    PgClassExpression199{{"PgClassExpression[199∈14]<br />ᐸ__third_pa...vss_score”ᐳ"}}:::plan
-    PgSelectSingle198 --> PgClassExpression199
-    PgClassExpression200{{"PgClassExpression[200∈14]<br />ᐸ__third_pa...ies__.”id”ᐳ"}}:::plan
-    PgSelectSingle198 --> PgClassExpression200
-    PgClassExpression201{{"PgClassExpression[201∈14]<br />ᐸ__third_pa...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle198 --> PgClassExpression201
-    PgSelect225[["PgSelect[225∈15]<br />ᐸorganizationsᐳ<br />ᐳGcpApplicationᐳOrganization"]]:::plan
-    Access224{{"Access[224∈15]<br />ᐸ223.0ᐳ"}}:::plan
-    Object18 & Access224 --> PgSelect225
-    PgSelect236[["PgSelect[236∈15]<br />ᐸpeopleᐳ<br />ᐳGcpApplicationᐳPerson"]]:::plan
-    Access235{{"Access[235∈15]<br />ᐸ234.0ᐳ"}}:::plan
-    Object18 & Access235 --> PgSelect236
-    JSONParse223[["JSONParse[223∈15]<br />ᐸ222ᐳ<br />ᐳGcpApplicationᐳOrganization"]]:::plan
-    Access222 --> JSONParse223
-    JSONParse223 --> Access224
-    First229{{"First[229∈15]"}}:::plan
-    PgSelect225 --> First229
-    PgSelectSingle230{{"PgSelectSingle[230∈15]<br />ᐸorganizationsᐳ"}}:::plan
-    First229 --> PgSelectSingle230
-    PgClassExpression231{{"PgClassExpression[231∈15]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
-    PgSelectSingle230 --> PgClassExpression231
-    PgClassExpression232{{"PgClassExpression[232∈15]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle230 --> PgClassExpression232
-    JSONParse234[["JSONParse[234∈15]<br />ᐸ222ᐳ<br />ᐳGcpApplicationᐳPerson"]]:::plan
-    Access222 --> JSONParse234
-    JSONParse234 --> Access235
-    First240{{"First[240∈15]"}}:::plan
-    PgSelect236 --> First240
-    PgSelectSingle241{{"PgSelectSingle[241∈15]<br />ᐸpeopleᐳ"}}:::plan
-    First240 --> PgSelectSingle241
-    PgClassExpression242{{"PgClassExpression[242∈15]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    PgSelectSingle241 --> PgClassExpression242
-    PgClassExpression243{{"PgClassExpression[243∈15]<br />ᐸ__people__.”username”ᐳ"}}:::plan
-    PgSelectSingle241 --> PgClassExpression243
-    __Item254[/"__Item[254∈16]<br />ᐸ250ᐳ"\]:::itemplan
-    PgUnionAll250 ==> __Item254
-    PgUnionAllSingle255["PgUnionAllSingle[255∈16]"]:::plan
-    __Item254 --> PgUnionAllSingle255
-    Access256{{"Access[256∈16]<br />ᐸ255.1ᐳ"}}:::plan
-    PgUnionAllSingle255 --> Access256
-    PgSelect259[["PgSelect[259∈17]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"]]:::plan
-    Access258{{"Access[258∈17]<br />ᐸ257.0ᐳ"}}:::plan
-    Object18 & Access258 --> PgSelect259
-    PgSelect272[["PgSelect[272∈17]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳGcpApplicationᐳThirdPartyVulnerability"]]:::plan
-    Access271{{"Access[271∈17]<br />ᐸ270.0ᐳ"}}:::plan
-    Object18 & Access271 --> PgSelect272
-    JSONParse257[["JSONParse[257∈17]<br />ᐸ256ᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"]]:::plan
-    Access256 --> JSONParse257
-    JSONParse257 --> Access258
-    First263{{"First[263∈17]"}}:::plan
-    PgSelect259 --> First263
-    PgSelectSingle264{{"PgSelectSingle[264∈17]<br />ᐸfirst_party_vulnerabilitiesᐳ"}}:::plan
-    First263 --> PgSelectSingle264
-    PgClassExpression265{{"PgClassExpression[265∈17]<br />ᐸ__first_pa...team_name”ᐳ"}}:::plan
-    PgSelectSingle264 --> PgClassExpression265
-    PgClassExpression266{{"PgClassExpression[266∈17]<br />ᐸ__first_pa...ies__.”id”ᐳ"}}:::plan
-    PgSelectSingle264 --> PgClassExpression266
-    PgClassExpression267{{"PgClassExpression[267∈17]<br />ᐸ__first_pa...vss_score”ᐳ"}}:::plan
-    PgSelectSingle264 --> PgClassExpression267
-    PgClassExpression268{{"PgClassExpression[268∈17]<br />ᐸ__first_pa...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle264 --> PgClassExpression268
-    JSONParse270[["JSONParse[270∈17]<br />ᐸ256ᐳ<br />ᐳGcpApplicationᐳThirdPartyVulnerability"]]:::plan
-    Access256 --> JSONParse270
-    JSONParse270 --> Access271
-    First276{{"First[276∈17]"}}:::plan
-    PgSelect272 --> First276
-    PgSelectSingle277{{"PgSelectSingle[277∈17]<br />ᐸthird_party_vulnerabilitiesᐳ"}}:::plan
-    First276 --> PgSelectSingle277
-    PgClassExpression278{{"PgClassExpression[278∈17]<br />ᐸ__third_pa...ndor_name”ᐳ"}}:::plan
-    PgSelectSingle277 --> PgClassExpression278
-    PgClassExpression279{{"PgClassExpression[279∈17]<br />ᐸ__third_pa...ies__.”id”ᐳ"}}:::plan
-    PgSelectSingle277 --> PgClassExpression279
-    PgClassExpression280{{"PgClassExpression[280∈17]<br />ᐸ__third_pa...vss_score”ᐳ"}}:::plan
-    PgSelectSingle277 --> PgClassExpression280
-    PgClassExpression281{{"PgClassExpression[281∈17]<br />ᐸ__third_pa...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle277 --> PgClassExpression281
-    __Item301[/"__Item[301∈18]<br />ᐸ300ᐳ"\]:::itemplan
-    PgUnionAll300 ==> __Item301
-    PgUnionAllSingle302["PgUnionAllSingle[302∈18]"]:::plan
-    __Item301 --> PgUnionAllSingle302
-    List306{{"List[306∈19]<br />ᐸ304,305ᐳ<br />ᐳGcpApplication"}}:::plan
-    Access304{{"Access[304∈19]<br />ᐸ302.0ᐳ"}}:::plan
-    Access305{{"Access[305∈19]<br />ᐸ302.1ᐳ"}}:::plan
-    Access304 & Access305 --> List306
-    PgCursor303{{"PgCursor[303∈19]"}}:::plan
-    List306 --> PgCursor303
-    PgUnionAllSingle302 --> Access304
-    PgUnionAllSingle302 --> Access305
-    PgSelect310[["PgSelect[310∈20]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"]]:::plan
-    Access309{{"Access[309∈20]<br />ᐸ308.0ᐳ"}}:::plan
-    Object18 & Access309 --> PgSelect310
-    PgSelect322[["PgSelect[322∈20]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳGcpApplicationᐳThirdPartyVulnerability"]]:::plan
-    Access321{{"Access[321∈20]<br />ᐸ320.0ᐳ"}}:::plan
-    Object18 & Access321 --> PgSelect322
-    JSONParse308[["JSONParse[308∈20]<br />ᐸ305ᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"]]:::plan
-    Access305 --> JSONParse308
-    JSONParse308 --> Access309
-    First314{{"First[314∈20]"}}:::plan
-    PgSelect310 --> First314
-    PgSelectSingle315{{"PgSelectSingle[315∈20]<br />ᐸfirst_party_vulnerabilitiesᐳ"}}:::plan
-    First314 --> PgSelectSingle315
-    PgClassExpression316{{"PgClassExpression[316∈20]<br />ᐸ__first_pa...vss_score”ᐳ"}}:::plan
-    PgSelectSingle315 --> PgClassExpression316
-    PgClassExpression317{{"PgClassExpression[317∈20]<br />ᐸ__first_pa...ies__.”id”ᐳ"}}:::plan
-    PgSelectSingle315 --> PgClassExpression317
-    PgClassExpression318{{"PgClassExpression[318∈20]<br />ᐸ__first_pa...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle315 --> PgClassExpression318
-    JSONParse320[["JSONParse[320∈20]<br />ᐸ305ᐳ<br />ᐳGcpApplicationᐳThirdPartyVulnerability"]]:::plan
-    Access305 --> JSONParse320
-    JSONParse320 --> Access321
-    First326{{"First[326∈20]"}}:::plan
-    PgSelect322 --> First326
-    PgSelectSingle327{{"PgSelectSingle[327∈20]<br />ᐸthird_party_vulnerabilitiesᐳ"}}:::plan
-    First326 --> PgSelectSingle327
-    PgClassExpression328{{"PgClassExpression[328∈20]<br />ᐸ__third_pa...vss_score”ᐳ"}}:::plan
-    PgSelectSingle327 --> PgClassExpression328
-    PgClassExpression329{{"PgClassExpression[329∈20]<br />ᐸ__third_pa...ies__.”id”ᐳ"}}:::plan
-    PgSelectSingle327 --> PgClassExpression329
-    PgClassExpression330{{"PgClassExpression[330∈20]<br />ᐸ__third_pa...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle327 --> PgClassExpression330
+    First41{{"First[41∈3]"}}:::plan
+    PgUnionAll40 --> First41
+    PgUnionAllSingle42["PgUnionAllSingle[42∈3]"]:::plan
+    First41 --> PgUnionAllSingle42
+    PgClassExpression43{{"PgClassExpression[43∈3]<br />ᐸcount(*)ᐳ"}}:::plan
+    PgUnionAllSingle42 --> PgClassExpression43
+    __Item45[/"__Item[45∈4]<br />ᐸ44ᐳ"\]:::itemplan
+    PgUnionAll44 ==> __Item45
+    PgUnionAllSingle46["PgUnionAllSingle[46∈4]"]:::plan
+    __Item45 --> PgUnionAllSingle46
+    List50{{"List[50∈5]<br />ᐸ48,49ᐳ"}}:::plan
+    Access48{{"Access[48∈5]<br />ᐸ46.0ᐳ"}}:::plan
+    Access49{{"Access[49∈5]<br />ᐸ46.1ᐳ"}}:::plan
+    Access48 & Access49 --> List50
+    PgCursor47{{"PgCursor[47∈5]"}}:::plan
+    List50 --> PgCursor47
+    PgUnionAllSingle46 --> Access48
+    PgUnionAllSingle46 --> Access49
+    PgSelect54[["PgSelect[54∈6]<br />ᐸaws_applicationsᐳ<br />ᐳAwsApplication"]]:::plan
+    Access53{{"Access[53∈6]<br />ᐸ52.0ᐳ"}}:::plan
+    Object18 & Access53 --> PgSelect54
+    PgSelect64[["PgSelect[64∈6]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
+    Access63{{"Access[63∈6]<br />ᐸ62.0ᐳ"}}:::plan
+    Object18 & Access63 --> PgSelect64
+    JSONParse52[["JSONParse[52∈6]<br />ᐸ49ᐳ<br />ᐳAwsApplication"]]:::plan
+    Access49 --> JSONParse52
+    JSONParse52 --> Access53
+    First58{{"First[58∈6]"}}:::plan
+    PgSelect54 --> First58
+    PgSelectSingle59{{"PgSelectSingle[59∈6]<br />ᐸaws_applicationsᐳ"}}:::plan
+    First58 --> PgSelectSingle59
+    PgClassExpression60{{"PgClassExpression[60∈6]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
+    PgSelectSingle59 --> PgClassExpression60
+    JSONParse62[["JSONParse[62∈6]<br />ᐸ49ᐳ<br />ᐳGcpApplication"]]:::plan
+    Access49 --> JSONParse62
+    JSONParse62 --> Access63
+    First68{{"First[68∈6]"}}:::plan
+    PgSelect64 --> First68
+    PgSelectSingle69{{"PgSelectSingle[69∈6]<br />ᐸgcp_applicationsᐳ"}}:::plan
+    First68 --> PgSelectSingle69
+    PgClassExpression70{{"PgClassExpression[70∈6]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
+    PgSelectSingle69 --> PgClassExpression70
+    __Item72[/"__Item[72∈7]<br />ᐸ71ᐳ"\]:::itemplan
+    PgUnionAll71 ==> __Item72
+    PgUnionAllSingle73["PgUnionAllSingle[73∈7]"]:::plan
+    __Item72 --> PgUnionAllSingle73
+    Access74{{"Access[74∈7]<br />ᐸ73.1ᐳ"}}:::plan
+    PgUnionAllSingle73 --> Access74
+    PgUnionAll170[["PgUnionAll[170∈8]<br />ᐳAwsApplication"]]:::plan
+    PgClassExpression84{{"PgClassExpression[84∈8]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
+    Connection169{{"Connection[169∈8]<br />ᐸ165ᐳ<br />ᐳAwsApplication"}}:::plan
+    Object18 & PgClassExpression84 & PgClassExpression84 & Connection169 --> PgUnionAll170
+    PgUnionAll174[["PgUnionAll[174∈8]<br />ᐳAwsApplication"]]:::plan
+    Object18 & PgClassExpression84 & PgClassExpression84 & Connection169 --> PgUnionAll174
+    PgUnionAll301[["PgUnionAll[301∈8]<br />ᐳGcpApplication"]]:::plan
+    PgClassExpression215{{"PgClassExpression[215∈8]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
+    Connection300{{"Connection[300∈8]<br />ᐸ296ᐳ<br />ᐳGcpApplication"}}:::plan
+    Object18 & PgClassExpression215 & PgClassExpression215 & Connection300 --> PgUnionAll301
+    PgUnionAll305[["PgUnionAll[305∈8]<br />ᐳGcpApplication"]]:::plan
+    Object18 & PgClassExpression215 & PgClassExpression215 & Connection300 --> PgUnionAll305
+    PgUnionAll88[["PgUnionAll[88∈8]<br />ᐳAwsApplication"]]:::plan
+    PgClassExpression86{{"PgClassExpression[86∈8]<br />ᐸ__aws_appl...person_id”ᐳ"}}:::plan
+    PgClassExpression87{{"PgClassExpression[87∈8]<br />ᐸ__aws_appl...zation_id”ᐳ"}}:::plan
+    Object18 & PgClassExpression86 & PgClassExpression87 --> PgUnionAll88
+    PgUnionAll123[["PgUnionAll[123∈8]<br />ᐳAwsApplication"]]:::plan
+    Object18 & PgClassExpression84 & PgClassExpression84 --> PgUnionAll123
+    PgUnionAll219[["PgUnionAll[219∈8]<br />ᐳGcpApplication"]]:::plan
+    PgClassExpression217{{"PgClassExpression[217∈8]<br />ᐸ__gcp_appl...person_id”ᐳ"}}:::plan
+    PgClassExpression218{{"PgClassExpression[218∈8]<br />ᐸ__gcp_appl...zation_id”ᐳ"}}:::plan
+    Object18 & PgClassExpression217 & PgClassExpression218 --> PgUnionAll219
+    PgUnionAll254[["PgUnionAll[254∈8]<br />ᐳGcpApplication"]]:::plan
+    Object18 & PgClassExpression215 & PgClassExpression215 --> PgUnionAll254
+    PgSelect77[["PgSelect[77∈8]<br />ᐸaws_applicationsᐳ<br />ᐳAwsApplication"]]:::plan
+    Access76{{"Access[76∈8]<br />ᐸ75.0ᐳ"}}:::plan
+    Object18 & Access76 --> PgSelect77
+    PgSelect208[["PgSelect[208∈8]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
+    Access207{{"Access[207∈8]<br />ᐸ206.0ᐳ"}}:::plan
+    Object18 & Access207 --> PgSelect208
+    JSONParse75[["JSONParse[75∈8]<br />ᐸ74ᐳ<br />ᐳAwsApplication"]]:::plan
+    Access74 --> JSONParse75
+    JSONParse75 --> Access76
+    First81{{"First[81∈8]"}}:::plan
+    PgSelect77 --> First81
+    PgSelectSingle82{{"PgSelectSingle[82∈8]<br />ᐸaws_applicationsᐳ"}}:::plan
+    First81 --> PgSelectSingle82
+    PgClassExpression83{{"PgClassExpression[83∈8]<br />ᐸ__aws_appl..._.”aws_id”ᐳ"}}:::plan
+    PgSelectSingle82 --> PgClassExpression83
+    PgSelectSingle82 --> PgClassExpression84
+    PgClassExpression85{{"PgClassExpression[85∈8]<br />ᐸ__aws_appl...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle82 --> PgClassExpression85
+    PgSelectSingle82 --> PgClassExpression86
+    PgSelectSingle82 --> PgClassExpression87
+    First92{{"First[92∈8]"}}:::plan
+    PgUnionAll88 --> First92
+    PgUnionAllSingle93["PgUnionAllSingle[93∈8]"]:::plan
+    First92 --> PgUnionAllSingle93
+    Access94{{"Access[94∈8]<br />ᐸ93.1ᐳ"}}:::plan
+    PgUnionAllSingle93 --> Access94
+    First171{{"First[171∈8]"}}:::plan
+    PgUnionAll170 --> First171
+    PgUnionAllSingle172["PgUnionAllSingle[172∈8]"]:::plan
+    First171 --> PgUnionAllSingle172
+    PgClassExpression173{{"PgClassExpression[173∈8]<br />ᐸcount(*)ᐳ"}}:::plan
+    PgUnionAllSingle172 --> PgClassExpression173
+    JSONParse206[["JSONParse[206∈8]<br />ᐸ74ᐳ<br />ᐳGcpApplication"]]:::plan
+    Access74 --> JSONParse206
+    JSONParse206 --> Access207
+    First212{{"First[212∈8]"}}:::plan
+    PgSelect208 --> First212
+    PgSelectSingle213{{"PgSelectSingle[213∈8]<br />ᐸgcp_applicationsᐳ"}}:::plan
+    First212 --> PgSelectSingle213
+    PgClassExpression214{{"PgClassExpression[214∈8]<br />ᐸ__gcp_appl..._.”gcp_id”ᐳ"}}:::plan
+    PgSelectSingle213 --> PgClassExpression214
+    PgSelectSingle213 --> PgClassExpression215
+    PgClassExpression216{{"PgClassExpression[216∈8]<br />ᐸ__gcp_appl...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle213 --> PgClassExpression216
+    PgSelectSingle213 --> PgClassExpression217
+    PgSelectSingle213 --> PgClassExpression218
+    First223{{"First[223∈8]"}}:::plan
+    PgUnionAll219 --> First223
+    PgUnionAllSingle224["PgUnionAllSingle[224∈8]"]:::plan
+    First223 --> PgUnionAllSingle224
+    Access225{{"Access[225∈8]<br />ᐸ224.1ᐳ"}}:::plan
+    PgUnionAllSingle224 --> Access225
+    First302{{"First[302∈8]"}}:::plan
+    PgUnionAll301 --> First302
+    PgUnionAllSingle303["PgUnionAllSingle[303∈8]"]:::plan
+    First302 --> PgUnionAllSingle303
+    PgClassExpression304{{"PgClassExpression[304∈8]<br />ᐸcount(*)ᐳ"}}:::plan
+    PgUnionAllSingle303 --> PgClassExpression304
+    PgSelect97[["PgSelect[97∈9]<br />ᐸorganizationsᐳ<br />ᐳAwsApplicationᐳOrganization"]]:::plan
+    Access96{{"Access[96∈9]<br />ᐸ95.0ᐳ"}}:::plan
+    Object18 & Access96 --> PgSelect97
+    PgSelect108[["PgSelect[108∈9]<br />ᐸpeopleᐳ<br />ᐳAwsApplicationᐳPerson"]]:::plan
+    Access107{{"Access[107∈9]<br />ᐸ106.0ᐳ"}}:::plan
+    Object18 & Access107 --> PgSelect108
+    JSONParse95[["JSONParse[95∈9]<br />ᐸ94ᐳ<br />ᐳAwsApplicationᐳOrganization"]]:::plan
+    Access94 --> JSONParse95
+    JSONParse95 --> Access96
+    First101{{"First[101∈9]"}}:::plan
+    PgSelect97 --> First101
+    PgSelectSingle102{{"PgSelectSingle[102∈9]<br />ᐸorganizationsᐳ"}}:::plan
+    First101 --> PgSelectSingle102
+    PgClassExpression103{{"PgClassExpression[103∈9]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
+    PgSelectSingle102 --> PgClassExpression103
+    PgClassExpression104{{"PgClassExpression[104∈9]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle102 --> PgClassExpression104
+    JSONParse106[["JSONParse[106∈9]<br />ᐸ94ᐳ<br />ᐳAwsApplicationᐳPerson"]]:::plan
+    Access94 --> JSONParse106
+    JSONParse106 --> Access107
+    First112{{"First[112∈9]"}}:::plan
+    PgSelect108 --> First112
+    PgSelectSingle113{{"PgSelectSingle[113∈9]<br />ᐸpeopleᐳ"}}:::plan
+    First112 --> PgSelectSingle113
+    PgClassExpression114{{"PgClassExpression[114∈9]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
+    PgSelectSingle113 --> PgClassExpression114
+    PgClassExpression115{{"PgClassExpression[115∈9]<br />ᐸ__people__.”username”ᐳ"}}:::plan
+    PgSelectSingle113 --> PgClassExpression115
+    __Item127[/"__Item[127∈10]<br />ᐸ123ᐳ"\]:::itemplan
+    PgUnionAll123 ==> __Item127
+    PgUnionAllSingle128["PgUnionAllSingle[128∈10]"]:::plan
+    __Item127 --> PgUnionAllSingle128
+    Access129{{"Access[129∈10]<br />ᐸ128.1ᐳ"}}:::plan
+    PgUnionAllSingle128 --> Access129
+    PgSelect132[["PgSelect[132∈11]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"]]:::plan
+    Access131{{"Access[131∈11]<br />ᐸ130.0ᐳ"}}:::plan
+    Object18 & Access131 --> PgSelect132
+    PgSelect145[["PgSelect[145∈11]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳAwsApplicationᐳThirdPartyVulnerability"]]:::plan
+    Access144{{"Access[144∈11]<br />ᐸ143.0ᐳ"}}:::plan
+    Object18 & Access144 --> PgSelect145
+    JSONParse130[["JSONParse[130∈11]<br />ᐸ129ᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"]]:::plan
+    Access129 --> JSONParse130
+    JSONParse130 --> Access131
+    First136{{"First[136∈11]"}}:::plan
+    PgSelect132 --> First136
+    PgSelectSingle137{{"PgSelectSingle[137∈11]<br />ᐸfirst_party_vulnerabilitiesᐳ"}}:::plan
+    First136 --> PgSelectSingle137
+    PgClassExpression138{{"PgClassExpression[138∈11]<br />ᐸ__first_pa...team_name”ᐳ"}}:::plan
+    PgSelectSingle137 --> PgClassExpression138
+    PgClassExpression139{{"PgClassExpression[139∈11]<br />ᐸ__first_pa...ies__.”id”ᐳ"}}:::plan
+    PgSelectSingle137 --> PgClassExpression139
+    PgClassExpression140{{"PgClassExpression[140∈11]<br />ᐸ__first_pa...vss_score”ᐳ"}}:::plan
+    PgSelectSingle137 --> PgClassExpression140
+    PgClassExpression141{{"PgClassExpression[141∈11]<br />ᐸ__first_pa...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle137 --> PgClassExpression141
+    JSONParse143[["JSONParse[143∈11]<br />ᐸ129ᐳ<br />ᐳAwsApplicationᐳThirdPartyVulnerability"]]:::plan
+    Access129 --> JSONParse143
+    JSONParse143 --> Access144
+    First149{{"First[149∈11]"}}:::plan
+    PgSelect145 --> First149
+    PgSelectSingle150{{"PgSelectSingle[150∈11]<br />ᐸthird_party_vulnerabilitiesᐳ"}}:::plan
+    First149 --> PgSelectSingle150
+    PgClassExpression151{{"PgClassExpression[151∈11]<br />ᐸ__third_pa...ndor_name”ᐳ"}}:::plan
+    PgSelectSingle150 --> PgClassExpression151
+    PgClassExpression152{{"PgClassExpression[152∈11]<br />ᐸ__third_pa...ies__.”id”ᐳ"}}:::plan
+    PgSelectSingle150 --> PgClassExpression152
+    PgClassExpression153{{"PgClassExpression[153∈11]<br />ᐸ__third_pa...vss_score”ᐳ"}}:::plan
+    PgSelectSingle150 --> PgClassExpression153
+    PgClassExpression154{{"PgClassExpression[154∈11]<br />ᐸ__third_pa...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle150 --> PgClassExpression154
+    __Item175[/"__Item[175∈12]<br />ᐸ174ᐳ"\]:::itemplan
+    PgUnionAll174 ==> __Item175
+    PgUnionAllSingle176["PgUnionAllSingle[176∈12]"]:::plan
+    __Item175 --> PgUnionAllSingle176
+    List180{{"List[180∈13]<br />ᐸ178,179ᐳ<br />ᐳAwsApplication"}}:::plan
+    Access178{{"Access[178∈13]<br />ᐸ176.0ᐳ"}}:::plan
+    Access179{{"Access[179∈13]<br />ᐸ176.1ᐳ"}}:::plan
+    Access178 & Access179 --> List180
+    PgCursor177{{"PgCursor[177∈13]"}}:::plan
+    List180 --> PgCursor177
+    PgUnionAllSingle176 --> Access178
+    PgUnionAllSingle176 --> Access179
+    PgSelect184[["PgSelect[184∈14]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"]]:::plan
+    Access183{{"Access[183∈14]<br />ᐸ182.0ᐳ"}}:::plan
+    Object18 & Access183 --> PgSelect184
+    PgSelect196[["PgSelect[196∈14]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳAwsApplicationᐳThirdPartyVulnerability"]]:::plan
+    Access195{{"Access[195∈14]<br />ᐸ194.0ᐳ"}}:::plan
+    Object18 & Access195 --> PgSelect196
+    JSONParse182[["JSONParse[182∈14]<br />ᐸ179ᐳ<br />ᐳAwsApplicationᐳFirstPartyVulnerability"]]:::plan
+    Access179 --> JSONParse182
+    JSONParse182 --> Access183
+    First188{{"First[188∈14]"}}:::plan
+    PgSelect184 --> First188
+    PgSelectSingle189{{"PgSelectSingle[189∈14]<br />ᐸfirst_party_vulnerabilitiesᐳ"}}:::plan
+    First188 --> PgSelectSingle189
+    PgClassExpression190{{"PgClassExpression[190∈14]<br />ᐸ__first_pa...vss_score”ᐳ"}}:::plan
+    PgSelectSingle189 --> PgClassExpression190
+    PgClassExpression191{{"PgClassExpression[191∈14]<br />ᐸ__first_pa...ies__.”id”ᐳ"}}:::plan
+    PgSelectSingle189 --> PgClassExpression191
+    PgClassExpression192{{"PgClassExpression[192∈14]<br />ᐸ__first_pa...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle189 --> PgClassExpression192
+    JSONParse194[["JSONParse[194∈14]<br />ᐸ179ᐳ<br />ᐳAwsApplicationᐳThirdPartyVulnerability"]]:::plan
+    Access179 --> JSONParse194
+    JSONParse194 --> Access195
+    First200{{"First[200∈14]"}}:::plan
+    PgSelect196 --> First200
+    PgSelectSingle201{{"PgSelectSingle[201∈14]<br />ᐸthird_party_vulnerabilitiesᐳ"}}:::plan
+    First200 --> PgSelectSingle201
+    PgClassExpression202{{"PgClassExpression[202∈14]<br />ᐸ__third_pa...vss_score”ᐳ"}}:::plan
+    PgSelectSingle201 --> PgClassExpression202
+    PgClassExpression203{{"PgClassExpression[203∈14]<br />ᐸ__third_pa...ies__.”id”ᐳ"}}:::plan
+    PgSelectSingle201 --> PgClassExpression203
+    PgClassExpression204{{"PgClassExpression[204∈14]<br />ᐸ__third_pa...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle201 --> PgClassExpression204
+    PgSelect228[["PgSelect[228∈15]<br />ᐸorganizationsᐳ<br />ᐳGcpApplicationᐳOrganization"]]:::plan
+    Access227{{"Access[227∈15]<br />ᐸ226.0ᐳ"}}:::plan
+    Object18 & Access227 --> PgSelect228
+    PgSelect239[["PgSelect[239∈15]<br />ᐸpeopleᐳ<br />ᐳGcpApplicationᐳPerson"]]:::plan
+    Access238{{"Access[238∈15]<br />ᐸ237.0ᐳ"}}:::plan
+    Object18 & Access238 --> PgSelect239
+    JSONParse226[["JSONParse[226∈15]<br />ᐸ225ᐳ<br />ᐳGcpApplicationᐳOrganization"]]:::plan
+    Access225 --> JSONParse226
+    JSONParse226 --> Access227
+    First232{{"First[232∈15]"}}:::plan
+    PgSelect228 --> First232
+    PgSelectSingle233{{"PgSelectSingle[233∈15]<br />ᐸorganizationsᐳ"}}:::plan
+    First232 --> PgSelectSingle233
+    PgClassExpression234{{"PgClassExpression[234∈15]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
+    PgSelectSingle233 --> PgClassExpression234
+    PgClassExpression235{{"PgClassExpression[235∈15]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle233 --> PgClassExpression235
+    JSONParse237[["JSONParse[237∈15]<br />ᐸ225ᐳ<br />ᐳGcpApplicationᐳPerson"]]:::plan
+    Access225 --> JSONParse237
+    JSONParse237 --> Access238
+    First243{{"First[243∈15]"}}:::plan
+    PgSelect239 --> First243
+    PgSelectSingle244{{"PgSelectSingle[244∈15]<br />ᐸpeopleᐳ"}}:::plan
+    First243 --> PgSelectSingle244
+    PgClassExpression245{{"PgClassExpression[245∈15]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
+    PgSelectSingle244 --> PgClassExpression245
+    PgClassExpression246{{"PgClassExpression[246∈15]<br />ᐸ__people__.”username”ᐳ"}}:::plan
+    PgSelectSingle244 --> PgClassExpression246
+    __Item258[/"__Item[258∈16]<br />ᐸ254ᐳ"\]:::itemplan
+    PgUnionAll254 ==> __Item258
+    PgUnionAllSingle259["PgUnionAllSingle[259∈16]"]:::plan
+    __Item258 --> PgUnionAllSingle259
+    Access260{{"Access[260∈16]<br />ᐸ259.1ᐳ"}}:::plan
+    PgUnionAllSingle259 --> Access260
+    PgSelect263[["PgSelect[263∈17]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"]]:::plan
+    Access262{{"Access[262∈17]<br />ᐸ261.0ᐳ"}}:::plan
+    Object18 & Access262 --> PgSelect263
+    PgSelect276[["PgSelect[276∈17]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳGcpApplicationᐳThirdPartyVulnerability"]]:::plan
+    Access275{{"Access[275∈17]<br />ᐸ274.0ᐳ"}}:::plan
+    Object18 & Access275 --> PgSelect276
+    JSONParse261[["JSONParse[261∈17]<br />ᐸ260ᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"]]:::plan
+    Access260 --> JSONParse261
+    JSONParse261 --> Access262
+    First267{{"First[267∈17]"}}:::plan
+    PgSelect263 --> First267
+    PgSelectSingle268{{"PgSelectSingle[268∈17]<br />ᐸfirst_party_vulnerabilitiesᐳ"}}:::plan
+    First267 --> PgSelectSingle268
+    PgClassExpression269{{"PgClassExpression[269∈17]<br />ᐸ__first_pa...team_name”ᐳ"}}:::plan
+    PgSelectSingle268 --> PgClassExpression269
+    PgClassExpression270{{"PgClassExpression[270∈17]<br />ᐸ__first_pa...ies__.”id”ᐳ"}}:::plan
+    PgSelectSingle268 --> PgClassExpression270
+    PgClassExpression271{{"PgClassExpression[271∈17]<br />ᐸ__first_pa...vss_score”ᐳ"}}:::plan
+    PgSelectSingle268 --> PgClassExpression271
+    PgClassExpression272{{"PgClassExpression[272∈17]<br />ᐸ__first_pa...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle268 --> PgClassExpression272
+    JSONParse274[["JSONParse[274∈17]<br />ᐸ260ᐳ<br />ᐳGcpApplicationᐳThirdPartyVulnerability"]]:::plan
+    Access260 --> JSONParse274
+    JSONParse274 --> Access275
+    First280{{"First[280∈17]"}}:::plan
+    PgSelect276 --> First280
+    PgSelectSingle281{{"PgSelectSingle[281∈17]<br />ᐸthird_party_vulnerabilitiesᐳ"}}:::plan
+    First280 --> PgSelectSingle281
+    PgClassExpression282{{"PgClassExpression[282∈17]<br />ᐸ__third_pa...ndor_name”ᐳ"}}:::plan
+    PgSelectSingle281 --> PgClassExpression282
+    PgClassExpression283{{"PgClassExpression[283∈17]<br />ᐸ__third_pa...ies__.”id”ᐳ"}}:::plan
+    PgSelectSingle281 --> PgClassExpression283
+    PgClassExpression284{{"PgClassExpression[284∈17]<br />ᐸ__third_pa...vss_score”ᐳ"}}:::plan
+    PgSelectSingle281 --> PgClassExpression284
+    PgClassExpression285{{"PgClassExpression[285∈17]<br />ᐸ__third_pa...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle281 --> PgClassExpression285
+    __Item306[/"__Item[306∈18]<br />ᐸ305ᐳ"\]:::itemplan
+    PgUnionAll305 ==> __Item306
+    PgUnionAllSingle307["PgUnionAllSingle[307∈18]"]:::plan
+    __Item306 --> PgUnionAllSingle307
+    List311{{"List[311∈19]<br />ᐸ309,310ᐳ<br />ᐳGcpApplication"}}:::plan
+    Access309{{"Access[309∈19]<br />ᐸ307.0ᐳ"}}:::plan
+    Access310{{"Access[310∈19]<br />ᐸ307.1ᐳ"}}:::plan
+    Access309 & Access310 --> List311
+    PgCursor308{{"PgCursor[308∈19]"}}:::plan
+    List311 --> PgCursor308
+    PgUnionAllSingle307 --> Access309
+    PgUnionAllSingle307 --> Access310
+    PgSelect315[["PgSelect[315∈20]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"]]:::plan
+    Access314{{"Access[314∈20]<br />ᐸ313.0ᐳ"}}:::plan
+    Object18 & Access314 --> PgSelect315
+    PgSelect327[["PgSelect[327∈20]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳGcpApplicationᐳThirdPartyVulnerability"]]:::plan
+    Access326{{"Access[326∈20]<br />ᐸ325.0ᐳ"}}:::plan
+    Object18 & Access326 --> PgSelect327
+    JSONParse313[["JSONParse[313∈20]<br />ᐸ310ᐳ<br />ᐳGcpApplicationᐳFirstPartyVulnerability"]]:::plan
+    Access310 --> JSONParse313
+    JSONParse313 --> Access314
+    First319{{"First[319∈20]"}}:::plan
+    PgSelect315 --> First319
+    PgSelectSingle320{{"PgSelectSingle[320∈20]<br />ᐸfirst_party_vulnerabilitiesᐳ"}}:::plan
+    First319 --> PgSelectSingle320
+    PgClassExpression321{{"PgClassExpression[321∈20]<br />ᐸ__first_pa...vss_score”ᐳ"}}:::plan
+    PgSelectSingle320 --> PgClassExpression321
+    PgClassExpression322{{"PgClassExpression[322∈20]<br />ᐸ__first_pa...ies__.”id”ᐳ"}}:::plan
+    PgSelectSingle320 --> PgClassExpression322
+    PgClassExpression323{{"PgClassExpression[323∈20]<br />ᐸ__first_pa...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle320 --> PgClassExpression323
+    JSONParse325[["JSONParse[325∈20]<br />ᐸ310ᐳ<br />ᐳGcpApplicationᐳThirdPartyVulnerability"]]:::plan
+    Access310 --> JSONParse325
+    JSONParse325 --> Access326
+    First331{{"First[331∈20]"}}:::plan
+    PgSelect327 --> First331
+    PgSelectSingle332{{"PgSelectSingle[332∈20]<br />ᐸthird_party_vulnerabilitiesᐳ"}}:::plan
+    First331 --> PgSelectSingle332
+    PgClassExpression333{{"PgClassExpression[333∈20]<br />ᐸ__third_pa...vss_score”ᐳ"}}:::plan
+    PgSelectSingle332 --> PgClassExpression333
+    PgClassExpression334{{"PgClassExpression[334∈20]<br />ᐸ__third_pa...ies__.”id”ᐳ"}}:::plan
+    PgSelectSingle332 --> PgClassExpression334
+    PgClassExpression335{{"PgClassExpression[335∈20]<br />ᐸ__third_pa...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle332 --> PgClassExpression335
 
     %% define steps
 
     subgraph "Buckets for queries/polymorphic/person-app-vulns"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value3,__Value5,Access16,Access17,Object18,Connection19,Constant331 bucket0
+    class Bucket0,__Value0,__Value3,__Value5,Access16,Access17,Object18,Connection19,Constant336 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 18, 19<br /><br />ROOT Connectionᐸ15ᐳ[19]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect20,Connection38 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 18, 38<br /><br />ROOT __Item{2}ᐸ20ᐳ[21]"):::bucket
+    class Bucket1,PgSelect20,Connection39 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 18, 39<br /><br />ROOT __Item{2}ᐸ20ᐳ[21]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item21,PgSelectSingle22 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 22, 18, 38<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[22]<br />1: <br />ᐳ: 23, 24<br />2: 39, 43, 70<br />ᐳ: First[40]<br />3: PgUnionAllSingle[41]<br />ᐳ: PgClassExpression[42]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 22, 18, 39<br /><br />ROOT PgSelectSingle{2}ᐸpeopleᐳ[22]<br />1: <br />ᐳ: 23, 24<br />2: 40, 44, 71<br />ᐳ: First[41]<br />3: PgUnionAllSingle[42]<br />ᐳ: PgClassExpression[43]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression23,PgClassExpression24,PgUnionAll39,First40,PgUnionAllSingle41,PgClassExpression42,PgUnionAll43,PgUnionAll70 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 18<br /><br />ROOT __Item{4}ᐸ43ᐳ[44]"):::bucket
+    class Bucket3,PgClassExpression23,PgClassExpression24,PgUnionAll40,First41,PgUnionAllSingle42,PgClassExpression43,PgUnionAll44,PgUnionAll71 bucket3
+    Bucket4("Bucket 4 (listItem)<br />Deps: 18<br /><br />ROOT __Item{4}ᐸ44ᐳ[45]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item44,PgUnionAllSingle45 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 45, 18<br /><br />ROOT PgUnionAllSingle{4}[45]"):::bucket
+    class Bucket4,__Item45,PgUnionAllSingle46 bucket4
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 46, 18<br /><br />ROOT PgUnionAllSingle{4}[46]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgCursor46,Access47,Access48,List49 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 48, 18, 45<br />ᐳAwsApplication<br />ᐳGcpApplication<br />1: JSONParse[51], JSONParse[61]<br />ᐳ: Access[52], Access[62]<br />2: PgSelect[53], PgSelect[63]<br />ᐳ: 57, 58, 59, 67, 68, 69"):::bucket
+    class Bucket5,PgCursor47,Access48,Access49,List50 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 49, 18, 46<br />ᐳAwsApplication<br />ᐳGcpApplication<br />1: JSONParse[52], JSONParse[62]<br />ᐳ: Access[53], Access[63]<br />2: PgSelect[54], PgSelect[64]<br />ᐳ: 58, 59, 60, 68, 69, 70"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,JSONParse51,Access52,PgSelect53,First57,PgSelectSingle58,PgClassExpression59,JSONParse61,Access62,PgSelect63,First67,PgSelectSingle68,PgClassExpression69 bucket6
-    Bucket7("Bucket 7 (listItem)<br />Deps: 18<br /><br />ROOT __Item{7}ᐸ70ᐳ[71]"):::bucket
+    class Bucket6,JSONParse52,Access53,PgSelect54,First58,PgSelectSingle59,PgClassExpression60,JSONParse62,Access63,PgSelect64,First68,PgSelectSingle69,PgClassExpression70 bucket6
+    Bucket7("Bucket 7 (listItem)<br />Deps: 18<br /><br />ROOT __Item{7}ᐸ71ᐳ[72]"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,__Item71,PgUnionAllSingle72,Access73 bucket7
-    Bucket8("Bucket 8 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 73, 18, 72<br />ᐳAwsApplication<br />ᐳGcpApplication<br />1: JSONParse[74], JSONParse[203]<br />ᐳ: 166, 295, 75, 204<br />2: PgSelect[76], PgSelect[205]<br />ᐳ: 80, 81, 82, 83, 84, 85, 86, 209, 210, 211, 212, 213, 214, 215<br />3: 87, 121, 167, 171, 216, 250, 296, 300<br />ᐳ: 91, 168, 220, 297<br />4: 92, 169, 221, 298<br />ᐳ: 93, 170, 222, 299"):::bucket
+    class Bucket7,__Item72,PgUnionAllSingle73,Access74 bucket7
+    Bucket8("Bucket 8 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 74, 18, 73<br />ᐳAwsApplication<br />ᐳGcpApplication<br />1: JSONParse[75], JSONParse[206]<br />ᐳ: 169, 300, 76, 207<br />2: PgSelect[77], PgSelect[208]<br />ᐳ: 81, 82, 83, 84, 85, 86, 87, 212, 213, 214, 215, 216, 217, 218<br />3: 88, 123, 170, 174, 219, 254, 301, 305<br />ᐳ: 92, 171, 223, 302<br />4: 93, 172, 224, 303<br />ᐳ: 94, 173, 225, 304"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,JSONParse74,Access75,PgSelect76,First80,PgSelectSingle81,PgClassExpression82,PgClassExpression83,PgClassExpression84,PgClassExpression85,PgClassExpression86,PgUnionAll87,First91,PgUnionAllSingle92,Access93,PgUnionAll121,Connection166,PgUnionAll167,First168,PgUnionAllSingle169,PgClassExpression170,PgUnionAll171,JSONParse203,Access204,PgSelect205,First209,PgSelectSingle210,PgClassExpression211,PgClassExpression212,PgClassExpression213,PgClassExpression214,PgClassExpression215,PgUnionAll216,First220,PgUnionAllSingle221,Access222,PgUnionAll250,Connection295,PgUnionAll296,First297,PgUnionAllSingle298,PgClassExpression299,PgUnionAll300 bucket8
-    Bucket9("Bucket 9 (polymorphic)<br />Organization,Person<br />Deps: 93, 18, 92<br />ᐳAwsApplicationᐳOrganization<br />ᐳAwsApplicationᐳPerson<br />1: JSONParse[94], JSONParse[105]<br />ᐳ: Access[95], Access[106]<br />2: PgSelect[96], PgSelect[107]<br />ᐳ: 100, 101, 102, 103, 111, 112, 113, 114"):::bucket
+    class Bucket8,JSONParse75,Access76,PgSelect77,First81,PgSelectSingle82,PgClassExpression83,PgClassExpression84,PgClassExpression85,PgClassExpression86,PgClassExpression87,PgUnionAll88,First92,PgUnionAllSingle93,Access94,PgUnionAll123,Connection169,PgUnionAll170,First171,PgUnionAllSingle172,PgClassExpression173,PgUnionAll174,JSONParse206,Access207,PgSelect208,First212,PgSelectSingle213,PgClassExpression214,PgClassExpression215,PgClassExpression216,PgClassExpression217,PgClassExpression218,PgUnionAll219,First223,PgUnionAllSingle224,Access225,PgUnionAll254,Connection300,PgUnionAll301,First302,PgUnionAllSingle303,PgClassExpression304,PgUnionAll305 bucket8
+    Bucket9("Bucket 9 (polymorphic)<br />Organization,Person<br />Deps: 94, 18, 93<br />ᐳAwsApplicationᐳOrganization<br />ᐳAwsApplicationᐳPerson<br />1: JSONParse[95], JSONParse[106]<br />ᐳ: Access[96], Access[107]<br />2: PgSelect[97], PgSelect[108]<br />ᐳ: 101, 102, 103, 104, 112, 113, 114, 115"):::bucket
     classDef bucket9 stroke:#ff0000
-    class Bucket9,JSONParse94,Access95,PgSelect96,First100,PgSelectSingle101,PgClassExpression102,PgClassExpression103,JSONParse105,Access106,PgSelect107,First111,PgSelectSingle112,PgClassExpression113,PgClassExpression114 bucket9
-    Bucket10("Bucket 10 (listItem)<br />Deps: 18<br /><br />ROOT __Item{10}ᐸ121ᐳ[125]"):::bucket
+    class Bucket9,JSONParse95,Access96,PgSelect97,First101,PgSelectSingle102,PgClassExpression103,PgClassExpression104,JSONParse106,Access107,PgSelect108,First112,PgSelectSingle113,PgClassExpression114,PgClassExpression115 bucket9
+    Bucket10("Bucket 10 (listItem)<br />Deps: 18<br /><br />ROOT __Item{10}ᐸ123ᐳ[127]"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,__Item125,PgUnionAllSingle126,Access127 bucket10
-    Bucket11("Bucket 11 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 127, 18, 126<br />ᐳAwsApplicationᐳFirstPartyVulnerability<br />ᐳAwsApplicationᐳThirdPartyVulnerability<br />1: JSONParse[128], JSONParse[141]<br />ᐳ: Access[129], Access[142]<br />2: PgSelect[130], PgSelect[143]<br />ᐳ: 134, 135, 136, 137, 138, 139, 147, 148, 149, 150, 151, 152"):::bucket
+    class Bucket10,__Item127,PgUnionAllSingle128,Access129 bucket10
+    Bucket11("Bucket 11 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 129, 18, 128<br />ᐳAwsApplicationᐳFirstPartyVulnerability<br />ᐳAwsApplicationᐳThirdPartyVulnerability<br />1: JSONParse[130], JSONParse[143]<br />ᐳ: Access[131], Access[144]<br />2: PgSelect[132], PgSelect[145]<br />ᐳ: 136, 137, 138, 139, 140, 141, 149, 150, 151, 152, 153, 154"):::bucket
     classDef bucket11 stroke:#00ffff
-    class Bucket11,JSONParse128,Access129,PgSelect130,First134,PgSelectSingle135,PgClassExpression136,PgClassExpression137,PgClassExpression138,PgClassExpression139,JSONParse141,Access142,PgSelect143,First147,PgSelectSingle148,PgClassExpression149,PgClassExpression150,PgClassExpression151,PgClassExpression152 bucket11
-    Bucket12("Bucket 12 (listItem)<br />Deps: 18<br /><br />ROOT __Item{12}ᐸ171ᐳ[172]"):::bucket
+    class Bucket11,JSONParse130,Access131,PgSelect132,First136,PgSelectSingle137,PgClassExpression138,PgClassExpression139,PgClassExpression140,PgClassExpression141,JSONParse143,Access144,PgSelect145,First149,PgSelectSingle150,PgClassExpression151,PgClassExpression152,PgClassExpression153,PgClassExpression154 bucket11
+    Bucket12("Bucket 12 (listItem)<br />Deps: 18<br /><br />ROOT __Item{12}ᐸ174ᐳ[175]"):::bucket
     classDef bucket12 stroke:#4169e1
-    class Bucket12,__Item172,PgUnionAllSingle173 bucket12
-    Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 173, 18<br /><br />ROOT PgUnionAllSingle{12}[173]"):::bucket
+    class Bucket12,__Item175,PgUnionAllSingle176 bucket12
+    Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 176, 18<br /><br />ROOT PgUnionAllSingle{12}[176]"):::bucket
     classDef bucket13 stroke:#3cb371
-    class Bucket13,PgCursor174,Access175,Access176,List177 bucket13
-    Bucket14("Bucket 14 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 176, 18, 173<br />ᐳAwsApplicationᐳFirstPartyVulnerability<br />ᐳAwsApplicationᐳThirdPartyVulnerability<br />1: JSONParse[179], JSONParse[191]<br />ᐳ: Access[180], Access[192]<br />2: PgSelect[181], PgSelect[193]<br />ᐳ: 185, 186, 187, 188, 189, 197, 198, 199, 200, 201"):::bucket
+    class Bucket13,PgCursor177,Access178,Access179,List180 bucket13
+    Bucket14("Bucket 14 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 179, 18, 176<br />ᐳAwsApplicationᐳFirstPartyVulnerability<br />ᐳAwsApplicationᐳThirdPartyVulnerability<br />1: JSONParse[182], JSONParse[194]<br />ᐳ: Access[183], Access[195]<br />2: PgSelect[184], PgSelect[196]<br />ᐳ: 188, 189, 190, 191, 192, 200, 201, 202, 203, 204"):::bucket
     classDef bucket14 stroke:#a52a2a
-    class Bucket14,JSONParse179,Access180,PgSelect181,First185,PgSelectSingle186,PgClassExpression187,PgClassExpression188,PgClassExpression189,JSONParse191,Access192,PgSelect193,First197,PgSelectSingle198,PgClassExpression199,PgClassExpression200,PgClassExpression201 bucket14
-    Bucket15("Bucket 15 (polymorphic)<br />Organization,Person<br />Deps: 222, 18, 221<br />ᐳGcpApplicationᐳOrganization<br />ᐳGcpApplicationᐳPerson<br />1: JSONParse[223], JSONParse[234]<br />ᐳ: Access[224], Access[235]<br />2: PgSelect[225], PgSelect[236]<br />ᐳ: 229, 230, 231, 232, 240, 241, 242, 243"):::bucket
+    class Bucket14,JSONParse182,Access183,PgSelect184,First188,PgSelectSingle189,PgClassExpression190,PgClassExpression191,PgClassExpression192,JSONParse194,Access195,PgSelect196,First200,PgSelectSingle201,PgClassExpression202,PgClassExpression203,PgClassExpression204 bucket14
+    Bucket15("Bucket 15 (polymorphic)<br />Organization,Person<br />Deps: 225, 18, 224<br />ᐳGcpApplicationᐳOrganization<br />ᐳGcpApplicationᐳPerson<br />1: JSONParse[226], JSONParse[237]<br />ᐳ: Access[227], Access[238]<br />2: PgSelect[228], PgSelect[239]<br />ᐳ: 232, 233, 234, 235, 243, 244, 245, 246"):::bucket
     classDef bucket15 stroke:#ff00ff
-    class Bucket15,JSONParse223,Access224,PgSelect225,First229,PgSelectSingle230,PgClassExpression231,PgClassExpression232,JSONParse234,Access235,PgSelect236,First240,PgSelectSingle241,PgClassExpression242,PgClassExpression243 bucket15
-    Bucket16("Bucket 16 (listItem)<br />Deps: 18<br /><br />ROOT __Item{16}ᐸ250ᐳ[254]"):::bucket
+    class Bucket15,JSONParse226,Access227,PgSelect228,First232,PgSelectSingle233,PgClassExpression234,PgClassExpression235,JSONParse237,Access238,PgSelect239,First243,PgSelectSingle244,PgClassExpression245,PgClassExpression246 bucket15
+    Bucket16("Bucket 16 (listItem)<br />Deps: 18<br /><br />ROOT __Item{16}ᐸ254ᐳ[258]"):::bucket
     classDef bucket16 stroke:#f5deb3
-    class Bucket16,__Item254,PgUnionAllSingle255,Access256 bucket16
-    Bucket17("Bucket 17 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 256, 18, 255<br />ᐳGcpApplicationᐳFirstPartyVulnerability<br />ᐳGcpApplicationᐳThirdPartyVulnerability<br />1: JSONParse[257], JSONParse[270]<br />ᐳ: Access[258], Access[271]<br />2: PgSelect[259], PgSelect[272]<br />ᐳ: 263, 264, 265, 266, 267, 268, 276, 277, 278, 279, 280, 281"):::bucket
+    class Bucket16,__Item258,PgUnionAllSingle259,Access260 bucket16
+    Bucket17("Bucket 17 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 260, 18, 259<br />ᐳGcpApplicationᐳFirstPartyVulnerability<br />ᐳGcpApplicationᐳThirdPartyVulnerability<br />1: JSONParse[261], JSONParse[274]<br />ᐳ: Access[262], Access[275]<br />2: PgSelect[263], PgSelect[276]<br />ᐳ: 267, 268, 269, 270, 271, 272, 280, 281, 282, 283, 284, 285"):::bucket
     classDef bucket17 stroke:#696969
-    class Bucket17,JSONParse257,Access258,PgSelect259,First263,PgSelectSingle264,PgClassExpression265,PgClassExpression266,PgClassExpression267,PgClassExpression268,JSONParse270,Access271,PgSelect272,First276,PgSelectSingle277,PgClassExpression278,PgClassExpression279,PgClassExpression280,PgClassExpression281 bucket17
-    Bucket18("Bucket 18 (listItem)<br />Deps: 18<br /><br />ROOT __Item{18}ᐸ300ᐳ[301]"):::bucket
+    class Bucket17,JSONParse261,Access262,PgSelect263,First267,PgSelectSingle268,PgClassExpression269,PgClassExpression270,PgClassExpression271,PgClassExpression272,JSONParse274,Access275,PgSelect276,First280,PgSelectSingle281,PgClassExpression282,PgClassExpression283,PgClassExpression284,PgClassExpression285 bucket17
+    Bucket18("Bucket 18 (listItem)<br />Deps: 18<br /><br />ROOT __Item{18}ᐸ305ᐳ[306]"):::bucket
     classDef bucket18 stroke:#00bfff
-    class Bucket18,__Item301,PgUnionAllSingle302 bucket18
-    Bucket19("Bucket 19 (nullableBoundary)<br />Deps: 302, 18<br /><br />ROOT PgUnionAllSingle{18}[302]"):::bucket
+    class Bucket18,__Item306,PgUnionAllSingle307 bucket18
+    Bucket19("Bucket 19 (nullableBoundary)<br />Deps: 307, 18<br /><br />ROOT PgUnionAllSingle{18}[307]"):::bucket
     classDef bucket19 stroke:#7f007f
-    class Bucket19,PgCursor303,Access304,Access305,List306 bucket19
-    Bucket20("Bucket 20 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 305, 18, 302<br />ᐳGcpApplicationᐳFirstPartyVulnerability<br />ᐳGcpApplicationᐳThirdPartyVulnerability<br />1: JSONParse[308], JSONParse[320]<br />ᐳ: Access[309], Access[321]<br />2: PgSelect[310], PgSelect[322]<br />ᐳ: 314, 315, 316, 317, 318, 326, 327, 328, 329, 330"):::bucket
+    class Bucket19,PgCursor308,Access309,Access310,List311 bucket19
+    Bucket20("Bucket 20 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 310, 18, 307<br />ᐳGcpApplicationᐳFirstPartyVulnerability<br />ᐳGcpApplicationᐳThirdPartyVulnerability<br />1: JSONParse[313], JSONParse[325]<br />ᐳ: Access[314], Access[326]<br />2: PgSelect[315], PgSelect[327]<br />ᐳ: 319, 320, 321, 322, 323, 331, 332, 333, 334, 335"):::bucket
     classDef bucket20 stroke:#ffa500
-    class Bucket20,JSONParse308,Access309,PgSelect310,First314,PgSelectSingle315,PgClassExpression316,PgClassExpression317,PgClassExpression318,JSONParse320,Access321,PgSelect322,First326,PgSelectSingle327,PgClassExpression328,PgClassExpression329,PgClassExpression330 bucket20
+    class Bucket20,JSONParse313,Access314,PgSelect315,First319,PgSelectSingle320,PgClassExpression321,PgClassExpression322,PgClassExpression323,JSONParse325,Access326,PgSelect327,First331,PgSelectSingle332,PgClassExpression333,PgClassExpression334,PgClassExpression335 bucket20
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.mermaid
@@ -9,197 +9,197 @@ graph TD
 
 
     %% plan dependencies
-    Connection19{{"Connection[19∈0]<br />ᐸ15ᐳ"}}:::plan
-    Constant138{{"Constant[138∈0]<br />ᐸ3ᐳ"}}:::plan
-    Lambda20{{"Lambda[20∈0]<br />ᐸparseCursorᐳ"}}:::plan
-    PgValidateParsedCursor25["PgValidateParsedCursor[25∈0]"]:::plan
-    Constant138 & Lambda20 & PgValidateParsedCursor25 & PgValidateParsedCursor25 & PgValidateParsedCursor25 & PgValidateParsedCursor25 --> Connection19
-    Object18{{"Object[18∈0]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Access16{{"Access[16∈0]<br />ᐸ3.pgSettingsᐳ"}}:::plan
-    Access17{{"Access[17∈0]<br />ᐸ3.withPgClientᐳ"}}:::plan
-    Access16 & Access17 --> Object18
+    Connection20{{"Connection[20∈0]<br />ᐸ16ᐳ"}}:::plan
+    Constant140{{"Constant[140∈0]<br />ᐸ3ᐳ"}}:::plan
+    Lambda21{{"Lambda[21∈0]<br />ᐸparseCursorᐳ"}}:::plan
+    PgValidateParsedCursor26["PgValidateParsedCursor[26∈0]"]:::plan
+    Constant140 & Lambda21 & PgValidateParsedCursor26 & PgValidateParsedCursor26 & PgValidateParsedCursor26 & PgValidateParsedCursor26 --> Connection20
+    Object19{{"Object[19∈0]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access17{{"Access[17∈0]<br />ᐸ3.pgSettingsᐳ"}}:::plan
+    Access18{{"Access[18∈0]<br />ᐸ3.withPgClientᐳ"}}:::plan
+    Access17 & Access18 --> Object19
     __Value3["__Value[3∈0]<br />ᐸcontextᐳ"]:::plan
-    __Value3 --> Access16
     __Value3 --> Access17
-    Constant139{{"Constant[139∈0]<br />ᐸ'WyIzMDY3N2Q5ZTIyIiwiMTAiLCJUaGlyZFBhcnR5VnVsbmVyYWJpbGl0eSIᐳ"}}:::plan
-    Constant139 --> Lambda20
-    Lambda20 --> PgValidateParsedCursor25
-    PgUnionAll101[["PgUnionAll[101∈0]"]]:::plan
-    Object18 --> PgUnionAll101
+    __Value3 --> Access18
+    Constant141{{"Constant[141∈0]<br />ᐸ'WyIzMDY3N2Q5ZTIyIiwiMTAiLCJUaGlyZFBhcnR5VnVsbmVyYWJpbGl0eSIᐳ"}}:::plan
+    Constant141 --> Lambda21
+    Lambda21 --> PgValidateParsedCursor26
+    PgUnionAll103[["PgUnionAll[103∈0]"]]:::plan
+    Object19 --> PgUnionAll103
     __Value0["__Value[0∈0]"]:::plan
     __Value5["__Value[5∈0]<br />ᐸrootValueᐳ"]:::plan
-    PgUnionAll21[["PgUnionAll[21∈1]"]]:::plan
-    ToPg27{{"ToPg[27∈1]"}}:::plan
-    ToPg29{{"ToPg[29∈1]"}}:::plan
-    Access30{{"Access[30∈1]<br />ᐸ20.3ᐳ"}}:::plan
-    Object18 & Connection19 & Lambda20 & ToPg27 & ToPg29 & Access30 --> PgUnionAll21
-    PgUnionAll65[["PgUnionAll[65∈1]"]]:::plan
-    Object18 & Connection19 & Lambda20 & ToPg27 & ToPg29 & Access30 --> PgUnionAll65
-    PgUnionAll79[["PgUnionAll[79∈1]"]]:::plan
-    Object18 & Connection19 & Lambda20 & ToPg27 & ToPg29 & Access30 --> PgUnionAll79
-    PgUnionAll93[["PgUnionAll[93∈1]"]]:::plan
-    Object18 & Connection19 & Lambda20 & ToPg27 & ToPg29 & Access30 --> PgUnionAll93
-    List78{{"List[78∈1]<br />ᐸ75,76,77ᐳ"}}:::plan
-    Access75{{"Access[75∈1]<br />ᐸ67.0ᐳ"}}:::plan
-    Access76{{"Access[76∈1]<br />ᐸ67.1ᐳ"}}:::plan
-    Access77{{"Access[77∈1]<br />ᐸ67.2ᐳ"}}:::plan
-    Access75 & Access76 & Access77 --> List78
-    List92{{"List[92∈1]<br />ᐸ89,90,91ᐳ"}}:::plan
-    Access89{{"Access[89∈1]<br />ᐸ81.0ᐳ"}}:::plan
-    Access90{{"Access[90∈1]<br />ᐸ81.1ᐳ"}}:::plan
-    Access91{{"Access[91∈1]<br />ᐸ81.2ᐳ"}}:::plan
-    Access89 & Access90 & Access91 --> List92
-    PgUnionAll60[["PgUnionAll[60∈1]"]]:::plan
-    Object18 & Connection19 --> PgUnionAll60
-    Access26{{"Access[26∈1]<br />ᐸ20.1ᐳ"}}:::plan
-    Lambda20 --> Access26
-    Access26 --> ToPg27
-    Access28{{"Access[28∈1]<br />ᐸ20.2ᐳ"}}:::plan
-    Lambda20 --> Access28
-    Access28 --> ToPg29
-    Lambda20 --> Access30
-    First61{{"First[61∈1]"}}:::plan
-    PgUnionAll60 --> First61
-    PgUnionAllSingle62["PgUnionAllSingle[62∈1]"]:::plan
-    First61 --> PgUnionAllSingle62
-    PgClassExpression63{{"PgClassExpression[63∈1]<br />ᐸcount(*)ᐳ"}}:::plan
-    PgUnionAllSingle62 --> PgClassExpression63
-    PgPageInfo64{{"PgPageInfo[64∈1]"}}:::plan
-    Connection19 --> PgPageInfo64
-    First66{{"First[66∈1]"}}:::plan
-    PgUnionAll65 --> First66
-    PgUnionAllSingle67["PgUnionAllSingle[67∈1]"]:::plan
-    First66 --> PgUnionAllSingle67
-    PgCursor68{{"PgCursor[68∈1]"}}:::plan
-    List78 --> PgCursor68
-    PgUnionAllSingle67 --> Access75
-    PgUnionAllSingle67 --> Access76
-    PgUnionAllSingle67 --> Access77
-    Last80{{"Last[80∈1]"}}:::plan
-    PgUnionAll79 --> Last80
-    PgUnionAllSingle81["PgUnionAllSingle[81∈1]"]:::plan
-    Last80 --> PgUnionAllSingle81
-    PgCursor82{{"PgCursor[82∈1]"}}:::plan
-    List92 --> PgCursor82
-    PgUnionAllSingle81 --> Access89
-    PgUnionAllSingle81 --> Access90
-    PgUnionAllSingle81 --> Access91
-    Access94{{"Access[94∈1]<br />ᐸ93.hasMoreᐳ"}}:::plan
-    PgUnionAll93 --> Access94
-    Constant95{{"Constant[95∈1]<br />ᐸfalseᐳ"}}:::plan
-    __Item22[/"__Item[22∈2]<br />ᐸ21ᐳ"\]:::itemplan
-    PgUnionAll21 ==> __Item22
-    PgUnionAllSingle23["PgUnionAllSingle[23∈2]"]:::plan
-    __Item22 --> PgUnionAllSingle23
-    List34{{"List[34∈3]<br />ᐸ31,32,33ᐳ"}}:::plan
-    Access31{{"Access[31∈3]<br />ᐸ23.0ᐳ"}}:::plan
-    Access32{{"Access[32∈3]<br />ᐸ23.1ᐳ"}}:::plan
-    Access33{{"Access[33∈3]<br />ᐸ23.2ᐳ"}}:::plan
-    Access31 & Access32 & Access33 --> List34
-    PgCursor24{{"PgCursor[24∈3]"}}:::plan
-    List34 --> PgCursor24
-    PgUnionAllSingle23 --> Access31
-    PgUnionAllSingle23 --> Access32
-    PgUnionAllSingle23 --> Access33
-    PgSelect38[["PgSelect[38∈4]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
-    Access37{{"Access[37∈4]<br />ᐸ36.0ᐳ"}}:::plan
-    Object18 & Access37 --> PgSelect38
-    PgSelect50[["PgSelect[50∈4]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
-    Access49{{"Access[49∈4]<br />ᐸ48.0ᐳ"}}:::plan
-    Object18 & Access49 --> PgSelect50
-    JSONParse36[["JSONParse[36∈4]<br />ᐸ33ᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
-    Access33 --> JSONParse36
-    JSONParse36 --> Access37
-    First42{{"First[42∈4]"}}:::plan
-    PgSelect38 --> First42
-    PgSelectSingle43{{"PgSelectSingle[43∈4]<br />ᐸfirst_party_vulnerabilitiesᐳ"}}:::plan
-    First42 --> PgSelectSingle43
-    PgClassExpression44{{"PgClassExpression[44∈4]<br />ᐸ__first_pa...ies__.”id”ᐳ"}}:::plan
-    PgSelectSingle43 --> PgClassExpression44
-    PgClassExpression45{{"PgClassExpression[45∈4]<br />ᐸ__first_pa...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle43 --> PgClassExpression45
-    PgClassExpression46{{"PgClassExpression[46∈4]<br />ᐸ__first_pa...vss_score”ᐳ"}}:::plan
-    PgSelectSingle43 --> PgClassExpression46
-    JSONParse48[["JSONParse[48∈4]<br />ᐸ33ᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
-    Access33 --> JSONParse48
-    JSONParse48 --> Access49
-    First54{{"First[54∈4]"}}:::plan
-    PgSelect50 --> First54
-    PgSelectSingle55{{"PgSelectSingle[55∈4]<br />ᐸthird_party_vulnerabilitiesᐳ"}}:::plan
-    First54 --> PgSelectSingle55
-    PgClassExpression56{{"PgClassExpression[56∈4]<br />ᐸ__third_pa...ies__.”id”ᐳ"}}:::plan
-    PgSelectSingle55 --> PgClassExpression56
-    PgClassExpression57{{"PgClassExpression[57∈4]<br />ᐸ__third_pa...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle55 --> PgClassExpression57
-    PgClassExpression58{{"PgClassExpression[58∈4]<br />ᐸ__third_pa...vss_score”ᐳ"}}:::plan
-    PgSelectSingle55 --> PgClassExpression58
-    PgClassExpression59{{"PgClassExpression[59∈4]<br />ᐸ__third_pa...ndor_name”ᐳ"}}:::plan
-    PgSelectSingle55 --> PgClassExpression59
-    __Item105[/"__Item[105∈5]<br />ᐸ101ᐳ"\]:::itemplan
-    PgUnionAll101 ==> __Item105
-    PgUnionAllSingle106["PgUnionAllSingle[106∈5]"]:::plan
-    __Item105 --> PgUnionAllSingle106
-    Access107{{"Access[107∈5]<br />ᐸ106.2ᐳ"}}:::plan
-    PgUnionAllSingle106 --> Access107
-    PgSelect110[["PgSelect[110∈6]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
-    Access109{{"Access[109∈6]<br />ᐸ108.0ᐳ"}}:::plan
-    Object18 & Access109 --> PgSelect110
-    PgSelect122[["PgSelect[122∈6]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
-    Access121{{"Access[121∈6]<br />ᐸ120.0ᐳ"}}:::plan
-    Object18 & Access121 --> PgSelect122
-    JSONParse108[["JSONParse[108∈6]<br />ᐸ107ᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
-    Access107 --> JSONParse108
-    JSONParse108 --> Access109
-    First114{{"First[114∈6]"}}:::plan
-    PgSelect110 --> First114
-    PgSelectSingle115{{"PgSelectSingle[115∈6]<br />ᐸfirst_party_vulnerabilitiesᐳ"}}:::plan
-    First114 --> PgSelectSingle115
-    PgClassExpression116{{"PgClassExpression[116∈6]<br />ᐸ__first_pa...ies__.”id”ᐳ"}}:::plan
-    PgSelectSingle115 --> PgClassExpression116
-    PgClassExpression117{{"PgClassExpression[117∈6]<br />ᐸ__first_pa...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle115 --> PgClassExpression117
-    PgClassExpression118{{"PgClassExpression[118∈6]<br />ᐸ__first_pa...vss_score”ᐳ"}}:::plan
-    PgSelectSingle115 --> PgClassExpression118
-    JSONParse120[["JSONParse[120∈6]<br />ᐸ107ᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
-    Access107 --> JSONParse120
-    JSONParse120 --> Access121
-    First126{{"First[126∈6]"}}:::plan
-    PgSelect122 --> First126
-    PgSelectSingle127{{"PgSelectSingle[127∈6]<br />ᐸthird_party_vulnerabilitiesᐳ"}}:::plan
-    First126 --> PgSelectSingle127
-    PgClassExpression128{{"PgClassExpression[128∈6]<br />ᐸ__third_pa...ies__.”id”ᐳ"}}:::plan
-    PgSelectSingle127 --> PgClassExpression128
-    PgClassExpression129{{"PgClassExpression[129∈6]<br />ᐸ__third_pa...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle127 --> PgClassExpression129
-    PgClassExpression130{{"PgClassExpression[130∈6]<br />ᐸ__third_pa...vss_score”ᐳ"}}:::plan
-    PgSelectSingle127 --> PgClassExpression130
-    PgClassExpression131{{"PgClassExpression[131∈6]<br />ᐸ__third_pa...ndor_name”ᐳ"}}:::plan
-    PgSelectSingle127 --> PgClassExpression131
+    PgUnionAll22[["PgUnionAll[22∈1]"]]:::plan
+    ToPg28{{"ToPg[28∈1]"}}:::plan
+    ToPg30{{"ToPg[30∈1]"}}:::plan
+    Access31{{"Access[31∈1]<br />ᐸ21.3ᐳ"}}:::plan
+    Object19 & Connection20 & Lambda21 & ToPg28 & ToPg30 & Access31 --> PgUnionAll22
+    PgUnionAll66[["PgUnionAll[66∈1]"]]:::plan
+    Object19 & Connection20 & Lambda21 & ToPg28 & ToPg30 & Access31 --> PgUnionAll66
+    PgUnionAll80[["PgUnionAll[80∈1]"]]:::plan
+    Object19 & Connection20 & Lambda21 & ToPg28 & ToPg30 & Access31 --> PgUnionAll80
+    PgUnionAll94[["PgUnionAll[94∈1]"]]:::plan
+    Object19 & Connection20 & Lambda21 & ToPg28 & ToPg30 & Access31 --> PgUnionAll94
+    List79{{"List[79∈1]<br />ᐸ76,77,78ᐳ"}}:::plan
+    Access76{{"Access[76∈1]<br />ᐸ68.0ᐳ"}}:::plan
+    Access77{{"Access[77∈1]<br />ᐸ68.1ᐳ"}}:::plan
+    Access78{{"Access[78∈1]<br />ᐸ68.2ᐳ"}}:::plan
+    Access76 & Access77 & Access78 --> List79
+    List93{{"List[93∈1]<br />ᐸ90,91,92ᐳ"}}:::plan
+    Access90{{"Access[90∈1]<br />ᐸ82.0ᐳ"}}:::plan
+    Access91{{"Access[91∈1]<br />ᐸ82.1ᐳ"}}:::plan
+    Access92{{"Access[92∈1]<br />ᐸ82.2ᐳ"}}:::plan
+    Access90 & Access91 & Access92 --> List93
+    PgUnionAll61[["PgUnionAll[61∈1]"]]:::plan
+    Object19 & Connection20 --> PgUnionAll61
+    Access27{{"Access[27∈1]<br />ᐸ21.1ᐳ"}}:::plan
+    Lambda21 --> Access27
+    Access27 --> ToPg28
+    Access29{{"Access[29∈1]<br />ᐸ21.2ᐳ"}}:::plan
+    Lambda21 --> Access29
+    Access29 --> ToPg30
+    Lambda21 --> Access31
+    First62{{"First[62∈1]"}}:::plan
+    PgUnionAll61 --> First62
+    PgUnionAllSingle63["PgUnionAllSingle[63∈1]"]:::plan
+    First62 --> PgUnionAllSingle63
+    PgClassExpression64{{"PgClassExpression[64∈1]<br />ᐸcount(*)ᐳ"}}:::plan
+    PgUnionAllSingle63 --> PgClassExpression64
+    PgPageInfo65{{"PgPageInfo[65∈1]"}}:::plan
+    Connection20 --> PgPageInfo65
+    First67{{"First[67∈1]"}}:::plan
+    PgUnionAll66 --> First67
+    PgUnionAllSingle68["PgUnionAllSingle[68∈1]"]:::plan
+    First67 --> PgUnionAllSingle68
+    PgCursor69{{"PgCursor[69∈1]"}}:::plan
+    List79 --> PgCursor69
+    PgUnionAllSingle68 --> Access76
+    PgUnionAllSingle68 --> Access77
+    PgUnionAllSingle68 --> Access78
+    Last81{{"Last[81∈1]"}}:::plan
+    PgUnionAll80 --> Last81
+    PgUnionAllSingle82["PgUnionAllSingle[82∈1]"]:::plan
+    Last81 --> PgUnionAllSingle82
+    PgCursor83{{"PgCursor[83∈1]"}}:::plan
+    List93 --> PgCursor83
+    PgUnionAllSingle82 --> Access90
+    PgUnionAllSingle82 --> Access91
+    PgUnionAllSingle82 --> Access92
+    Access95{{"Access[95∈1]<br />ᐸ94.hasMoreᐳ"}}:::plan
+    PgUnionAll94 --> Access95
+    Constant96{{"Constant[96∈1]<br />ᐸfalseᐳ"}}:::plan
+    __Item23[/"__Item[23∈2]<br />ᐸ22ᐳ"\]:::itemplan
+    PgUnionAll22 ==> __Item23
+    PgUnionAllSingle24["PgUnionAllSingle[24∈2]"]:::plan
+    __Item23 --> PgUnionAllSingle24
+    List35{{"List[35∈3]<br />ᐸ32,33,34ᐳ"}}:::plan
+    Access32{{"Access[32∈3]<br />ᐸ24.0ᐳ"}}:::plan
+    Access33{{"Access[33∈3]<br />ᐸ24.1ᐳ"}}:::plan
+    Access34{{"Access[34∈3]<br />ᐸ24.2ᐳ"}}:::plan
+    Access32 & Access33 & Access34 --> List35
+    PgCursor25{{"PgCursor[25∈3]"}}:::plan
+    List35 --> PgCursor25
+    PgUnionAllSingle24 --> Access32
+    PgUnionAllSingle24 --> Access33
+    PgUnionAllSingle24 --> Access34
+    PgSelect39[["PgSelect[39∈4]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
+    Access38{{"Access[38∈4]<br />ᐸ37.0ᐳ"}}:::plan
+    Object19 & Access38 --> PgSelect39
+    PgSelect51[["PgSelect[51∈4]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
+    Access50{{"Access[50∈4]<br />ᐸ49.0ᐳ"}}:::plan
+    Object19 & Access50 --> PgSelect51
+    JSONParse37[["JSONParse[37∈4]<br />ᐸ34ᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
+    Access34 --> JSONParse37
+    JSONParse37 --> Access38
+    First43{{"First[43∈4]"}}:::plan
+    PgSelect39 --> First43
+    PgSelectSingle44{{"PgSelectSingle[44∈4]<br />ᐸfirst_party_vulnerabilitiesᐳ"}}:::plan
+    First43 --> PgSelectSingle44
+    PgClassExpression45{{"PgClassExpression[45∈4]<br />ᐸ__first_pa...ies__.”id”ᐳ"}}:::plan
+    PgSelectSingle44 --> PgClassExpression45
+    PgClassExpression46{{"PgClassExpression[46∈4]<br />ᐸ__first_pa...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle44 --> PgClassExpression46
+    PgClassExpression47{{"PgClassExpression[47∈4]<br />ᐸ__first_pa...vss_score”ᐳ"}}:::plan
+    PgSelectSingle44 --> PgClassExpression47
+    JSONParse49[["JSONParse[49∈4]<br />ᐸ34ᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
+    Access34 --> JSONParse49
+    JSONParse49 --> Access50
+    First55{{"First[55∈4]"}}:::plan
+    PgSelect51 --> First55
+    PgSelectSingle56{{"PgSelectSingle[56∈4]<br />ᐸthird_party_vulnerabilitiesᐳ"}}:::plan
+    First55 --> PgSelectSingle56
+    PgClassExpression57{{"PgClassExpression[57∈4]<br />ᐸ__third_pa...ies__.”id”ᐳ"}}:::plan
+    PgSelectSingle56 --> PgClassExpression57
+    PgClassExpression58{{"PgClassExpression[58∈4]<br />ᐸ__third_pa...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle56 --> PgClassExpression58
+    PgClassExpression59{{"PgClassExpression[59∈4]<br />ᐸ__third_pa...vss_score”ᐳ"}}:::plan
+    PgSelectSingle56 --> PgClassExpression59
+    PgClassExpression60{{"PgClassExpression[60∈4]<br />ᐸ__third_pa...ndor_name”ᐳ"}}:::plan
+    PgSelectSingle56 --> PgClassExpression60
+    __Item107[/"__Item[107∈5]<br />ᐸ103ᐳ"\]:::itemplan
+    PgUnionAll103 ==> __Item107
+    PgUnionAllSingle108["PgUnionAllSingle[108∈5]"]:::plan
+    __Item107 --> PgUnionAllSingle108
+    Access109{{"Access[109∈5]<br />ᐸ108.2ᐳ"}}:::plan
+    PgUnionAllSingle108 --> Access109
+    PgSelect112[["PgSelect[112∈6]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
+    Access111{{"Access[111∈6]<br />ᐸ110.0ᐳ"}}:::plan
+    Object19 & Access111 --> PgSelect112
+    PgSelect124[["PgSelect[124∈6]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
+    Access123{{"Access[123∈6]<br />ᐸ122.0ᐳ"}}:::plan
+    Object19 & Access123 --> PgSelect124
+    JSONParse110[["JSONParse[110∈6]<br />ᐸ109ᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
+    Access109 --> JSONParse110
+    JSONParse110 --> Access111
+    First116{{"First[116∈6]"}}:::plan
+    PgSelect112 --> First116
+    PgSelectSingle117{{"PgSelectSingle[117∈6]<br />ᐸfirst_party_vulnerabilitiesᐳ"}}:::plan
+    First116 --> PgSelectSingle117
+    PgClassExpression118{{"PgClassExpression[118∈6]<br />ᐸ__first_pa...ies__.”id”ᐳ"}}:::plan
+    PgSelectSingle117 --> PgClassExpression118
+    PgClassExpression119{{"PgClassExpression[119∈6]<br />ᐸ__first_pa...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle117 --> PgClassExpression119
+    PgClassExpression120{{"PgClassExpression[120∈6]<br />ᐸ__first_pa...vss_score”ᐳ"}}:::plan
+    PgSelectSingle117 --> PgClassExpression120
+    JSONParse122[["JSONParse[122∈6]<br />ᐸ109ᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
+    Access109 --> JSONParse122
+    JSONParse122 --> Access123
+    First128{{"First[128∈6]"}}:::plan
+    PgSelect124 --> First128
+    PgSelectSingle129{{"PgSelectSingle[129∈6]<br />ᐸthird_party_vulnerabilitiesᐳ"}}:::plan
+    First128 --> PgSelectSingle129
+    PgClassExpression130{{"PgClassExpression[130∈6]<br />ᐸ__third_pa...ies__.”id”ᐳ"}}:::plan
+    PgSelectSingle129 --> PgClassExpression130
+    PgClassExpression131{{"PgClassExpression[131∈6]<br />ᐸ__third_pa...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle129 --> PgClassExpression131
+    PgClassExpression132{{"PgClassExpression[132∈6]<br />ᐸ__third_pa...vss_score”ᐳ"}}:::plan
+    PgSelectSingle129 --> PgClassExpression132
+    PgClassExpression133{{"PgClassExpression[133∈6]<br />ᐸ__third_pa...ndor_name”ᐳ"}}:::plan
+    PgSelectSingle129 --> PgClassExpression133
 
     %% define steps
 
     subgraph "Buckets for queries/polymorphic/vulns"
-    Bucket0("Bucket 0 (root)<br />1: <br />ᐳ: 16, 17, 138, 139, 18, 20<br />2: 25, 101<br />ᐳ: Connection[19]"):::bucket
+    Bucket0("Bucket 0 (root)<br />1: <br />ᐳ: 17, 18, 140, 141, 19, 21<br />2: 26, 103<br />ᐳ: Connection[20]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value3,__Value5,Access16,Access17,Object18,Connection19,Lambda20,PgValidateParsedCursor25,PgUnionAll101,Constant138,Constant139 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 18, 19, 20<br /><br />ROOT Connectionᐸ15ᐳ[19]<br />1: PgUnionAll[60]<br />ᐳ: 26, 28, 30, 64, 95, 27, 29, 61<br />2: 21, 62, 65, 79, 93<br />ᐳ: 63, 66, 80, 94<br />3: 67, 81<br />ᐳ: 75, 76, 77, 78, 89, 90, 91, 92, 68, 82"):::bucket
+    class Bucket0,__Value0,__Value3,__Value5,Access17,Access18,Object19,Connection20,Lambda21,PgValidateParsedCursor26,PgUnionAll103,Constant140,Constant141 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 19, 20, 21<br /><br />ROOT Connectionᐸ16ᐳ[20]<br />1: PgUnionAll[61]<br />ᐳ: 27, 29, 31, 65, 96, 28, 30, 62<br />2: 22, 63, 66, 80, 94<br />ᐳ: 64, 67, 81, 95<br />3: 68, 82<br />ᐳ: 76, 77, 78, 79, 90, 91, 92, 93, 69, 83"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgUnionAll21,Access26,ToPg27,Access28,ToPg29,Access30,PgUnionAll60,First61,PgUnionAllSingle62,PgClassExpression63,PgPageInfo64,PgUnionAll65,First66,PgUnionAllSingle67,PgCursor68,Access75,Access76,Access77,List78,PgUnionAll79,Last80,PgUnionAllSingle81,PgCursor82,Access89,Access90,Access91,List92,PgUnionAll93,Access94,Constant95 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 18<br /><br />ROOT __Item{2}ᐸ21ᐳ[22]"):::bucket
+    class Bucket1,PgUnionAll22,Access27,ToPg28,Access29,ToPg30,Access31,PgUnionAll61,First62,PgUnionAllSingle63,PgClassExpression64,PgPageInfo65,PgUnionAll66,First67,PgUnionAllSingle68,PgCursor69,Access76,Access77,Access78,List79,PgUnionAll80,Last81,PgUnionAllSingle82,PgCursor83,Access90,Access91,Access92,List93,PgUnionAll94,Access95,Constant96 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 19<br /><br />ROOT __Item{2}ᐸ22ᐳ[23]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,__Item22,PgUnionAllSingle23 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 23, 18<br /><br />ROOT PgUnionAllSingle{2}[23]"):::bucket
+    class Bucket2,__Item23,PgUnionAllSingle24 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 24, 19<br /><br />ROOT PgUnionAllSingle{2}[24]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgCursor24,Access31,Access32,Access33,List34 bucket3
-    Bucket4("Bucket 4 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 33, 18, 23<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br />1: JSONParse[36], JSONParse[48]<br />ᐳ: Access[37], Access[49]<br />2: PgSelect[38], PgSelect[50]<br />ᐳ: 42, 43, 44, 45, 46, 54, 55, 56, 57, 58, 59"):::bucket
+    class Bucket3,PgCursor25,Access32,Access33,Access34,List35 bucket3
+    Bucket4("Bucket 4 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 34, 19, 24<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br />1: JSONParse[37], JSONParse[49]<br />ᐳ: Access[38], Access[50]<br />2: PgSelect[39], PgSelect[51]<br />ᐳ: 43, 44, 45, 46, 47, 55, 56, 57, 58, 59, 60"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,JSONParse36,Access37,PgSelect38,First42,PgSelectSingle43,PgClassExpression44,PgClassExpression45,PgClassExpression46,JSONParse48,Access49,PgSelect50,First54,PgSelectSingle55,PgClassExpression56,PgClassExpression57,PgClassExpression58,PgClassExpression59 bucket4
-    Bucket5("Bucket 5 (listItem)<br />Deps: 18<br /><br />ROOT __Item{5}ᐸ101ᐳ[105]"):::bucket
+    class Bucket4,JSONParse37,Access38,PgSelect39,First43,PgSelectSingle44,PgClassExpression45,PgClassExpression46,PgClassExpression47,JSONParse49,Access50,PgSelect51,First55,PgSelectSingle56,PgClassExpression57,PgClassExpression58,PgClassExpression59,PgClassExpression60 bucket4
+    Bucket5("Bucket 5 (listItem)<br />Deps: 19<br /><br />ROOT __Item{5}ᐸ103ᐳ[107]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,__Item105,PgUnionAllSingle106,Access107 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 107, 18, 106<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br />1: JSONParse[108], JSONParse[120]<br />ᐳ: Access[109], Access[121]<br />2: PgSelect[110], PgSelect[122]<br />ᐳ: 114, 115, 116, 117, 118, 126, 127, 128, 129, 130, 131"):::bucket
+    class Bucket5,__Item107,PgUnionAllSingle108,Access109 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 109, 19, 108<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br />1: JSONParse[110], JSONParse[122]<br />ᐳ: Access[111], Access[123]<br />2: PgSelect[112], PgSelect[124]<br />ᐳ: 116, 117, 118, 119, 120, 128, 129, 130, 131, 132, 133"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,JSONParse108,Access109,PgSelect110,First114,PgSelectSingle115,PgClassExpression116,PgClassExpression117,PgClassExpression118,JSONParse120,Access121,PgSelect122,First126,PgSelectSingle127,PgClassExpression128,PgClassExpression129,PgClassExpression130,PgClassExpression131 bucket6
+    class Bucket6,JSONParse110,Access111,PgSelect112,First116,PgSelectSingle117,PgClassExpression118,PgClassExpression119,PgClassExpression120,JSONParse122,Access123,PgSelect124,First128,PgSelectSingle129,PgClassExpression130,PgClassExpression131,PgClassExpression132,PgClassExpression133 bucket6
     Bucket0 --> Bucket1 & Bucket5
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.mermaid
@@ -9,924 +9,924 @@ graph TD
 
 
     %% plan dependencies
-    Object17{{"Object[17∈0]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Access15{{"Access[15∈0]<br />ᐸ3.pgSettingsᐳ"}}:::plan
-    Access16{{"Access[16∈0]<br />ᐸ3.withPgClientᐳ"}}:::plan
-    Access15 & Access16 --> Object17
+    Object18{{"Object[18∈0]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access16{{"Access[16∈0]<br />ᐸ3.pgSettingsᐳ"}}:::plan
+    Access17{{"Access[17∈0]<br />ᐸ3.withPgClientᐳ"}}:::plan
+    Access16 & Access17 --> Object18
     __Value3["__Value[3∈0]<br />ᐸcontextᐳ"]:::plan
-    __Value3 --> Access15
     __Value3 --> Access16
-    Connection18{{"Connection[18∈0]<br />ᐸ14ᐳ"}}:::plan
-    Constant664{{"Constant[664∈0]<br />ᐸ2ᐳ"}}:::plan
-    Constant664 --> Connection18
+    __Value3 --> Access17
+    Connection19{{"Connection[19∈0]<br />ᐸ15ᐳ"}}:::plan
+    Constant669{{"Constant[669∈0]<br />ᐸ2ᐳ"}}:::plan
+    Constant669 --> Connection19
     __Value0["__Value[0∈0]"]:::plan
     __Value5["__Value[5∈0]<br />ᐸrootValueᐳ"]:::plan
-    PgUnionAll19[["PgUnionAll[19∈1]"]]:::plan
-    Object17 & Connection18 --> PgUnionAll19
-    __Item20[/"__Item[20∈2]<br />ᐸ19ᐳ"\]:::itemplan
-    PgUnionAll19 ==> __Item20
-    PgUnionAllSingle21["PgUnionAllSingle[21∈2]"]:::plan
-    __Item20 --> PgUnionAllSingle21
-    Access22{{"Access[22∈2]<br />ᐸ21.1ᐳ"}}:::plan
-    PgUnionAllSingle21 --> Access22
-    PgUnionAll274[["PgUnionAll[274∈3]<br />ᐳFirstPartyVulnerability"]]:::plan
-    PgClassExpression32{{"PgClassExpression[32∈3]<br />ᐸ__first_pa...ies__.”id”ᐳ"}}:::plan
-    Connection273{{"Connection[273∈3]<br />ᐸ269ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
-    Object17 & PgClassExpression32 & PgClassExpression32 & PgClassExpression32 & PgClassExpression32 & Connection273 --> PgUnionAll274
-    PgUnionAll595[["PgUnionAll[595∈3]<br />ᐳThirdPartyVulnerability"]]:::plan
-    PgClassExpression353{{"PgClassExpression[353∈3]<br />ᐸ__third_pa...ies__.”id”ᐳ"}}:::plan
-    Connection594{{"Connection[594∈3]<br />ᐸ590ᐳ<br />ᐳThirdPartyVulnerability"}}:::plan
-    Object17 & PgClassExpression353 & PgClassExpression353 & PgClassExpression353 & PgClassExpression353 & Connection594 --> PgUnionAll595
-    PgUnionAll309[["PgUnionAll[309∈3]<br />ᐳFirstPartyVulnerability"]]:::plan
-    Object17 & PgClassExpression32 & PgClassExpression32 & PgClassExpression32 & PgClassExpression32 --> PgUnionAll309
-    PgUnionAll630[["PgUnionAll[630∈3]<br />ᐳThirdPartyVulnerability"]]:::plan
-    Object17 & PgClassExpression353 & PgClassExpression353 & PgClassExpression353 & PgClassExpression353 --> PgUnionAll630
-    PgUnionAll50[["PgUnionAll[50∈3]<br />ᐳFirstPartyVulnerability"]]:::plan
-    Connection49{{"Connection[49∈3]<br />ᐸ45ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
-    Object17 & PgClassExpression32 & PgClassExpression32 & Connection49 --> PgUnionAll50
-    PgUnionAll371[["PgUnionAll[371∈3]<br />ᐳThirdPartyVulnerability"]]:::plan
-    Connection370{{"Connection[370∈3]<br />ᐸ366ᐳ<br />ᐳThirdPartyVulnerability"}}:::plan
-    Object17 & PgClassExpression353 & PgClassExpression353 & Connection370 --> PgUnionAll371
-    PgUnionAll159[["PgUnionAll[159∈3]<br />ᐳFirstPartyVulnerability"]]:::plan
-    Object17 & PgClassExpression32 & PgClassExpression32 --> PgUnionAll159
-    PgUnionAll480[["PgUnionAll[480∈3]<br />ᐳThirdPartyVulnerability"]]:::plan
-    Object17 & PgClassExpression353 & PgClassExpression353 --> PgUnionAll480
-    PgSelect25[["PgSelect[25∈3]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
-    Access24{{"Access[24∈3]<br />ᐸ23.0ᐳ"}}:::plan
-    Object17 & Access24 --> PgSelect25
-    List33{{"List[33∈3]<br />ᐸ31,32ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
-    Constant31{{"Constant[31∈3]<br />ᐸ'first_party_vulnerabilities'ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
-    Constant31 & PgClassExpression32 --> List33
-    PgSelect346[["PgSelect[346∈3]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
-    Access345{{"Access[345∈3]<br />ᐸ344.0ᐳ"}}:::plan
-    Object17 & Access345 --> PgSelect346
-    List354{{"List[354∈3]<br />ᐸ352,353ᐳ<br />ᐳThirdPartyVulnerability"}}:::plan
-    Constant352{{"Constant[352∈3]<br />ᐸ'third_party_vulnerabilities'ᐳ<br />ᐳThirdPartyVulnerability"}}:::plan
-    Constant352 & PgClassExpression353 --> List354
-    JSONParse23[["JSONParse[23∈3]<br />ᐸ22ᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
-    Access22 --> JSONParse23
-    JSONParse23 --> Access24
-    First29{{"First[29∈3]"}}:::plan
-    PgSelect25 --> First29
-    PgSelectSingle30{{"PgSelectSingle[30∈3]<br />ᐸfirst_party_vulnerabilitiesᐳ"}}:::plan
-    First29 --> PgSelectSingle30
-    PgSelectSingle30 --> PgClassExpression32
-    Lambda34{{"Lambda[34∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List33 --> Lambda34
-    PgClassExpression35{{"PgClassExpression[35∈3]<br />ᐸ__first_pa...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle30 --> PgClassExpression35
-    JSONParse344[["JSONParse[344∈3]<br />ᐸ22ᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
-    Access22 --> JSONParse344
-    JSONParse344 --> Access345
-    First350{{"First[350∈3]"}}:::plan
-    PgSelect346 --> First350
-    PgSelectSingle351{{"PgSelectSingle[351∈3]<br />ᐸthird_party_vulnerabilitiesᐳ"}}:::plan
-    First350 --> PgSelectSingle351
-    PgSelectSingle351 --> PgClassExpression353
-    Lambda355{{"Lambda[355∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List354 --> Lambda355
-    PgClassExpression356{{"PgClassExpression[356∈3]<br />ᐸ__third_pa...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle351 --> PgClassExpression356
-    __Item51[/"__Item[51∈4]<br />ᐸ50ᐳ"\]:::itemplan
-    PgUnionAll50 ==> __Item51
-    PgUnionAllSingle52["PgUnionAllSingle[52∈4]"]:::plan
-    __Item51 --> PgUnionAllSingle52
-    Access53{{"Access[53∈4]<br />ᐸ52.1ᐳ"}}:::plan
-    PgUnionAllSingle52 --> Access53
-    PgUnionAll69[["PgUnionAll[69∈5]<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"]]:::plan
-    PgClassExpression67{{"PgClassExpression[67∈5]<br />ᐸ__aws_appl...person_id”ᐳ"}}:::plan
-    PgClassExpression68{{"PgClassExpression[68∈5]<br />ᐸ__aws_appl...zation_id”ᐳ"}}:::plan
-    Object17 & PgClassExpression67 & PgClassExpression68 --> PgUnionAll69
-    PgUnionAll119[["PgUnionAll[119∈5]<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"]]:::plan
-    PgClassExpression117{{"PgClassExpression[117∈5]<br />ᐸ__gcp_appl...person_id”ᐳ"}}:::plan
-    PgClassExpression118{{"PgClassExpression[118∈5]<br />ᐸ__gcp_appl...zation_id”ᐳ"}}:::plan
-    Object17 & PgClassExpression117 & PgClassExpression118 --> PgUnionAll119
-    PgSelect56[["PgSelect[56∈5]<br />ᐸaws_applicationsᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"]]:::plan
-    Access55{{"Access[55∈5]<br />ᐸ54.0ᐳ"}}:::plan
-    Object17 & Access55 --> PgSelect56
-    List64{{"List[64∈5]<br />ᐸ62,63ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"}}:::plan
-    Constant62{{"Constant[62∈5]<br />ᐸ'aws_applications'ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"}}:::plan
-    PgClassExpression63{{"PgClassExpression[63∈5]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
-    Constant62 & PgClassExpression63 --> List64
-    PgSelect106[["PgSelect[106∈5]<br />ᐸgcp_applicationsᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"]]:::plan
-    Access105{{"Access[105∈5]<br />ᐸ104.0ᐳ"}}:::plan
-    Object17 & Access105 --> PgSelect106
-    List114{{"List[114∈5]<br />ᐸ112,113ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"}}:::plan
-    Constant112{{"Constant[112∈5]<br />ᐸ'gcp_applications'ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"}}:::plan
-    PgClassExpression113{{"PgClassExpression[113∈5]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
-    Constant112 & PgClassExpression113 --> List114
-    JSONParse54[["JSONParse[54∈5]<br />ᐸ53ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"]]:::plan
-    Access53 --> JSONParse54
-    JSONParse54 --> Access55
-    First60{{"First[60∈5]"}}:::plan
-    PgSelect56 --> First60
-    PgSelectSingle61{{"PgSelectSingle[61∈5]<br />ᐸaws_applicationsᐳ"}}:::plan
-    First60 --> PgSelectSingle61
-    PgSelectSingle61 --> PgClassExpression63
-    Lambda65{{"Lambda[65∈5]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List64 --> Lambda65
-    PgClassExpression66{{"PgClassExpression[66∈5]<br />ᐸ__aws_appl...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle61 --> PgClassExpression66
-    PgSelectSingle61 --> PgClassExpression67
-    PgSelectSingle61 --> PgClassExpression68
-    First73{{"First[73∈5]"}}:::plan
-    PgUnionAll69 --> First73
-    PgUnionAllSingle74["PgUnionAllSingle[74∈5]"]:::plan
-    First73 --> PgUnionAllSingle74
-    Access75{{"Access[75∈5]<br />ᐸ74.1ᐳ"}}:::plan
-    PgUnionAllSingle74 --> Access75
-    JSONParse104[["JSONParse[104∈5]<br />ᐸ53ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"]]:::plan
-    Access53 --> JSONParse104
-    JSONParse104 --> Access105
-    First110{{"First[110∈5]"}}:::plan
-    PgSelect106 --> First110
-    PgSelectSingle111{{"PgSelectSingle[111∈5]<br />ᐸgcp_applicationsᐳ"}}:::plan
-    First110 --> PgSelectSingle111
-    PgSelectSingle111 --> PgClassExpression113
-    Lambda115{{"Lambda[115∈5]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List114 --> Lambda115
-    PgClassExpression116{{"PgClassExpression[116∈5]<br />ᐸ__gcp_appl...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle111 --> PgClassExpression116
-    PgSelectSingle111 --> PgClassExpression117
-    PgSelectSingle111 --> PgClassExpression118
-    First123{{"First[123∈5]"}}:::plan
-    PgUnionAll119 --> First123
-    PgUnionAllSingle124["PgUnionAllSingle[124∈5]"]:::plan
-    First123 --> PgUnionAllSingle124
-    Access125{{"Access[125∈5]<br />ᐸ124.1ᐳ"}}:::plan
-    PgUnionAllSingle124 --> Access125
-    PgSelect78[["PgSelect[78∈6]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
-    Access77{{"Access[77∈6]<br />ᐸ76.0ᐳ"}}:::plan
-    Object17 & Access77 --> PgSelect78
-    List86{{"List[86∈6]<br />ᐸ84,85ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
-    Constant84{{"Constant[84∈6]<br />ᐸ'organizations'ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
-    PgClassExpression85{{"PgClassExpression[85∈6]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
-    Constant84 & PgClassExpression85 --> List86
-    PgSelect92[["PgSelect[92∈6]<br />ᐸpeopleᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson"]]:::plan
-    Access91{{"Access[91∈6]<br />ᐸ90.0ᐳ"}}:::plan
-    Object17 & Access91 --> PgSelect92
-    List100{{"List[100∈6]<br />ᐸ98,99ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson"}}:::plan
-    Constant98{{"Constant[98∈6]<br />ᐸ'people'ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson"}}:::plan
-    PgClassExpression99{{"PgClassExpression[99∈6]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Constant98 & PgClassExpression99 --> List100
-    JSONParse76[["JSONParse[76∈6]<br />ᐸ75ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
-    Access75 --> JSONParse76
-    JSONParse76 --> Access77
-    First82{{"First[82∈6]"}}:::plan
-    PgSelect78 --> First82
-    PgSelectSingle83{{"PgSelectSingle[83∈6]<br />ᐸorganizationsᐳ"}}:::plan
-    First82 --> PgSelectSingle83
-    PgSelectSingle83 --> PgClassExpression85
-    Lambda87{{"Lambda[87∈6]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List86 --> Lambda87
-    PgClassExpression88{{"PgClassExpression[88∈6]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle83 --> PgClassExpression88
-    JSONParse90[["JSONParse[90∈6]<br />ᐸ75ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson"]]:::plan
-    Access75 --> JSONParse90
-    JSONParse90 --> Access91
-    First96{{"First[96∈6]"}}:::plan
-    PgSelect92 --> First96
-    PgSelectSingle97{{"PgSelectSingle[97∈6]<br />ᐸpeopleᐳ"}}:::plan
-    First96 --> PgSelectSingle97
-    PgSelectSingle97 --> PgClassExpression99
-    Lambda101{{"Lambda[101∈6]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List100 --> Lambda101
-    PgClassExpression102{{"PgClassExpression[102∈6]<br />ᐸ__people__.”username”ᐳ"}}:::plan
-    PgSelectSingle97 --> PgClassExpression102
-    PgSelect128[["PgSelect[128∈7]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
-    Access127{{"Access[127∈7]<br />ᐸ126.0ᐳ"}}:::plan
-    Object17 & Access127 --> PgSelect128
-    List136{{"List[136∈7]<br />ᐸ134,135ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
-    Constant134{{"Constant[134∈7]<br />ᐸ'organizations'ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
-    PgClassExpression135{{"PgClassExpression[135∈7]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
-    Constant134 & PgClassExpression135 --> List136
-    PgSelect142[["PgSelect[142∈7]<br />ᐸpeopleᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson"]]:::plan
-    Access141{{"Access[141∈7]<br />ᐸ140.0ᐳ"}}:::plan
-    Object17 & Access141 --> PgSelect142
-    List150{{"List[150∈7]<br />ᐸ148,149ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson"}}:::plan
-    Constant148{{"Constant[148∈7]<br />ᐸ'people'ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson"}}:::plan
-    PgClassExpression149{{"PgClassExpression[149∈7]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Constant148 & PgClassExpression149 --> List150
-    JSONParse126[["JSONParse[126∈7]<br />ᐸ125ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
-    Access125 --> JSONParse126
-    JSONParse126 --> Access127
-    First132{{"First[132∈7]"}}:::plan
-    PgSelect128 --> First132
-    PgSelectSingle133{{"PgSelectSingle[133∈7]<br />ᐸorganizationsᐳ"}}:::plan
-    First132 --> PgSelectSingle133
-    PgSelectSingle133 --> PgClassExpression135
-    Lambda137{{"Lambda[137∈7]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List136 --> Lambda137
-    PgClassExpression138{{"PgClassExpression[138∈7]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle133 --> PgClassExpression138
-    JSONParse140[["JSONParse[140∈7]<br />ᐸ125ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson"]]:::plan
-    Access125 --> JSONParse140
-    JSONParse140 --> Access141
-    First146{{"First[146∈7]"}}:::plan
-    PgSelect142 --> First146
-    PgSelectSingle147{{"PgSelectSingle[147∈7]<br />ᐸpeopleᐳ"}}:::plan
-    First146 --> PgSelectSingle147
-    PgSelectSingle147 --> PgClassExpression149
-    Lambda151{{"Lambda[151∈7]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List150 --> Lambda151
-    PgClassExpression152{{"PgClassExpression[152∈7]<br />ᐸ__people__.”username”ᐳ"}}:::plan
-    PgSelectSingle147 --> PgClassExpression152
-    __Item163[/"__Item[163∈8]<br />ᐸ159ᐳ"\]:::itemplan
-    PgUnionAll159 ==> __Item163
-    PgUnionAllSingle164["PgUnionAllSingle[164∈8]"]:::plan
-    __Item163 --> PgUnionAllSingle164
-    Access165{{"Access[165∈8]<br />ᐸ164.1ᐳ"}}:::plan
-    PgUnionAllSingle164 --> Access165
-    PgUnionAll181[["PgUnionAll[181∈9]<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"]]:::plan
-    PgClassExpression179{{"PgClassExpression[179∈9]<br />ᐸ__aws_appl...person_id”ᐳ"}}:::plan
-    PgClassExpression180{{"PgClassExpression[180∈9]<br />ᐸ__aws_appl...zation_id”ᐳ"}}:::plan
-    Object17 & PgClassExpression179 & PgClassExpression180 --> PgUnionAll181
-    PgUnionAll231[["PgUnionAll[231∈9]<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"]]:::plan
-    PgClassExpression229{{"PgClassExpression[229∈9]<br />ᐸ__gcp_appl...person_id”ᐳ"}}:::plan
-    PgClassExpression230{{"PgClassExpression[230∈9]<br />ᐸ__gcp_appl...zation_id”ᐳ"}}:::plan
-    Object17 & PgClassExpression229 & PgClassExpression230 --> PgUnionAll231
-    PgSelect168[["PgSelect[168∈9]<br />ᐸaws_applicationsᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"]]:::plan
-    Access167{{"Access[167∈9]<br />ᐸ166.0ᐳ"}}:::plan
-    Object17 & Access167 --> PgSelect168
-    List176{{"List[176∈9]<br />ᐸ174,175ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"}}:::plan
-    Constant174{{"Constant[174∈9]<br />ᐸ'aws_applications'ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"}}:::plan
-    PgClassExpression175{{"PgClassExpression[175∈9]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
-    Constant174 & PgClassExpression175 --> List176
-    PgSelect218[["PgSelect[218∈9]<br />ᐸgcp_applicationsᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"]]:::plan
-    Access217{{"Access[217∈9]<br />ᐸ216.0ᐳ"}}:::plan
-    Object17 & Access217 --> PgSelect218
-    List226{{"List[226∈9]<br />ᐸ224,225ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"}}:::plan
-    Constant224{{"Constant[224∈9]<br />ᐸ'gcp_applications'ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"}}:::plan
-    PgClassExpression225{{"PgClassExpression[225∈9]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
-    Constant224 & PgClassExpression225 --> List226
-    JSONParse166[["JSONParse[166∈9]<br />ᐸ165ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"]]:::plan
-    Access165 --> JSONParse166
-    JSONParse166 --> Access167
-    First172{{"First[172∈9]"}}:::plan
-    PgSelect168 --> First172
-    PgSelectSingle173{{"PgSelectSingle[173∈9]<br />ᐸaws_applicationsᐳ"}}:::plan
-    First172 --> PgSelectSingle173
-    PgSelectSingle173 --> PgClassExpression175
-    Lambda177{{"Lambda[177∈9]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List176 --> Lambda177
-    PgClassExpression178{{"PgClassExpression[178∈9]<br />ᐸ__aws_appl...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle173 --> PgClassExpression178
-    PgSelectSingle173 --> PgClassExpression179
-    PgSelectSingle173 --> PgClassExpression180
-    First185{{"First[185∈9]"}}:::plan
-    PgUnionAll181 --> First185
-    PgUnionAllSingle186["PgUnionAllSingle[186∈9]"]:::plan
-    First185 --> PgUnionAllSingle186
-    Access187{{"Access[187∈9]<br />ᐸ186.1ᐳ"}}:::plan
-    PgUnionAllSingle186 --> Access187
-    JSONParse216[["JSONParse[216∈9]<br />ᐸ165ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"]]:::plan
-    Access165 --> JSONParse216
-    JSONParse216 --> Access217
-    First222{{"First[222∈9]"}}:::plan
-    PgSelect218 --> First222
-    PgSelectSingle223{{"PgSelectSingle[223∈9]<br />ᐸgcp_applicationsᐳ"}}:::plan
-    First222 --> PgSelectSingle223
-    PgSelectSingle223 --> PgClassExpression225
-    Lambda227{{"Lambda[227∈9]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List226 --> Lambda227
-    PgClassExpression228{{"PgClassExpression[228∈9]<br />ᐸ__gcp_appl...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle223 --> PgClassExpression228
-    PgSelectSingle223 --> PgClassExpression229
-    PgSelectSingle223 --> PgClassExpression230
-    First235{{"First[235∈9]"}}:::plan
-    PgUnionAll231 --> First235
-    PgUnionAllSingle236["PgUnionAllSingle[236∈9]"]:::plan
-    First235 --> PgUnionAllSingle236
-    Access237{{"Access[237∈9]<br />ᐸ236.1ᐳ"}}:::plan
-    PgUnionAllSingle236 --> Access237
-    PgSelect190[["PgSelect[190∈10]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
-    Access189{{"Access[189∈10]<br />ᐸ188.0ᐳ"}}:::plan
-    Object17 & Access189 --> PgSelect190
-    List198{{"List[198∈10]<br />ᐸ196,197ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
-    Constant196{{"Constant[196∈10]<br />ᐸ'organizations'ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
-    PgClassExpression197{{"PgClassExpression[197∈10]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
-    Constant196 & PgClassExpression197 --> List198
-    PgSelect204[["PgSelect[204∈10]<br />ᐸpeopleᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson"]]:::plan
-    Access203{{"Access[203∈10]<br />ᐸ202.0ᐳ"}}:::plan
-    Object17 & Access203 --> PgSelect204
-    List212{{"List[212∈10]<br />ᐸ210,211ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson"}}:::plan
-    Constant210{{"Constant[210∈10]<br />ᐸ'people'ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson"}}:::plan
-    PgClassExpression211{{"PgClassExpression[211∈10]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Constant210 & PgClassExpression211 --> List212
-    JSONParse188[["JSONParse[188∈10]<br />ᐸ187ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
-    Access187 --> JSONParse188
-    JSONParse188 --> Access189
-    First194{{"First[194∈10]"}}:::plan
-    PgSelect190 --> First194
-    PgSelectSingle195{{"PgSelectSingle[195∈10]<br />ᐸorganizationsᐳ"}}:::plan
-    First194 --> PgSelectSingle195
-    PgSelectSingle195 --> PgClassExpression197
-    Lambda199{{"Lambda[199∈10]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List198 --> Lambda199
-    PgClassExpression200{{"PgClassExpression[200∈10]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle195 --> PgClassExpression200
-    JSONParse202[["JSONParse[202∈10]<br />ᐸ187ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson"]]:::plan
-    Access187 --> JSONParse202
-    JSONParse202 --> Access203
-    First208{{"First[208∈10]"}}:::plan
-    PgSelect204 --> First208
-    PgSelectSingle209{{"PgSelectSingle[209∈10]<br />ᐸpeopleᐳ"}}:::plan
-    First208 --> PgSelectSingle209
-    PgSelectSingle209 --> PgClassExpression211
-    Lambda213{{"Lambda[213∈10]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List212 --> Lambda213
-    PgClassExpression214{{"PgClassExpression[214∈10]<br />ᐸ__people__.”username”ᐳ"}}:::plan
-    PgSelectSingle209 --> PgClassExpression214
-    PgSelect240[["PgSelect[240∈11]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
-    Access239{{"Access[239∈11]<br />ᐸ238.0ᐳ"}}:::plan
-    Object17 & Access239 --> PgSelect240
-    List248{{"List[248∈11]<br />ᐸ246,247ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
-    Constant246{{"Constant[246∈11]<br />ᐸ'organizations'ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
-    PgClassExpression247{{"PgClassExpression[247∈11]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
-    Constant246 & PgClassExpression247 --> List248
-    PgSelect254[["PgSelect[254∈11]<br />ᐸpeopleᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson"]]:::plan
-    Access253{{"Access[253∈11]<br />ᐸ252.0ᐳ"}}:::plan
-    Object17 & Access253 --> PgSelect254
-    List262{{"List[262∈11]<br />ᐸ260,261ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson"}}:::plan
-    Constant260{{"Constant[260∈11]<br />ᐸ'people'ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson"}}:::plan
-    PgClassExpression261{{"PgClassExpression[261∈11]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Constant260 & PgClassExpression261 --> List262
-    JSONParse238[["JSONParse[238∈11]<br />ᐸ237ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
-    Access237 --> JSONParse238
-    JSONParse238 --> Access239
-    First244{{"First[244∈11]"}}:::plan
-    PgSelect240 --> First244
-    PgSelectSingle245{{"PgSelectSingle[245∈11]<br />ᐸorganizationsᐳ"}}:::plan
-    First244 --> PgSelectSingle245
-    PgSelectSingle245 --> PgClassExpression247
-    Lambda249{{"Lambda[249∈11]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List248 --> Lambda249
-    PgClassExpression250{{"PgClassExpression[250∈11]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle245 --> PgClassExpression250
-    JSONParse252[["JSONParse[252∈11]<br />ᐸ237ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson"]]:::plan
-    Access237 --> JSONParse252
-    JSONParse252 --> Access253
-    First258{{"First[258∈11]"}}:::plan
-    PgSelect254 --> First258
-    PgSelectSingle259{{"PgSelectSingle[259∈11]<br />ᐸpeopleᐳ"}}:::plan
-    First258 --> PgSelectSingle259
-    PgSelectSingle259 --> PgClassExpression261
-    Lambda263{{"Lambda[263∈11]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List262 --> Lambda263
-    PgClassExpression264{{"PgClassExpression[264∈11]<br />ᐸ__people__.”username”ᐳ"}}:::plan
-    PgSelectSingle259 --> PgClassExpression264
-    __Item275[/"__Item[275∈12]<br />ᐸ274ᐳ"\]:::itemplan
-    PgUnionAll274 ==> __Item275
-    PgUnionAllSingle276["PgUnionAllSingle[276∈12]"]:::plan
-    __Item275 --> PgUnionAllSingle276
-    Access277{{"Access[277∈12]<br />ᐸ276.1ᐳ"}}:::plan
-    PgUnionAllSingle276 --> Access277
-    PgSelect280[["PgSelect[280∈13]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"]]:::plan
-    Access279{{"Access[279∈13]<br />ᐸ278.0ᐳ"}}:::plan
-    Object17 & Access279 --> PgSelect280
-    List288{{"List[288∈13]<br />ᐸ286,287ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"}}:::plan
-    Constant286{{"Constant[286∈13]<br />ᐸ'organizations'ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"}}:::plan
-    PgClassExpression287{{"PgClassExpression[287∈13]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
-    Constant286 & PgClassExpression287 --> List288
-    PgSelect294[["PgSelect[294∈13]<br />ᐸpeopleᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"]]:::plan
-    Access293{{"Access[293∈13]<br />ᐸ292.0ᐳ"}}:::plan
-    Object17 & Access293 --> PgSelect294
-    List302{{"List[302∈13]<br />ᐸ300,301ᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"}}:::plan
-    Constant300{{"Constant[300∈13]<br />ᐸ'people'ᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"}}:::plan
-    PgClassExpression301{{"PgClassExpression[301∈13]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Constant300 & PgClassExpression301 --> List302
-    JSONParse278[["JSONParse[278∈13]<br />ᐸ277ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"]]:::plan
-    Access277 --> JSONParse278
-    JSONParse278 --> Access279
-    First284{{"First[284∈13]"}}:::plan
-    PgSelect280 --> First284
-    PgSelectSingle285{{"PgSelectSingle[285∈13]<br />ᐸorganizationsᐳ"}}:::plan
-    First284 --> PgSelectSingle285
-    PgSelectSingle285 --> PgClassExpression287
-    Lambda289{{"Lambda[289∈13]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List288 --> Lambda289
-    PgClassExpression290{{"PgClassExpression[290∈13]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle285 --> PgClassExpression290
-    JSONParse292[["JSONParse[292∈13]<br />ᐸ277ᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"]]:::plan
-    Access277 --> JSONParse292
-    JSONParse292 --> Access293
-    First298{{"First[298∈13]"}}:::plan
-    PgSelect294 --> First298
-    PgSelectSingle299{{"PgSelectSingle[299∈13]<br />ᐸpeopleᐳ"}}:::plan
-    First298 --> PgSelectSingle299
-    PgSelectSingle299 --> PgClassExpression301
-    Lambda303{{"Lambda[303∈13]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List302 --> Lambda303
-    PgClassExpression304{{"PgClassExpression[304∈13]<br />ᐸ__people__.”username”ᐳ"}}:::plan
-    PgSelectSingle299 --> PgClassExpression304
-    __Item313[/"__Item[313∈14]<br />ᐸ309ᐳ"\]:::itemplan
-    PgUnionAll309 ==> __Item313
-    PgUnionAllSingle314["PgUnionAllSingle[314∈14]"]:::plan
-    __Item313 --> PgUnionAllSingle314
-    Access315{{"Access[315∈14]<br />ᐸ314.1ᐳ"}}:::plan
-    PgUnionAllSingle314 --> Access315
-    PgSelect318[["PgSelect[318∈15]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"]]:::plan
-    Access317{{"Access[317∈15]<br />ᐸ316.0ᐳ"}}:::plan
-    Object17 & Access317 --> PgSelect318
-    List326{{"List[326∈15]<br />ᐸ324,325ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"}}:::plan
-    Constant324{{"Constant[324∈15]<br />ᐸ'organizations'ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"}}:::plan
-    PgClassExpression325{{"PgClassExpression[325∈15]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
-    Constant324 & PgClassExpression325 --> List326
-    PgSelect332[["PgSelect[332∈15]<br />ᐸpeopleᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"]]:::plan
-    Access331{{"Access[331∈15]<br />ᐸ330.0ᐳ"}}:::plan
-    Object17 & Access331 --> PgSelect332
-    List340{{"List[340∈15]<br />ᐸ338,339ᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"}}:::plan
-    Constant338{{"Constant[338∈15]<br />ᐸ'people'ᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"}}:::plan
-    PgClassExpression339{{"PgClassExpression[339∈15]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Constant338 & PgClassExpression339 --> List340
-    JSONParse316[["JSONParse[316∈15]<br />ᐸ315ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"]]:::plan
-    Access315 --> JSONParse316
-    JSONParse316 --> Access317
-    First322{{"First[322∈15]"}}:::plan
-    PgSelect318 --> First322
-    PgSelectSingle323{{"PgSelectSingle[323∈15]<br />ᐸorganizationsᐳ"}}:::plan
-    First322 --> PgSelectSingle323
-    PgSelectSingle323 --> PgClassExpression325
-    Lambda327{{"Lambda[327∈15]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List326 --> Lambda327
-    PgClassExpression328{{"PgClassExpression[328∈15]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle323 --> PgClassExpression328
-    JSONParse330[["JSONParse[330∈15]<br />ᐸ315ᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"]]:::plan
-    Access315 --> JSONParse330
-    JSONParse330 --> Access331
-    First336{{"First[336∈15]"}}:::plan
-    PgSelect332 --> First336
-    PgSelectSingle337{{"PgSelectSingle[337∈15]<br />ᐸpeopleᐳ"}}:::plan
-    First336 --> PgSelectSingle337
-    PgSelectSingle337 --> PgClassExpression339
-    Lambda341{{"Lambda[341∈15]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List340 --> Lambda341
-    PgClassExpression342{{"PgClassExpression[342∈15]<br />ᐸ__people__.”username”ᐳ"}}:::plan
-    PgSelectSingle337 --> PgClassExpression342
-    __Item372[/"__Item[372∈16]<br />ᐸ371ᐳ"\]:::itemplan
-    PgUnionAll371 ==> __Item372
-    PgUnionAllSingle373["PgUnionAllSingle[373∈16]"]:::plan
-    __Item372 --> PgUnionAllSingle373
-    Access374{{"Access[374∈16]<br />ᐸ373.1ᐳ"}}:::plan
-    PgUnionAllSingle373 --> Access374
-    PgUnionAll390[["PgUnionAll[390∈17]<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"]]:::plan
-    PgClassExpression388{{"PgClassExpression[388∈17]<br />ᐸ__aws_appl...person_id”ᐳ"}}:::plan
-    PgClassExpression389{{"PgClassExpression[389∈17]<br />ᐸ__aws_appl...zation_id”ᐳ"}}:::plan
-    Object17 & PgClassExpression388 & PgClassExpression389 --> PgUnionAll390
-    PgUnionAll440[["PgUnionAll[440∈17]<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"]]:::plan
-    PgClassExpression438{{"PgClassExpression[438∈17]<br />ᐸ__gcp_appl...person_id”ᐳ"}}:::plan
-    PgClassExpression439{{"PgClassExpression[439∈17]<br />ᐸ__gcp_appl...zation_id”ᐳ"}}:::plan
-    Object17 & PgClassExpression438 & PgClassExpression439 --> PgUnionAll440
-    PgSelect377[["PgSelect[377∈17]<br />ᐸaws_applicationsᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"]]:::plan
-    Access376{{"Access[376∈17]<br />ᐸ375.0ᐳ"}}:::plan
-    Object17 & Access376 --> PgSelect377
-    List385{{"List[385∈17]<br />ᐸ383,384ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"}}:::plan
-    Constant383{{"Constant[383∈17]<br />ᐸ'aws_applications'ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"}}:::plan
-    PgClassExpression384{{"PgClassExpression[384∈17]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
-    Constant383 & PgClassExpression384 --> List385
-    PgSelect427[["PgSelect[427∈17]<br />ᐸgcp_applicationsᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"]]:::plan
-    Access426{{"Access[426∈17]<br />ᐸ425.0ᐳ"}}:::plan
-    Object17 & Access426 --> PgSelect427
-    List435{{"List[435∈17]<br />ᐸ433,434ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"}}:::plan
-    Constant433{{"Constant[433∈17]<br />ᐸ'gcp_applications'ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"}}:::plan
-    PgClassExpression434{{"PgClassExpression[434∈17]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
-    Constant433 & PgClassExpression434 --> List435
-    JSONParse375[["JSONParse[375∈17]<br />ᐸ374ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"]]:::plan
-    Access374 --> JSONParse375
-    JSONParse375 --> Access376
-    First381{{"First[381∈17]"}}:::plan
-    PgSelect377 --> First381
-    PgSelectSingle382{{"PgSelectSingle[382∈17]<br />ᐸaws_applicationsᐳ"}}:::plan
-    First381 --> PgSelectSingle382
-    PgSelectSingle382 --> PgClassExpression384
-    Lambda386{{"Lambda[386∈17]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List385 --> Lambda386
-    PgClassExpression387{{"PgClassExpression[387∈17]<br />ᐸ__aws_appl...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle382 --> PgClassExpression387
-    PgSelectSingle382 --> PgClassExpression388
-    PgSelectSingle382 --> PgClassExpression389
-    First394{{"First[394∈17]"}}:::plan
-    PgUnionAll390 --> First394
-    PgUnionAllSingle395["PgUnionAllSingle[395∈17]"]:::plan
-    First394 --> PgUnionAllSingle395
-    Access396{{"Access[396∈17]<br />ᐸ395.1ᐳ"}}:::plan
-    PgUnionAllSingle395 --> Access396
-    JSONParse425[["JSONParse[425∈17]<br />ᐸ374ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"]]:::plan
-    Access374 --> JSONParse425
-    JSONParse425 --> Access426
-    First431{{"First[431∈17]"}}:::plan
-    PgSelect427 --> First431
-    PgSelectSingle432{{"PgSelectSingle[432∈17]<br />ᐸgcp_applicationsᐳ"}}:::plan
-    First431 --> PgSelectSingle432
-    PgSelectSingle432 --> PgClassExpression434
-    Lambda436{{"Lambda[436∈17]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List435 --> Lambda436
-    PgClassExpression437{{"PgClassExpression[437∈17]<br />ᐸ__gcp_appl...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle432 --> PgClassExpression437
-    PgSelectSingle432 --> PgClassExpression438
-    PgSelectSingle432 --> PgClassExpression439
-    First444{{"First[444∈17]"}}:::plan
-    PgUnionAll440 --> First444
-    PgUnionAllSingle445["PgUnionAllSingle[445∈17]"]:::plan
-    First444 --> PgUnionAllSingle445
-    Access446{{"Access[446∈17]<br />ᐸ445.1ᐳ"}}:::plan
-    PgUnionAllSingle445 --> Access446
-    PgSelect399[["PgSelect[399∈18]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
-    Access398{{"Access[398∈18]<br />ᐸ397.0ᐳ"}}:::plan
-    Object17 & Access398 --> PgSelect399
-    List407{{"List[407∈18]<br />ᐸ405,406ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
-    Constant405{{"Constant[405∈18]<br />ᐸ'organizations'ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
-    PgClassExpression406{{"PgClassExpression[406∈18]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
-    Constant405 & PgClassExpression406 --> List407
-    PgSelect413[["PgSelect[413∈18]<br />ᐸpeopleᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson"]]:::plan
-    Access412{{"Access[412∈18]<br />ᐸ411.0ᐳ"}}:::plan
-    Object17 & Access412 --> PgSelect413
-    List421{{"List[421∈18]<br />ᐸ419,420ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson"}}:::plan
-    Constant419{{"Constant[419∈18]<br />ᐸ'people'ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson"}}:::plan
-    PgClassExpression420{{"PgClassExpression[420∈18]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Constant419 & PgClassExpression420 --> List421
-    JSONParse397[["JSONParse[397∈18]<br />ᐸ396ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
-    Access396 --> JSONParse397
-    JSONParse397 --> Access398
-    First403{{"First[403∈18]"}}:::plan
-    PgSelect399 --> First403
-    PgSelectSingle404{{"PgSelectSingle[404∈18]<br />ᐸorganizationsᐳ"}}:::plan
-    First403 --> PgSelectSingle404
-    PgSelectSingle404 --> PgClassExpression406
-    Lambda408{{"Lambda[408∈18]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List407 --> Lambda408
-    PgClassExpression409{{"PgClassExpression[409∈18]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle404 --> PgClassExpression409
-    JSONParse411[["JSONParse[411∈18]<br />ᐸ396ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson"]]:::plan
-    Access396 --> JSONParse411
-    JSONParse411 --> Access412
-    First417{{"First[417∈18]"}}:::plan
-    PgSelect413 --> First417
-    PgSelectSingle418{{"PgSelectSingle[418∈18]<br />ᐸpeopleᐳ"}}:::plan
-    First417 --> PgSelectSingle418
-    PgSelectSingle418 --> PgClassExpression420
-    Lambda422{{"Lambda[422∈18]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List421 --> Lambda422
-    PgClassExpression423{{"PgClassExpression[423∈18]<br />ᐸ__people__.”username”ᐳ"}}:::plan
-    PgSelectSingle418 --> PgClassExpression423
-    PgSelect449[["PgSelect[449∈19]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
-    Access448{{"Access[448∈19]<br />ᐸ447.0ᐳ"}}:::plan
-    Object17 & Access448 --> PgSelect449
-    List457{{"List[457∈19]<br />ᐸ455,456ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
-    Constant455{{"Constant[455∈19]<br />ᐸ'organizations'ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
-    PgClassExpression456{{"PgClassExpression[456∈19]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
-    Constant455 & PgClassExpression456 --> List457
-    PgSelect463[["PgSelect[463∈19]<br />ᐸpeopleᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson"]]:::plan
-    Access462{{"Access[462∈19]<br />ᐸ461.0ᐳ"}}:::plan
-    Object17 & Access462 --> PgSelect463
-    List471{{"List[471∈19]<br />ᐸ469,470ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson"}}:::plan
-    Constant469{{"Constant[469∈19]<br />ᐸ'people'ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson"}}:::plan
-    PgClassExpression470{{"PgClassExpression[470∈19]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Constant469 & PgClassExpression470 --> List471
-    JSONParse447[["JSONParse[447∈19]<br />ᐸ446ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
-    Access446 --> JSONParse447
-    JSONParse447 --> Access448
-    First453{{"First[453∈19]"}}:::plan
-    PgSelect449 --> First453
-    PgSelectSingle454{{"PgSelectSingle[454∈19]<br />ᐸorganizationsᐳ"}}:::plan
-    First453 --> PgSelectSingle454
-    PgSelectSingle454 --> PgClassExpression456
-    Lambda458{{"Lambda[458∈19]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List457 --> Lambda458
-    PgClassExpression459{{"PgClassExpression[459∈19]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle454 --> PgClassExpression459
-    JSONParse461[["JSONParse[461∈19]<br />ᐸ446ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson"]]:::plan
-    Access446 --> JSONParse461
-    JSONParse461 --> Access462
-    First467{{"First[467∈19]"}}:::plan
-    PgSelect463 --> First467
-    PgSelectSingle468{{"PgSelectSingle[468∈19]<br />ᐸpeopleᐳ"}}:::plan
-    First467 --> PgSelectSingle468
-    PgSelectSingle468 --> PgClassExpression470
-    Lambda472{{"Lambda[472∈19]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List471 --> Lambda472
-    PgClassExpression473{{"PgClassExpression[473∈19]<br />ᐸ__people__.”username”ᐳ"}}:::plan
-    PgSelectSingle468 --> PgClassExpression473
-    __Item484[/"__Item[484∈20]<br />ᐸ480ᐳ"\]:::itemplan
-    PgUnionAll480 ==> __Item484
-    PgUnionAllSingle485["PgUnionAllSingle[485∈20]"]:::plan
-    __Item484 --> PgUnionAllSingle485
-    Access486{{"Access[486∈20]<br />ᐸ485.1ᐳ"}}:::plan
-    PgUnionAllSingle485 --> Access486
-    PgUnionAll502[["PgUnionAll[502∈21]<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"]]:::plan
-    PgClassExpression500{{"PgClassExpression[500∈21]<br />ᐸ__aws_appl...person_id”ᐳ"}}:::plan
-    PgClassExpression501{{"PgClassExpression[501∈21]<br />ᐸ__aws_appl...zation_id”ᐳ"}}:::plan
-    Object17 & PgClassExpression500 & PgClassExpression501 --> PgUnionAll502
-    PgUnionAll552[["PgUnionAll[552∈21]<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"]]:::plan
-    PgClassExpression550{{"PgClassExpression[550∈21]<br />ᐸ__gcp_appl...person_id”ᐳ"}}:::plan
-    PgClassExpression551{{"PgClassExpression[551∈21]<br />ᐸ__gcp_appl...zation_id”ᐳ"}}:::plan
-    Object17 & PgClassExpression550 & PgClassExpression551 --> PgUnionAll552
-    PgSelect489[["PgSelect[489∈21]<br />ᐸaws_applicationsᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"]]:::plan
-    Access488{{"Access[488∈21]<br />ᐸ487.0ᐳ"}}:::plan
-    Object17 & Access488 --> PgSelect489
-    List497{{"List[497∈21]<br />ᐸ495,496ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"}}:::plan
-    Constant495{{"Constant[495∈21]<br />ᐸ'aws_applications'ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"}}:::plan
-    PgClassExpression496{{"PgClassExpression[496∈21]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
-    Constant495 & PgClassExpression496 --> List497
-    PgSelect539[["PgSelect[539∈21]<br />ᐸgcp_applicationsᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"]]:::plan
-    Access538{{"Access[538∈21]<br />ᐸ537.0ᐳ"}}:::plan
-    Object17 & Access538 --> PgSelect539
-    List547{{"List[547∈21]<br />ᐸ545,546ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"}}:::plan
-    Constant545{{"Constant[545∈21]<br />ᐸ'gcp_applications'ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"}}:::plan
-    PgClassExpression546{{"PgClassExpression[546∈21]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
-    Constant545 & PgClassExpression546 --> List547
-    JSONParse487[["JSONParse[487∈21]<br />ᐸ486ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"]]:::plan
-    Access486 --> JSONParse487
-    JSONParse487 --> Access488
-    First493{{"First[493∈21]"}}:::plan
-    PgSelect489 --> First493
-    PgSelectSingle494{{"PgSelectSingle[494∈21]<br />ᐸaws_applicationsᐳ"}}:::plan
-    First493 --> PgSelectSingle494
-    PgSelectSingle494 --> PgClassExpression496
-    Lambda498{{"Lambda[498∈21]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List497 --> Lambda498
-    PgClassExpression499{{"PgClassExpression[499∈21]<br />ᐸ__aws_appl...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle494 --> PgClassExpression499
-    PgSelectSingle494 --> PgClassExpression500
-    PgSelectSingle494 --> PgClassExpression501
-    First506{{"First[506∈21]"}}:::plan
-    PgUnionAll502 --> First506
-    PgUnionAllSingle507["PgUnionAllSingle[507∈21]"]:::plan
-    First506 --> PgUnionAllSingle507
-    Access508{{"Access[508∈21]<br />ᐸ507.1ᐳ"}}:::plan
-    PgUnionAllSingle507 --> Access508
-    JSONParse537[["JSONParse[537∈21]<br />ᐸ486ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"]]:::plan
-    Access486 --> JSONParse537
-    JSONParse537 --> Access538
-    First543{{"First[543∈21]"}}:::plan
-    PgSelect539 --> First543
-    PgSelectSingle544{{"PgSelectSingle[544∈21]<br />ᐸgcp_applicationsᐳ"}}:::plan
-    First543 --> PgSelectSingle544
-    PgSelectSingle544 --> PgClassExpression546
-    Lambda548{{"Lambda[548∈21]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List547 --> Lambda548
-    PgClassExpression549{{"PgClassExpression[549∈21]<br />ᐸ__gcp_appl...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle544 --> PgClassExpression549
-    PgSelectSingle544 --> PgClassExpression550
-    PgSelectSingle544 --> PgClassExpression551
-    First556{{"First[556∈21]"}}:::plan
-    PgUnionAll552 --> First556
-    PgUnionAllSingle557["PgUnionAllSingle[557∈21]"]:::plan
-    First556 --> PgUnionAllSingle557
-    Access558{{"Access[558∈21]<br />ᐸ557.1ᐳ"}}:::plan
-    PgUnionAllSingle557 --> Access558
-    PgSelect511[["PgSelect[511∈22]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
-    Access510{{"Access[510∈22]<br />ᐸ509.0ᐳ"}}:::plan
-    Object17 & Access510 --> PgSelect511
-    List519{{"List[519∈22]<br />ᐸ517,518ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
-    Constant517{{"Constant[517∈22]<br />ᐸ'organizations'ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
-    PgClassExpression518{{"PgClassExpression[518∈22]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
-    Constant517 & PgClassExpression518 --> List519
-    PgSelect525[["PgSelect[525∈22]<br />ᐸpeopleᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson"]]:::plan
-    Access524{{"Access[524∈22]<br />ᐸ523.0ᐳ"}}:::plan
-    Object17 & Access524 --> PgSelect525
-    List533{{"List[533∈22]<br />ᐸ531,532ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson"}}:::plan
-    Constant531{{"Constant[531∈22]<br />ᐸ'people'ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson"}}:::plan
-    PgClassExpression532{{"PgClassExpression[532∈22]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Constant531 & PgClassExpression532 --> List533
-    JSONParse509[["JSONParse[509∈22]<br />ᐸ508ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
-    Access508 --> JSONParse509
-    JSONParse509 --> Access510
-    First515{{"First[515∈22]"}}:::plan
-    PgSelect511 --> First515
-    PgSelectSingle516{{"PgSelectSingle[516∈22]<br />ᐸorganizationsᐳ"}}:::plan
-    First515 --> PgSelectSingle516
-    PgSelectSingle516 --> PgClassExpression518
-    Lambda520{{"Lambda[520∈22]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List519 --> Lambda520
-    PgClassExpression521{{"PgClassExpression[521∈22]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle516 --> PgClassExpression521
-    JSONParse523[["JSONParse[523∈22]<br />ᐸ508ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson"]]:::plan
-    Access508 --> JSONParse523
-    JSONParse523 --> Access524
-    First529{{"First[529∈22]"}}:::plan
-    PgSelect525 --> First529
-    PgSelectSingle530{{"PgSelectSingle[530∈22]<br />ᐸpeopleᐳ"}}:::plan
-    First529 --> PgSelectSingle530
-    PgSelectSingle530 --> PgClassExpression532
-    Lambda534{{"Lambda[534∈22]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List533 --> Lambda534
-    PgClassExpression535{{"PgClassExpression[535∈22]<br />ᐸ__people__.”username”ᐳ"}}:::plan
-    PgSelectSingle530 --> PgClassExpression535
-    PgSelect561[["PgSelect[561∈23]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
-    Access560{{"Access[560∈23]<br />ᐸ559.0ᐳ"}}:::plan
-    Object17 & Access560 --> PgSelect561
-    List569{{"List[569∈23]<br />ᐸ567,568ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
-    Constant567{{"Constant[567∈23]<br />ᐸ'organizations'ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
-    PgClassExpression568{{"PgClassExpression[568∈23]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
-    Constant567 & PgClassExpression568 --> List569
-    PgSelect575[["PgSelect[575∈23]<br />ᐸpeopleᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson"]]:::plan
-    Access574{{"Access[574∈23]<br />ᐸ573.0ᐳ"}}:::plan
-    Object17 & Access574 --> PgSelect575
-    List583{{"List[583∈23]<br />ᐸ581,582ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson"}}:::plan
-    Constant581{{"Constant[581∈23]<br />ᐸ'people'ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson"}}:::plan
-    PgClassExpression582{{"PgClassExpression[582∈23]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Constant581 & PgClassExpression582 --> List583
-    JSONParse559[["JSONParse[559∈23]<br />ᐸ558ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
-    Access558 --> JSONParse559
-    JSONParse559 --> Access560
-    First565{{"First[565∈23]"}}:::plan
-    PgSelect561 --> First565
-    PgSelectSingle566{{"PgSelectSingle[566∈23]<br />ᐸorganizationsᐳ"}}:::plan
-    First565 --> PgSelectSingle566
-    PgSelectSingle566 --> PgClassExpression568
-    Lambda570{{"Lambda[570∈23]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List569 --> Lambda570
-    PgClassExpression571{{"PgClassExpression[571∈23]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle566 --> PgClassExpression571
-    JSONParse573[["JSONParse[573∈23]<br />ᐸ558ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson"]]:::plan
-    Access558 --> JSONParse573
-    JSONParse573 --> Access574
-    First579{{"First[579∈23]"}}:::plan
-    PgSelect575 --> First579
-    PgSelectSingle580{{"PgSelectSingle[580∈23]<br />ᐸpeopleᐳ"}}:::plan
-    First579 --> PgSelectSingle580
-    PgSelectSingle580 --> PgClassExpression582
-    Lambda584{{"Lambda[584∈23]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List583 --> Lambda584
-    PgClassExpression585{{"PgClassExpression[585∈23]<br />ᐸ__people__.”username”ᐳ"}}:::plan
-    PgSelectSingle580 --> PgClassExpression585
-    __Item596[/"__Item[596∈24]<br />ᐸ595ᐳ"\]:::itemplan
-    PgUnionAll595 ==> __Item596
-    PgUnionAllSingle597["PgUnionAllSingle[597∈24]"]:::plan
-    __Item596 --> PgUnionAllSingle597
-    Access598{{"Access[598∈24]<br />ᐸ597.1ᐳ"}}:::plan
-    PgUnionAllSingle597 --> Access598
-    PgSelect601[["PgSelect[601∈25]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"]]:::plan
-    Access600{{"Access[600∈25]<br />ᐸ599.0ᐳ"}}:::plan
-    Object17 & Access600 --> PgSelect601
-    List609{{"List[609∈25]<br />ᐸ607,608ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"}}:::plan
-    Constant607{{"Constant[607∈25]<br />ᐸ'organizations'ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"}}:::plan
-    PgClassExpression608{{"PgClassExpression[608∈25]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
-    Constant607 & PgClassExpression608 --> List609
-    PgSelect615[["PgSelect[615∈25]<br />ᐸpeopleᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"]]:::plan
-    Access614{{"Access[614∈25]<br />ᐸ613.0ᐳ"}}:::plan
-    Object17 & Access614 --> PgSelect615
-    List623{{"List[623∈25]<br />ᐸ621,622ᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"}}:::plan
-    Constant621{{"Constant[621∈25]<br />ᐸ'people'ᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"}}:::plan
-    PgClassExpression622{{"PgClassExpression[622∈25]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Constant621 & PgClassExpression622 --> List623
-    JSONParse599[["JSONParse[599∈25]<br />ᐸ598ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"]]:::plan
-    Access598 --> JSONParse599
-    JSONParse599 --> Access600
-    First605{{"First[605∈25]"}}:::plan
-    PgSelect601 --> First605
-    PgSelectSingle606{{"PgSelectSingle[606∈25]<br />ᐸorganizationsᐳ"}}:::plan
-    First605 --> PgSelectSingle606
-    PgSelectSingle606 --> PgClassExpression608
-    Lambda610{{"Lambda[610∈25]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List609 --> Lambda610
-    PgClassExpression611{{"PgClassExpression[611∈25]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle606 --> PgClassExpression611
-    JSONParse613[["JSONParse[613∈25]<br />ᐸ598ᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"]]:::plan
-    Access598 --> JSONParse613
-    JSONParse613 --> Access614
-    First619{{"First[619∈25]"}}:::plan
-    PgSelect615 --> First619
-    PgSelectSingle620{{"PgSelectSingle[620∈25]<br />ᐸpeopleᐳ"}}:::plan
-    First619 --> PgSelectSingle620
-    PgSelectSingle620 --> PgClassExpression622
-    Lambda624{{"Lambda[624∈25]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List623 --> Lambda624
-    PgClassExpression625{{"PgClassExpression[625∈25]<br />ᐸ__people__.”username”ᐳ"}}:::plan
-    PgSelectSingle620 --> PgClassExpression625
-    __Item634[/"__Item[634∈26]<br />ᐸ630ᐳ"\]:::itemplan
-    PgUnionAll630 ==> __Item634
-    PgUnionAllSingle635["PgUnionAllSingle[635∈26]"]:::plan
-    __Item634 --> PgUnionAllSingle635
-    Access636{{"Access[636∈26]<br />ᐸ635.1ᐳ"}}:::plan
-    PgUnionAllSingle635 --> Access636
-    PgSelect639[["PgSelect[639∈27]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"]]:::plan
-    Access638{{"Access[638∈27]<br />ᐸ637.0ᐳ"}}:::plan
-    Object17 & Access638 --> PgSelect639
-    List647{{"List[647∈27]<br />ᐸ645,646ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"}}:::plan
-    Constant645{{"Constant[645∈27]<br />ᐸ'organizations'ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"}}:::plan
-    PgClassExpression646{{"PgClassExpression[646∈27]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
-    Constant645 & PgClassExpression646 --> List647
-    PgSelect653[["PgSelect[653∈27]<br />ᐸpeopleᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"]]:::plan
-    Access652{{"Access[652∈27]<br />ᐸ651.0ᐳ"}}:::plan
-    Object17 & Access652 --> PgSelect653
-    List661{{"List[661∈27]<br />ᐸ659,660ᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"}}:::plan
-    Constant659{{"Constant[659∈27]<br />ᐸ'people'ᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"}}:::plan
-    PgClassExpression660{{"PgClassExpression[660∈27]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Constant659 & PgClassExpression660 --> List661
-    JSONParse637[["JSONParse[637∈27]<br />ᐸ636ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"]]:::plan
-    Access636 --> JSONParse637
-    JSONParse637 --> Access638
-    First643{{"First[643∈27]"}}:::plan
-    PgSelect639 --> First643
-    PgSelectSingle644{{"PgSelectSingle[644∈27]<br />ᐸorganizationsᐳ"}}:::plan
-    First643 --> PgSelectSingle644
-    PgSelectSingle644 --> PgClassExpression646
-    Lambda648{{"Lambda[648∈27]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List647 --> Lambda648
-    PgClassExpression649{{"PgClassExpression[649∈27]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle644 --> PgClassExpression649
-    JSONParse651[["JSONParse[651∈27]<br />ᐸ636ᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"]]:::plan
-    Access636 --> JSONParse651
-    JSONParse651 --> Access652
-    First657{{"First[657∈27]"}}:::plan
-    PgSelect653 --> First657
-    PgSelectSingle658{{"PgSelectSingle[658∈27]<br />ᐸpeopleᐳ"}}:::plan
-    First657 --> PgSelectSingle658
-    PgSelectSingle658 --> PgClassExpression660
-    Lambda662{{"Lambda[662∈27]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List661 --> Lambda662
-    PgClassExpression663{{"PgClassExpression[663∈27]<br />ᐸ__people__.”username”ᐳ"}}:::plan
-    PgSelectSingle658 --> PgClassExpression663
+    PgUnionAll20[["PgUnionAll[20∈1]"]]:::plan
+    Object18 & Connection19 --> PgUnionAll20
+    __Item21[/"__Item[21∈2]<br />ᐸ20ᐳ"\]:::itemplan
+    PgUnionAll20 ==> __Item21
+    PgUnionAllSingle22["PgUnionAllSingle[22∈2]"]:::plan
+    __Item21 --> PgUnionAllSingle22
+    Access23{{"Access[23∈2]<br />ᐸ22.1ᐳ"}}:::plan
+    PgUnionAllSingle22 --> Access23
+    PgUnionAll277[["PgUnionAll[277∈3]<br />ᐳFirstPartyVulnerability"]]:::plan
+    PgClassExpression33{{"PgClassExpression[33∈3]<br />ᐸ__first_pa...ies__.”id”ᐳ"}}:::plan
+    Connection276{{"Connection[276∈3]<br />ᐸ272ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
+    Object18 & PgClassExpression33 & PgClassExpression33 & PgClassExpression33 & PgClassExpression33 & Connection276 --> PgUnionAll277
+    PgUnionAll600[["PgUnionAll[600∈3]<br />ᐳThirdPartyVulnerability"]]:::plan
+    PgClassExpression356{{"PgClassExpression[356∈3]<br />ᐸ__third_pa...ies__.”id”ᐳ"}}:::plan
+    Connection599{{"Connection[599∈3]<br />ᐸ595ᐳ<br />ᐳThirdPartyVulnerability"}}:::plan
+    Object18 & PgClassExpression356 & PgClassExpression356 & PgClassExpression356 & PgClassExpression356 & Connection599 --> PgUnionAll600
+    PgUnionAll312[["PgUnionAll[312∈3]<br />ᐳFirstPartyVulnerability"]]:::plan
+    Object18 & PgClassExpression33 & PgClassExpression33 & PgClassExpression33 & PgClassExpression33 --> PgUnionAll312
+    PgUnionAll635[["PgUnionAll[635∈3]<br />ᐳThirdPartyVulnerability"]]:::plan
+    Object18 & PgClassExpression356 & PgClassExpression356 & PgClassExpression356 & PgClassExpression356 --> PgUnionAll635
+    PgUnionAll52[["PgUnionAll[52∈3]<br />ᐳFirstPartyVulnerability"]]:::plan
+    Connection51{{"Connection[51∈3]<br />ᐸ47ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
+    Object18 & PgClassExpression33 & PgClassExpression33 & Connection51 --> PgUnionAll52
+    PgUnionAll375[["PgUnionAll[375∈3]<br />ᐳThirdPartyVulnerability"]]:::plan
+    Connection374{{"Connection[374∈3]<br />ᐸ370ᐳ<br />ᐳThirdPartyVulnerability"}}:::plan
+    Object18 & PgClassExpression356 & PgClassExpression356 & Connection374 --> PgUnionAll375
+    PgUnionAll162[["PgUnionAll[162∈3]<br />ᐳFirstPartyVulnerability"]]:::plan
+    Object18 & PgClassExpression33 & PgClassExpression33 --> PgUnionAll162
+    PgUnionAll485[["PgUnionAll[485∈3]<br />ᐳThirdPartyVulnerability"]]:::plan
+    Object18 & PgClassExpression356 & PgClassExpression356 --> PgUnionAll485
+    PgSelect26[["PgSelect[26∈3]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
+    Access25{{"Access[25∈3]<br />ᐸ24.0ᐳ"}}:::plan
+    Object18 & Access25 --> PgSelect26
+    List34{{"List[34∈3]<br />ᐸ32,33ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
+    Constant32{{"Constant[32∈3]<br />ᐸ'first_party_vulnerabilities'ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
+    Constant32 & PgClassExpression33 --> List34
+    PgSelect349[["PgSelect[349∈3]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
+    Access348{{"Access[348∈3]<br />ᐸ347.0ᐳ"}}:::plan
+    Object18 & Access348 --> PgSelect349
+    List357{{"List[357∈3]<br />ᐸ355,356ᐳ<br />ᐳThirdPartyVulnerability"}}:::plan
+    Constant355{{"Constant[355∈3]<br />ᐸ'third_party_vulnerabilities'ᐳ<br />ᐳThirdPartyVulnerability"}}:::plan
+    Constant355 & PgClassExpression356 --> List357
+    JSONParse24[["JSONParse[24∈3]<br />ᐸ23ᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
+    Access23 --> JSONParse24
+    JSONParse24 --> Access25
+    First30{{"First[30∈3]"}}:::plan
+    PgSelect26 --> First30
+    PgSelectSingle31{{"PgSelectSingle[31∈3]<br />ᐸfirst_party_vulnerabilitiesᐳ"}}:::plan
+    First30 --> PgSelectSingle31
+    PgSelectSingle31 --> PgClassExpression33
+    Lambda35{{"Lambda[35∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List34 --> Lambda35
+    PgClassExpression36{{"PgClassExpression[36∈3]<br />ᐸ__first_pa...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle31 --> PgClassExpression36
+    JSONParse347[["JSONParse[347∈3]<br />ᐸ23ᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
+    Access23 --> JSONParse347
+    JSONParse347 --> Access348
+    First353{{"First[353∈3]"}}:::plan
+    PgSelect349 --> First353
+    PgSelectSingle354{{"PgSelectSingle[354∈3]<br />ᐸthird_party_vulnerabilitiesᐳ"}}:::plan
+    First353 --> PgSelectSingle354
+    PgSelectSingle354 --> PgClassExpression356
+    Lambda358{{"Lambda[358∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List357 --> Lambda358
+    PgClassExpression359{{"PgClassExpression[359∈3]<br />ᐸ__third_pa...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle354 --> PgClassExpression359
+    __Item53[/"__Item[53∈4]<br />ᐸ52ᐳ"\]:::itemplan
+    PgUnionAll52 ==> __Item53
+    PgUnionAllSingle54["PgUnionAllSingle[54∈4]"]:::plan
+    __Item53 --> PgUnionAllSingle54
+    Access55{{"Access[55∈4]<br />ᐸ54.1ᐳ"}}:::plan
+    PgUnionAllSingle54 --> Access55
+    PgUnionAll71[["PgUnionAll[71∈5]<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"]]:::plan
+    PgClassExpression69{{"PgClassExpression[69∈5]<br />ᐸ__aws_appl...person_id”ᐳ"}}:::plan
+    PgClassExpression70{{"PgClassExpression[70∈5]<br />ᐸ__aws_appl...zation_id”ᐳ"}}:::plan
+    Object18 & PgClassExpression69 & PgClassExpression70 --> PgUnionAll71
+    PgUnionAll121[["PgUnionAll[121∈5]<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"]]:::plan
+    PgClassExpression119{{"PgClassExpression[119∈5]<br />ᐸ__gcp_appl...person_id”ᐳ"}}:::plan
+    PgClassExpression120{{"PgClassExpression[120∈5]<br />ᐸ__gcp_appl...zation_id”ᐳ"}}:::plan
+    Object18 & PgClassExpression119 & PgClassExpression120 --> PgUnionAll121
+    PgSelect58[["PgSelect[58∈5]<br />ᐸaws_applicationsᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"]]:::plan
+    Access57{{"Access[57∈5]<br />ᐸ56.0ᐳ"}}:::plan
+    Object18 & Access57 --> PgSelect58
+    List66{{"List[66∈5]<br />ᐸ64,65ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"}}:::plan
+    Constant64{{"Constant[64∈5]<br />ᐸ'aws_applications'ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"}}:::plan
+    PgClassExpression65{{"PgClassExpression[65∈5]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
+    Constant64 & PgClassExpression65 --> List66
+    PgSelect108[["PgSelect[108∈5]<br />ᐸgcp_applicationsᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"]]:::plan
+    Access107{{"Access[107∈5]<br />ᐸ106.0ᐳ"}}:::plan
+    Object18 & Access107 --> PgSelect108
+    List116{{"List[116∈5]<br />ᐸ114,115ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"}}:::plan
+    Constant114{{"Constant[114∈5]<br />ᐸ'gcp_applications'ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"}}:::plan
+    PgClassExpression115{{"PgClassExpression[115∈5]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
+    Constant114 & PgClassExpression115 --> List116
+    JSONParse56[["JSONParse[56∈5]<br />ᐸ55ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"]]:::plan
+    Access55 --> JSONParse56
+    JSONParse56 --> Access57
+    First62{{"First[62∈5]"}}:::plan
+    PgSelect58 --> First62
+    PgSelectSingle63{{"PgSelectSingle[63∈5]<br />ᐸaws_applicationsᐳ"}}:::plan
+    First62 --> PgSelectSingle63
+    PgSelectSingle63 --> PgClassExpression65
+    Lambda67{{"Lambda[67∈5]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List66 --> Lambda67
+    PgClassExpression68{{"PgClassExpression[68∈5]<br />ᐸ__aws_appl...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle63 --> PgClassExpression68
+    PgSelectSingle63 --> PgClassExpression69
+    PgSelectSingle63 --> PgClassExpression70
+    First75{{"First[75∈5]"}}:::plan
+    PgUnionAll71 --> First75
+    PgUnionAllSingle76["PgUnionAllSingle[76∈5]"]:::plan
+    First75 --> PgUnionAllSingle76
+    Access77{{"Access[77∈5]<br />ᐸ76.1ᐳ"}}:::plan
+    PgUnionAllSingle76 --> Access77
+    JSONParse106[["JSONParse[106∈5]<br />ᐸ55ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"]]:::plan
+    Access55 --> JSONParse106
+    JSONParse106 --> Access107
+    First112{{"First[112∈5]"}}:::plan
+    PgSelect108 --> First112
+    PgSelectSingle113{{"PgSelectSingle[113∈5]<br />ᐸgcp_applicationsᐳ"}}:::plan
+    First112 --> PgSelectSingle113
+    PgSelectSingle113 --> PgClassExpression115
+    Lambda117{{"Lambda[117∈5]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List116 --> Lambda117
+    PgClassExpression118{{"PgClassExpression[118∈5]<br />ᐸ__gcp_appl...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle113 --> PgClassExpression118
+    PgSelectSingle113 --> PgClassExpression119
+    PgSelectSingle113 --> PgClassExpression120
+    First125{{"First[125∈5]"}}:::plan
+    PgUnionAll121 --> First125
+    PgUnionAllSingle126["PgUnionAllSingle[126∈5]"]:::plan
+    First125 --> PgUnionAllSingle126
+    Access127{{"Access[127∈5]<br />ᐸ126.1ᐳ"}}:::plan
+    PgUnionAllSingle126 --> Access127
+    PgSelect80[["PgSelect[80∈6]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
+    Access79{{"Access[79∈6]<br />ᐸ78.0ᐳ"}}:::plan
+    Object18 & Access79 --> PgSelect80
+    List88{{"List[88∈6]<br />ᐸ86,87ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
+    Constant86{{"Constant[86∈6]<br />ᐸ'organizations'ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
+    PgClassExpression87{{"PgClassExpression[87∈6]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
+    Constant86 & PgClassExpression87 --> List88
+    PgSelect94[["PgSelect[94∈6]<br />ᐸpeopleᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson"]]:::plan
+    Access93{{"Access[93∈6]<br />ᐸ92.0ᐳ"}}:::plan
+    Object18 & Access93 --> PgSelect94
+    List102{{"List[102∈6]<br />ᐸ100,101ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson"}}:::plan
+    Constant100{{"Constant[100∈6]<br />ᐸ'people'ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson"}}:::plan
+    PgClassExpression101{{"PgClassExpression[101∈6]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
+    Constant100 & PgClassExpression101 --> List102
+    JSONParse78[["JSONParse[78∈6]<br />ᐸ77ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
+    Access77 --> JSONParse78
+    JSONParse78 --> Access79
+    First84{{"First[84∈6]"}}:::plan
+    PgSelect80 --> First84
+    PgSelectSingle85{{"PgSelectSingle[85∈6]<br />ᐸorganizationsᐳ"}}:::plan
+    First84 --> PgSelectSingle85
+    PgSelectSingle85 --> PgClassExpression87
+    Lambda89{{"Lambda[89∈6]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List88 --> Lambda89
+    PgClassExpression90{{"PgClassExpression[90∈6]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle85 --> PgClassExpression90
+    JSONParse92[["JSONParse[92∈6]<br />ᐸ77ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson"]]:::plan
+    Access77 --> JSONParse92
+    JSONParse92 --> Access93
+    First98{{"First[98∈6]"}}:::plan
+    PgSelect94 --> First98
+    PgSelectSingle99{{"PgSelectSingle[99∈6]<br />ᐸpeopleᐳ"}}:::plan
+    First98 --> PgSelectSingle99
+    PgSelectSingle99 --> PgClassExpression101
+    Lambda103{{"Lambda[103∈6]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List102 --> Lambda103
+    PgClassExpression104{{"PgClassExpression[104∈6]<br />ᐸ__people__.”username”ᐳ"}}:::plan
+    PgSelectSingle99 --> PgClassExpression104
+    PgSelect130[["PgSelect[130∈7]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
+    Access129{{"Access[129∈7]<br />ᐸ128.0ᐳ"}}:::plan
+    Object18 & Access129 --> PgSelect130
+    List138{{"List[138∈7]<br />ᐸ136,137ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
+    Constant136{{"Constant[136∈7]<br />ᐸ'organizations'ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
+    PgClassExpression137{{"PgClassExpression[137∈7]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
+    Constant136 & PgClassExpression137 --> List138
+    PgSelect144[["PgSelect[144∈7]<br />ᐸpeopleᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson"]]:::plan
+    Access143{{"Access[143∈7]<br />ᐸ142.0ᐳ"}}:::plan
+    Object18 & Access143 --> PgSelect144
+    List152{{"List[152∈7]<br />ᐸ150,151ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson"}}:::plan
+    Constant150{{"Constant[150∈7]<br />ᐸ'people'ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson"}}:::plan
+    PgClassExpression151{{"PgClassExpression[151∈7]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
+    Constant150 & PgClassExpression151 --> List152
+    JSONParse128[["JSONParse[128∈7]<br />ᐸ127ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
+    Access127 --> JSONParse128
+    JSONParse128 --> Access129
+    First134{{"First[134∈7]"}}:::plan
+    PgSelect130 --> First134
+    PgSelectSingle135{{"PgSelectSingle[135∈7]<br />ᐸorganizationsᐳ"}}:::plan
+    First134 --> PgSelectSingle135
+    PgSelectSingle135 --> PgClassExpression137
+    Lambda139{{"Lambda[139∈7]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List138 --> Lambda139
+    PgClassExpression140{{"PgClassExpression[140∈7]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle135 --> PgClassExpression140
+    JSONParse142[["JSONParse[142∈7]<br />ᐸ127ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson"]]:::plan
+    Access127 --> JSONParse142
+    JSONParse142 --> Access143
+    First148{{"First[148∈7]"}}:::plan
+    PgSelect144 --> First148
+    PgSelectSingle149{{"PgSelectSingle[149∈7]<br />ᐸpeopleᐳ"}}:::plan
+    First148 --> PgSelectSingle149
+    PgSelectSingle149 --> PgClassExpression151
+    Lambda153{{"Lambda[153∈7]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List152 --> Lambda153
+    PgClassExpression154{{"PgClassExpression[154∈7]<br />ᐸ__people__.”username”ᐳ"}}:::plan
+    PgSelectSingle149 --> PgClassExpression154
+    __Item166[/"__Item[166∈8]<br />ᐸ162ᐳ"\]:::itemplan
+    PgUnionAll162 ==> __Item166
+    PgUnionAllSingle167["PgUnionAllSingle[167∈8]"]:::plan
+    __Item166 --> PgUnionAllSingle167
+    Access168{{"Access[168∈8]<br />ᐸ167.1ᐳ"}}:::plan
+    PgUnionAllSingle167 --> Access168
+    PgUnionAll184[["PgUnionAll[184∈9]<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"]]:::plan
+    PgClassExpression182{{"PgClassExpression[182∈9]<br />ᐸ__aws_appl...person_id”ᐳ"}}:::plan
+    PgClassExpression183{{"PgClassExpression[183∈9]<br />ᐸ__aws_appl...zation_id”ᐳ"}}:::plan
+    Object18 & PgClassExpression182 & PgClassExpression183 --> PgUnionAll184
+    PgUnionAll234[["PgUnionAll[234∈9]<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"]]:::plan
+    PgClassExpression232{{"PgClassExpression[232∈9]<br />ᐸ__gcp_appl...person_id”ᐳ"}}:::plan
+    PgClassExpression233{{"PgClassExpression[233∈9]<br />ᐸ__gcp_appl...zation_id”ᐳ"}}:::plan
+    Object18 & PgClassExpression232 & PgClassExpression233 --> PgUnionAll234
+    PgSelect171[["PgSelect[171∈9]<br />ᐸaws_applicationsᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"]]:::plan
+    Access170{{"Access[170∈9]<br />ᐸ169.0ᐳ"}}:::plan
+    Object18 & Access170 --> PgSelect171
+    List179{{"List[179∈9]<br />ᐸ177,178ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"}}:::plan
+    Constant177{{"Constant[177∈9]<br />ᐸ'aws_applications'ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"}}:::plan
+    PgClassExpression178{{"PgClassExpression[178∈9]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
+    Constant177 & PgClassExpression178 --> List179
+    PgSelect221[["PgSelect[221∈9]<br />ᐸgcp_applicationsᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"]]:::plan
+    Access220{{"Access[220∈9]<br />ᐸ219.0ᐳ"}}:::plan
+    Object18 & Access220 --> PgSelect221
+    List229{{"List[229∈9]<br />ᐸ227,228ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"}}:::plan
+    Constant227{{"Constant[227∈9]<br />ᐸ'gcp_applications'ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"}}:::plan
+    PgClassExpression228{{"PgClassExpression[228∈9]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
+    Constant227 & PgClassExpression228 --> List229
+    JSONParse169[["JSONParse[169∈9]<br />ᐸ168ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplication"]]:::plan
+    Access168 --> JSONParse169
+    JSONParse169 --> Access170
+    First175{{"First[175∈9]"}}:::plan
+    PgSelect171 --> First175
+    PgSelectSingle176{{"PgSelectSingle[176∈9]<br />ᐸaws_applicationsᐳ"}}:::plan
+    First175 --> PgSelectSingle176
+    PgSelectSingle176 --> PgClassExpression178
+    Lambda180{{"Lambda[180∈9]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List179 --> Lambda180
+    PgClassExpression181{{"PgClassExpression[181∈9]<br />ᐸ__aws_appl...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle176 --> PgClassExpression181
+    PgSelectSingle176 --> PgClassExpression182
+    PgSelectSingle176 --> PgClassExpression183
+    First188{{"First[188∈9]"}}:::plan
+    PgUnionAll184 --> First188
+    PgUnionAllSingle189["PgUnionAllSingle[189∈9]"]:::plan
+    First188 --> PgUnionAllSingle189
+    Access190{{"Access[190∈9]<br />ᐸ189.1ᐳ"}}:::plan
+    PgUnionAllSingle189 --> Access190
+    JSONParse219[["JSONParse[219∈9]<br />ᐸ168ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplication"]]:::plan
+    Access168 --> JSONParse219
+    JSONParse219 --> Access220
+    First225{{"First[225∈9]"}}:::plan
+    PgSelect221 --> First225
+    PgSelectSingle226{{"PgSelectSingle[226∈9]<br />ᐸgcp_applicationsᐳ"}}:::plan
+    First225 --> PgSelectSingle226
+    PgSelectSingle226 --> PgClassExpression228
+    Lambda230{{"Lambda[230∈9]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List229 --> Lambda230
+    PgClassExpression231{{"PgClassExpression[231∈9]<br />ᐸ__gcp_appl...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle226 --> PgClassExpression231
+    PgSelectSingle226 --> PgClassExpression232
+    PgSelectSingle226 --> PgClassExpression233
+    First238{{"First[238∈9]"}}:::plan
+    PgUnionAll234 --> First238
+    PgUnionAllSingle239["PgUnionAllSingle[239∈9]"]:::plan
+    First238 --> PgUnionAllSingle239
+    Access240{{"Access[240∈9]<br />ᐸ239.1ᐳ"}}:::plan
+    PgUnionAllSingle239 --> Access240
+    PgSelect193[["PgSelect[193∈10]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
+    Access192{{"Access[192∈10]<br />ᐸ191.0ᐳ"}}:::plan
+    Object18 & Access192 --> PgSelect193
+    List201{{"List[201∈10]<br />ᐸ199,200ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
+    Constant199{{"Constant[199∈10]<br />ᐸ'organizations'ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
+    PgClassExpression200{{"PgClassExpression[200∈10]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
+    Constant199 & PgClassExpression200 --> List201
+    PgSelect207[["PgSelect[207∈10]<br />ᐸpeopleᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson"]]:::plan
+    Access206{{"Access[206∈10]<br />ᐸ205.0ᐳ"}}:::plan
+    Object18 & Access206 --> PgSelect207
+    List215{{"List[215∈10]<br />ᐸ213,214ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson"}}:::plan
+    Constant213{{"Constant[213∈10]<br />ᐸ'people'ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson"}}:::plan
+    PgClassExpression214{{"PgClassExpression[214∈10]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
+    Constant213 & PgClassExpression214 --> List215
+    JSONParse191[["JSONParse[191∈10]<br />ᐸ190ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
+    Access190 --> JSONParse191
+    JSONParse191 --> Access192
+    First197{{"First[197∈10]"}}:::plan
+    PgSelect193 --> First197
+    PgSelectSingle198{{"PgSelectSingle[198∈10]<br />ᐸorganizationsᐳ"}}:::plan
+    First197 --> PgSelectSingle198
+    PgSelectSingle198 --> PgClassExpression200
+    Lambda202{{"Lambda[202∈10]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List201 --> Lambda202
+    PgClassExpression203{{"PgClassExpression[203∈10]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle198 --> PgClassExpression203
+    JSONParse205[["JSONParse[205∈10]<br />ᐸ190ᐳ<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson"]]:::plan
+    Access190 --> JSONParse205
+    JSONParse205 --> Access206
+    First211{{"First[211∈10]"}}:::plan
+    PgSelect207 --> First211
+    PgSelectSingle212{{"PgSelectSingle[212∈10]<br />ᐸpeopleᐳ"}}:::plan
+    First211 --> PgSelectSingle212
+    PgSelectSingle212 --> PgClassExpression214
+    Lambda216{{"Lambda[216∈10]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List215 --> Lambda216
+    PgClassExpression217{{"PgClassExpression[217∈10]<br />ᐸ__people__.”username”ᐳ"}}:::plan
+    PgSelectSingle212 --> PgClassExpression217
+    PgSelect243[["PgSelect[243∈11]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
+    Access242{{"Access[242∈11]<br />ᐸ241.0ᐳ"}}:::plan
+    Object18 & Access242 --> PgSelect243
+    List251{{"List[251∈11]<br />ᐸ249,250ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
+    Constant249{{"Constant[249∈11]<br />ᐸ'organizations'ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
+    PgClassExpression250{{"PgClassExpression[250∈11]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
+    Constant249 & PgClassExpression250 --> List251
+    PgSelect257[["PgSelect[257∈11]<br />ᐸpeopleᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson"]]:::plan
+    Access256{{"Access[256∈11]<br />ᐸ255.0ᐳ"}}:::plan
+    Object18 & Access256 --> PgSelect257
+    List265{{"List[265∈11]<br />ᐸ263,264ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson"}}:::plan
+    Constant263{{"Constant[263∈11]<br />ᐸ'people'ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson"}}:::plan
+    PgClassExpression264{{"PgClassExpression[264∈11]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
+    Constant263 & PgClassExpression264 --> List265
+    JSONParse241[["JSONParse[241∈11]<br />ᐸ240ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
+    Access240 --> JSONParse241
+    JSONParse241 --> Access242
+    First247{{"First[247∈11]"}}:::plan
+    PgSelect243 --> First247
+    PgSelectSingle248{{"PgSelectSingle[248∈11]<br />ᐸorganizationsᐳ"}}:::plan
+    First247 --> PgSelectSingle248
+    PgSelectSingle248 --> PgClassExpression250
+    Lambda252{{"Lambda[252∈11]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List251 --> Lambda252
+    PgClassExpression253{{"PgClassExpression[253∈11]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle248 --> PgClassExpression253
+    JSONParse255[["JSONParse[255∈11]<br />ᐸ240ᐳ<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson"]]:::plan
+    Access240 --> JSONParse255
+    JSONParse255 --> Access256
+    First261{{"First[261∈11]"}}:::plan
+    PgSelect257 --> First261
+    PgSelectSingle262{{"PgSelectSingle[262∈11]<br />ᐸpeopleᐳ"}}:::plan
+    First261 --> PgSelectSingle262
+    PgSelectSingle262 --> PgClassExpression264
+    Lambda266{{"Lambda[266∈11]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List265 --> Lambda266
+    PgClassExpression267{{"PgClassExpression[267∈11]<br />ᐸ__people__.”username”ᐳ"}}:::plan
+    PgSelectSingle262 --> PgClassExpression267
+    __Item278[/"__Item[278∈12]<br />ᐸ277ᐳ"\]:::itemplan
+    PgUnionAll277 ==> __Item278
+    PgUnionAllSingle279["PgUnionAllSingle[279∈12]"]:::plan
+    __Item278 --> PgUnionAllSingle279
+    Access280{{"Access[280∈12]<br />ᐸ279.1ᐳ"}}:::plan
+    PgUnionAllSingle279 --> Access280
+    PgSelect283[["PgSelect[283∈13]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"]]:::plan
+    Access282{{"Access[282∈13]<br />ᐸ281.0ᐳ"}}:::plan
+    Object18 & Access282 --> PgSelect283
+    List291{{"List[291∈13]<br />ᐸ289,290ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"}}:::plan
+    Constant289{{"Constant[289∈13]<br />ᐸ'organizations'ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"}}:::plan
+    PgClassExpression290{{"PgClassExpression[290∈13]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
+    Constant289 & PgClassExpression290 --> List291
+    PgSelect297[["PgSelect[297∈13]<br />ᐸpeopleᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"]]:::plan
+    Access296{{"Access[296∈13]<br />ᐸ295.0ᐳ"}}:::plan
+    Object18 & Access296 --> PgSelect297
+    List305{{"List[305∈13]<br />ᐸ303,304ᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"}}:::plan
+    Constant303{{"Constant[303∈13]<br />ᐸ'people'ᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"}}:::plan
+    PgClassExpression304{{"PgClassExpression[304∈13]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
+    Constant303 & PgClassExpression304 --> List305
+    JSONParse281[["JSONParse[281∈13]<br />ᐸ280ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"]]:::plan
+    Access280 --> JSONParse281
+    JSONParse281 --> Access282
+    First287{{"First[287∈13]"}}:::plan
+    PgSelect283 --> First287
+    PgSelectSingle288{{"PgSelectSingle[288∈13]<br />ᐸorganizationsᐳ"}}:::plan
+    First287 --> PgSelectSingle288
+    PgSelectSingle288 --> PgClassExpression290
+    Lambda292{{"Lambda[292∈13]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List291 --> Lambda292
+    PgClassExpression293{{"PgClassExpression[293∈13]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle288 --> PgClassExpression293
+    JSONParse295[["JSONParse[295∈13]<br />ᐸ280ᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"]]:::plan
+    Access280 --> JSONParse295
+    JSONParse295 --> Access296
+    First301{{"First[301∈13]"}}:::plan
+    PgSelect297 --> First301
+    PgSelectSingle302{{"PgSelectSingle[302∈13]<br />ᐸpeopleᐳ"}}:::plan
+    First301 --> PgSelectSingle302
+    PgSelectSingle302 --> PgClassExpression304
+    Lambda306{{"Lambda[306∈13]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List305 --> Lambda306
+    PgClassExpression307{{"PgClassExpression[307∈13]<br />ᐸ__people__.”username”ᐳ"}}:::plan
+    PgSelectSingle302 --> PgClassExpression307
+    __Item316[/"__Item[316∈14]<br />ᐸ312ᐳ"\]:::itemplan
+    PgUnionAll312 ==> __Item316
+    PgUnionAllSingle317["PgUnionAllSingle[317∈14]"]:::plan
+    __Item316 --> PgUnionAllSingle317
+    Access318{{"Access[318∈14]<br />ᐸ317.1ᐳ"}}:::plan
+    PgUnionAllSingle317 --> Access318
+    PgSelect321[["PgSelect[321∈15]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"]]:::plan
+    Access320{{"Access[320∈15]<br />ᐸ319.0ᐳ"}}:::plan
+    Object18 & Access320 --> PgSelect321
+    List329{{"List[329∈15]<br />ᐸ327,328ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"}}:::plan
+    Constant327{{"Constant[327∈15]<br />ᐸ'organizations'ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"}}:::plan
+    PgClassExpression328{{"PgClassExpression[328∈15]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
+    Constant327 & PgClassExpression328 --> List329
+    PgSelect335[["PgSelect[335∈15]<br />ᐸpeopleᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"]]:::plan
+    Access334{{"Access[334∈15]<br />ᐸ333.0ᐳ"}}:::plan
+    Object18 & Access334 --> PgSelect335
+    List343{{"List[343∈15]<br />ᐸ341,342ᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"}}:::plan
+    Constant341{{"Constant[341∈15]<br />ᐸ'people'ᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"}}:::plan
+    PgClassExpression342{{"PgClassExpression[342∈15]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
+    Constant341 & PgClassExpression342 --> List343
+    JSONParse319[["JSONParse[319∈15]<br />ᐸ318ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"]]:::plan
+    Access318 --> JSONParse319
+    JSONParse319 --> Access320
+    First325{{"First[325∈15]"}}:::plan
+    PgSelect321 --> First325
+    PgSelectSingle326{{"PgSelectSingle[326∈15]<br />ᐸorganizationsᐳ"}}:::plan
+    First325 --> PgSelectSingle326
+    PgSelectSingle326 --> PgClassExpression328
+    Lambda330{{"Lambda[330∈15]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List329 --> Lambda330
+    PgClassExpression331{{"PgClassExpression[331∈15]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle326 --> PgClassExpression331
+    JSONParse333[["JSONParse[333∈15]<br />ᐸ318ᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"]]:::plan
+    Access318 --> JSONParse333
+    JSONParse333 --> Access334
+    First339{{"First[339∈15]"}}:::plan
+    PgSelect335 --> First339
+    PgSelectSingle340{{"PgSelectSingle[340∈15]<br />ᐸpeopleᐳ"}}:::plan
+    First339 --> PgSelectSingle340
+    PgSelectSingle340 --> PgClassExpression342
+    Lambda344{{"Lambda[344∈15]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List343 --> Lambda344
+    PgClassExpression345{{"PgClassExpression[345∈15]<br />ᐸ__people__.”username”ᐳ"}}:::plan
+    PgSelectSingle340 --> PgClassExpression345
+    __Item376[/"__Item[376∈16]<br />ᐸ375ᐳ"\]:::itemplan
+    PgUnionAll375 ==> __Item376
+    PgUnionAllSingle377["PgUnionAllSingle[377∈16]"]:::plan
+    __Item376 --> PgUnionAllSingle377
+    Access378{{"Access[378∈16]<br />ᐸ377.1ᐳ"}}:::plan
+    PgUnionAllSingle377 --> Access378
+    PgUnionAll394[["PgUnionAll[394∈17]<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"]]:::plan
+    PgClassExpression392{{"PgClassExpression[392∈17]<br />ᐸ__aws_appl...person_id”ᐳ"}}:::plan
+    PgClassExpression393{{"PgClassExpression[393∈17]<br />ᐸ__aws_appl...zation_id”ᐳ"}}:::plan
+    Object18 & PgClassExpression392 & PgClassExpression393 --> PgUnionAll394
+    PgUnionAll444[["PgUnionAll[444∈17]<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"]]:::plan
+    PgClassExpression442{{"PgClassExpression[442∈17]<br />ᐸ__gcp_appl...person_id”ᐳ"}}:::plan
+    PgClassExpression443{{"PgClassExpression[443∈17]<br />ᐸ__gcp_appl...zation_id”ᐳ"}}:::plan
+    Object18 & PgClassExpression442 & PgClassExpression443 --> PgUnionAll444
+    PgSelect381[["PgSelect[381∈17]<br />ᐸaws_applicationsᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"]]:::plan
+    Access380{{"Access[380∈17]<br />ᐸ379.0ᐳ"}}:::plan
+    Object18 & Access380 --> PgSelect381
+    List389{{"List[389∈17]<br />ᐸ387,388ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"}}:::plan
+    Constant387{{"Constant[387∈17]<br />ᐸ'aws_applications'ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"}}:::plan
+    PgClassExpression388{{"PgClassExpression[388∈17]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
+    Constant387 & PgClassExpression388 --> List389
+    PgSelect431[["PgSelect[431∈17]<br />ᐸgcp_applicationsᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"]]:::plan
+    Access430{{"Access[430∈17]<br />ᐸ429.0ᐳ"}}:::plan
+    Object18 & Access430 --> PgSelect431
+    List439{{"List[439∈17]<br />ᐸ437,438ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"}}:::plan
+    Constant437{{"Constant[437∈17]<br />ᐸ'gcp_applications'ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"}}:::plan
+    PgClassExpression438{{"PgClassExpression[438∈17]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
+    Constant437 & PgClassExpression438 --> List439
+    JSONParse379[["JSONParse[379∈17]<br />ᐸ378ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"]]:::plan
+    Access378 --> JSONParse379
+    JSONParse379 --> Access380
+    First385{{"First[385∈17]"}}:::plan
+    PgSelect381 --> First385
+    PgSelectSingle386{{"PgSelectSingle[386∈17]<br />ᐸaws_applicationsᐳ"}}:::plan
+    First385 --> PgSelectSingle386
+    PgSelectSingle386 --> PgClassExpression388
+    Lambda390{{"Lambda[390∈17]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List389 --> Lambda390
+    PgClassExpression391{{"PgClassExpression[391∈17]<br />ᐸ__aws_appl...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle386 --> PgClassExpression391
+    PgSelectSingle386 --> PgClassExpression392
+    PgSelectSingle386 --> PgClassExpression393
+    First398{{"First[398∈17]"}}:::plan
+    PgUnionAll394 --> First398
+    PgUnionAllSingle399["PgUnionAllSingle[399∈17]"]:::plan
+    First398 --> PgUnionAllSingle399
+    Access400{{"Access[400∈17]<br />ᐸ399.1ᐳ"}}:::plan
+    PgUnionAllSingle399 --> Access400
+    JSONParse429[["JSONParse[429∈17]<br />ᐸ378ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"]]:::plan
+    Access378 --> JSONParse429
+    JSONParse429 --> Access430
+    First435{{"First[435∈17]"}}:::plan
+    PgSelect431 --> First435
+    PgSelectSingle436{{"PgSelectSingle[436∈17]<br />ᐸgcp_applicationsᐳ"}}:::plan
+    First435 --> PgSelectSingle436
+    PgSelectSingle436 --> PgClassExpression438
+    Lambda440{{"Lambda[440∈17]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List439 --> Lambda440
+    PgClassExpression441{{"PgClassExpression[441∈17]<br />ᐸ__gcp_appl...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle436 --> PgClassExpression441
+    PgSelectSingle436 --> PgClassExpression442
+    PgSelectSingle436 --> PgClassExpression443
+    First448{{"First[448∈17]"}}:::plan
+    PgUnionAll444 --> First448
+    PgUnionAllSingle449["PgUnionAllSingle[449∈17]"]:::plan
+    First448 --> PgUnionAllSingle449
+    Access450{{"Access[450∈17]<br />ᐸ449.1ᐳ"}}:::plan
+    PgUnionAllSingle449 --> Access450
+    PgSelect403[["PgSelect[403∈18]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
+    Access402{{"Access[402∈18]<br />ᐸ401.0ᐳ"}}:::plan
+    Object18 & Access402 --> PgSelect403
+    List411{{"List[411∈18]<br />ᐸ409,410ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
+    Constant409{{"Constant[409∈18]<br />ᐸ'organizations'ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
+    PgClassExpression410{{"PgClassExpression[410∈18]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
+    Constant409 & PgClassExpression410 --> List411
+    PgSelect417[["PgSelect[417∈18]<br />ᐸpeopleᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson"]]:::plan
+    Access416{{"Access[416∈18]<br />ᐸ415.0ᐳ"}}:::plan
+    Object18 & Access416 --> PgSelect417
+    List425{{"List[425∈18]<br />ᐸ423,424ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson"}}:::plan
+    Constant423{{"Constant[423∈18]<br />ᐸ'people'ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson"}}:::plan
+    PgClassExpression424{{"PgClassExpression[424∈18]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
+    Constant423 & PgClassExpression424 --> List425
+    JSONParse401[["JSONParse[401∈18]<br />ᐸ400ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
+    Access400 --> JSONParse401
+    JSONParse401 --> Access402
+    First407{{"First[407∈18]"}}:::plan
+    PgSelect403 --> First407
+    PgSelectSingle408{{"PgSelectSingle[408∈18]<br />ᐸorganizationsᐳ"}}:::plan
+    First407 --> PgSelectSingle408
+    PgSelectSingle408 --> PgClassExpression410
+    Lambda412{{"Lambda[412∈18]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List411 --> Lambda412
+    PgClassExpression413{{"PgClassExpression[413∈18]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle408 --> PgClassExpression413
+    JSONParse415[["JSONParse[415∈18]<br />ᐸ400ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson"]]:::plan
+    Access400 --> JSONParse415
+    JSONParse415 --> Access416
+    First421{{"First[421∈18]"}}:::plan
+    PgSelect417 --> First421
+    PgSelectSingle422{{"PgSelectSingle[422∈18]<br />ᐸpeopleᐳ"}}:::plan
+    First421 --> PgSelectSingle422
+    PgSelectSingle422 --> PgClassExpression424
+    Lambda426{{"Lambda[426∈18]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List425 --> Lambda426
+    PgClassExpression427{{"PgClassExpression[427∈18]<br />ᐸ__people__.”username”ᐳ"}}:::plan
+    PgSelectSingle422 --> PgClassExpression427
+    PgSelect453[["PgSelect[453∈19]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
+    Access452{{"Access[452∈19]<br />ᐸ451.0ᐳ"}}:::plan
+    Object18 & Access452 --> PgSelect453
+    List461{{"List[461∈19]<br />ᐸ459,460ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
+    Constant459{{"Constant[459∈19]<br />ᐸ'organizations'ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
+    PgClassExpression460{{"PgClassExpression[460∈19]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
+    Constant459 & PgClassExpression460 --> List461
+    PgSelect467[["PgSelect[467∈19]<br />ᐸpeopleᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson"]]:::plan
+    Access466{{"Access[466∈19]<br />ᐸ465.0ᐳ"}}:::plan
+    Object18 & Access466 --> PgSelect467
+    List475{{"List[475∈19]<br />ᐸ473,474ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson"}}:::plan
+    Constant473{{"Constant[473∈19]<br />ᐸ'people'ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson"}}:::plan
+    PgClassExpression474{{"PgClassExpression[474∈19]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
+    Constant473 & PgClassExpression474 --> List475
+    JSONParse451[["JSONParse[451∈19]<br />ᐸ450ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
+    Access450 --> JSONParse451
+    JSONParse451 --> Access452
+    First457{{"First[457∈19]"}}:::plan
+    PgSelect453 --> First457
+    PgSelectSingle458{{"PgSelectSingle[458∈19]<br />ᐸorganizationsᐳ"}}:::plan
+    First457 --> PgSelectSingle458
+    PgSelectSingle458 --> PgClassExpression460
+    Lambda462{{"Lambda[462∈19]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List461 --> Lambda462
+    PgClassExpression463{{"PgClassExpression[463∈19]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle458 --> PgClassExpression463
+    JSONParse465[["JSONParse[465∈19]<br />ᐸ450ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson"]]:::plan
+    Access450 --> JSONParse465
+    JSONParse465 --> Access466
+    First471{{"First[471∈19]"}}:::plan
+    PgSelect467 --> First471
+    PgSelectSingle472{{"PgSelectSingle[472∈19]<br />ᐸpeopleᐳ"}}:::plan
+    First471 --> PgSelectSingle472
+    PgSelectSingle472 --> PgClassExpression474
+    Lambda476{{"Lambda[476∈19]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List475 --> Lambda476
+    PgClassExpression477{{"PgClassExpression[477∈19]<br />ᐸ__people__.”username”ᐳ"}}:::plan
+    PgSelectSingle472 --> PgClassExpression477
+    __Item489[/"__Item[489∈20]<br />ᐸ485ᐳ"\]:::itemplan
+    PgUnionAll485 ==> __Item489
+    PgUnionAllSingle490["PgUnionAllSingle[490∈20]"]:::plan
+    __Item489 --> PgUnionAllSingle490
+    Access491{{"Access[491∈20]<br />ᐸ490.1ᐳ"}}:::plan
+    PgUnionAllSingle490 --> Access491
+    PgUnionAll507[["PgUnionAll[507∈21]<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"]]:::plan
+    PgClassExpression505{{"PgClassExpression[505∈21]<br />ᐸ__aws_appl...person_id”ᐳ"}}:::plan
+    PgClassExpression506{{"PgClassExpression[506∈21]<br />ᐸ__aws_appl...zation_id”ᐳ"}}:::plan
+    Object18 & PgClassExpression505 & PgClassExpression506 --> PgUnionAll507
+    PgUnionAll557[["PgUnionAll[557∈21]<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"]]:::plan
+    PgClassExpression555{{"PgClassExpression[555∈21]<br />ᐸ__gcp_appl...person_id”ᐳ"}}:::plan
+    PgClassExpression556{{"PgClassExpression[556∈21]<br />ᐸ__gcp_appl...zation_id”ᐳ"}}:::plan
+    Object18 & PgClassExpression555 & PgClassExpression556 --> PgUnionAll557
+    PgSelect494[["PgSelect[494∈21]<br />ᐸaws_applicationsᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"]]:::plan
+    Access493{{"Access[493∈21]<br />ᐸ492.0ᐳ"}}:::plan
+    Object18 & Access493 --> PgSelect494
+    List502{{"List[502∈21]<br />ᐸ500,501ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"}}:::plan
+    Constant500{{"Constant[500∈21]<br />ᐸ'aws_applications'ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"}}:::plan
+    PgClassExpression501{{"PgClassExpression[501∈21]<br />ᐸ__aws_appl...ons__.”id”ᐳ"}}:::plan
+    Constant500 & PgClassExpression501 --> List502
+    PgSelect544[["PgSelect[544∈21]<br />ᐸgcp_applicationsᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"]]:::plan
+    Access543{{"Access[543∈21]<br />ᐸ542.0ᐳ"}}:::plan
+    Object18 & Access543 --> PgSelect544
+    List552{{"List[552∈21]<br />ᐸ550,551ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"}}:::plan
+    Constant550{{"Constant[550∈21]<br />ᐸ'gcp_applications'ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"}}:::plan
+    PgClassExpression551{{"PgClassExpression[551∈21]<br />ᐸ__gcp_appl...ons__.”id”ᐳ"}}:::plan
+    Constant550 & PgClassExpression551 --> List552
+    JSONParse492[["JSONParse[492∈21]<br />ᐸ491ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplication"]]:::plan
+    Access491 --> JSONParse492
+    JSONParse492 --> Access493
+    First498{{"First[498∈21]"}}:::plan
+    PgSelect494 --> First498
+    PgSelectSingle499{{"PgSelectSingle[499∈21]<br />ᐸaws_applicationsᐳ"}}:::plan
+    First498 --> PgSelectSingle499
+    PgSelectSingle499 --> PgClassExpression501
+    Lambda503{{"Lambda[503∈21]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List502 --> Lambda503
+    PgClassExpression504{{"PgClassExpression[504∈21]<br />ᐸ__aws_appl...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle499 --> PgClassExpression504
+    PgSelectSingle499 --> PgClassExpression505
+    PgSelectSingle499 --> PgClassExpression506
+    First511{{"First[511∈21]"}}:::plan
+    PgUnionAll507 --> First511
+    PgUnionAllSingle512["PgUnionAllSingle[512∈21]"]:::plan
+    First511 --> PgUnionAllSingle512
+    Access513{{"Access[513∈21]<br />ᐸ512.1ᐳ"}}:::plan
+    PgUnionAllSingle512 --> Access513
+    JSONParse542[["JSONParse[542∈21]<br />ᐸ491ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplication"]]:::plan
+    Access491 --> JSONParse542
+    JSONParse542 --> Access543
+    First548{{"First[548∈21]"}}:::plan
+    PgSelect544 --> First548
+    PgSelectSingle549{{"PgSelectSingle[549∈21]<br />ᐸgcp_applicationsᐳ"}}:::plan
+    First548 --> PgSelectSingle549
+    PgSelectSingle549 --> PgClassExpression551
+    Lambda553{{"Lambda[553∈21]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List552 --> Lambda553
+    PgClassExpression554{{"PgClassExpression[554∈21]<br />ᐸ__gcp_appl...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle549 --> PgClassExpression554
+    PgSelectSingle549 --> PgClassExpression555
+    PgSelectSingle549 --> PgClassExpression556
+    First561{{"First[561∈21]"}}:::plan
+    PgUnionAll557 --> First561
+    PgUnionAllSingle562["PgUnionAllSingle[562∈21]"]:::plan
+    First561 --> PgUnionAllSingle562
+    Access563{{"Access[563∈21]<br />ᐸ562.1ᐳ"}}:::plan
+    PgUnionAllSingle562 --> Access563
+    PgSelect516[["PgSelect[516∈22]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
+    Access515{{"Access[515∈22]<br />ᐸ514.0ᐳ"}}:::plan
+    Object18 & Access515 --> PgSelect516
+    List524{{"List[524∈22]<br />ᐸ522,523ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
+    Constant522{{"Constant[522∈22]<br />ᐸ'organizations'ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"}}:::plan
+    PgClassExpression523{{"PgClassExpression[523∈22]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
+    Constant522 & PgClassExpression523 --> List524
+    PgSelect530[["PgSelect[530∈22]<br />ᐸpeopleᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson"]]:::plan
+    Access529{{"Access[529∈22]<br />ᐸ528.0ᐳ"}}:::plan
+    Object18 & Access529 --> PgSelect530
+    List538{{"List[538∈22]<br />ᐸ536,537ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson"}}:::plan
+    Constant536{{"Constant[536∈22]<br />ᐸ'people'ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson"}}:::plan
+    PgClassExpression537{{"PgClassExpression[537∈22]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
+    Constant536 & PgClassExpression537 --> List538
+    JSONParse514[["JSONParse[514∈22]<br />ᐸ513ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization"]]:::plan
+    Access513 --> JSONParse514
+    JSONParse514 --> Access515
+    First520{{"First[520∈22]"}}:::plan
+    PgSelect516 --> First520
+    PgSelectSingle521{{"PgSelectSingle[521∈22]<br />ᐸorganizationsᐳ"}}:::plan
+    First520 --> PgSelectSingle521
+    PgSelectSingle521 --> PgClassExpression523
+    Lambda525{{"Lambda[525∈22]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List524 --> Lambda525
+    PgClassExpression526{{"PgClassExpression[526∈22]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle521 --> PgClassExpression526
+    JSONParse528[["JSONParse[528∈22]<br />ᐸ513ᐳ<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson"]]:::plan
+    Access513 --> JSONParse528
+    JSONParse528 --> Access529
+    First534{{"First[534∈22]"}}:::plan
+    PgSelect530 --> First534
+    PgSelectSingle535{{"PgSelectSingle[535∈22]<br />ᐸpeopleᐳ"}}:::plan
+    First534 --> PgSelectSingle535
+    PgSelectSingle535 --> PgClassExpression537
+    Lambda539{{"Lambda[539∈22]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List538 --> Lambda539
+    PgClassExpression540{{"PgClassExpression[540∈22]<br />ᐸ__people__.”username”ᐳ"}}:::plan
+    PgSelectSingle535 --> PgClassExpression540
+    PgSelect566[["PgSelect[566∈23]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
+    Access565{{"Access[565∈23]<br />ᐸ564.0ᐳ"}}:::plan
+    Object18 & Access565 --> PgSelect566
+    List574{{"List[574∈23]<br />ᐸ572,573ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
+    Constant572{{"Constant[572∈23]<br />ᐸ'organizations'ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"}}:::plan
+    PgClassExpression573{{"PgClassExpression[573∈23]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
+    Constant572 & PgClassExpression573 --> List574
+    PgSelect580[["PgSelect[580∈23]<br />ᐸpeopleᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson"]]:::plan
+    Access579{{"Access[579∈23]<br />ᐸ578.0ᐳ"}}:::plan
+    Object18 & Access579 --> PgSelect580
+    List588{{"List[588∈23]<br />ᐸ586,587ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson"}}:::plan
+    Constant586{{"Constant[586∈23]<br />ᐸ'people'ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson"}}:::plan
+    PgClassExpression587{{"PgClassExpression[587∈23]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
+    Constant586 & PgClassExpression587 --> List588
+    JSONParse564[["JSONParse[564∈23]<br />ᐸ563ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization"]]:::plan
+    Access563 --> JSONParse564
+    JSONParse564 --> Access565
+    First570{{"First[570∈23]"}}:::plan
+    PgSelect566 --> First570
+    PgSelectSingle571{{"PgSelectSingle[571∈23]<br />ᐸorganizationsᐳ"}}:::plan
+    First570 --> PgSelectSingle571
+    PgSelectSingle571 --> PgClassExpression573
+    Lambda575{{"Lambda[575∈23]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List574 --> Lambda575
+    PgClassExpression576{{"PgClassExpression[576∈23]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle571 --> PgClassExpression576
+    JSONParse578[["JSONParse[578∈23]<br />ᐸ563ᐳ<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson"]]:::plan
+    Access563 --> JSONParse578
+    JSONParse578 --> Access579
+    First584{{"First[584∈23]"}}:::plan
+    PgSelect580 --> First584
+    PgSelectSingle585{{"PgSelectSingle[585∈23]<br />ᐸpeopleᐳ"}}:::plan
+    First584 --> PgSelectSingle585
+    PgSelectSingle585 --> PgClassExpression587
+    Lambda589{{"Lambda[589∈23]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List588 --> Lambda589
+    PgClassExpression590{{"PgClassExpression[590∈23]<br />ᐸ__people__.”username”ᐳ"}}:::plan
+    PgSelectSingle585 --> PgClassExpression590
+    __Item601[/"__Item[601∈24]<br />ᐸ600ᐳ"\]:::itemplan
+    PgUnionAll600 ==> __Item601
+    PgUnionAllSingle602["PgUnionAllSingle[602∈24]"]:::plan
+    __Item601 --> PgUnionAllSingle602
+    Access603{{"Access[603∈24]<br />ᐸ602.1ᐳ"}}:::plan
+    PgUnionAllSingle602 --> Access603
+    PgSelect606[["PgSelect[606∈25]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"]]:::plan
+    Access605{{"Access[605∈25]<br />ᐸ604.0ᐳ"}}:::plan
+    Object18 & Access605 --> PgSelect606
+    List614{{"List[614∈25]<br />ᐸ612,613ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"}}:::plan
+    Constant612{{"Constant[612∈25]<br />ᐸ'organizations'ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"}}:::plan
+    PgClassExpression613{{"PgClassExpression[613∈25]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
+    Constant612 & PgClassExpression613 --> List614
+    PgSelect620[["PgSelect[620∈25]<br />ᐸpeopleᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"]]:::plan
+    Access619{{"Access[619∈25]<br />ᐸ618.0ᐳ"}}:::plan
+    Object18 & Access619 --> PgSelect620
+    List628{{"List[628∈25]<br />ᐸ626,627ᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"}}:::plan
+    Constant626{{"Constant[626∈25]<br />ᐸ'people'ᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"}}:::plan
+    PgClassExpression627{{"PgClassExpression[627∈25]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
+    Constant626 & PgClassExpression627 --> List628
+    JSONParse604[["JSONParse[604∈25]<br />ᐸ603ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"]]:::plan
+    Access603 --> JSONParse604
+    JSONParse604 --> Access605
+    First610{{"First[610∈25]"}}:::plan
+    PgSelect606 --> First610
+    PgSelectSingle611{{"PgSelectSingle[611∈25]<br />ᐸorganizationsᐳ"}}:::plan
+    First610 --> PgSelectSingle611
+    PgSelectSingle611 --> PgClassExpression613
+    Lambda615{{"Lambda[615∈25]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List614 --> Lambda615
+    PgClassExpression616{{"PgClassExpression[616∈25]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle611 --> PgClassExpression616
+    JSONParse618[["JSONParse[618∈25]<br />ᐸ603ᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"]]:::plan
+    Access603 --> JSONParse618
+    JSONParse618 --> Access619
+    First624{{"First[624∈25]"}}:::plan
+    PgSelect620 --> First624
+    PgSelectSingle625{{"PgSelectSingle[625∈25]<br />ᐸpeopleᐳ"}}:::plan
+    First624 --> PgSelectSingle625
+    PgSelectSingle625 --> PgClassExpression627
+    Lambda629{{"Lambda[629∈25]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List628 --> Lambda629
+    PgClassExpression630{{"PgClassExpression[630∈25]<br />ᐸ__people__.”username”ᐳ"}}:::plan
+    PgSelectSingle625 --> PgClassExpression630
+    __Item639[/"__Item[639∈26]<br />ᐸ635ᐳ"\]:::itemplan
+    PgUnionAll635 ==> __Item639
+    PgUnionAllSingle640["PgUnionAllSingle[640∈26]"]:::plan
+    __Item639 --> PgUnionAllSingle640
+    Access641{{"Access[641∈26]<br />ᐸ640.1ᐳ"}}:::plan
+    PgUnionAllSingle640 --> Access641
+    PgSelect644[["PgSelect[644∈27]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"]]:::plan
+    Access643{{"Access[643∈27]<br />ᐸ642.0ᐳ"}}:::plan
+    Object18 & Access643 --> PgSelect644
+    List652{{"List[652∈27]<br />ᐸ650,651ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"}}:::plan
+    Constant650{{"Constant[650∈27]<br />ᐸ'organizations'ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"}}:::plan
+    PgClassExpression651{{"PgClassExpression[651∈27]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
+    Constant650 & PgClassExpression651 --> List652
+    PgSelect658[["PgSelect[658∈27]<br />ᐸpeopleᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"]]:::plan
+    Access657{{"Access[657∈27]<br />ᐸ656.0ᐳ"}}:::plan
+    Object18 & Access657 --> PgSelect658
+    List666{{"List[666∈27]<br />ᐸ664,665ᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"}}:::plan
+    Constant664{{"Constant[664∈27]<br />ᐸ'people'ᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"}}:::plan
+    PgClassExpression665{{"PgClassExpression[665∈27]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
+    Constant664 & PgClassExpression665 --> List666
+    JSONParse642[["JSONParse[642∈27]<br />ᐸ641ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"]]:::plan
+    Access641 --> JSONParse642
+    JSONParse642 --> Access643
+    First648{{"First[648∈27]"}}:::plan
+    PgSelect644 --> First648
+    PgSelectSingle649{{"PgSelectSingle[649∈27]<br />ᐸorganizationsᐳ"}}:::plan
+    First648 --> PgSelectSingle649
+    PgSelectSingle649 --> PgClassExpression651
+    Lambda653{{"Lambda[653∈27]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List652 --> Lambda653
+    PgClassExpression654{{"PgClassExpression[654∈27]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle649 --> PgClassExpression654
+    JSONParse656[["JSONParse[656∈27]<br />ᐸ641ᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"]]:::plan
+    Access641 --> JSONParse656
+    JSONParse656 --> Access657
+    First662{{"First[662∈27]"}}:::plan
+    PgSelect658 --> First662
+    PgSelectSingle663{{"PgSelectSingle[663∈27]<br />ᐸpeopleᐳ"}}:::plan
+    First662 --> PgSelectSingle663
+    PgSelectSingle663 --> PgClassExpression665
+    Lambda667{{"Lambda[667∈27]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List666 --> Lambda667
+    PgClassExpression668{{"PgClassExpression[668∈27]<br />ᐸ__people__.”username”ᐳ"}}:::plan
+    PgSelectSingle663 --> PgClassExpression668
 
     %% define steps
 
     subgraph "Buckets for queries/polymorphic/vulns.union_owners"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value3,__Value5,Access15,Access16,Object17,Connection18,Constant664 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 17, 18<br /><br />ROOT Connectionᐸ14ᐳ[18]"):::bucket
+    class Bucket0,__Value0,__Value3,__Value5,Access16,Access17,Object18,Connection19,Constant669 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 18, 19<br /><br />ROOT Connectionᐸ15ᐳ[19]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgUnionAll19 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 17<br /><br />ROOT __Item{2}ᐸ19ᐳ[20]"):::bucket
+    class Bucket1,PgUnionAll20 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 18<br /><br />ROOT __Item{2}ᐸ20ᐳ[21]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,__Item20,PgUnionAllSingle21,Access22 bucket2
-    Bucket3("Bucket 3 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 22, 17, 21<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br />1: JSONParse[23], JSONParse[344]<br />ᐳ: 31, 49, 273, 352, 370, 594, 24, 345<br />2: PgSelect[25], PgSelect[346]<br />ᐳ: 29, 30, 32, 33, 34, 35, 350, 351, 353, 354, 355, 356<br />3: 50, 159, 274, 309, 371, 480, 595, 630"):::bucket
+    class Bucket2,__Item21,PgUnionAllSingle22,Access23 bucket2
+    Bucket3("Bucket 3 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 23, 18, 22<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br />1: JSONParse[24], JSONParse[347]<br />ᐳ: 32, 51, 276, 355, 374, 599, 25, 348<br />2: PgSelect[26], PgSelect[349]<br />ᐳ: 30, 31, 33, 34, 35, 36, 353, 354, 356, 357, 358, 359<br />3: 52, 162, 277, 312, 375, 485, 600, 635"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,JSONParse23,Access24,PgSelect25,First29,PgSelectSingle30,Constant31,PgClassExpression32,List33,Lambda34,PgClassExpression35,Connection49,PgUnionAll50,PgUnionAll159,Connection273,PgUnionAll274,PgUnionAll309,JSONParse344,Access345,PgSelect346,First350,PgSelectSingle351,Constant352,PgClassExpression353,List354,Lambda355,PgClassExpression356,Connection370,PgUnionAll371,PgUnionAll480,Connection594,PgUnionAll595,PgUnionAll630 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 17<br /><br />ROOT __Item{4}ᐸ50ᐳ[51]"):::bucket
+    class Bucket3,JSONParse24,Access25,PgSelect26,First30,PgSelectSingle31,Constant32,PgClassExpression33,List34,Lambda35,PgClassExpression36,Connection51,PgUnionAll52,PgUnionAll162,Connection276,PgUnionAll277,PgUnionAll312,JSONParse347,Access348,PgSelect349,First353,PgSelectSingle354,Constant355,PgClassExpression356,List357,Lambda358,PgClassExpression359,Connection374,PgUnionAll375,PgUnionAll485,Connection599,PgUnionAll600,PgUnionAll635 bucket3
+    Bucket4("Bucket 4 (listItem)<br />Deps: 18<br /><br />ROOT __Item{4}ᐸ52ᐳ[53]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item51,PgUnionAllSingle52,Access53 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 53, 17, 52<br />ᐳFirstPartyVulnerabilityᐳAwsApplication<br />ᐳFirstPartyVulnerabilityᐳGcpApplication<br />1: JSONParse[54], JSONParse[104]<br />ᐳ: 62, 112, 55, 105<br />2: PgSelect[56], PgSelect[106]<br />ᐳ: 60, 61, 63, 64, 65, 66, 67, 68, 110, 111, 113, 114, 115, 116, 117, 118<br />3: PgUnionAll[69], PgUnionAll[119]<br />ᐳ: First[73], First[123]<br />4: 74, 124<br />ᐳ: Access[75], Access[125]"):::bucket
+    class Bucket4,__Item53,PgUnionAllSingle54,Access55 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 55, 18, 54<br />ᐳFirstPartyVulnerabilityᐳAwsApplication<br />ᐳFirstPartyVulnerabilityᐳGcpApplication<br />1: JSONParse[56], JSONParse[106]<br />ᐳ: 64, 114, 57, 107<br />2: PgSelect[58], PgSelect[108]<br />ᐳ: 62, 63, 65, 66, 67, 68, 69, 70, 112, 113, 115, 116, 117, 118, 119, 120<br />3: PgUnionAll[71], PgUnionAll[121]<br />ᐳ: First[75], First[125]<br />4: 76, 126<br />ᐳ: Access[77], Access[127]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,JSONParse54,Access55,PgSelect56,First60,PgSelectSingle61,Constant62,PgClassExpression63,List64,Lambda65,PgClassExpression66,PgClassExpression67,PgClassExpression68,PgUnionAll69,First73,PgUnionAllSingle74,Access75,JSONParse104,Access105,PgSelect106,First110,PgSelectSingle111,Constant112,PgClassExpression113,List114,Lambda115,PgClassExpression116,PgClassExpression117,PgClassExpression118,PgUnionAll119,First123,PgUnionAllSingle124,Access125 bucket5
-    Bucket6("Bucket 6 (polymorphic)<br />Organization,Person<br />Deps: 75, 17, 74<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson<br />1: JSONParse[76], JSONParse[90]<br />ᐳ: 84, 98, 77, 91<br />2: PgSelect[78], PgSelect[92]<br />ᐳ: 82, 83, 85, 86, 87, 88, 96, 97, 99, 100, 101, 102"):::bucket
+    class Bucket5,JSONParse56,Access57,PgSelect58,First62,PgSelectSingle63,Constant64,PgClassExpression65,List66,Lambda67,PgClassExpression68,PgClassExpression69,PgClassExpression70,PgUnionAll71,First75,PgUnionAllSingle76,Access77,JSONParse106,Access107,PgSelect108,First112,PgSelectSingle113,Constant114,PgClassExpression115,List116,Lambda117,PgClassExpression118,PgClassExpression119,PgClassExpression120,PgUnionAll121,First125,PgUnionAllSingle126,Access127 bucket5
+    Bucket6("Bucket 6 (polymorphic)<br />Organization,Person<br />Deps: 77, 18, 76<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson<br />1: JSONParse[78], JSONParse[92]<br />ᐳ: 86, 100, 79, 93<br />2: PgSelect[80], PgSelect[94]<br />ᐳ: 84, 85, 87, 88, 89, 90, 98, 99, 101, 102, 103, 104"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,JSONParse76,Access77,PgSelect78,First82,PgSelectSingle83,Constant84,PgClassExpression85,List86,Lambda87,PgClassExpression88,JSONParse90,Access91,PgSelect92,First96,PgSelectSingle97,Constant98,PgClassExpression99,List100,Lambda101,PgClassExpression102 bucket6
-    Bucket7("Bucket 7 (polymorphic)<br />Organization,Person<br />Deps: 125, 17, 124<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson<br />1: JSONParse[126], JSONParse[140]<br />ᐳ: 134, 148, 127, 141<br />2: PgSelect[128], PgSelect[142]<br />ᐳ: 132, 133, 135, 136, 137, 138, 146, 147, 149, 150, 151, 152"):::bucket
+    class Bucket6,JSONParse78,Access79,PgSelect80,First84,PgSelectSingle85,Constant86,PgClassExpression87,List88,Lambda89,PgClassExpression90,JSONParse92,Access93,PgSelect94,First98,PgSelectSingle99,Constant100,PgClassExpression101,List102,Lambda103,PgClassExpression104 bucket6
+    Bucket7("Bucket 7 (polymorphic)<br />Organization,Person<br />Deps: 127, 18, 126<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson<br />1: JSONParse[128], JSONParse[142]<br />ᐳ: 136, 150, 129, 143<br />2: PgSelect[130], PgSelect[144]<br />ᐳ: 134, 135, 137, 138, 139, 140, 148, 149, 151, 152, 153, 154"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,JSONParse126,Access127,PgSelect128,First132,PgSelectSingle133,Constant134,PgClassExpression135,List136,Lambda137,PgClassExpression138,JSONParse140,Access141,PgSelect142,First146,PgSelectSingle147,Constant148,PgClassExpression149,List150,Lambda151,PgClassExpression152 bucket7
-    Bucket8("Bucket 8 (listItem)<br />Deps: 17<br /><br />ROOT __Item{8}ᐸ159ᐳ[163]"):::bucket
+    class Bucket7,JSONParse128,Access129,PgSelect130,First134,PgSelectSingle135,Constant136,PgClassExpression137,List138,Lambda139,PgClassExpression140,JSONParse142,Access143,PgSelect144,First148,PgSelectSingle149,Constant150,PgClassExpression151,List152,Lambda153,PgClassExpression154 bucket7
+    Bucket8("Bucket 8 (listItem)<br />Deps: 18<br /><br />ROOT __Item{8}ᐸ162ᐳ[166]"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,__Item163,PgUnionAllSingle164,Access165 bucket8
-    Bucket9("Bucket 9 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 165, 17, 164<br />ᐳFirstPartyVulnerabilityᐳAwsApplication<br />ᐳFirstPartyVulnerabilityᐳGcpApplication<br />1: JSONParse[166], JSONParse[216]<br />ᐳ: 174, 224, 167, 217<br />2: PgSelect[168], PgSelect[218]<br />ᐳ: 172, 173, 175, 176, 177, 178, 179, 180, 222, 223, 225, 226, 227, 228, 229, 230<br />3: PgUnionAll[181], PgUnionAll[231]<br />ᐳ: First[185], First[235]<br />4: 186, 236<br />ᐳ: Access[187], Access[237]"):::bucket
+    class Bucket8,__Item166,PgUnionAllSingle167,Access168 bucket8
+    Bucket9("Bucket 9 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 168, 18, 167<br />ᐳFirstPartyVulnerabilityᐳAwsApplication<br />ᐳFirstPartyVulnerabilityᐳGcpApplication<br />1: JSONParse[169], JSONParse[219]<br />ᐳ: 177, 227, 170, 220<br />2: PgSelect[171], PgSelect[221]<br />ᐳ: 175, 176, 178, 179, 180, 181, 182, 183, 225, 226, 228, 229, 230, 231, 232, 233<br />3: PgUnionAll[184], PgUnionAll[234]<br />ᐳ: First[188], First[238]<br />4: 189, 239<br />ᐳ: Access[190], Access[240]"):::bucket
     classDef bucket9 stroke:#ff0000
-    class Bucket9,JSONParse166,Access167,PgSelect168,First172,PgSelectSingle173,Constant174,PgClassExpression175,List176,Lambda177,PgClassExpression178,PgClassExpression179,PgClassExpression180,PgUnionAll181,First185,PgUnionAllSingle186,Access187,JSONParse216,Access217,PgSelect218,First222,PgSelectSingle223,Constant224,PgClassExpression225,List226,Lambda227,PgClassExpression228,PgClassExpression229,PgClassExpression230,PgUnionAll231,First235,PgUnionAllSingle236,Access237 bucket9
-    Bucket10("Bucket 10 (polymorphic)<br />Organization,Person<br />Deps: 187, 17, 186<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson<br />1: JSONParse[188], JSONParse[202]<br />ᐳ: 196, 210, 189, 203<br />2: PgSelect[190], PgSelect[204]<br />ᐳ: 194, 195, 197, 198, 199, 200, 208, 209, 211, 212, 213, 214"):::bucket
+    class Bucket9,JSONParse169,Access170,PgSelect171,First175,PgSelectSingle176,Constant177,PgClassExpression178,List179,Lambda180,PgClassExpression181,PgClassExpression182,PgClassExpression183,PgUnionAll184,First188,PgUnionAllSingle189,Access190,JSONParse219,Access220,PgSelect221,First225,PgSelectSingle226,Constant227,PgClassExpression228,List229,Lambda230,PgClassExpression231,PgClassExpression232,PgClassExpression233,PgUnionAll234,First238,PgUnionAllSingle239,Access240 bucket9
+    Bucket10("Bucket 10 (polymorphic)<br />Organization,Person<br />Deps: 190, 18, 189<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳAwsApplicationᐳPerson<br />1: JSONParse[191], JSONParse[205]<br />ᐳ: 199, 213, 192, 206<br />2: PgSelect[193], PgSelect[207]<br />ᐳ: 197, 198, 200, 201, 202, 203, 211, 212, 214, 215, 216, 217"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,JSONParse188,Access189,PgSelect190,First194,PgSelectSingle195,Constant196,PgClassExpression197,List198,Lambda199,PgClassExpression200,JSONParse202,Access203,PgSelect204,First208,PgSelectSingle209,Constant210,PgClassExpression211,List212,Lambda213,PgClassExpression214 bucket10
-    Bucket11("Bucket 11 (polymorphic)<br />Organization,Person<br />Deps: 237, 17, 236<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson<br />1: JSONParse[238], JSONParse[252]<br />ᐳ: 246, 260, 239, 253<br />2: PgSelect[240], PgSelect[254]<br />ᐳ: 244, 245, 247, 248, 249, 250, 258, 259, 261, 262, 263, 264"):::bucket
+    class Bucket10,JSONParse191,Access192,PgSelect193,First197,PgSelectSingle198,Constant199,PgClassExpression200,List201,Lambda202,PgClassExpression203,JSONParse205,Access206,PgSelect207,First211,PgSelectSingle212,Constant213,PgClassExpression214,List215,Lambda216,PgClassExpression217 bucket10
+    Bucket11("Bucket 11 (polymorphic)<br />Organization,Person<br />Deps: 240, 18, 239<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳGcpApplicationᐳPerson<br />1: JSONParse[241], JSONParse[255]<br />ᐳ: 249, 263, 242, 256<br />2: PgSelect[243], PgSelect[257]<br />ᐳ: 247, 248, 250, 251, 252, 253, 261, 262, 264, 265, 266, 267"):::bucket
     classDef bucket11 stroke:#00ffff
-    class Bucket11,JSONParse238,Access239,PgSelect240,First244,PgSelectSingle245,Constant246,PgClassExpression247,List248,Lambda249,PgClassExpression250,JSONParse252,Access253,PgSelect254,First258,PgSelectSingle259,Constant260,PgClassExpression261,List262,Lambda263,PgClassExpression264 bucket11
-    Bucket12("Bucket 12 (listItem)<br />Deps: 17<br /><br />ROOT __Item{12}ᐸ274ᐳ[275]"):::bucket
+    class Bucket11,JSONParse241,Access242,PgSelect243,First247,PgSelectSingle248,Constant249,PgClassExpression250,List251,Lambda252,PgClassExpression253,JSONParse255,Access256,PgSelect257,First261,PgSelectSingle262,Constant263,PgClassExpression264,List265,Lambda266,PgClassExpression267 bucket11
+    Bucket12("Bucket 12 (listItem)<br />Deps: 18<br /><br />ROOT __Item{12}ᐸ277ᐳ[278]"):::bucket
     classDef bucket12 stroke:#4169e1
-    class Bucket12,__Item275,PgUnionAllSingle276,Access277 bucket12
-    Bucket13("Bucket 13 (polymorphic)<br />Organization,Person<br />Deps: 277, 17, 276<br />ᐳFirstPartyVulnerabilityᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳPerson<br />1: JSONParse[278], JSONParse[292]<br />ᐳ: 286, 300, 279, 293<br />2: PgSelect[280], PgSelect[294]<br />ᐳ: 284, 285, 287, 288, 289, 290, 298, 299, 301, 302, 303, 304"):::bucket
+    class Bucket12,__Item278,PgUnionAllSingle279,Access280 bucket12
+    Bucket13("Bucket 13 (polymorphic)<br />Organization,Person<br />Deps: 280, 18, 279<br />ᐳFirstPartyVulnerabilityᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳPerson<br />1: JSONParse[281], JSONParse[295]<br />ᐳ: 289, 303, 282, 296<br />2: PgSelect[283], PgSelect[297]<br />ᐳ: 287, 288, 290, 291, 292, 293, 301, 302, 304, 305, 306, 307"):::bucket
     classDef bucket13 stroke:#3cb371
-    class Bucket13,JSONParse278,Access279,PgSelect280,First284,PgSelectSingle285,Constant286,PgClassExpression287,List288,Lambda289,PgClassExpression290,JSONParse292,Access293,PgSelect294,First298,PgSelectSingle299,Constant300,PgClassExpression301,List302,Lambda303,PgClassExpression304 bucket13
-    Bucket14("Bucket 14 (listItem)<br />Deps: 17<br /><br />ROOT __Item{14}ᐸ309ᐳ[313]"):::bucket
+    class Bucket13,JSONParse281,Access282,PgSelect283,First287,PgSelectSingle288,Constant289,PgClassExpression290,List291,Lambda292,PgClassExpression293,JSONParse295,Access296,PgSelect297,First301,PgSelectSingle302,Constant303,PgClassExpression304,List305,Lambda306,PgClassExpression307 bucket13
+    Bucket14("Bucket 14 (listItem)<br />Deps: 18<br /><br />ROOT __Item{14}ᐸ312ᐳ[316]"):::bucket
     classDef bucket14 stroke:#a52a2a
-    class Bucket14,__Item313,PgUnionAllSingle314,Access315 bucket14
-    Bucket15("Bucket 15 (polymorphic)<br />Organization,Person<br />Deps: 315, 17, 314<br />ᐳFirstPartyVulnerabilityᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳPerson<br />1: JSONParse[316], JSONParse[330]<br />ᐳ: 324, 338, 317, 331<br />2: PgSelect[318], PgSelect[332]<br />ᐳ: 322, 323, 325, 326, 327, 328, 336, 337, 339, 340, 341, 342"):::bucket
+    class Bucket14,__Item316,PgUnionAllSingle317,Access318 bucket14
+    Bucket15("Bucket 15 (polymorphic)<br />Organization,Person<br />Deps: 318, 18, 317<br />ᐳFirstPartyVulnerabilityᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳPerson<br />1: JSONParse[319], JSONParse[333]<br />ᐳ: 327, 341, 320, 334<br />2: PgSelect[321], PgSelect[335]<br />ᐳ: 325, 326, 328, 329, 330, 331, 339, 340, 342, 343, 344, 345"):::bucket
     classDef bucket15 stroke:#ff00ff
-    class Bucket15,JSONParse316,Access317,PgSelect318,First322,PgSelectSingle323,Constant324,PgClassExpression325,List326,Lambda327,PgClassExpression328,JSONParse330,Access331,PgSelect332,First336,PgSelectSingle337,Constant338,PgClassExpression339,List340,Lambda341,PgClassExpression342 bucket15
-    Bucket16("Bucket 16 (listItem)<br />Deps: 17<br /><br />ROOT __Item{16}ᐸ371ᐳ[372]"):::bucket
+    class Bucket15,JSONParse319,Access320,PgSelect321,First325,PgSelectSingle326,Constant327,PgClassExpression328,List329,Lambda330,PgClassExpression331,JSONParse333,Access334,PgSelect335,First339,PgSelectSingle340,Constant341,PgClassExpression342,List343,Lambda344,PgClassExpression345 bucket15
+    Bucket16("Bucket 16 (listItem)<br />Deps: 18<br /><br />ROOT __Item{16}ᐸ375ᐳ[376]"):::bucket
     classDef bucket16 stroke:#f5deb3
-    class Bucket16,__Item372,PgUnionAllSingle373,Access374 bucket16
-    Bucket17("Bucket 17 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 374, 17, 373<br />ᐳThirdPartyVulnerabilityᐳAwsApplication<br />ᐳThirdPartyVulnerabilityᐳGcpApplication<br />1: JSONParse[375], JSONParse[425]<br />ᐳ: 383, 433, 376, 426<br />2: PgSelect[377], PgSelect[427]<br />ᐳ: 381, 382, 384, 385, 386, 387, 388, 389, 431, 432, 434, 435, 436, 437, 438, 439<br />3: PgUnionAll[390], PgUnionAll[440]<br />ᐳ: First[394], First[444]<br />4: 395, 445<br />ᐳ: Access[396], Access[446]"):::bucket
+    class Bucket16,__Item376,PgUnionAllSingle377,Access378 bucket16
+    Bucket17("Bucket 17 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 378, 18, 377<br />ᐳThirdPartyVulnerabilityᐳAwsApplication<br />ᐳThirdPartyVulnerabilityᐳGcpApplication<br />1: JSONParse[379], JSONParse[429]<br />ᐳ: 387, 437, 380, 430<br />2: PgSelect[381], PgSelect[431]<br />ᐳ: 385, 386, 388, 389, 390, 391, 392, 393, 435, 436, 438, 439, 440, 441, 442, 443<br />3: PgUnionAll[394], PgUnionAll[444]<br />ᐳ: First[398], First[448]<br />4: 399, 449<br />ᐳ: Access[400], Access[450]"):::bucket
     classDef bucket17 stroke:#696969
-    class Bucket17,JSONParse375,Access376,PgSelect377,First381,PgSelectSingle382,Constant383,PgClassExpression384,List385,Lambda386,PgClassExpression387,PgClassExpression388,PgClassExpression389,PgUnionAll390,First394,PgUnionAllSingle395,Access396,JSONParse425,Access426,PgSelect427,First431,PgSelectSingle432,Constant433,PgClassExpression434,List435,Lambda436,PgClassExpression437,PgClassExpression438,PgClassExpression439,PgUnionAll440,First444,PgUnionAllSingle445,Access446 bucket17
-    Bucket18("Bucket 18 (polymorphic)<br />Organization,Person<br />Deps: 396, 17, 395<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson<br />1: JSONParse[397], JSONParse[411]<br />ᐳ: 405, 419, 398, 412<br />2: PgSelect[399], PgSelect[413]<br />ᐳ: 403, 404, 406, 407, 408, 409, 417, 418, 420, 421, 422, 423"):::bucket
+    class Bucket17,JSONParse379,Access380,PgSelect381,First385,PgSelectSingle386,Constant387,PgClassExpression388,List389,Lambda390,PgClassExpression391,PgClassExpression392,PgClassExpression393,PgUnionAll394,First398,PgUnionAllSingle399,Access400,JSONParse429,Access430,PgSelect431,First435,PgSelectSingle436,Constant437,PgClassExpression438,List439,Lambda440,PgClassExpression441,PgClassExpression442,PgClassExpression443,PgUnionAll444,First448,PgUnionAllSingle449,Access450 bucket17
+    Bucket18("Bucket 18 (polymorphic)<br />Organization,Person<br />Deps: 400, 18, 399<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson<br />1: JSONParse[401], JSONParse[415]<br />ᐳ: 409, 423, 402, 416<br />2: PgSelect[403], PgSelect[417]<br />ᐳ: 407, 408, 410, 411, 412, 413, 421, 422, 424, 425, 426, 427"):::bucket
     classDef bucket18 stroke:#00bfff
-    class Bucket18,JSONParse397,Access398,PgSelect399,First403,PgSelectSingle404,Constant405,PgClassExpression406,List407,Lambda408,PgClassExpression409,JSONParse411,Access412,PgSelect413,First417,PgSelectSingle418,Constant419,PgClassExpression420,List421,Lambda422,PgClassExpression423 bucket18
-    Bucket19("Bucket 19 (polymorphic)<br />Organization,Person<br />Deps: 446, 17, 445<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson<br />1: JSONParse[447], JSONParse[461]<br />ᐳ: 455, 469, 448, 462<br />2: PgSelect[449], PgSelect[463]<br />ᐳ: 453, 454, 456, 457, 458, 459, 467, 468, 470, 471, 472, 473"):::bucket
+    class Bucket18,JSONParse401,Access402,PgSelect403,First407,PgSelectSingle408,Constant409,PgClassExpression410,List411,Lambda412,PgClassExpression413,JSONParse415,Access416,PgSelect417,First421,PgSelectSingle422,Constant423,PgClassExpression424,List425,Lambda426,PgClassExpression427 bucket18
+    Bucket19("Bucket 19 (polymorphic)<br />Organization,Person<br />Deps: 450, 18, 449<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson<br />1: JSONParse[451], JSONParse[465]<br />ᐳ: 459, 473, 452, 466<br />2: PgSelect[453], PgSelect[467]<br />ᐳ: 457, 458, 460, 461, 462, 463, 471, 472, 474, 475, 476, 477"):::bucket
     classDef bucket19 stroke:#7f007f
-    class Bucket19,JSONParse447,Access448,PgSelect449,First453,PgSelectSingle454,Constant455,PgClassExpression456,List457,Lambda458,PgClassExpression459,JSONParse461,Access462,PgSelect463,First467,PgSelectSingle468,Constant469,PgClassExpression470,List471,Lambda472,PgClassExpression473 bucket19
-    Bucket20("Bucket 20 (listItem)<br />Deps: 17<br /><br />ROOT __Item{20}ᐸ480ᐳ[484]"):::bucket
+    class Bucket19,JSONParse451,Access452,PgSelect453,First457,PgSelectSingle458,Constant459,PgClassExpression460,List461,Lambda462,PgClassExpression463,JSONParse465,Access466,PgSelect467,First471,PgSelectSingle472,Constant473,PgClassExpression474,List475,Lambda476,PgClassExpression477 bucket19
+    Bucket20("Bucket 20 (listItem)<br />Deps: 18<br /><br />ROOT __Item{20}ᐸ485ᐳ[489]"):::bucket
     classDef bucket20 stroke:#ffa500
-    class Bucket20,__Item484,PgUnionAllSingle485,Access486 bucket20
-    Bucket21("Bucket 21 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 486, 17, 485<br />ᐳThirdPartyVulnerabilityᐳAwsApplication<br />ᐳThirdPartyVulnerabilityᐳGcpApplication<br />1: JSONParse[487], JSONParse[537]<br />ᐳ: 495, 545, 488, 538<br />2: PgSelect[489], PgSelect[539]<br />ᐳ: 493, 494, 496, 497, 498, 499, 500, 501, 543, 544, 546, 547, 548, 549, 550, 551<br />3: PgUnionAll[502], PgUnionAll[552]<br />ᐳ: First[506], First[556]<br />4: 507, 557<br />ᐳ: Access[508], Access[558]"):::bucket
+    class Bucket20,__Item489,PgUnionAllSingle490,Access491 bucket20
+    Bucket21("Bucket 21 (polymorphic)<br />AwsApplication,GcpApplication<br />Deps: 491, 18, 490<br />ᐳThirdPartyVulnerabilityᐳAwsApplication<br />ᐳThirdPartyVulnerabilityᐳGcpApplication<br />1: JSONParse[492], JSONParse[542]<br />ᐳ: 500, 550, 493, 543<br />2: PgSelect[494], PgSelect[544]<br />ᐳ: 498, 499, 501, 502, 503, 504, 505, 506, 548, 549, 551, 552, 553, 554, 555, 556<br />3: PgUnionAll[507], PgUnionAll[557]<br />ᐳ: First[511], First[561]<br />4: 512, 562<br />ᐳ: Access[513], Access[563]"):::bucket
     classDef bucket21 stroke:#0000ff
-    class Bucket21,JSONParse487,Access488,PgSelect489,First493,PgSelectSingle494,Constant495,PgClassExpression496,List497,Lambda498,PgClassExpression499,PgClassExpression500,PgClassExpression501,PgUnionAll502,First506,PgUnionAllSingle507,Access508,JSONParse537,Access538,PgSelect539,First543,PgSelectSingle544,Constant545,PgClassExpression546,List547,Lambda548,PgClassExpression549,PgClassExpression550,PgClassExpression551,PgUnionAll552,First556,PgUnionAllSingle557,Access558 bucket21
-    Bucket22("Bucket 22 (polymorphic)<br />Organization,Person<br />Deps: 508, 17, 507<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson<br />1: JSONParse[509], JSONParse[523]<br />ᐳ: 517, 531, 510, 524<br />2: PgSelect[511], PgSelect[525]<br />ᐳ: 515, 516, 518, 519, 520, 521, 529, 530, 532, 533, 534, 535"):::bucket
+    class Bucket21,JSONParse492,Access493,PgSelect494,First498,PgSelectSingle499,Constant500,PgClassExpression501,List502,Lambda503,PgClassExpression504,PgClassExpression505,PgClassExpression506,PgUnionAll507,First511,PgUnionAllSingle512,Access513,JSONParse542,Access543,PgSelect544,First548,PgSelectSingle549,Constant550,PgClassExpression551,List552,Lambda553,PgClassExpression554,PgClassExpression555,PgClassExpression556,PgUnionAll557,First561,PgUnionAllSingle562,Access563 bucket21
+    Bucket22("Bucket 22 (polymorphic)<br />Organization,Person<br />Deps: 513, 18, 512<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳAwsApplicationᐳPerson<br />1: JSONParse[514], JSONParse[528]<br />ᐳ: 522, 536, 515, 529<br />2: PgSelect[516], PgSelect[530]<br />ᐳ: 520, 521, 523, 524, 525, 526, 534, 535, 537, 538, 539, 540"):::bucket
     classDef bucket22 stroke:#7fff00
-    class Bucket22,JSONParse509,Access510,PgSelect511,First515,PgSelectSingle516,Constant517,PgClassExpression518,List519,Lambda520,PgClassExpression521,JSONParse523,Access524,PgSelect525,First529,PgSelectSingle530,Constant531,PgClassExpression532,List533,Lambda534,PgClassExpression535 bucket22
-    Bucket23("Bucket 23 (polymorphic)<br />Organization,Person<br />Deps: 558, 17, 557<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson<br />1: JSONParse[559], JSONParse[573]<br />ᐳ: 567, 581, 560, 574<br />2: PgSelect[561], PgSelect[575]<br />ᐳ: 565, 566, 568, 569, 570, 571, 579, 580, 582, 583, 584, 585"):::bucket
+    class Bucket22,JSONParse514,Access515,PgSelect516,First520,PgSelectSingle521,Constant522,PgClassExpression523,List524,Lambda525,PgClassExpression526,JSONParse528,Access529,PgSelect530,First534,PgSelectSingle535,Constant536,PgClassExpression537,List538,Lambda539,PgClassExpression540 bucket22
+    Bucket23("Bucket 23 (polymorphic)<br />Organization,Person<br />Deps: 563, 18, 562<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳGcpApplicationᐳPerson<br />1: JSONParse[564], JSONParse[578]<br />ᐳ: 572, 586, 565, 579<br />2: PgSelect[566], PgSelect[580]<br />ᐳ: 570, 571, 573, 574, 575, 576, 584, 585, 587, 588, 589, 590"):::bucket
     classDef bucket23 stroke:#ff1493
-    class Bucket23,JSONParse559,Access560,PgSelect561,First565,PgSelectSingle566,Constant567,PgClassExpression568,List569,Lambda570,PgClassExpression571,JSONParse573,Access574,PgSelect575,First579,PgSelectSingle580,Constant581,PgClassExpression582,List583,Lambda584,PgClassExpression585 bucket23
-    Bucket24("Bucket 24 (listItem)<br />Deps: 17<br /><br />ROOT __Item{24}ᐸ595ᐳ[596]"):::bucket
+    class Bucket23,JSONParse564,Access565,PgSelect566,First570,PgSelectSingle571,Constant572,PgClassExpression573,List574,Lambda575,PgClassExpression576,JSONParse578,Access579,PgSelect580,First584,PgSelectSingle585,Constant586,PgClassExpression587,List588,Lambda589,PgClassExpression590 bucket23
+    Bucket24("Bucket 24 (listItem)<br />Deps: 18<br /><br />ROOT __Item{24}ᐸ600ᐳ[601]"):::bucket
     classDef bucket24 stroke:#808000
-    class Bucket24,__Item596,PgUnionAllSingle597,Access598 bucket24
-    Bucket25("Bucket 25 (polymorphic)<br />Organization,Person<br />Deps: 598, 17, 597<br />ᐳThirdPartyVulnerabilityᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳPerson<br />1: JSONParse[599], JSONParse[613]<br />ᐳ: 607, 621, 600, 614<br />2: PgSelect[601], PgSelect[615]<br />ᐳ: 605, 606, 608, 609, 610, 611, 619, 620, 622, 623, 624, 625"):::bucket
+    class Bucket24,__Item601,PgUnionAllSingle602,Access603 bucket24
+    Bucket25("Bucket 25 (polymorphic)<br />Organization,Person<br />Deps: 603, 18, 602<br />ᐳThirdPartyVulnerabilityᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳPerson<br />1: JSONParse[604], JSONParse[618]<br />ᐳ: 612, 626, 605, 619<br />2: PgSelect[606], PgSelect[620]<br />ᐳ: 610, 611, 613, 614, 615, 616, 624, 625, 627, 628, 629, 630"):::bucket
     classDef bucket25 stroke:#dda0dd
-    class Bucket25,JSONParse599,Access600,PgSelect601,First605,PgSelectSingle606,Constant607,PgClassExpression608,List609,Lambda610,PgClassExpression611,JSONParse613,Access614,PgSelect615,First619,PgSelectSingle620,Constant621,PgClassExpression622,List623,Lambda624,PgClassExpression625 bucket25
-    Bucket26("Bucket 26 (listItem)<br />Deps: 17<br /><br />ROOT __Item{26}ᐸ630ᐳ[634]"):::bucket
+    class Bucket25,JSONParse604,Access605,PgSelect606,First610,PgSelectSingle611,Constant612,PgClassExpression613,List614,Lambda615,PgClassExpression616,JSONParse618,Access619,PgSelect620,First624,PgSelectSingle625,Constant626,PgClassExpression627,List628,Lambda629,PgClassExpression630 bucket25
+    Bucket26("Bucket 26 (listItem)<br />Deps: 18<br /><br />ROOT __Item{26}ᐸ635ᐳ[639]"):::bucket
     classDef bucket26 stroke:#ff0000
-    class Bucket26,__Item634,PgUnionAllSingle635,Access636 bucket26
-    Bucket27("Bucket 27 (polymorphic)<br />Organization,Person<br />Deps: 636, 17, 635<br />ᐳThirdPartyVulnerabilityᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳPerson<br />1: JSONParse[637], JSONParse[651]<br />ᐳ: 645, 659, 638, 652<br />2: PgSelect[639], PgSelect[653]<br />ᐳ: 643, 644, 646, 647, 648, 649, 657, 658, 660, 661, 662, 663"):::bucket
+    class Bucket26,__Item639,PgUnionAllSingle640,Access641 bucket26
+    Bucket27("Bucket 27 (polymorphic)<br />Organization,Person<br />Deps: 641, 18, 640<br />ᐳThirdPartyVulnerabilityᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳPerson<br />1: JSONParse[642], JSONParse[656]<br />ᐳ: 650, 664, 643, 657<br />2: PgSelect[644], PgSelect[658]<br />ᐳ: 648, 649, 651, 652, 653, 654, 662, 663, 665, 666, 667, 668"):::bucket
     classDef bucket27 stroke:#ffff00
-    class Bucket27,JSONParse637,Access638,PgSelect639,First643,PgSelectSingle644,Constant645,PgClassExpression646,List647,Lambda648,PgClassExpression649,JSONParse651,Access652,PgSelect653,First657,PgSelectSingle658,Constant659,PgClassExpression660,List661,Lambda662,PgClassExpression663 bucket27
+    class Bucket27,JSONParse642,Access643,PgSelect644,First648,PgSelectSingle649,Constant650,PgClassExpression651,List652,Lambda653,PgClassExpression654,JSONParse656,Access657,PgSelect658,First662,PgSelectSingle663,Constant664,PgClassExpression665,List666,Lambda667,PgClassExpression668 bucket27
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.simple.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/vulns.union_owners.simple.mermaid
@@ -9,186 +9,186 @@ graph TD
 
 
     %% plan dependencies
-    Object17{{"Object[17∈0]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Access15{{"Access[15∈0]<br />ᐸ3.pgSettingsᐳ"}}:::plan
-    Access16{{"Access[16∈0]<br />ᐸ3.withPgClientᐳ"}}:::plan
-    Access15 & Access16 --> Object17
+    Object18{{"Object[18∈0]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access16{{"Access[16∈0]<br />ᐸ3.pgSettingsᐳ"}}:::plan
+    Access17{{"Access[17∈0]<br />ᐸ3.withPgClientᐳ"}}:::plan
+    Access16 & Access17 --> Object18
     __Value3["__Value[3∈0]<br />ᐸcontextᐳ"]:::plan
-    __Value3 --> Access15
     __Value3 --> Access16
-    Connection18{{"Connection[18∈0]<br />ᐸ14ᐳ"}}:::plan
-    Constant130{{"Constant[130∈0]<br />ᐸ2ᐳ"}}:::plan
-    Constant130 --> Connection18
+    __Value3 --> Access17
+    Connection19{{"Connection[19∈0]<br />ᐸ15ᐳ"}}:::plan
+    Constant131{{"Constant[131∈0]<br />ᐸ2ᐳ"}}:::plan
+    Constant131 --> Connection19
     __Value0["__Value[0∈0]"]:::plan
     __Value5["__Value[5∈0]<br />ᐸrootValueᐳ"]:::plan
-    PgUnionAll19[["PgUnionAll[19∈1]"]]:::plan
-    Object17 & Connection18 --> PgUnionAll19
-    __Item20[/"__Item[20∈2]<br />ᐸ19ᐳ"\]:::itemplan
-    PgUnionAll19 ==> __Item20
-    PgUnionAllSingle21["PgUnionAllSingle[21∈2]"]:::plan
-    __Item20 --> PgUnionAllSingle21
-    Access22{{"Access[22∈2]<br />ᐸ21.1ᐳ"}}:::plan
-    PgUnionAllSingle21 --> Access22
-    PgUnionAll45[["PgUnionAll[45∈3]<br />ᐳFirstPartyVulnerability"]]:::plan
-    PgClassExpression32{{"PgClassExpression[32∈3]<br />ᐸ__first_pa...ies__.”id”ᐳ"}}:::plan
-    Connection44{{"Connection[44∈3]<br />ᐸ40ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
-    Object17 & PgClassExpression32 & PgClassExpression32 & PgClassExpression32 & PgClassExpression32 & Connection44 --> PgUnionAll45
-    PgUnionAll99[["PgUnionAll[99∈3]<br />ᐳThirdPartyVulnerability"]]:::plan
-    PgClassExpression86{{"PgClassExpression[86∈3]<br />ᐸ__third_pa...ies__.”id”ᐳ"}}:::plan
-    Connection98{{"Connection[98∈3]<br />ᐸ94ᐳ<br />ᐳThirdPartyVulnerability"}}:::plan
-    Object17 & PgClassExpression86 & PgClassExpression86 & PgClassExpression86 & PgClassExpression86 & Connection98 --> PgUnionAll99
-    PgSelect25[["PgSelect[25∈3]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
-    Access24{{"Access[24∈3]<br />ᐸ23.0ᐳ"}}:::plan
-    Object17 & Access24 --> PgSelect25
-    List33{{"List[33∈3]<br />ᐸ31,32ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
-    Constant31{{"Constant[31∈3]<br />ᐸ'first_party_vulnerabilities'ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
-    Constant31 & PgClassExpression32 --> List33
-    PgSelect79[["PgSelect[79∈3]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
-    Access78{{"Access[78∈3]<br />ᐸ77.0ᐳ"}}:::plan
-    Object17 & Access78 --> PgSelect79
-    List87{{"List[87∈3]<br />ᐸ85,86ᐳ<br />ᐳThirdPartyVulnerability"}}:::plan
-    Constant85{{"Constant[85∈3]<br />ᐸ'third_party_vulnerabilities'ᐳ<br />ᐳThirdPartyVulnerability"}}:::plan
-    Constant85 & PgClassExpression86 --> List87
-    JSONParse23[["JSONParse[23∈3]<br />ᐸ22ᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
-    Access22 --> JSONParse23
-    JSONParse23 --> Access24
-    First29{{"First[29∈3]"}}:::plan
-    PgSelect25 --> First29
-    PgSelectSingle30{{"PgSelectSingle[30∈3]<br />ᐸfirst_party_vulnerabilitiesᐳ"}}:::plan
-    First29 --> PgSelectSingle30
-    PgSelectSingle30 --> PgClassExpression32
-    Lambda34{{"Lambda[34∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List33 --> Lambda34
-    PgClassExpression35{{"PgClassExpression[35∈3]<br />ᐸ__first_pa...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle30 --> PgClassExpression35
-    JSONParse77[["JSONParse[77∈3]<br />ᐸ22ᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
-    Access22 --> JSONParse77
-    JSONParse77 --> Access78
-    First83{{"First[83∈3]"}}:::plan
-    PgSelect79 --> First83
-    PgSelectSingle84{{"PgSelectSingle[84∈3]<br />ᐸthird_party_vulnerabilitiesᐳ"}}:::plan
-    First83 --> PgSelectSingle84
-    PgSelectSingle84 --> PgClassExpression86
-    Lambda88{{"Lambda[88∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List87 --> Lambda88
-    PgClassExpression89{{"PgClassExpression[89∈3]<br />ᐸ__third_pa...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle84 --> PgClassExpression89
-    __Item46[/"__Item[46∈4]<br />ᐸ45ᐳ"\]:::itemplan
-    PgUnionAll45 ==> __Item46
-    PgUnionAllSingle47["PgUnionAllSingle[47∈4]"]:::plan
-    __Item46 --> PgUnionAllSingle47
-    Access48{{"Access[48∈4]<br />ᐸ47.1ᐳ"}}:::plan
-    PgUnionAllSingle47 --> Access48
-    PgSelect51[["PgSelect[51∈5]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"]]:::plan
-    Access50{{"Access[50∈5]<br />ᐸ49.0ᐳ"}}:::plan
-    Object17 & Access50 --> PgSelect51
-    List59{{"List[59∈5]<br />ᐸ57,58ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"}}:::plan
-    Constant57{{"Constant[57∈5]<br />ᐸ'organizations'ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"}}:::plan
-    PgClassExpression58{{"PgClassExpression[58∈5]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
-    Constant57 & PgClassExpression58 --> List59
-    PgSelect65[["PgSelect[65∈5]<br />ᐸpeopleᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"]]:::plan
-    Access64{{"Access[64∈5]<br />ᐸ63.0ᐳ"}}:::plan
-    Object17 & Access64 --> PgSelect65
-    List73{{"List[73∈5]<br />ᐸ71,72ᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"}}:::plan
-    Constant71{{"Constant[71∈5]<br />ᐸ'people'ᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"}}:::plan
-    PgClassExpression72{{"PgClassExpression[72∈5]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Constant71 & PgClassExpression72 --> List73
-    JSONParse49[["JSONParse[49∈5]<br />ᐸ48ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"]]:::plan
-    Access48 --> JSONParse49
-    JSONParse49 --> Access50
-    First55{{"First[55∈5]"}}:::plan
-    PgSelect51 --> First55
-    PgSelectSingle56{{"PgSelectSingle[56∈5]<br />ᐸorganizationsᐳ"}}:::plan
-    First55 --> PgSelectSingle56
-    PgSelectSingle56 --> PgClassExpression58
-    Lambda60{{"Lambda[60∈5]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List59 --> Lambda60
-    PgClassExpression61{{"PgClassExpression[61∈5]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle56 --> PgClassExpression61
-    JSONParse63[["JSONParse[63∈5]<br />ᐸ48ᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"]]:::plan
-    Access48 --> JSONParse63
-    JSONParse63 --> Access64
-    First69{{"First[69∈5]"}}:::plan
-    PgSelect65 --> First69
-    PgSelectSingle70{{"PgSelectSingle[70∈5]<br />ᐸpeopleᐳ"}}:::plan
-    First69 --> PgSelectSingle70
-    PgSelectSingle70 --> PgClassExpression72
-    Lambda74{{"Lambda[74∈5]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List73 --> Lambda74
-    PgClassExpression75{{"PgClassExpression[75∈5]<br />ᐸ__people__.”username”ᐳ"}}:::plan
-    PgSelectSingle70 --> PgClassExpression75
-    __Item100[/"__Item[100∈6]<br />ᐸ99ᐳ"\]:::itemplan
-    PgUnionAll99 ==> __Item100
-    PgUnionAllSingle101["PgUnionAllSingle[101∈6]"]:::plan
-    __Item100 --> PgUnionAllSingle101
-    Access102{{"Access[102∈6]<br />ᐸ101.1ᐳ"}}:::plan
-    PgUnionAllSingle101 --> Access102
-    PgSelect105[["PgSelect[105∈7]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"]]:::plan
-    Access104{{"Access[104∈7]<br />ᐸ103.0ᐳ"}}:::plan
-    Object17 & Access104 --> PgSelect105
-    List113{{"List[113∈7]<br />ᐸ111,112ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"}}:::plan
-    Constant111{{"Constant[111∈7]<br />ᐸ'organizations'ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"}}:::plan
-    PgClassExpression112{{"PgClassExpression[112∈7]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
-    Constant111 & PgClassExpression112 --> List113
-    PgSelect119[["PgSelect[119∈7]<br />ᐸpeopleᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"]]:::plan
-    Access118{{"Access[118∈7]<br />ᐸ117.0ᐳ"}}:::plan
-    Object17 & Access118 --> PgSelect119
-    List127{{"List[127∈7]<br />ᐸ125,126ᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"}}:::plan
-    Constant125{{"Constant[125∈7]<br />ᐸ'people'ᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"}}:::plan
-    PgClassExpression126{{"PgClassExpression[126∈7]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
-    Constant125 & PgClassExpression126 --> List127
-    JSONParse103[["JSONParse[103∈7]<br />ᐸ102ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"]]:::plan
-    Access102 --> JSONParse103
-    JSONParse103 --> Access104
-    First109{{"First[109∈7]"}}:::plan
-    PgSelect105 --> First109
-    PgSelectSingle110{{"PgSelectSingle[110∈7]<br />ᐸorganizationsᐳ"}}:::plan
-    First109 --> PgSelectSingle110
-    PgSelectSingle110 --> PgClassExpression112
-    Lambda114{{"Lambda[114∈7]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List113 --> Lambda114
-    PgClassExpression115{{"PgClassExpression[115∈7]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
-    PgSelectSingle110 --> PgClassExpression115
-    JSONParse117[["JSONParse[117∈7]<br />ᐸ102ᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"]]:::plan
-    Access102 --> JSONParse117
-    JSONParse117 --> Access118
-    First123{{"First[123∈7]"}}:::plan
-    PgSelect119 --> First123
-    PgSelectSingle124{{"PgSelectSingle[124∈7]<br />ᐸpeopleᐳ"}}:::plan
-    First123 --> PgSelectSingle124
-    PgSelectSingle124 --> PgClassExpression126
-    Lambda128{{"Lambda[128∈7]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List127 --> Lambda128
-    PgClassExpression129{{"PgClassExpression[129∈7]<br />ᐸ__people__.”username”ᐳ"}}:::plan
-    PgSelectSingle124 --> PgClassExpression129
+    PgUnionAll20[["PgUnionAll[20∈1]"]]:::plan
+    Object18 & Connection19 --> PgUnionAll20
+    __Item21[/"__Item[21∈2]<br />ᐸ20ᐳ"\]:::itemplan
+    PgUnionAll20 ==> __Item21
+    PgUnionAllSingle22["PgUnionAllSingle[22∈2]"]:::plan
+    __Item21 --> PgUnionAllSingle22
+    Access23{{"Access[23∈2]<br />ᐸ22.1ᐳ"}}:::plan
+    PgUnionAllSingle22 --> Access23
+    PgUnionAll46[["PgUnionAll[46∈3]<br />ᐳFirstPartyVulnerability"]]:::plan
+    PgClassExpression33{{"PgClassExpression[33∈3]<br />ᐸ__first_pa...ies__.”id”ᐳ"}}:::plan
+    Connection45{{"Connection[45∈3]<br />ᐸ41ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
+    Object18 & PgClassExpression33 & PgClassExpression33 & PgClassExpression33 & PgClassExpression33 & Connection45 --> PgUnionAll46
+    PgUnionAll100[["PgUnionAll[100∈3]<br />ᐳThirdPartyVulnerability"]]:::plan
+    PgClassExpression87{{"PgClassExpression[87∈3]<br />ᐸ__third_pa...ies__.”id”ᐳ"}}:::plan
+    Connection99{{"Connection[99∈3]<br />ᐸ95ᐳ<br />ᐳThirdPartyVulnerability"}}:::plan
+    Object18 & PgClassExpression87 & PgClassExpression87 & PgClassExpression87 & PgClassExpression87 & Connection99 --> PgUnionAll100
+    PgSelect26[["PgSelect[26∈3]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
+    Access25{{"Access[25∈3]<br />ᐸ24.0ᐳ"}}:::plan
+    Object18 & Access25 --> PgSelect26
+    List34{{"List[34∈3]<br />ᐸ32,33ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
+    Constant32{{"Constant[32∈3]<br />ᐸ'first_party_vulnerabilities'ᐳ<br />ᐳFirstPartyVulnerability"}}:::plan
+    Constant32 & PgClassExpression33 --> List34
+    PgSelect80[["PgSelect[80∈3]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
+    Access79{{"Access[79∈3]<br />ᐸ78.0ᐳ"}}:::plan
+    Object18 & Access79 --> PgSelect80
+    List88{{"List[88∈3]<br />ᐸ86,87ᐳ<br />ᐳThirdPartyVulnerability"}}:::plan
+    Constant86{{"Constant[86∈3]<br />ᐸ'third_party_vulnerabilities'ᐳ<br />ᐳThirdPartyVulnerability"}}:::plan
+    Constant86 & PgClassExpression87 --> List88
+    JSONParse24[["JSONParse[24∈3]<br />ᐸ23ᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
+    Access23 --> JSONParse24
+    JSONParse24 --> Access25
+    First30{{"First[30∈3]"}}:::plan
+    PgSelect26 --> First30
+    PgSelectSingle31{{"PgSelectSingle[31∈3]<br />ᐸfirst_party_vulnerabilitiesᐳ"}}:::plan
+    First30 --> PgSelectSingle31
+    PgSelectSingle31 --> PgClassExpression33
+    Lambda35{{"Lambda[35∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List34 --> Lambda35
+    PgClassExpression36{{"PgClassExpression[36∈3]<br />ᐸ__first_pa...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle31 --> PgClassExpression36
+    JSONParse78[["JSONParse[78∈3]<br />ᐸ23ᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
+    Access23 --> JSONParse78
+    JSONParse78 --> Access79
+    First84{{"First[84∈3]"}}:::plan
+    PgSelect80 --> First84
+    PgSelectSingle85{{"PgSelectSingle[85∈3]<br />ᐸthird_party_vulnerabilitiesᐳ"}}:::plan
+    First84 --> PgSelectSingle85
+    PgSelectSingle85 --> PgClassExpression87
+    Lambda89{{"Lambda[89∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List88 --> Lambda89
+    PgClassExpression90{{"PgClassExpression[90∈3]<br />ᐸ__third_pa...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle85 --> PgClassExpression90
+    __Item47[/"__Item[47∈4]<br />ᐸ46ᐳ"\]:::itemplan
+    PgUnionAll46 ==> __Item47
+    PgUnionAllSingle48["PgUnionAllSingle[48∈4]"]:::plan
+    __Item47 --> PgUnionAllSingle48
+    Access49{{"Access[49∈4]<br />ᐸ48.1ᐳ"}}:::plan
+    PgUnionAllSingle48 --> Access49
+    PgSelect52[["PgSelect[52∈5]<br />ᐸorganizationsᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"]]:::plan
+    Access51{{"Access[51∈5]<br />ᐸ50.0ᐳ"}}:::plan
+    Object18 & Access51 --> PgSelect52
+    List60{{"List[60∈5]<br />ᐸ58,59ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"}}:::plan
+    Constant58{{"Constant[58∈5]<br />ᐸ'organizations'ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"}}:::plan
+    PgClassExpression59{{"PgClassExpression[59∈5]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
+    Constant58 & PgClassExpression59 --> List60
+    PgSelect66[["PgSelect[66∈5]<br />ᐸpeopleᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"]]:::plan
+    Access65{{"Access[65∈5]<br />ᐸ64.0ᐳ"}}:::plan
+    Object18 & Access65 --> PgSelect66
+    List74{{"List[74∈5]<br />ᐸ72,73ᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"}}:::plan
+    Constant72{{"Constant[72∈5]<br />ᐸ'people'ᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"}}:::plan
+    PgClassExpression73{{"PgClassExpression[73∈5]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
+    Constant72 & PgClassExpression73 --> List74
+    JSONParse50[["JSONParse[50∈5]<br />ᐸ49ᐳ<br />ᐳFirstPartyVulnerabilityᐳOrganization"]]:::plan
+    Access49 --> JSONParse50
+    JSONParse50 --> Access51
+    First56{{"First[56∈5]"}}:::plan
+    PgSelect52 --> First56
+    PgSelectSingle57{{"PgSelectSingle[57∈5]<br />ᐸorganizationsᐳ"}}:::plan
+    First56 --> PgSelectSingle57
+    PgSelectSingle57 --> PgClassExpression59
+    Lambda61{{"Lambda[61∈5]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List60 --> Lambda61
+    PgClassExpression62{{"PgClassExpression[62∈5]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle57 --> PgClassExpression62
+    JSONParse64[["JSONParse[64∈5]<br />ᐸ49ᐳ<br />ᐳFirstPartyVulnerabilityᐳPerson"]]:::plan
+    Access49 --> JSONParse64
+    JSONParse64 --> Access65
+    First70{{"First[70∈5]"}}:::plan
+    PgSelect66 --> First70
+    PgSelectSingle71{{"PgSelectSingle[71∈5]<br />ᐸpeopleᐳ"}}:::plan
+    First70 --> PgSelectSingle71
+    PgSelectSingle71 --> PgClassExpression73
+    Lambda75{{"Lambda[75∈5]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List74 --> Lambda75
+    PgClassExpression76{{"PgClassExpression[76∈5]<br />ᐸ__people__.”username”ᐳ"}}:::plan
+    PgSelectSingle71 --> PgClassExpression76
+    __Item101[/"__Item[101∈6]<br />ᐸ100ᐳ"\]:::itemplan
+    PgUnionAll100 ==> __Item101
+    PgUnionAllSingle102["PgUnionAllSingle[102∈6]"]:::plan
+    __Item101 --> PgUnionAllSingle102
+    Access103{{"Access[103∈6]<br />ᐸ102.1ᐳ"}}:::plan
+    PgUnionAllSingle102 --> Access103
+    PgSelect106[["PgSelect[106∈7]<br />ᐸorganizationsᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"]]:::plan
+    Access105{{"Access[105∈7]<br />ᐸ104.0ᐳ"}}:::plan
+    Object18 & Access105 --> PgSelect106
+    List114{{"List[114∈7]<br />ᐸ112,113ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"}}:::plan
+    Constant112{{"Constant[112∈7]<br />ᐸ'organizations'ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"}}:::plan
+    PgClassExpression113{{"PgClassExpression[113∈7]<br />ᐸ__organiza...zation_id”ᐳ"}}:::plan
+    Constant112 & PgClassExpression113 --> List114
+    PgSelect120[["PgSelect[120∈7]<br />ᐸpeopleᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"]]:::plan
+    Access119{{"Access[119∈7]<br />ᐸ118.0ᐳ"}}:::plan
+    Object18 & Access119 --> PgSelect120
+    List128{{"List[128∈7]<br />ᐸ126,127ᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"}}:::plan
+    Constant126{{"Constant[126∈7]<br />ᐸ'people'ᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"}}:::plan
+    PgClassExpression127{{"PgClassExpression[127∈7]<br />ᐸ__people__.”person_id”ᐳ"}}:::plan
+    Constant126 & PgClassExpression127 --> List128
+    JSONParse104[["JSONParse[104∈7]<br />ᐸ103ᐳ<br />ᐳThirdPartyVulnerabilityᐳOrganization"]]:::plan
+    Access103 --> JSONParse104
+    JSONParse104 --> Access105
+    First110{{"First[110∈7]"}}:::plan
+    PgSelect106 --> First110
+    PgSelectSingle111{{"PgSelectSingle[111∈7]<br />ᐸorganizationsᐳ"}}:::plan
+    First110 --> PgSelectSingle111
+    PgSelectSingle111 --> PgClassExpression113
+    Lambda115{{"Lambda[115∈7]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List114 --> Lambda115
+    PgClassExpression116{{"PgClassExpression[116∈7]<br />ᐸ__organiza...s__.”name”ᐳ"}}:::plan
+    PgSelectSingle111 --> PgClassExpression116
+    JSONParse118[["JSONParse[118∈7]<br />ᐸ103ᐳ<br />ᐳThirdPartyVulnerabilityᐳPerson"]]:::plan
+    Access103 --> JSONParse118
+    JSONParse118 --> Access119
+    First124{{"First[124∈7]"}}:::plan
+    PgSelect120 --> First124
+    PgSelectSingle125{{"PgSelectSingle[125∈7]<br />ᐸpeopleᐳ"}}:::plan
+    First124 --> PgSelectSingle125
+    PgSelectSingle125 --> PgClassExpression127
+    Lambda129{{"Lambda[129∈7]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List128 --> Lambda129
+    PgClassExpression130{{"PgClassExpression[130∈7]<br />ᐸ__people__.”username”ᐳ"}}:::plan
+    PgSelectSingle125 --> PgClassExpression130
 
     %% define steps
 
     subgraph "Buckets for queries/polymorphic/vulns.union_owners.simple"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value3,__Value5,Access15,Access16,Object17,Connection18,Constant130 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 17, 18<br /><br />ROOT Connectionᐸ14ᐳ[18]"):::bucket
+    class Bucket0,__Value0,__Value3,__Value5,Access16,Access17,Object18,Connection19,Constant131 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 18, 19<br /><br />ROOT Connectionᐸ15ᐳ[19]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgUnionAll19 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 17<br /><br />ROOT __Item{2}ᐸ19ᐳ[20]"):::bucket
+    class Bucket1,PgUnionAll20 bucket1
+    Bucket2("Bucket 2 (listItem)<br />Deps: 18<br /><br />ROOT __Item{2}ᐸ20ᐳ[21]"):::bucket
     classDef bucket2 stroke:#7f007f
-    class Bucket2,__Item20,PgUnionAllSingle21,Access22 bucket2
-    Bucket3("Bucket 3 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 22, 17, 21<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br />1: JSONParse[23], JSONParse[77]<br />ᐳ: 31, 44, 85, 98, 24, 78<br />2: PgSelect[25], PgSelect[79]<br />ᐳ: 29, 30, 32, 33, 34, 35, 83, 84, 86, 87, 88, 89<br />3: PgUnionAll[45], PgUnionAll[99]"):::bucket
+    class Bucket2,__Item21,PgUnionAllSingle22,Access23 bucket2
+    Bucket3("Bucket 3 (polymorphic)<br />FirstPartyVulnerability,ThirdPartyVulnerability<br />Deps: 23, 18, 22<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability<br />1: JSONParse[24], JSONParse[78]<br />ᐳ: 32, 45, 86, 99, 25, 79<br />2: PgSelect[26], PgSelect[80]<br />ᐳ: 30, 31, 33, 34, 35, 36, 84, 85, 87, 88, 89, 90<br />3: PgUnionAll[46], PgUnionAll[100]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,JSONParse23,Access24,PgSelect25,First29,PgSelectSingle30,Constant31,PgClassExpression32,List33,Lambda34,PgClassExpression35,Connection44,PgUnionAll45,JSONParse77,Access78,PgSelect79,First83,PgSelectSingle84,Constant85,PgClassExpression86,List87,Lambda88,PgClassExpression89,Connection98,PgUnionAll99 bucket3
-    Bucket4("Bucket 4 (listItem)<br />Deps: 17<br /><br />ROOT __Item{4}ᐸ45ᐳ[46]"):::bucket
+    class Bucket3,JSONParse24,Access25,PgSelect26,First30,PgSelectSingle31,Constant32,PgClassExpression33,List34,Lambda35,PgClassExpression36,Connection45,PgUnionAll46,JSONParse78,Access79,PgSelect80,First84,PgSelectSingle85,Constant86,PgClassExpression87,List88,Lambda89,PgClassExpression90,Connection99,PgUnionAll100 bucket3
+    Bucket4("Bucket 4 (listItem)<br />Deps: 18<br /><br />ROOT __Item{4}ᐸ46ᐳ[47]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,__Item46,PgUnionAllSingle47,Access48 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />Organization,Person<br />Deps: 48, 17, 47<br />ᐳFirstPartyVulnerabilityᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳPerson<br />1: JSONParse[49], JSONParse[63]<br />ᐳ: 57, 71, 50, 64<br />2: PgSelect[51], PgSelect[65]<br />ᐳ: 55, 56, 58, 59, 60, 61, 69, 70, 72, 73, 74, 75"):::bucket
+    class Bucket4,__Item47,PgUnionAllSingle48,Access49 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />Organization,Person<br />Deps: 49, 18, 48<br />ᐳFirstPartyVulnerabilityᐳOrganization<br />ᐳFirstPartyVulnerabilityᐳPerson<br />1: JSONParse[50], JSONParse[64]<br />ᐳ: 58, 72, 51, 65<br />2: PgSelect[52], PgSelect[66]<br />ᐳ: 56, 57, 59, 60, 61, 62, 70, 71, 73, 74, 75, 76"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,JSONParse49,Access50,PgSelect51,First55,PgSelectSingle56,Constant57,PgClassExpression58,List59,Lambda60,PgClassExpression61,JSONParse63,Access64,PgSelect65,First69,PgSelectSingle70,Constant71,PgClassExpression72,List73,Lambda74,PgClassExpression75 bucket5
-    Bucket6("Bucket 6 (listItem)<br />Deps: 17<br /><br />ROOT __Item{6}ᐸ99ᐳ[100]"):::bucket
+    class Bucket5,JSONParse50,Access51,PgSelect52,First56,PgSelectSingle57,Constant58,PgClassExpression59,List60,Lambda61,PgClassExpression62,JSONParse64,Access65,PgSelect66,First70,PgSelectSingle71,Constant72,PgClassExpression73,List74,Lambda75,PgClassExpression76 bucket5
+    Bucket6("Bucket 6 (listItem)<br />Deps: 18<br /><br />ROOT __Item{6}ᐸ100ᐳ[101]"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,__Item100,PgUnionAllSingle101,Access102 bucket6
-    Bucket7("Bucket 7 (polymorphic)<br />Organization,Person<br />Deps: 102, 17, 101<br />ᐳThirdPartyVulnerabilityᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳPerson<br />1: JSONParse[103], JSONParse[117]<br />ᐳ: 111, 125, 104, 118<br />2: PgSelect[105], PgSelect[119]<br />ᐳ: 109, 110, 112, 113, 114, 115, 123, 124, 126, 127, 128, 129"):::bucket
+    class Bucket6,__Item101,PgUnionAllSingle102,Access103 bucket6
+    Bucket7("Bucket 7 (polymorphic)<br />Organization,Person<br />Deps: 103, 18, 102<br />ᐳThirdPartyVulnerabilityᐳOrganization<br />ᐳThirdPartyVulnerabilityᐳPerson<br />1: JSONParse[104], JSONParse[118]<br />ᐳ: 112, 126, 105, 119<br />2: PgSelect[106], PgSelect[120]<br />ᐳ: 110, 111, 113, 114, 115, 116, 124, 125, 127, 128, 129, 130"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,JSONParse103,Access104,PgSelect105,First109,PgSelectSingle110,Constant111,PgClassExpression112,List113,Lambda114,PgClassExpression115,JSONParse117,Access118,PgSelect119,First123,PgSelectSingle124,Constant125,PgClassExpression126,List127,Lambda128,PgClassExpression129 bucket7
+    class Bucket7,JSONParse104,Access105,PgSelect106,First110,PgSelectSingle111,Constant112,PgClassExpression113,List114,Lambda115,PgClassExpression116,JSONParse118,Access119,PgSelect120,First124,PgSelectSingle125,Constant126,PgClassExpression127,List128,Lambda129,PgClassExpression130 bucket7
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3

--- a/postgraphile/postgraphile/__tests__/schema/v4/polymorphic.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/polymorphic.1.graphql
@@ -32,6 +32,9 @@ interface Application implements Node {
     based pagination. May not be used with `last`.
     """
     offset: Int
+
+    """Filter results to only those of the given types"""
+    only: [VulnerabilityType!] @deprecated(reason: "EXPERIMENTAL")
   ): VulnerabilitiesConnection!
 }
 
@@ -48,6 +51,11 @@ input ApplicationCondition {
 
   """Checks for equality with the object’s `name` field."""
   name: String
+}
+
+enum ApplicationType {
+  AwsApplication
+  GcpApplication
 }
 
 """A connection to a list of `Application` values."""
@@ -137,6 +145,9 @@ type AwsApplication implements Application & Node {
     based pagination. May not be used with `last`.
     """
     offset: Int
+
+    """Filter results to only those of the given types"""
+    only: [VulnerabilityType!] @deprecated(reason: "EXPERIMENTAL")
 
     """The method to use when ordering `Vulnerability`."""
     orderBy: [VulnerabilitiesOrderBy!]
@@ -1467,6 +1478,9 @@ type FirstPartyVulnerability implements Node & Vulnerability {
     """
     offset: Int
 
+    """Filter results to only those of the given types"""
+    only: [ApplicationType!] @deprecated(reason: "EXPERIMENTAL")
+
     """The method to use when ordering `Application`."""
     orderBy: [ApplicationsOrderBy!]
   ): ApplicationsConnection!
@@ -1570,6 +1584,9 @@ type GcpApplication implements Application & Node {
     based pagination. May not be used with `last`.
     """
     offset: Int
+
+    """Filter results to only those of the given types"""
+    only: [VulnerabilityType!] @deprecated(reason: "EXPERIMENTAL")
 
     """The method to use when ordering `Vulnerability`."""
     orderBy: [VulnerabilitiesOrderBy!]
@@ -2584,6 +2601,9 @@ type Person implements Node {
     """
     offset: Int
 
+    """Filter results to only those of the given types"""
+    only: [ApplicationType!] @deprecated(reason: "EXPERIMENTAL")
+
     """The method to use when ordering `Application`."""
     orderBy: [ApplicationsOrderBy!]
   ): ApplicationsConnection!
@@ -2881,6 +2901,9 @@ type Query implements Node {
     based pagination. May not be used with `last`.
     """
     offset: Int
+
+    """Filter results to only those of the given types"""
+    only: [ApplicationType!] @deprecated(reason: "EXPERIMENTAL")
 
     """The method to use when ordering `Application`."""
     orderBy: [ApplicationsOrderBy!]
@@ -3465,6 +3488,9 @@ type Query implements Node {
     based pagination. May not be used with `last`.
     """
     offset: Int
+
+    """Filter results to only those of the given types"""
+    only: [VulnerabilityType!] @deprecated(reason: "EXPERIMENTAL")
 
     """The method to use when ordering `Vulnerability`."""
     orderBy: [VulnerabilitiesOrderBy!]
@@ -7182,6 +7208,9 @@ type ThirdPartyVulnerability implements Node & Vulnerability {
     """
     offset: Int
 
+    """Filter results to only those of the given types"""
+    only: [ApplicationType!] @deprecated(reason: "EXPERIMENTAL")
+
     """The method to use when ordering `Application`."""
     orderBy: [ApplicationsOrderBy!]
   ): ApplicationsConnection!
@@ -8067,6 +8096,9 @@ interface Vulnerability implements Node {
     based pagination. May not be used with `last`.
     """
     offset: Int
+
+    """Filter results to only those of the given types"""
+    only: [ApplicationType!] @deprecated(reason: "EXPERIMENTAL")
   ): ApplicationsConnection!
   cvssScore: Float!
   id: Int!
@@ -8094,6 +8126,11 @@ input VulnerabilityCondition {
 
   """Checks for equality with the object’s `name` field."""
   name: String
+}
+
+enum VulnerabilityType {
+  FirstPartyVulnerability
+  ThirdPartyVulnerability
 }
 
 interface ZeroImplementation implements Node {

--- a/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.polymorphic.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.polymorphic.1.graphql
@@ -27,6 +27,9 @@ interface Application {
     based pagination. May not be used with `last`.
     """
     offset: Int
+
+    """Filter results to only those of the given types"""
+    only: [VulnerabilityType!] @deprecated(reason: "EXPERIMENTAL")
   ): VulnerabilitiesConnection!
 }
 
@@ -43,6 +46,11 @@ input ApplicationCondition {
 
   """Checks for equality with the object’s `name` field."""
   name: String
+}
+
+enum ApplicationType {
+  AwsApplication
+  GcpApplication
 }
 
 """A connection to a list of `Application` values."""
@@ -127,6 +135,9 @@ type AwsApplication implements Application {
     based pagination. May not be used with `last`.
     """
     offset: Int
+
+    """Filter results to only those of the given types"""
+    only: [VulnerabilityType!] @deprecated(reason: "EXPERIMENTAL")
 
     """The method to use when ordering `Vulnerability`."""
     orderBy: [VulnerabilitiesOrderBy!]
@@ -1266,6 +1277,9 @@ type FirstPartyVulnerability implements Vulnerability {
     """
     offset: Int
 
+    """Filter results to only those of the given types"""
+    only: [ApplicationType!] @deprecated(reason: "EXPERIMENTAL")
+
     """The method to use when ordering `Application`."""
     orderBy: [ApplicationsOrderBy!]
   ): ApplicationsConnection!
@@ -1359,6 +1373,9 @@ type GcpApplication implements Application {
     based pagination. May not be used with `last`.
     """
     offset: Int
+
+    """Filter results to only those of the given types"""
+    only: [VulnerabilityType!] @deprecated(reason: "EXPERIMENTAL")
 
     """The method to use when ordering `Vulnerability`."""
     orderBy: [VulnerabilitiesOrderBy!]
@@ -2143,6 +2160,9 @@ type Person {
     """
     offset: Int
 
+    """Filter results to only those of the given types"""
+    only: [ApplicationType!] @deprecated(reason: "EXPERIMENTAL")
+
     """The method to use when ordering `Application`."""
     orderBy: [ApplicationsOrderBy!]
   ): ApplicationsConnection!
@@ -2430,6 +2450,9 @@ type Query {
     based pagination. May not be used with `last`.
     """
     offset: Int
+
+    """Filter results to only those of the given types"""
+    only: [ApplicationType!] @deprecated(reason: "EXPERIMENTAL")
 
     """The method to use when ordering `Application`."""
     orderBy: [ApplicationsOrderBy!]
@@ -3014,6 +3037,9 @@ type Query {
     based pagination. May not be used with `last`.
     """
     offset: Int
+
+    """Filter results to only those of the given types"""
+    only: [VulnerabilityType!] @deprecated(reason: "EXPERIMENTAL")
 
     """The method to use when ordering `Vulnerability`."""
     orderBy: [VulnerabilitiesOrderBy!]
@@ -6454,6 +6480,9 @@ type ThirdPartyVulnerability implements Vulnerability {
     """
     offset: Int
 
+    """Filter results to only those of the given types"""
+    only: [ApplicationType!] @deprecated(reason: "EXPERIMENTAL")
+
     """The method to use when ordering `Application`."""
     orderBy: [ApplicationsOrderBy!]
   ): ApplicationsConnection!
@@ -7125,6 +7154,9 @@ interface Vulnerability {
     based pagination. May not be used with `last`.
     """
     offset: Int
+
+    """Filter results to only those of the given types"""
+    only: [ApplicationType!] @deprecated(reason: "EXPERIMENTAL")
   ): ApplicationsConnection!
   cvssScore: Float!
   id: Int!
@@ -7147,6 +7179,11 @@ input VulnerabilityCondition {
 
   """Checks for equality with the object’s `name` field."""
   name: String
+}
+
+enum VulnerabilityType {
+  FirstPartyVulnerability
+  ThirdPartyVulnerability
 }
 
 interface ZeroImplementation {

--- a/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.polymorphic.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.polymorphic.1.graphql
@@ -27,6 +27,9 @@ interface Application {
     based pagination. May not be used with `last`.
     """
     offset: Int
+
+    """Filter results to only those of the given types"""
+    only: [VulnerabilityType!] @deprecated(reason: "EXPERIMENTAL")
   ): VulnerabilityConnection!
 }
 
@@ -80,6 +83,11 @@ enum ApplicationOrderBy {
   NAME_ASC
   NAME_DESC
   NATURAL
+}
+
+enum ApplicationType {
+  AwsApplication
+  GcpApplication
 }
 
 type AwsApplication implements Application {
@@ -192,6 +200,9 @@ type AwsApplication implements Application {
     based pagination. May not be used with `last`.
     """
     offset: Int
+
+    """Filter results to only those of the given types"""
+    only: [VulnerabilityType!] @deprecated(reason: "EXPERIMENTAL")
 
     """The method to use when ordering `Vulnerability`."""
     orderBy: [VulnerabilityOrderBy!]
@@ -1768,6 +1779,9 @@ type FirstPartyVulnerability implements Vulnerability {
     """
     offset: Int
 
+    """Filter results to only those of the given types"""
+    only: [ApplicationType!] @deprecated(reason: "EXPERIMENTAL")
+
     """The method to use when ordering `Application`."""
     orderBy: [ApplicationOrderBy!]
   ): ApplicationConnection!
@@ -2035,6 +2049,9 @@ type GcpApplication implements Application {
     based pagination. May not be used with `last`.
     """
     offset: Int
+
+    """Filter results to only those of the given types"""
+    only: [VulnerabilityType!] @deprecated(reason: "EXPERIMENTAL")
 
     """The method to use when ordering `Vulnerability`."""
     orderBy: [VulnerabilityOrderBy!]
@@ -3088,6 +3105,9 @@ type Person {
     """
     offset: Int
 
+    """Filter results to only those of the given types"""
+    only: [ApplicationType!] @deprecated(reason: "EXPERIMENTAL")
+
     """The method to use when ordering `Application`."""
     orderBy: [ApplicationOrderBy!]
   ): ApplicationConnection!
@@ -3449,6 +3469,9 @@ type Query {
     based pagination. May not be used with `last`.
     """
     offset: Int
+
+    """Filter results to only those of the given types"""
+    only: [ApplicationType!] @deprecated(reason: "EXPERIMENTAL")
 
     """The method to use when ordering `Application`."""
     orderBy: [ApplicationOrderBy!]
@@ -4173,6 +4196,9 @@ type Query {
     based pagination. May not be used with `last`.
     """
     offset: Int
+
+    """Filter results to only those of the given types"""
+    only: [VulnerabilityType!] @deprecated(reason: "EXPERIMENTAL")
 
     """The method to use when ordering `Vulnerability`."""
     orderBy: [VulnerabilityOrderBy!]
@@ -7582,6 +7608,9 @@ type ThirdPartyVulnerability implements Vulnerability {
     """
     offset: Int
 
+    """Filter results to only those of the given types"""
+    only: [ApplicationType!] @deprecated(reason: "EXPERIMENTAL")
+
     """The method to use when ordering `Application`."""
     orderBy: [ApplicationOrderBy!]
   ): ApplicationConnection!
@@ -8498,6 +8527,9 @@ interface Vulnerability {
     based pagination. May not be used with `last`.
     """
     offset: Int
+
+    """Filter results to only those of the given types"""
+    only: [ApplicationType!] @deprecated(reason: "EXPERIMENTAL")
   ): ApplicationConnection!
   cvssScore: Float!
   name: String!
@@ -8557,6 +8589,11 @@ enum VulnerabilityOrderBy {
   NAME_ASC
   NAME_DESC
   NATURAL
+}
+
+enum VulnerabilityType {
+  FirstPartyVulnerability
+  ThirdPartyVulnerability
 }
 
 interface ZeroImplementation {

--- a/postgraphile/website/docusaurus.config.js
+++ b/postgraphile/website/docusaurus.config.js
@@ -55,8 +55,7 @@ const config = {
         },
         pages: {
           remarkPlugins: [
-            require("@docusaurus/remark-plugin-npm2yarn"),
-            { sync: true },
+            [require("@docusaurus/remark-plugin-npm2yarn"), { sync: true }],
           ],
         },
         blog: false,


### PR DESCRIPTION
## Description

Adds an `only` argument (an enum list) to _some_ polymorphic relation fields (currently only those for lists/connections of "mode=union" interfaces). When present, only the given types will be included in the result. 

Currently this is enabled by default but marked as experimental. Due to #1816 Ruru won't recognize the argument exists, but it's there so just write it and ignore the red squigglies. The enum values are the exact names of the types.

Example query:

```graphql
{
  allApplications(only: [GcpApplication, AwsApplication]) {
    nodes {
      __typename
      ... on AwsApplication {
        awsId
      }
      ... on GcpApplication {
        gcpId
      }
      vulnerabilities(only: [ThirdPartyVulnerability]) {
        nodes {
          __typename
          id
          name
          ... on FirstPartyVulnerability {
            teamName
          }
          ... on ThirdPartyVulnerability {
            vendorName
          }
        }
      }
    }
  }
}
```

## Performance impact

Plan-time only.

## Security impact

None known.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
