### PR TITLE
Fix orderBy:null regression

### DIFF
--- a/.changeset/nice-lobsters-add.md
+++ b/.changeset/nice-lobsters-add.md
@@ -1,0 +1,6 @@
+---
+"graphile-build-pg": patch
+"postgraphile": patch
+---
+
+Fix `orderBy:null` regression

--- a/graphile-build/graphile-build-pg/src/plugins/PgConnectionArgOrderByPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgConnectionArgOrderByPlugin.ts
@@ -234,6 +234,9 @@ export const applyOrderToPlan = EXPORTABLE(
       TableOrderByType: GraphQLEnumType,
     ) => {
       const val = $value.eval();
+      if (val == null) {
+        return;
+      }
       if (!Array.isArray(val)) {
         throw new Error("Invalid!");
       }


### PR DESCRIPTION
## Description

Fixes graphile/crystal-pre-merge#487 (probably... I didn't test it).

## Performance impact

Negligible.

## Security impact

Negligible.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
