### PR TITLE
List codec names; fix missing await

### DIFF
--- a/.changeset/giant-cobras-smell.md
+++ b/.changeset/giant-cobras-smell.md
@@ -1,0 +1,7 @@
+---
+"graphile-build-pg": patch
+"postgraphile": patch
+---
+
+Fixes multiple pgServices codec name conflicts by prepending the service name if
+it's not 'main'.

--- a/.changeset/mighty-flies-do.md
+++ b/.changeset/mighty-flies-do.md
@@ -1,0 +1,6 @@
+---
+"graphile-build-pg": patch
+---
+
+Fixes missing await which might cause process to exit when something goes wrong
+during schema building.

--- a/.changeset/sweet-books-tie.md
+++ b/.changeset/sweet-books-tie.md
@@ -1,0 +1,7 @@
+---
+"graphile-build-pg": patch
+"postgraphile": patch
+"@dataplan/pg": patch
+---
+
+List codecs can now have names.

--- a/graphile-build/graphile-build-pg/src/plugins/PgCodecsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgCodecsPlugin.ts
@@ -780,14 +780,7 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
                     extensions,
                   });
                   return EXPORTABLE(
-                    (
-                      description,
-                      extensions,
-                      innerCodec,
-                      listOfCodec,
-                      typeDelim,
-                    ) =>
-                      listOfCodec(innerCodec, {
+                    (description, extensions, info, innerCodec, listOfCodec, serviceName, type, typeDelim) => listOfCodec(innerCodec, {
                         extensions,
                         typeDelim,
                         description,
@@ -796,13 +789,7 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
                           serviceName,
                         }),
                       }),
-                    [
-                      description,
-                      extensions,
-                      innerCodec,
-                      listOfCodec,
-                      typeDelim,
-                    ],
+                    [description, extensions, info, innerCodec, listOfCodec, serviceName, type, typeDelim],
                   );
                 }
               }

--- a/graphile-build/graphile-build-pg/src/plugins/PgCodecsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgCodecsPlugin.ts
@@ -173,7 +173,11 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
       typeCodecName(options, { pgType, serviceName }) {
         const pgNamespace = pgType.getNamespace()!;
         const schemaPrefix = this._schemaPrefix({ pgNamespace, serviceName });
-        return this.camelCase(`${schemaPrefix}${pgType.typname}`);
+        const name =
+          pgType.typcategory === "A" && pgType.typname.startsWith("_")
+            ? pgType.typname.substring(1) + "_array"
+            : pgType.typname;
+        return this.camelCase(`${schemaPrefix}${name}`);
       },
       scalarCodecTypeName(options, codec) {
         return this.upperCamelCase(
@@ -787,6 +791,10 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
                         extensions,
                         typeDelim,
                         description,
+                        name: info.inflection.typeCodecName({
+                          pgType: type,
+                          serviceName,
+                        }),
                       }),
                     [
                       description,

--- a/graphile-build/graphile-build-pg/src/plugins/PgCodecsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgCodecsPlugin.ts
@@ -780,7 +780,17 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
                     extensions,
                   });
                   return EXPORTABLE(
-                    (description, extensions, info, innerCodec, listOfCodec, serviceName, type, typeDelim) => listOfCodec(innerCodec, {
+                    (
+                      description,
+                      extensions,
+                      info,
+                      innerCodec,
+                      listOfCodec,
+                      serviceName,
+                      type,
+                      typeDelim,
+                    ) =>
+                      listOfCodec(innerCodec, {
                         extensions,
                         typeDelim,
                         description,
@@ -789,7 +799,16 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
                           serviceName,
                         }),
                       }),
-                    [description, extensions, info, innerCodec, listOfCodec, serviceName, type, typeDelim],
+                    [
+                      description,
+                      extensions,
+                      info,
+                      innerCodec,
+                      listOfCodec,
+                      serviceName,
+                      type,
+                      typeDelim,
+                    ],
                   );
                 }
               }

--- a/graphile-build/graphile-build-pg/src/plugins/PgCodecsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgCodecsPlugin.ts
@@ -779,34 +779,31 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
                     innerCodec,
                     extensions,
                   });
