### PR TITLE
Add note to `makeExtendSchemaPlugin` docs indicating where `Channel` type originated

### DIFF
--- a/postgraphile/website/postgraphile/make-extend-schema-plugin.md
+++ b/postgraphile/website/postgraphile/make-extend-schema-plugin.md
@@ -268,9 +268,12 @@ export const MyChannelsPlugin = makeExtendSchemaPlugin((build) => {
 });
 ```
 
-:::info
+:::note
 
-Notice `Channel` type used in the `typeDefs` for `channels` table, this is automatically created by `postgraphile` while introspecting the database. [Read more on the artifacts that are created for each database table here.](https://postgraphile.org/postgraphile/next/tables)
+The `Channel` type used in the `typeDefs` above is the type that PostGraphile
+generated automatically for the `channels` table. See
+[Tables](/postgraphile/next/tables) for more on the artifacts generated for each
+database table.
 
 :::
 

--- a/postgraphile/website/postgraphile/make-extend-schema-plugin.md
+++ b/postgraphile/website/postgraphile/make-extend-schema-plugin.md
@@ -270,6 +270,12 @@ export const MyChannelsPlugin = makeExtendSchemaPlugin((build) => {
 
 :::info
 
+Notice `Channel` type used in the `typeDefs` for `channels` table, this is automatically created by `postgraphile` while introspecting the database. [Read more on the artifacts that are created for each database table here.](https://postgraphile.org/postgraphile/next/tables)
+
+:::
+
+:::info
+
 Though you might be thinking that this would result in multiple requests being
 issued to the database, thanks to the magic of Gra*fast* and `@dataplan/pg`,
 this is not the case. During the optimization phase for the operation plan,


### PR DESCRIPTION
Added a new info section to explain that the table types are automatically created while introspection of the database. It provides a link to https://postgraphile.org/postgraphile/next/tables for further reading.

## Description

It enhances the documentation with relevant link to the section for further reading.

## Performance impact

No performance impact

## Security impact

No security impact

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [ ] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
