### PR TITLE
Fix RBAC permission detection for tables

### DIFF
--- a/.changeset/sour-lions-live.md
+++ b/.changeset/sour-lions-live.md
@@ -1,0 +1,6 @@
+---
+"pg-introspection": patch
+"postgraphile": patch
+---
+
+Fix logic around RBAC permissions for tables and sequences.

--- a/utils/pg-introspection/src/acl.ts
+++ b/utils/pg-introspection/src/acl.ts
@@ -1,9 +1,4 @@
-import type {
-  Introspection,
-  PgClass,
-  PgEntity,
-  PgRoles,
-} from "./introspection.js";
+import type { Introspection, PgEntity, PgRoles } from "./introspection.js";
 
 /**
  * A fake 'pg_roles' record representing the 'public' meta-role.

--- a/utils/pg-introspection/src/acl.ts
+++ b/utils/pg-introspection/src/acl.ts
@@ -345,71 +345,67 @@ export function parseAcls(
     inAcls ||
     (() => {
       const owner = getRole(introspection, ownerId);
+      let worldDefault: string;
+      let ownerDefault: string;
       switch (type) {
         case OBJECT_COLUMN:
-          return [
-            `=${ACL_NO_RIGHTS}/${owner.rolname}`,
-            `${owner.rolname}=${ACL_NO_RIGHTS}/${owner.rolname}`,
-          ];
+          worldDefault = ACL_NO_RIGHTS;
+          ownerDefault = ACL_NO_RIGHTS;
+          break;
         case OBJECT_TABLE:
-          return [
-            `=${ACL_NO_RIGHTS}/${owner.rolname}`,
-            `${owner.rolname}=${ACL_ALL_RIGHTS_RELATION}/${owner.rolname}`,
-          ];
+          worldDefault = ACL_NO_RIGHTS;
+          ownerDefault = ACL_ALL_RIGHTS_RELATION;
+          break;
         case OBJECT_SEQUENCE:
-          return [
-            `=${ACL_NO_RIGHTS}/${owner.rolname}`,
-            `${owner.rolname}=${ACL_ALL_RIGHTS_SEQUENCE}/${owner.rolname}`,
-          ];
+          worldDefault = ACL_NO_RIGHTS;
+          ownerDefault = ACL_ALL_RIGHTS_SEQUENCE;
+          break;
         case OBJECT_DATABASE:
-          return [
-            `=${ACL_CREATE_TEMP + ACL_CONNECT}/${owner.rolname}`,
-            `${owner.rolname}=${ACL_ALL_RIGHTS_DATABASE}/${owner.rolname}`,
-          ];
+          worldDefault = ACL_CREATE_TEMP + ACL_CONNECT;
+          ownerDefault = ACL_ALL_RIGHTS_DATABASE;
+          break;
         case OBJECT_FUNCTION:
-          return [
-            `=${ACL_EXECUTE}/${owner.rolname}`,
-            `${owner.rolname}=${ACL_ALL_RIGHTS_FUNCTION}/${owner.rolname}`,
-          ];
+          worldDefault = ACL_EXECUTE;
+          ownerDefault = ACL_ALL_RIGHTS_FUNCTION;
+          break;
         case OBJECT_LANGUAGE:
-          return [
-            `=${ACL_USAGE}/${owner.rolname}`,
-            `${owner.rolname}=${ACL_ALL_RIGHTS_LANGUAGE}/${owner.rolname}`,
-          ];
+          worldDefault = ACL_USAGE;
+          ownerDefault = ACL_ALL_RIGHTS_LANGUAGE;
+          break;
         case OBJECT_LARGEOBJECT:
-          return [
-            `=${ACL_NO_RIGHTS}/${owner.rolname}`,
-            `${owner.rolname}=${ACL_ALL_RIGHTS_LARGEOBJECT}/${owner.rolname}`,
-          ];
+          worldDefault = ACL_NO_RIGHTS;
+          ownerDefault = ACL_ALL_RIGHTS_LARGEOBJECT;
+          break;
         case OBJECT_SCHEMA:
-          return [
-            `=${ACL_NO_RIGHTS}/${owner.rolname}`,
-            `${owner.rolname}=${ACL_ALL_RIGHTS_SCHEMA}/${owner.rolname}`,
-          ];
+          worldDefault = ACL_NO_RIGHTS;
+          ownerDefault = ACL_ALL_RIGHTS_SCHEMA;
+          break;
         case OBJECT_TABLESPACE:
-          return [
-            `=${ACL_NO_RIGHTS}/${owner.rolname}`,
-            `${owner.rolname}=${ACL_ALL_RIGHTS_TABLESPACE}/${owner.rolname}`,
-          ];
+          worldDefault = ACL_NO_RIGHTS;
+          ownerDefault = ACL_ALL_RIGHTS_TABLESPACE;
+          break;
         case OBJECT_FDW:
-          return [
-            `=${ACL_NO_RIGHTS}/${owner.rolname}`,
-            `${owner.rolname}=${ACL_ALL_RIGHTS_FDW}/${owner.rolname}`,
-          ];
+          worldDefault = ACL_NO_RIGHTS;
+          ownerDefault = ACL_ALL_RIGHTS_FDW;
+          break;
         case OBJECT_FOREIGN_SERVER:
-          return [
-            `=${ACL_NO_RIGHTS}/${owner.rolname}`,
-            `${owner.rolname}=${ACL_ALL_RIGHTS_FOREIGN_SERVER}/${owner.rolname}`,
-          ];
+          worldDefault = ACL_NO_RIGHTS;
+          ownerDefault = ACL_ALL_RIGHTS_FOREIGN_SERVER;
+          break;
         case OBJECT_DOMAIN:
         case OBJECT_TYPE:
-          return [
-            `=${ACL_USAGE}/${owner.rolname}`,
-            `${owner.rolname}=${ACL_ALL_RIGHTS_TYPE}/${owner.rolname}`,
-          ];
+          worldDefault = ACL_USAGE;
+          ownerDefault = ACL_ALL_RIGHTS_TYPE;
+          break;
         default:
-          return [];
+          worldDefault = ACL_NO_RIGHTS;
+          ownerDefault = ACL_NO_RIGHTS;
       }
+
+      return [
+        `=${worldDefault}/${owner.rolname}`,
+        `${owner.rolname}=${ownerDefault}/${owner.rolname}`,
+      ];
     })();
 
   const acls = aclStrings.map((aclString) => parseAcl(aclString));

--- a/utils/pg-introspection/src/acl.ts
+++ b/utils/pg-introspection/src/acl.ts
@@ -271,6 +271,7 @@ export const OBJECT_FOREIGN_SERVER = "OBJECT_FOREIGN_SERVER";
 export const OBJECT_DOMAIN = "OBJECT_DOMAIN";
 export const OBJECT_TYPE = "OBJECT_TYPE";
 
+// https://github.com/postgres/postgres/blob/4908c5872059c409aa647bcde758dfeffe07996e/src/include/nodes/parsenodes.h#L2094-L2148
 export type AclDefaultObjectType =
   | typeof OBJECT_COLUMN
   | typeof OBJECT_TABLE
@@ -286,6 +287,7 @@ export type AclDefaultObjectType =
   | typeof OBJECT_DOMAIN
   | typeof OBJECT_TYPE;
 
+// https://github.com/postgres/postgres/blob/4908c5872059c409aa647bcde758dfeffe07996e/src/include/nodes/parsenodes.h#L76-L89
 // https://www.postgresql.org/docs/current/ddl-priv.html#PRIVILEGE-ABBREVS-TABLE
 const ACL_SELECT = "r";
 const ACL_INSERT = "a";
@@ -299,11 +301,13 @@ const ACL_CONNECT = "c";
 const ACL_CREATE_TEMP = "T";
 const ACL_EXECUTE = "X";
 const ACL_USAGE = "U";
-// ACL_SET = "s"
-// ACL_ALTER_SYSTEM = "A"
+// const ACL_SET = "s";
+// const ACL_ALTER_SYSTEM = "A";
 
+/** @see {@link https://github.com/postgres/postgres/blob/4908c5872059c409aa647bcde758dfeffe07996e/src/include/nodes/parsenodes.h#L91} */
 const ACL_NO_RIGHTS = "";
