### PR TITLE
Fix schema emptying issue from watch mode

### DIFF
--- a/.changeset/red-coins-impress.md
+++ b/.changeset/red-coins-impress.md
@@ -1,0 +1,7 @@
+---
+"graphile-build-pg": patch
+"postgraphile": patch
+---
+
+Fix issue with watch mode where schema omits database resources in some
+situations.

--- a/graphile-build/graphile-build-pg/src/plugins/PgIntrospectionPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgIntrospectionPlugin.ts
@@ -695,17 +695,20 @@ export const PgIntrospectionPlugin: GraphileConfig.Plugin = {
   }),
 };
 
-async function introspectPgServices(
+function introspectPgServices(
   pgServices: ReadonlyArray<GraphileConfig.PgServiceConfiguration> | undefined,
 ): Promise<IntrospectionResults> {
   if (!pgServices) {
-    return [];
+    return Promise.resolve([]);
   }
+
   const seenNames = new Map<string, number>();
   const seenPgSettingsKeys = new Map<string, number>();
   const seenWithPgClientKeys = new Map<string, number>();
-  // Resolve the promise ASAP so dependents can `getIntrospection()` and then `getClass` or whatever from the result.
-  const introspectionPromise = Promise.all(
+
+  // Resolve the promise ASAP so dependents can `getIntrospection()` and then
+  // `getClass` or whatever from the result.
+  return Promise.all(
     pgServices.map(async (pgService, i) => {
       // Validate there's no conflicts between pgServices
       const { name, pgSettingsKey, withPgClientKey } = pgService;
@@ -768,5 +771,4 @@ async function introspectPgServices(
       return { pgService, introspection };
     }),
   );
-  return introspectionPromise;
 }


### PR DESCRIPTION
## Description

Fixes #1761

There was two bugs in the introspection plugin:

1. the cache was being invalidated too early, which meant that multiple database events in quick succession would incorrectly reuse previous caches
2. the cache _also_ cached the "announcements" of introspection, meaning when the cache is used the schema building wouldn't even see the database changes!

I've refactored the code to separate the side effects from the introspection so that they can be cached separately (side effects to state, introspection to permanent cache) and I've now tracked whether the introspection results are "dirty" or not - if another event arrives before introspection of the DB occurs then we'll mark the introspection as dirty to ensure that it isn't reused.

## Performance impact

None known.

## Security impact

None known.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~~I've added tests for the new feature, and `yarn test` passes.~~
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
