### PR TITLE
Fix spelling of PostgreSQL

### DIFF
--- a/postgraphile/website/src/pages/index.js
+++ b/postgraphile/website/src/pages/index.js
@@ -70,7 +70,7 @@ export default function Home() {
   return (
     <Layout
       title={`PostGraphile`}
-      description="Extensible high-performance automatic GraphQL API for PostgresSQL"
+      description="Extensible high-performance automatic GraphQL API for PostgreSQL"
     >
       <WarningSection
         title={`PostGraphile Version 5 Public Beta`}


### PR DESCRIPTION
## Description

Truly the smallest documentation change. I noticed that PostgreSQL had an extra "s" when I took a look at the documentation site today.

## Performance impact

None

## Security impact

None

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.
