### PR TITLE
Make smart tags parser track parenthesis to allow for spaces

### DIFF
--- a/.changeset/seven-experts-grow.md
+++ b/.changeset/seven-experts-grow.md
@@ -1,0 +1,5 @@
+---
+"graphile-build-pg": patch
+---
+
+Make smart tags parser more forgiving (track parenthesis)

--- a/graphile-build/graphile-build-pg/__tests__/utils.test.ts
+++ b/graphile-build/graphile-build-pg/__tests__/utils.test.ts
@@ -14,6 +14,16 @@ const EXPECTED_VALUE_2 = {
     singular: "",
   },
 };
+const EXPECTED_VALUE_3 = {
+  args: ["( { [ 1, {2} ], }, )(){}[]({[]})"],
+  params: {},
+};
+const EXPECTED_VALUE_4 = {
+  args: ["blah"],
+  params: {
+    stuff: "( { [ 1, {2} ], }, )(){}[]({[]})",
+  },
+};
 
 test.each([
   ["TOPIC name:SingleTableTopic attributes:title>subject!", EXPECTED_VALUE_1],
@@ -34,6 +44,8 @@ test.each([
 
   ['typeA via:"(id_1,id_2)->types_a.a(id_1, id_2)" singular', EXPECTED_VALUE_2],
   ["typeA via:(id_1,id_2)->types_a.a(id_1, id_2) singular", EXPECTED_VALUE_2],
+  ["( { [ 1, {2} ], }, )(){}[]({[]})", EXPECTED_VALUE_3],
+  ["blah stuff:( { [ 1, {2} ], }, )(){}[]({[]})", EXPECTED_VALUE_4],
 ])("%s", (str, expected) => {
   const result = parseSmartTagsOptsString(str, 1);
   expect(result).toEqual(expected);

--- a/graphile-build/graphile-build-pg/__tests__/utils.test.ts
+++ b/graphile-build/graphile-build-pg/__tests__/utils.test.ts
@@ -8,6 +8,14 @@ const EXPECTED_VALUE_1 = {
   },
 };
 
+const EXPECTED_VALUE_2 = {
+  args: ["typeA"],
+  params: {
+    via: "(id_1,id_2)->types_a.a(id_1, id_2)",
+    singular: "",
+  },
+};
+
 test.each([
   ["TOPIC name:SingleTableTopic attributes:title>subject!", EXPECTED_VALUE_1],
   ["TOPIC name:SingleTableTopic attributes:title>subject!", EXPECTED_VALUE_1],
@@ -24,6 +32,8 @@ test.each([
     ' \t   TOPIC name:\t"SingleTableTopic" attributes:t"i""tle>subj"ect!',
     EXPECTED_VALUE_1,
   ],
+
+  ['typeA via:"(id_1,id_2)->types_a.a(id_1, id_2)" singular', EXPECTED_VALUE_2],
 ])("%s", (str, expected) => {
   const result = parseSmartTagsOptsString(str, 1);
   expect(result).toEqual(expected);

--- a/graphile-build/graphile-build-pg/__tests__/utils.test.ts
+++ b/graphile-build/graphile-build-pg/__tests__/utils.test.ts
@@ -45,7 +45,9 @@ test.each([
   ['typeA via:"(id_1,id_2)->types_a.a(id_1, id_2)" singular', EXPECTED_VALUE_2],
   ["typeA via:(id_1,id_2)->types_a.a(id_1, id_2) singular", EXPECTED_VALUE_2],
   ["( { [ 1, {2} ], }, )(){}[]({[]})", EXPECTED_VALUE_3],
+  ['"( { [ 1, {2} ], }, )(){}[]({[]})"', EXPECTED_VALUE_3],
   ["blah stuff:( { [ 1, {2} ], }, )(){}[]({[]})", EXPECTED_VALUE_4],
+  ['blah stuff:"( { [ 1, {2} ], }, )(){}[]({[]})"', EXPECTED_VALUE_4],
 ])("%s", (str, expected) => {
   const result = parseSmartTagsOptsString(str, 1);
   expect(result).toEqual(expected);

--- a/graphile-build/graphile-build-pg/__tests__/utils.test.ts
+++ b/graphile-build/graphile-build-pg/__tests__/utils.test.ts
@@ -7,7 +7,6 @@ const EXPECTED_VALUE_1 = {
     attributes: "title>subject!",
   },
 };
-
 const EXPECTED_VALUE_2 = {
   args: ["typeA"],
   params: {
@@ -34,6 +33,7 @@ test.each([
   ],
 
   ['typeA via:"(id_1,id_2)->types_a.a(id_1, id_2)" singular', EXPECTED_VALUE_2],
+  ["typeA via:(id_1,id_2)->types_a.a(id_1, id_2) singular", EXPECTED_VALUE_2],
 ])("%s", (str, expected) => {
   const result = parseSmartTagsOptsString(str, 1);
   expect(result).toEqual(expected);

--- a/graphile-build/graphile-build-pg/package.json
+++ b/graphile-build/graphile-build-pg/package.json
@@ -17,6 +17,7 @@
     }
   },
   "scripts": {
+    "test": "jest -i",
     "prepack": "tsc -b && cp src/.npmignore dist/.npmignore"
   },
   "repository": {

--- a/graphile-build/graphile-build-pg/src/utils.ts
+++ b/graphile-build/graphile-build-pg/src/utils.ts
@@ -74,7 +74,11 @@ export function parseSmartTagsOptsString<TParamName extends string = string>(
       throw new Error(`Empty parameter name not allowed`);
     }
     if (!SAFE_PARAMETER_NAME.test(name)) {
-      throw new Error(`Invalid parameter name`);
+      throw new Error(
+        `Invalid parameter name '${name}' - please carefully check your syntax, especially the placement of spaces and quotes. (Opts string: ${JSON.stringify(
+          optsString,
+        )})`,
+      );
     }
     return name as TParamName;
   }

--- a/graphile-build/graphile-build-pg/src/utils.ts
+++ b/graphile-build/graphile-build-pg/src/utils.ts
@@ -69,7 +69,7 @@ export function parseSmartTagsOptsString<TParamName extends string = string>(
   let inQuotes = false;
   let str = "";
   let name = "";
-  let stack: number[] = [];
+  const stack: number[] = [];
 
   function validateParameterName(name: string): TParamName {
     if (name in result.params) {
@@ -170,7 +170,7 @@ export function parseSmartTagsOptsString<TParamName extends string = string>(
                 throw new Error("Invalid position for special char");
               }
               str = char;
-              let openIdx = OPEN_PARENS.indexOf(char);
+              const openIdx = OPEN_PARENS.indexOf(char);
               if (openIdx >= 0) {
                 stack.push(openIdx);
               } else if (CLOSE_PARENS.includes(char)) {
@@ -191,7 +191,7 @@ export function parseSmartTagsOptsString<TParamName extends string = string>(
               throw new Error("Invalid position for special char");
             }
             str = char;
-            let openIdx = OPEN_PARENS.indexOf(char);
+            const openIdx = OPEN_PARENS.indexOf(char);
             if (openIdx >= 0) {
               stack.push(openIdx);
             } else if (CLOSE_PARENS.includes(char)) {
@@ -215,7 +215,7 @@ export function parseSmartTagsOptsString<TParamName extends string = string>(
                 throw new Error("Invalid position for special char");
               }
               str = char;
-              let openIdx = OPEN_PARENS.indexOf(char);
+              const openIdx = OPEN_PARENS.indexOf(char);
               if (openIdx >= 0) {
                 stack.push(openIdx);
               } else if (CLOSE_PARENS.includes(char)) {


### PR DESCRIPTION
## Description

Fixes #1836; see that issue for details.

This is technically a breaking change, but I very very much doubt anyone would be impacted negatively by it.

## Performance impact

Marginal additional cost when parsing smart tags.

## Security impact

None known.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
