### PR TITLE
Only add stack traces to extensions if they're already present

### DIFF
--- a/.changeset/metal-impalas-scream.md
+++ b/.changeset/metal-impalas-scream.md
@@ -1,0 +1,5 @@
+---
+"grafserv": patch
+---
+
+Fix bug where stack traces are added to masked errors


### PR DESCRIPTION
## Description

Fixes #1898

## Performance impact

Negligible.

## Security impact

Improvement.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~~I've added tests for the new feature, and `yarn test` passes.~~
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] ~~If this is a breaking change I've explained why.~~

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