+                  const name = info.inflection.typeCodecName({
+                    pgType: type,
+                    serviceName,
+                  });
                   return EXPORTABLE(
                     (
                       description,
                       extensions,
-                      info,
                       innerCodec,
                       listOfCodec,
-                      serviceName,
-                      type,
+                      name,
                       typeDelim,
                     ) =>
                       listOfCodec(innerCodec, {
                         extensions,
                         typeDelim,
                         description,
-                        name: info.inflection.typeCodecName({
-                          pgType: type,
-                          serviceName,
-                        }),
+                        name,
                       }),
                     [
                       description,
                       extensions,
-                      info,
                       innerCodec,
                       listOfCodec,
-                      serviceName,
-                      type,
+                      name,
                       typeDelim,
                     ],
                   );

--- a/graphile-build/graphile-build-pg/src/plugins/PgProceduresPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgProceduresPlugin.ts
@@ -664,7 +664,7 @@ export const PgProceduresPlugin: GraphileConfig.Plugin = {
           return;
         }
 
-        helpers.pgProcedures.getResourceOptions(serviceName, pgProc);
+        await helpers.pgProcedures.getResourceOptions(serviceName, pgProc);
       },
     },
   }),

--- a/graphile-build/graphile-build-pg/src/plugins/PgTablesPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgTablesPlugin.ts
@@ -228,8 +228,7 @@ export const PgTablesPlugin: GraphileConfig.Plugin = {
         const pgService = options.pgServices?.find(
           (db) => db.name === serviceName,
         );
-        const databasePrefix =
-          serviceName === pgService?.name ? "" : `${serviceName}_`;
+        const databasePrefix = serviceName === "main" ? "" : `${serviceName}_`;
         const schemaPrefix =
           pgNamespace.nspname === pgService?.schemas?.[0]
             ? ""

--- a/postgraphile/postgraphile/graphile.config.ts
+++ b/postgraphile/postgraphile/graphile.config.ts
@@ -333,7 +333,7 @@ const preset: GraphileConfig.Preset = {
   pgServices: [
     makePgService({
       // Database connection string:
-      connectionString: process.env.DATABASE_URL ?? "pggql_test",
+      connectionString: process.env.DATABASE_URL ?? "postgres:///pggql_test",
       // List of schemas to expose:
       schemas:
         process.env.DATABASE_SCHEMAS?.split(",") ??

--- a/postgraphile/postgraphile/src/plugins/PgV4InflectionPlugin.ts
+++ b/postgraphile/postgraphile/src/plugins/PgV4InflectionPlugin.ts
@@ -18,8 +18,13 @@ export const PgV4InflectionPlugin: GraphileConfig.Plugin = {
   inflection: {
     ignoreReplaceIfNotExists: ["deletedNodeId"],
     replace: {
-      _schemaPrefix() {
-        return ``;
+      _schemaPrefix(previous, options, { serviceName }) {
+        const pgService = options.pgServices?.find(
+          (db) => db.name === serviceName,
+        );
+        const databasePrefix = serviceName === "main" ? "" : `${serviceName}_`;
+        const schemaPrefix = "";
+        return `${databasePrefix}${schemaPrefix}`;
       },
       enumValue(previous, options, value, codec) {
         const oldValue = previous!.call(this, value, codec);

--- a/postgraphile/postgraphile/src/plugins/PgV4InflectionPlugin.ts
+++ b/postgraphile/postgraphile/src/plugins/PgV4InflectionPlugin.ts
@@ -19,9 +19,6 @@ export const PgV4InflectionPlugin: GraphileConfig.Plugin = {
     ignoreReplaceIfNotExists: ["deletedNodeId"],
     replace: {
       _schemaPrefix(previous, options, { serviceName }) {
-        const pgService = options.pgServices?.find(
-          (db) => db.name === serviceName,
-        );
         const databasePrefix = serviceName === "main" ? "" : `${serviceName}_`;
         const schemaPrefix = "";
         return `${databasePrefix}${schemaPrefix}`;


### PR DESCRIPTION
## Description

Codec naming conflicts were happening when you had multiple pgServices due to a bug in the `_schemaPrefix` inflector (fixed) and duplicate names being generated for array codecs (fixed). Also, the process was exiting when it hit specific bugs in watch mode; this turned out to be a missing `await`... Also fixed.

Potentially breaking change since we're changing the names of things; but only impacts people who have set a name for their service and have set it to not `main` which you [should not do](https://github.com/graphile/crystal/pull/1881) unless you have more than one pgService.

## Performance impact

Gather-phase, schema-phase, and watch mode only. No runtime impact.

## Security impact

Less crashy = more better-er?

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
