### PR TITLE
fix(ruru-components): use the headers while introspecting

### DIFF
--- a/.changeset/warm-rabbits-provide.md
+++ b/.changeset/warm-rabbits-provide.md
@@ -1,0 +1,6 @@
+---
+"ruru-components": patch
+---
+
+use the headers provided in the GraphiQL headers editor while performing
+introspection

--- a/grafast/ruru-components/src/hooks/useSchema.ts
+++ b/grafast/ruru-components/src/hooks/useSchema.ts
@@ -13,11 +13,24 @@ import type { RuruProps } from "../interfaces.js";
 // import { updateGraphiQLDocExplorerNavStack } from "../updateGraphiQLDocExplorerNavStack.js";
 import { useGraphQLChangeStream } from "./useGraphQLChangeStream.js";
 
+function tryParseJson(text: string | undefined): Record<string, unknown> | null {
+  if (text) {
+    try {
+      return JSON.parse(text);
+    } catch (e) {
+      return null
+    }
+  } else {
+    return null
+  }
+}
+
 export const useSchema = (
   props: RuruProps,
   fetcher: GraphiQLProps["fetcher"],
   setError: Dispatch<SetStateAction<Error | null>>,
   streamEndpoint: string | null,
+  headers: string | undefined
 ) => {
   const [schema, setSchema] = useState<GraphQLSchema | null>(null);
   const refetchStatusRef = useRef({
@@ -37,7 +50,7 @@ export const useSchema = (
       const result = await fetcher({
         query: getIntrospectionQuery(),
         operationName: null,
-      });
+      }, { headers: tryParseJson(headers) || {} });
       let payload;
       if (isAsyncIterable(result)) {
         // Handle async iterator; we're only expecting a single payload.
@@ -91,7 +104,7 @@ export const useSchema = (
           refetchStatusRef.current.fetchAgain();
         }
       });
-  }, [fetcher, setError]);
+  }, [fetcher, setError, headers]);
   useGraphQLChangeStream(props, refetch, streamEndpoint);
 
   useEffect(() => {


### PR DESCRIPTION
## Description

fixes https://github.com/graphile/crystal/issues/1828

This fix feels a bit less idiomatic but we need to get access to the `EditorContext` so we can fill in the `headers` and use them for the schema. I see the reason for the custom `useSchema` is the syncing stream so I figured this might be an acceptable solutions to get to the best of both worlds case

## Performance impact

unknown

## Security impact

unknown

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes. I could not find tests, feel free to point me in the right direction
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.
