### PR TITLE
Fix plugin ordering bug

### DIFF
--- a/.changeset/curvy-vans-sleep.md
+++ b/.changeset/curvy-vans-sleep.md
@@ -1,0 +1,8 @@
+---
+"graphile-config": patch
+"postgraphile": patch
+---
+
+Fix plugin ordering bug that ignored before/after when there was no provider;
+this now means PgSmartTagsPlugin is correctly loaded before
+PgFakeConstraintPlugin, fixing the `postgraphile.tags.json5` file.

--- a/utils/graphile-config/__tests__/sorting-without-provider.test.ts
+++ b/utils/graphile-config/__tests__/sorting-without-provider.test.ts
@@ -1,0 +1,26 @@
+import { expect } from "chai";
+import { it } from "mocha";
+
+import { sortedPlugins } from "../dist/index.js";
+
+const PLUGINS: GraphileConfig.Plugin[] = [
+  {
+    name: "Plugin2",
+    version: "0.0.0",
+    after: ["Plugin1"],
+    provides: ["things"],
+  },
+  { name: "Plugin4", version: "0.0.0", after: ["stuff"] },
+  { name: "Plugin3", version: "0.0.0", before: ["stuff"], after: ["things"] },
+  { name: "Plugin1", version: "0.0.0", before: ["Plugin3"] },
+];
+
+it("sorts plugins correctly", () => {
+  const plugins = sortedPlugins(PLUGINS);
+  expect(plugins.map((p) => p.name)).to.deep.equal([
+    "Plugin1",
+    "Plugin2",
+    "Plugin3",
+    "Plugin4",
+  ]);
+});

--- a/utils/graphile-config/src/sort.ts
+++ b/utils/graphile-config/src/sort.ts
@@ -128,8 +128,6 @@ export function sortWithBeforeAfterProvides<
   }
 
   if (final.length !== rawList.length) {
-    console.dir(final);
-    console.dir(rawList);
     throw new Error(
       `Expected the same number of list entries after sorting (${final.length} != ${rawList.length})`,
     );


### PR DESCRIPTION
## Description

Previously if there was no provider for a particular order constraint, then that order was ignored. It turns out there's no provider for `smart-tags`, but it has a lot of `before` and `after` constraints on it; all of which were ignored, which could result in plugins with `before: ["smart-tags"]` being loaded after plugins with `after: ["smart-tags"]`. Even though there's no provider for this, clearly this shouldn't be the case.

This PR solves the issue by creating a fake provider during the plugin sorting and then filtering it back out again at the end, enforcing that all `before: ["smart-tags"]` plugins are loaded before all `after: ["smart-tags"]` plugins.

## Performance impact

Negligible startup cost.

## Security impact

None known, unless someone is playing silly buggers with plugin ordering... but plugins are trusted code so we don't see that as a security vulnerability.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] ~~If this is a breaking change I've explained why.~~

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
