### PR TITLE
Add __assertStep support to makeGrafastSchema and makeExtendSchemaPlugin

### DIFF
--- a/.changeset/nasty-dragons-rush.md
+++ b/.changeset/nasty-dragons-rush.md
@@ -1,0 +1,7 @@
+---
+"graphile-utils": patch
+"grafast": patch
+---
+
+Add `__assertStep` registration support to makeGrafastSchema and PostGraphile's
+makeExtendSchemaPlugin.

--- a/grafast/grafast/src/makeGrafastSchema.ts
+++ b/grafast/grafast/src/makeGrafastSchema.ts
@@ -48,7 +48,9 @@ export type FieldPlans =
  * The plans/config for each field of a GraphQL object type.
  */
 export type ObjectPlans = {
-  __Step?: { new (...args: any[]): ExecutableStep };
+  __assertStep?:
+    | ((step: ExecutableStep) => asserts step is ExecutableStep)
+    | { new (...args: any[]): ExecutableStep };
 } & {
   [fieldName: string]: FieldPlans;
 };
@@ -142,6 +144,10 @@ export function makeGrafastSchema(details: {
             type.extensions as graphql.GraphQLObjectTypeExtensions<any, any>
           ).grafast = { assertStep: fieldSpec as any };
           continue;
+        } else if (fieldName.startsWith("__")) {
+          throw new Error(
+            `Unsupported field name '${fieldName}'; perhaps you meant '__assertStep'?`,
+          );
         }
 
         const field = fields[fieldName];

--- a/graphile-build/graphile-utils/src/makeExtendSchemaPlugin.ts
+++ b/graphile-build/graphile-utils/src/makeExtendSchemaPlugin.ts
@@ -14,7 +14,6 @@ import type {
   // Config:
   GraphQLEnumValueConfigMap,
   GraphQLFieldConfigMap,
-  GraphQLObjectTypeExtensions,
   // Resolvers:
   GraphQLFieldResolver,
   GraphQLInputFieldConfigMap,
@@ -25,6 +24,7 @@ import type {
   GraphQLIsTypeOfFn,
   GraphQLNamedType,
   GraphQLObjectType,
+  GraphQLObjectTypeExtensions,
   GraphQLOutputType,
   GraphQLScalarType,
   GraphQLScalarTypeConfig,

--- a/graphile-build/graphile-utils/src/makeExtendSchemaPlugin.ts
+++ b/graphile-build/graphile-utils/src/makeExtendSchemaPlugin.ts
@@ -1,4 +1,4 @@
-import type { FieldPlanResolver } from "grafast";
+import type { ExecutableStep, FieldPlanResolver } from "grafast";
 import type {
   DefinitionNode,
   DirectiveDefinitionNode,
@@ -14,6 +14,7 @@ import type {
   // Config:
   GraphQLEnumValueConfigMap,
   GraphQLFieldConfigMap,
+  GraphQLObjectTypeExtensions,
   // Resolvers:
   GraphQLFieldResolver,
   GraphQLInputFieldConfigMap,
@@ -69,11 +70,15 @@ export interface ObjectResolver<TSource = any, TContext = any> {
     | ObjectFieldConfig<TSource, TContext>;
 }
 
-export interface ObjectPlan<TSource = any, TContext = any> {
+export type ObjectPlan<TSource = any, TContext = any> = {
+  __assertStep?:
+    | ((step: ExecutableStep) => asserts step is ExecutableStep)
+    | { new (...args: any[]): ExecutableStep };
+} & {
   [key: string]:
     | FieldPlanResolver<any, any, any>
     | ObjectFieldConfig<TSource, TContext>;
-}
+};
 
 export interface EnumResolver {
   [key: string]: string | number | Array<any> | Record<string, any> | symbol;
@@ -410,6 +415,15 @@ export function makeExtendSchemaPlugin(
                   ...(description
                     ? {
                         description,
+                      }
+                    : null),
+                  ...(plans?.[name]?.__assertStep
+                    ? {
+                        extensions: {
+                          grafast: {
+                            assertStep: plans[name].__assertStep as any,
+                          },
+                        } as GraphQLObjectTypeExtensions<any, any>,
                       }
                     : null),
                 }),


### PR DESCRIPTION
## Description

Relates to #1915 (but doesn't fix it).

Object types in Grafast can indicate that they must be represented by a particular step or set of steps; this can help to catch bugs early. For example, in PostGraphile a database table resource should be represented by a `pgSelectSingle` or similar class; representing it with `object({id: 1})` or similar would mean the step doesn't have the expected helper methods and downstream fields may fail to plan because their expectations are broken.

When writing a schema manually, you set this via `objectTypeConfig.extensions.grafast.assertStep` which can either be a step class itself (e.g. `objectTypeConfig.extensions = {grafast: {assertStep: PgSelectSingleStep}}`) or it can be an "assertion function" that throws an error if the passed step is not of the right type, e.g.:

```ts
objectTypeConfig.extensions = {
  grafast: {
    assertStep($step) {
      if ($step instanceof PgSelectSingleStep) return true;
      if ($step instanceof PgInsertSingleStep) return true;
      if ($step instanceof PgUpdateSingleStep) return true;
      throw new Error(`Type 'User' expects a step of type PgSelectSingleStep, PgInsertSingleStep or PgUpdateSingleStep; but found step of type '${$step.constructor.name}'.`);
    }
  }
};
```

Further, if you have a union (e.g. `union U = A | B | C`) then all types in the union must either expect a plan, or not expect a plan.

Previous to this PR, you could not indicate that your custom type created in makeExtendSchemaPlugin expects a plan. Further, the types of makeGrafastSchema were wrong, filing this under the removed `__Step` property. This PR makes it so that you can define `__assertStep` as part of defining the field plans for an object type; the `__` prefix ensures that it cannot conflict with any field names (since GraphQL forbids field names that start with `__`). E.g.:

```ts
const plugin = makeExtendSchemaPlugin({
  typeDefs: gql`
    type UnameTaken {
      message: String
    }

    type EmailTaken {
      message: String
    }
  `,
  plans: {
    UnameTaken: {
      __assertStep: ExecutableStep,
    },
    EmailTaken: {
      __assertStep: ($step) => {
        if ($step instanceof ObjectStep) return true;
        throw new Error(`EmailTaken expected an 'ObjectStep' but instead received '${$step.constructor.name}'`);
      }
    },
  }
});
```


## Performance impact

Negligible.

## Security impact

None known.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] ~~If this is a breaking change I've explained why.~~
