### PR TITLE
Attempt to detect bad plan resolvers sooner

### DIFF
--- a/.changeset/fluffy-eagles-jam.md
+++ b/.changeset/fluffy-eagles-jam.md
@@ -1,0 +1,7 @@
+---
+"graphile-utils": patch
+"grafast": patch
+---
+
+Attempt to catch invalid plan resolvers (e.g. those returning `undefined`)
+sooner.

--- a/grafast/grafast/src/engine/OperationPlan.ts
+++ b/grafast/grafast/src/engine/OperationPlan.ts
@@ -1802,7 +1802,16 @@ export class OperationPlan {
       let haltTree = false;
       if (step === null || (step instanceof ConstantStep && step.isNull())) {
         // Constantly null; do not step any further in this tree.
-        step = step || constant(null);
+        step =
+          step ||
+          // `withGlobalLayerPlan(layerPlan, polymorphicPaths, () => constant(null))` but with reduced memory allocation
+          withGlobalLayerPlan(
+            layerPlan,
+            polymorphicPaths,
+            constant,
+            null,
+            null,
+          );
         haltTree = true;
       }
       assertExecutableStep(step);

--- a/graphile-build/graphile-utils/src/makeWrapPlansPlugin.ts
+++ b/graphile-build/graphile-utils/src/makeWrapPlansPlugin.ts
@@ -6,7 +6,6 @@ import type {
   FieldPlanResolver,
   GrafastFieldConfig,
 } from "grafast";
-import { isExecutableStep } from "grafast";
 
 type ToOptional<T> = { [K in keyof T]+?: T[K] };
 
@@ -97,7 +96,10 @@ export function makeWrapPlansPlugin<T>(
         },
         GraphQLObjectType_fields_field(field, build, context) {
           const rules = (build as any)[symbol].rules as PlanWrapperRules | null;
-          const { access, ExecutableStep } = build.grafast;
+          const {
+            EXPORTABLE,
+            grafast: { access, ExecutableStep, isExecutableStep },
+          } = build;
           const filter = (build as any)[symbol]
             .filter as PlanWrapperFilter<T> | null;
           const {
@@ -146,44 +148,67 @@ export function makeWrapPlansPlugin<T>(
           } = field;
           return {
             ...field,
-            plan(...planParams) {
-              // A replacement for `oldPlan` that automatically passes through arguments that weren't replaced
-              const smartPlan = (...overrideParams: Array<any>) => {
-                const $prev = oldPlan(
-                  // @ts-ignore We're calling it dynamically, allowing the parent to override args.
-                  ...overrideParams.concat(
-                    planParams.slice(overrideParams.length),
-                  ),
-                );
-                if (!($prev instanceof ExecutableStep)) {
-                  console.error(
-                    `Wrapped a plan function, but that function did not return a step!\n${String(
-                      oldPlan,
-                    )}\n${inspect(field)}`,
-                  );
+            plan: EXPORTABLE(
+              (
+                ExecutableStep,
+                field,
+                inspect,
+                isExecutableStep,
+                oldPlan,
+                planWrapper,
+              ) =>
+                (...planParams) => {
+                  // A replacement for `oldPlan` that automatically passes through arguments that weren't replaced
+                  const smartPlan = (...overrideParams: Array<any>) => {
+                    const $prev = oldPlan(
+                      // @ts-ignore We're calling it dynamically, allowing the parent to override args.
+                      ...overrideParams.concat(
+                        planParams.slice(overrideParams.length),
+                      ),
+                    );
+                    if (!($prev instanceof ExecutableStep)) {
+                      console.error(
+                        `Wrapped a plan function, but that function did not return a step!\n${String(
+                          oldPlan,
+                        )}\n${inspect(field)}`,
+                      );
 
-                  throw new Error(
-                    "Wrapped a plan function, but that function did not return a step!",
+                      throw new Error(
+                        "Wrapped a plan function, but that function did not return a step!",
+                      );
+                    }
+                    return $prev;
+                  };
+                  const [$source, fieldArgs, info] = planParams;
+                  const $newPlan = planWrapper(
+                    smartPlan,
+                    $source,
+                    fieldArgs,
+                    info,
                   );
-                }
-                return $prev;
-              };
-              const [$source, fieldArgs, info] = planParams;
-              const $newPlan = planWrapper(smartPlan, $source, fieldArgs, info);
-              if ($newPlan === undefined) {
-                throw new Error(
-                  "Your plan wrapper didn't return anything; it must return a step or null!",
-                );
-              }
-              if ($newPlan !== null && !isExecutableStep($newPlan)) {
-                throw new Error(
-                  `Your plan wrapper returned something other than a step... It must return a step (or null). (Returned: ${inspect(
-                    $newPlan,
-                  )})`,
-                );
-              }
-              return $newPlan;
-            },
+                  if ($newPlan === undefined) {
+                    throw new Error(
+                      "Your plan wrapper didn't return anything; it must return a step or null!",
+                    );
+                  }
+                  if ($newPlan !== null && !isExecutableStep($newPlan)) {
+                    throw new Error(
+                      `Your plan wrapper returned something other than a step... It must return a step (or null). (Returned: ${inspect(
+                        $newPlan,
+                      )})`,
+                    );
+                  }
+                  return $newPlan;
+                },
+              [
+                ExecutableStep,
+                field,
+                inspect,
+                isExecutableStep,
+                oldPlan,
+                planWrapper,
+              ],
+            ),
           };
         },
       },

--- a/graphile-build/graphile-utils/src/makeWrapPlansPlugin.ts
+++ b/graphile-build/graphile-utils/src/makeWrapPlansPlugin.ts
@@ -142,9 +142,13 @@ export function makeWrapPlansPlugin<T>(
             return field;
           }
           const {
-            // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-            plan: oldPlan = ($obj: import("grafast").ExecutableStep) =>
-              access($obj, fieldName),
+            plan: oldPlan = EXPORTABLE(
+              (access, fieldName) =>
+                // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+                ($obj: import("grafast").ExecutableStep) =>
+                  access($obj, fieldName),
+              [access, fieldName],
+            ),
           } = field;
           return {
             ...field,

--- a/graphile-build/graphile-utils/src/makeWrapPlansPlugin.ts
+++ b/graphile-build/graphile-utils/src/makeWrapPlansPlugin.ts
@@ -6,6 +6,7 @@ import type {
   FieldPlanResolver,
   GrafastFieldConfig,
 } from "grafast";
+import { isExecutableStep } from "grafast";
 
 type ToOptional<T> = { [K in keyof T]+?: T[K] };
 
@@ -168,7 +169,20 @@ export function makeWrapPlansPlugin<T>(
                 return $prev;
               };
               const [$source, fieldArgs, info] = planParams;
-              return planWrapper(smartPlan, $source, fieldArgs, info);
+              const $newPlan = planWrapper(smartPlan, $source, fieldArgs, info);
+              if ($newPlan === undefined) {
+                throw new Error(
+                  "Your plan wrapper didn't return anything; it must return a step or null!",
+                );
+              }
+              if ($newPlan !== null && !isExecutableStep($newPlan)) {
+                throw new Error(
+                  `Your plan wrapper returned something other than a step... It must return a step (or null). (Returned: ${inspect(
+                    $newPlan,
+                  )})`,
+                );
+              }
+              return $newPlan;
             },
           };
         },


### PR DESCRIPTION
## Description

Plan resolvers should return a step (or `null`); sometimes people forget the `return` statement and this can lead to misleading errors. Attempt to give a more sensible error up front.

## Performance impact

Planning only.

## Security impact

None known.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
