### PR TITLE
Fix loadOne/loadMany ioEquivalence for object specs

### DIFF
--- a/.changeset/fifty-donkeys-sort.md
+++ b/.changeset/fifty-donkeys-sort.md
@@ -1,0 +1,8 @@
+---
+"grafast": patch
+---
+
+Fixes a bug in loadOne/loadMany where ioEquivalence for objects doesn't work
+right. Also now requires that `$obj.get('...')` rather than
+`access($obj, '...')` is used with loaded records in order to get attributes
+(consistency fix).

--- a/grafast/grafast/__tests__/errorHandlingStreamTermination-test.ts
+++ b/grafast/grafast/__tests__/errorHandlingStreamTermination-test.ts
@@ -172,7 +172,6 @@ function throwOnUnhandledRejections(callback: () => Promise<void>) {
       } else {
         payloads = [stream];
       }
-      console.dir(payloads, { depth: 8 });
       const result = payloads[0];
       expect(result.data).to.deep.equal({
         list: [null, null],

--- a/grafast/grafast/__tests__/loadOne-test.ts
+++ b/grafast/grafast/__tests__/loadOne-test.ts
@@ -2,8 +2,14 @@ import { expect } from "chai";
 import type { ExecutionResult } from "graphql";
 import { it } from "mocha";
 
-import type { LoadOneCallback } from "../dist/index.js";
-import { grafast, loadOne, makeGrafastSchema } from "../dist/index.js";
+import type { ExecutableStep, LoadOneCallback } from "../dist/index.js";
+import {
+  grafast,
+  loadOne,
+  makeGrafastSchema,
+  object,
+  list,
+} from "../dist/index.js";
 
 interface Thing {
   id: number;
@@ -33,20 +39,44 @@ function pick<T extends object, K extends keyof T>(
 }
 
 let CALLS: {
-  ids: readonly number[];
+  specs: readonly (number | { identifier: number } | readonly number[])[];
   result: object;
   attributes: readonly (keyof Thing)[] | null;
   params: object;
 }[] = [];
 
 const loadThingByIds: LoadOneCallback<number, Thing, Record<string, never>> = (
-  ids,
+  specs,
   { attributes, params },
 ) => {
-  const result = ids
+  const result = specs
     .map((id) => THINGS.find((t) => t.id === id))
     .map((t) => (t && attributes ? pick(t, attributes) : t));
-  CALLS.push({ ids, result, attributes, params });
+  CALLS.push({ specs, result, attributes, params });
+  return result;
+};
+
+const loadThingByIdentifierObjs: LoadOneCallback<
+  { identifier: number },
+  Thing,
+  Record<string, never>
+> = (specs, { attributes, params }) => {
+  const result = specs
+    .map((spec) => THINGS.find((t) => t.id === spec.identifier))
+    .map((t) => (t && attributes ? pick(t, attributes) : t));
+  CALLS.push({ specs, result, attributes, params });
+  return result;
+};
+
+const loadThingByIdentifierLists: LoadOneCallback<
+  readonly [identifier: number],
+  Thing,
+  Record<string, never>
+> = (specs, { attributes, params }) => {
+  const result = specs
+    .map((spec) => THINGS.find((t) => t.id === spec[0]))
+    .map((t) => (t && attributes ? pick(t, attributes) : t));
+  CALLS.push({ specs, result, attributes, params });
   return result;
 };
 
@@ -60,12 +90,28 @@ const makeSchema = (useStreamableStep = false) => {
       }
       type Query {
         thingById(id: Int!): Thing
+        thingByIdObj(id: Int!): Thing
+        thingByIdList(id: Int!): Thing
       }
     `,
     plans: {
       Query: {
         thingById(_, { $id }) {
-          return loadOne($id, loadThingByIds);
+          return loadOne($id as ExecutableStep<number>, loadThingByIds);
+        },
+        thingByIdObj(_, { $id }) {
+          return loadOne(
+            object({ identifier: $id as ExecutableStep<number> }),
+            { identifier: "id" },
+            loadThingByIdentifierObjs,
+          );
+        },
+        thingByIdList(_, { $id }) {
+          return loadOne(
+            list([$id as ExecutableStep<number>]),
+            ["id"],
+            loadThingByIdentifierLists,
+          );
         },
       },
     },
@@ -117,6 +163,7 @@ it("batches across parallel trees with identical selection sets", async () => {
   expect(CALLS).to.have.length(1);
   expect(CALLS[0].attributes).to.deep.equal(["id", "name"]);
 });
+
 it("batches across parallel trees with non-identical selection sets", async () => {
   const source = /* GraphQL */ `
     {
@@ -158,4 +205,117 @@ it("batches across parallel trees with non-identical selection sets", async () =
   });
   expect(CALLS).to.have.length(1);
   expect(CALLS[0].attributes).to.deep.equal(["id", "name", "reallyLongBio"]);
+});
+
+it("skips call on pure ioEquivalence (obj)", async () => {
+  const source = /* GraphQL */ `
+    {
+      t1: thingByIdObj(id: 1) {
+        id
+      }
+    }
+  `;
+  const schema = makeSchema(false);
+
+  CALLS = [];
+  const result = (await grafast(
+    {
+      schema,
+      source,
+    },
+    {},
+    {},
+  )) as ExecutionResult;
+  expect(result).to.deep.equal({
+    data: {
+      t1: {
+        id: 1,
+      },
+    },
+  });
+  expect(CALLS).to.have.length(1);
+  expect(CALLS[0].attributes).to.have.length(0);
+});
+
+it("gets input step on pure ioEquivalence (list)", async () => {
+  const source = /* GraphQL */ `
+    {
+      t1: thingByIdList(id: 1) {
+        id
+      }
+    }
+  `;
+  const schema = makeSchema(false);
+
+  CALLS = [];
+  const result = (await grafast(
+    {
+      schema,
+      source,
+    },
+    {},
+    {},
+  )) as ExecutionResult;
+  expect(result).to.deep.equal({
+    data: {
+      t1: {
+        id: 1,
+      },
+    },
+  });
+  expect(CALLS).to.have.length(1);
+  expect(CALLS[0].attributes).to.have.length(0);
+});
+
+it("supports full call with ioEquivalence", async () => {
+  const source = /* GraphQL */ `
+    {
+      t1: thingById(id: 1) {
+        id
+        name
+      }
+      t2: thingByIdObj(id: 1) {
+        id
+        name
+      }
+      t3: thingByIdList(id: 1) {
+        id
+        name
+      }
+    }
+  `;
+  const schema = makeSchema(false);
+
+  CALLS = [];
+  const result = (await grafast(
+    {
+      schema,
+      source,
+    },
+    {},
+    {},
+  )) as ExecutionResult;
+  expect(result).to.deep.equal({
+    data: {
+      t1: {
+        id: 1,
+        name: "Eyedee Won",
+      },
+      t2: {
+        id: 1,
+        name: "Eyedee Won",
+      },
+      t3: {
+        id: 1,
+        name: "Eyedee Won",
+      },
+    },
+  });
+  expect(CALLS).to.have.length(3);
+  expect(CALLS[0].specs).to.deep.equal([1]);
+  expect(CALLS[0].attributes).to.deep.equal(["id", "name"]);
+  expect(CALLS[1].specs).to.deep.equal([{ identifier: 1 }]);
+  expect(CALLS[1].attributes).to.deep.equal(["name"]);
+  expect(CALLS[2].specs).to.deep.equal([[1]]);
+  expect(CALLS[2].attributes).to.deep.equal(["name"]);
 });

--- a/grafast/grafast/__tests__/loadOne-test.ts
+++ b/grafast/grafast/__tests__/loadOne-test.ts
@@ -5,10 +5,10 @@ import { it } from "mocha";
 import type { ExecutableStep, LoadOneCallback } from "../dist/index.js";
 import {
   grafast,
+  list,
   loadOne,
   makeGrafastSchema,
   object,
-  list,
 } from "../dist/index.js";
 
 interface Thing {

--- a/grafast/grafast/src/interfaces.ts
+++ b/grafast/grafast/src/interfaces.ts
@@ -988,7 +988,7 @@ export type UnwrapPlanTuple</* const */ TIn extends readonly ExecutableStep[]> =
     [Index in keyof TIn]: TIn[Index] extends ExecutableStep<infer U>
       ? U
       : never;
-  } & { length: number };
+  };
 
 export type NotVariableValueNode = Exclude<ValueNode, VariableNode>;
 

--- a/grafast/website/grafast/step-library/standard-steps/access.md
+++ b/grafast/website/grafast/step-library/standard-steps/access.md
@@ -2,6 +2,19 @@
 
 Accesses a (potentially nested) property from the result of a source step.
 
+:::warning
+
+`access()` bypasses `.get()` / `.at()`, so you should only use it where doing
+so is truly what you mean. Always use a step's `.get()` or `.at()` if present
+unless you know better.
+
+Many steps require that you use `.get()` or `.at()` in order to function
+properly, for example if you don't call `.get('attribute_name')` on a [`loadOne()`
+step](./loadOne.md) then it won't know to request the `attribute_name` attribute,
+and you may end up with unexpected nulls/undefineds.
+
+:::
+
 Usage:
 
 ```ts


### PR DESCRIPTION
## Description

Follow-up to #1868; a quick scan of the source had me scratching my head and it turns out there was a bug hiding there - we never used the values of an ioEquivalence object, just assumed that keys and values were the same! This is now fixed.

## Performance impact

Negligible.

## Security impact

Fixes a bug.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
