### PR TITLE
Refactor smart comment parsing

### DIFF
--- a/postgraphile/website/postgraphile/smart-comments.md
+++ b/postgraphile/website/postgraphile/smart-comments.md
@@ -81,6 +81,38 @@ This field has a load of arbitrary tags.
 $$;
 ```
 
+Note that adding two newlines in a row will be interpreted as the start of a multi-line comment, no tags added after the first
+newline will be parsed & will be treated as part of the description.
+
+```sql
+comment on column my_schema.my_table.my_column is $$
+@name meta
+@isImportant
+@jsonField date timestamp
+@jsonField name text
+
+This field has a load of arbitrary tags.
+@jsonField episode enum ONE=1 TWO=2
+$$;
+```
+
+Results in the following JSON tags object:
+
+```json
+{
+  "name": "meta",
+  "isImportant": true,
+  "jsonField": ["date timestamp", "name text"]
+}
+```
+
+and the description:
+
+```
+This field has a load of arbitrary tags.
+@jsonField episode enum ONE=1 TWO=2
+```
+
 ### Applying smart tags to database entities
 
 #### Tables

--- a/postgraphile/website/postgraphile/smart-comments.md
+++ b/postgraphile/website/postgraphile/smart-comments.md
@@ -85,6 +85,8 @@ Note that adding two newlines in a row separates the smart tags section from the
 descriptive prose. Content after two newlines will not be parsed for smart tags
 even if it starts with an `@` character.
 
+For example:
+
 ```sql
 comment on column my_schema.my_table.my_column is $$
 @name meta
@@ -97,7 +99,7 @@ This field has a load of arbitrary tags.
 $$;
 ```
 
-Results in the following JSON tags object:
+results in the following JSON tags object:
 
 ```json
 {

--- a/postgraphile/website/postgraphile/smart-comments.md
+++ b/postgraphile/website/postgraphile/smart-comments.md
@@ -81,8 +81,9 @@ This field has a load of arbitrary tags.
 $$;
 ```
 
-Note that adding two newlines in a row will be interpreted as the start of a multi-line comment, no tags added after the first
-newline will be parsed & will be treated as part of the description.
+Note that adding two newlines in a row separates the smart tags section from the
+descriptive prose. Content after two newlines will not be parsed for smart tags
+even if it starts with an `@` character.
 
 ```sql
 comment on column my_schema.my_table.my_column is $$


### PR DESCRIPTION
I've been doing some digging into Postgraphile V5 and trying to build my own Plugin. While learning the codebase i decided to tackle a smaller issue i found with smart comment parsing. The following SQL:

```sql
COMMENT ON TABLE reports_public.report_base IS $$
    @name ReportBase

    @interface mode:relational type: report_type
    @type Foo references: foo
    @type Bar references: bar
$$;
```

Is currently parsed by the `parseSmartComment` as:

```json
{
    "name": "ReportBase",
    "description": "@interface mode:relational type: report_type\n@type Foo...."
}
```

The issue here is the `@interface` & `@type` tags being parsed as part of the description, rather than their own tags. This may be intentional, but i found it unintuitive and didn't realise that the extra `\n` i had placed between `@name` & `@interface` was causing none of the tags to be picked up by the Polymorphism plugin later. I think it's worth supporting extraneous empty lines by simply ignoring them.

This PR refactors the code so that:
* All empty lines are ignored
* Any line not starting with `@` is included in the documentation.
* It also adds some unit test cases.
* Some changeset stuff the GH but was complaining about, sorry if i did that wrong.

With these changes, the following SQL:

```sql
COMMENT ON TABLE test_table IS $$
This is a description.

@tag1 value1
@tag2 value2
How many of these can i add?
@tag3

This is also a description.

This is another description, with a newline before and after it.

$$;
```
```ts
{
      tags: {
        tag1: "value1",
        tag2: "value2",
        tag3: true,
      },
      description:
        "This is a description.\n\nHow many of these can i add?\nThis is also a description.\n\nThis is another description, with a newline before and after it.",
    }
```

I know this wasn't pre-discussed so please feel free to close if you don't think this change is a good fit or needs further changes.