### PR TITLE
Ensure response body contains expected error object when grafast context function throws an error

### DIFF
--- a/grafast/grafserv/__tests__/errors.test.ts
+++ b/grafast/grafserv/__tests__/errors.test.ts
@@ -1,0 +1,40 @@
+import { fetch } from "@whatwg-node/fetch";
+
+import { makeExampleServer } from "./exampleServer.js";
+
+let server: Awaited<ReturnType<typeof makeExampleServer>> | null = null;
+
+afterAll(() => {
+  server?.release();
+});
+
+test("response body contains expected error object when function provided as grafast context option throws an error", async () => {
+  const maskError = jest.fn((error) => error);
+  server = await makeExampleServer({
+    grafserv: {
+      graphqlOverGET: true,
+      graphqlPath: "/graphql",
+      dangerouslyAllowAllCORSRequests: true,
+      maskError,
+    },
+    grafast: {
+      context: () => {
+        throw new Error("a particular error");
+      },
+    },
+  });
+  const res = await fetch(server!.url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/graphql-response+json",
+    },
+    body: JSON.stringify({ query: "{ __typename }" }),
+  });
+  const responseBody = await res.json();
+  expect(responseBody).toHaveProperty(
+    "errors[0].message",
+    "a particular error",
+  );
+  expect(maskError).toHaveBeenCalledTimes(1);
+});

--- a/grafast/grafserv/__tests__/exampleServer.ts
+++ b/grafast/grafserv/__tests__/exampleServer.ts
@@ -5,7 +5,15 @@ import { constant, makeGrafastSchema } from "grafast";
 
 import { grafserv } from "../src/servers/node/index.js";
 
-export async function makeExampleServer() {
+export async function makeExampleServer(
+  preset: GraphileConfig.Preset = {
+    grafserv: {
+      graphqlOverGET: true,
+      graphqlPath: "/graphql",
+      dangerouslyAllowAllCORSRequests: true,
+    },
+  },
+) {
   const schema = makeGrafastSchema({
     typeDefs: /* GraphQL */ `
       type Query {
@@ -21,13 +29,6 @@ export async function makeExampleServer() {
     },
   });
 
-  const preset = {
-    grafserv: {
-      graphqlOverGET: true,
-      graphqlPath: "/graphql",
-      dangerouslyAllowAllCORSRequests: true,
-    },
-  }; /*satisfies GraphileConfig.Preset*/
   const serv = grafserv({ schema, preset });
   const server = createServer(serv.createHandler());
   const promise = new Promise<void>((resolve, reject) => {

--- a/grafast/grafserv/src/middleware/graphql.ts
+++ b/grafast/grafserv/src/middleware/graphql.ts
@@ -516,12 +516,11 @@ const _makeGraphQLHandlerInternal = (
       operationName,
     };
 
-    await hookArgs(args, resolvedPreset, {
-      ...request.requestContext,
-      http: request,
-    });
-
     try {
+      await hookArgs(args, resolvedPreset, {
+        ...request.requestContext,
+        http: request,
+      });
       const result = await grafastExecute(args, resolvedPreset);
       if (isAsyncIterable(result)) {
         return {


### PR DESCRIPTION
## Description

<!-- If this PR adds a feature, what does it add and what was the motivation for it? -->
<!-- If this PR fixes an issue, what is the issue? -->
Currently, when you provide a function for the `grafast.context` option to populate context, and an error is thrown in the function (eg when parsing an auth header into context, but the auth header is malformed), execution bypasses the 'maskError' function, resulting in an 'Unknown error occurred' error in the response body, 500 status code, accompanied by a complete stack trace in the response.

<!-- Please link to the relevant GitHub issues/Discord discussion/etc as appropriate -->
https://discord.com/channels/489127045289476126/498852330754801666/1197168131756531732

I believe this fix also addresses the root cause of:
https://github.com/graphile/crystal/issues/1847

## Performance impact

Unknown

## Security impact

<!-- Detail any impact on security of this PR, or put 'unknown' if not known -->
_Should_ improve security by not disclosing stack trace information if errors are thrown in the context function.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