-const ACL_ALL_RIGHTS_SEQUENCE = ACL_USAGE + ACL_SELECT + ACL_UPDATE;
+
+/** @see {@link https://github.com/postgres/postgres/blob/4908c5872059c409aa647bcde758dfeffe07996e/src/include/utils/acl.h#L159} */
 const ACL_ALL_RIGHTS_RELATION =
   ACL_INSERT +
   ACL_SELECT +
@@ -312,14 +316,15 @@ const ACL_ALL_RIGHTS_RELATION =
   ACL_TRUNCATE +
   ACL_REFERENCES +
   ACL_TRIGGER;
+const ACL_ALL_RIGHTS_SEQUENCE = ACL_USAGE + ACL_SELECT + ACL_UPDATE;
 const ACL_ALL_RIGHTS_DATABASE = ACL_CREATE + ACL_CREATE_TEMP + ACL_CONNECT;
+const ACL_ALL_RIGHTS_FDW = ACL_USAGE;
+const ACL_ALL_RIGHTS_FOREIGN_SERVER = ACL_USAGE;
 const ACL_ALL_RIGHTS_FUNCTION = ACL_EXECUTE;
 const ACL_ALL_RIGHTS_LANGUAGE = ACL_USAGE;
 const ACL_ALL_RIGHTS_LARGEOBJECT = ACL_SELECT + ACL_UPDATE;
 const ACL_ALL_RIGHTS_SCHEMA = ACL_USAGE + ACL_CREATE;
 const ACL_ALL_RIGHTS_TABLESPACE = ACL_CREATE;
