### PR TITLE
Fix bug in postgraphile CLI parser for no `--watch`

### DIFF
--- a/.changeset/hip-ants-flash.md
+++ b/.changeset/hip-ants-flash.md
@@ -1,0 +1,6 @@
+---
+"postgraphile": patch
+---
+
+Fix bug in CLI parser where omitting `--watch` would force `watch: false` even
+if config sets `watch: true`.

--- a/postgraphile/postgraphile/src/cli.ts
+++ b/postgraphile/postgraphile/src/cli.ts
@@ -45,7 +45,6 @@ export function options(yargs: Argv) {
       alias: "w",
       type: "boolean",
       description: "Watch mode (monitor DB for schema changes)",
-      default: false,
     })
     .option("port", {
       alias: "p",
@@ -56,7 +55,6 @@ export function options(yargs: Argv) {
       alias: "n",
       type: "string",
       description: "The host to bind our HTTP server to",
-      default: "localhost",
     })
     .option("subscriptions", {
       type: "boolean",


### PR DESCRIPTION
## Description

CLI flags override the config; so if you have `watch: false` in the config but run the CLI with `postgraphile --watch` then watch mode should be enabled. However because we had `default: false` in the config for the argument parser, we were overriding `watch: true` in the config with `watch: false` from the CLI.

Removing this default resolves the issue.

Issue raised by @TimoStolz via Discord: (sponsors only channel): https://discord.com/channels/489127045289476126/953710447087980654/1176875333560062145

## Performance impact

None.

## Security impact

None.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~~I've added tests for the new feature, and `yarn test` passes.~~
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
