### PR TITLE
Fix 'create' to 'insert' in behavior example

### DIFF
--- a/postgraphile/website/postgraphile/crud-mutations.md
+++ b/postgraphile/website/postgraphile/crud-mutations.md
@@ -18,7 +18,7 @@ CRUD mutations can easily be disabled by disabling the `create`,
 export default {
   // ...
   schema: {
-    defaultBehavior: "-create -update -delete",
+    defaultBehavior: "-insert -update -delete",
   },
 };
 ```


### PR DESCRIPTION
With example, get the error "Error: 'create' behavior is forbidden; did you mean 'insert'?" Using insert worked.

## Description

<!-- If this PR fixes an issue, what is the issue? -->
documentation

## Performance impact

<!-- Detail any impact on performance of this PR, or put 'unknown' if not known -->

## Security impact

none

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [ ] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