-const ACL_ALL_RIGHTS_FDW = ACL_USAGE;
-const ACL_ALL_RIGHTS_FOREIGN_SERVER = ACL_USAGE;
 const ACL_ALL_RIGHTS_TYPE = ACL_USAGE;
 
 /**

--- a/utils/pg-introspection/src/acl.ts
+++ b/utils/pg-introspection/src/acl.ts
@@ -298,6 +298,10 @@ export type AclDefaultObjectType =
  * and:
  *
  * https://github.com/postgres/postgres/blob/fb3b098fe88441f9531a5169008ea17eac01301f/src/include/utils/acl.h#L153-L167
+ *
+ * and for what the privileges mean, see:
+ *
+ * https://www.postgresql.org/docs/current/ddl-priv.html#PRIVILEGE-ABBREVS-TABLE
  */
 export function parseAcls(
   introspection: Introspection,
@@ -374,30 +378,6 @@ export const Permission = {
   temporaryGrant: "temporaryGrant",
 } as const;
 
-/*
- * For default permissions, see:
- * https://github.com/postgres/postgres/blob/14aec03502302eff6c67981d8fd121175c436ce9/src/backend/utils/adt/acl.c#L748-L854
- *
- * For what the privileges mean, see:
- * https://www.postgresql.org/docs/current/ddl-priv.html#PRIVILEGE-ABBREVS-TABLE
- */
-
-export function aclsForTable(
-  introspection: Introspection,
-  table: PgClass,
-): AclObject[] {
-  const dbOwner = getRole(introspection, introspection.database.datdba);
-  const isSequence = table.relkind === "S";
-  const tableOwner = getRole(introspection, table.relowner);
-  const defaultAcl = isSequence
-    ? [`${tableOwner.rolname}=/${dbOwner.rolname}`]
-    : [`=/${dbOwner.rolname}`, `${dbOwner.rolname}=/${dbOwner.rolname}`];
-
-  const acls = (table.relacl || defaultAcl).map((aclString) =>
-    parseAcl(aclString),
-  );
-  return acls;
-}
 
 /**
  * Returns all the roles role has been granted (including PUBLIC),

--- a/utils/pg-introspection/src/acl.ts
+++ b/utils/pg-introspection/src/acl.ts
@@ -339,7 +339,7 @@ export function parseAcls(
   introspection: Introspection,
   inAcls: readonly string[] | null,
   ownerId: string,
-  type: AclDefaultObjectType,
+  objtype: AclDefaultObjectType,
 ): AclObject[] {
   const aclStrings: readonly string[] =
     inAcls ||
@@ -347,7 +347,7 @@ export function parseAcls(
       const owner = getRole(introspection, ownerId);
       let worldDefault: string;
       let ownerDefault: string;
-      switch (type) {
+      switch (objtype) {
         case OBJECT_COLUMN:
           worldDefault = ACL_NO_RIGHTS;
           ownerDefault = ACL_NO_RIGHTS;
@@ -400,12 +400,17 @@ export function parseAcls(
         default:
           worldDefault = ACL_NO_RIGHTS;
           ownerDefault = ACL_NO_RIGHTS;
+          break;
       }
 
-      return [
-        `=${worldDefault}/${owner.rolname}`,
-        `${owner.rolname}=${ownerDefault}/${owner.rolname}`,
-      ];
+      const acl: string[] = [];
+      if (worldDefault !== ACL_NO_RIGHTS) {
+        acl.push(`=${worldDefault}/${owner.rolname}`);
+      }
+      if (ownerDefault !== ACL_NO_RIGHTS) {
+        acl.push(`${owner.rolname}=${ownerDefault}/${owner.rolname}`);
+      }
+      return acl;
     })();
 
   const acls = aclStrings.map((aclString) => parseAcl(aclString));

--- a/utils/pg-introspection/src/augmentIntrospection.ts
+++ b/utils/pg-introspection/src/augmentIntrospection.ts
@@ -1,5 +1,5 @@
 import {
-  OBJECT_ATTRIBUTE,
+  OBJECT_COLUMN,
   OBJECT_DATABASE,
   OBJECT_FUNCTION,
   OBJECT_SCHEMA,
@@ -327,7 +327,7 @@ export function augmentIntrospection(
         introspection,
         entity.attacl,
         entity.getClass()!.relowner,
-        OBJECT_ATTRIBUTE,
+        OBJECT_COLUMN,
       ),
     );
   });

--- a/utils/pg-introspection/src/augmentIntrospection.ts
+++ b/utils/pg-introspection/src/augmentIntrospection.ts
@@ -1,9 +1,10 @@
 import {
-  aclsForTable,
   OBJECT_ATTRIBUTE,
   OBJECT_DATABASE,
   OBJECT_FUNCTION,
   OBJECT_SCHEMA,
+  OBJECT_SEQUENCE,
+  OBJECT_TABLE,
   parseAcls,
 } from "./acl.js";
 import type {
@@ -274,7 +275,14 @@ export function augmentIntrospection(
       }),
     );
     entity.getTags = memo(() => entity.getTagsAndDescription().tags);
-    entity.getACL = memo(() => aclsForTable(introspection, entity));
+    entity.getACL = memo(() =>
+      parseAcls(
+        introspection,
+        entity.relacl,
+        entity.relowner,
+        entity.relkind === "S" ? OBJECT_SEQUENCE : OBJECT_TABLE,
+      ),
+    );
 
     entity.getAttribute = (by) => {
       const attributes = entity.getAttributes();


### PR DESCRIPTION
## Description

Looks like there was some older code hanging around which had faulty logic (in particular, it granted _NO PERMISSIONS_ to the owner of a table by default ?!); we already have a chain of logic that matches the Postgres source so we've deleted `aclsForTable` and used the shared logic instead.

I've also taken the time to make the code closer to the postgres source to make auditing easier.

## Performance impact

Marginal, gather/build phase only.

## Security impact

Exposes more resources (because it's more correct).

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
