### PR TITLE
Ensure SafeError and isSafeError are marked as exported for graphile-export

### DIFF
--- a/.changeset/khaki-zoos-exercise.md
+++ b/.changeset/khaki-zoos-exercise.md
@@ -1,0 +1,6 @@
+---
+"grafast": patch
+---
+
+Bugfix: mark SafeError, isSafeError as exportable for graphile-export
+compatibility.

--- a/grafast/grafast/src/error.ts
+++ b/grafast/grafast/src/error.ts
@@ -67,6 +67,10 @@ export class SafeError<
     | Record<string, any>
     | undefined,
 > extends Error {
+  static $$export = {
+    moduleName: "grafast",
+    exportName: "SafeError",
+  };
   [$$safeError] = true;
   constructor(
     message: string,

--- a/grafast/grafast/src/index.ts
+++ b/grafast/grafast/src/index.ts
@@ -531,6 +531,8 @@ exportAsMany("grafast", {
   loadManyCallback,
   LoadedRecordStep,
   LoadStep,
+  isSafeError,
+  SafeError,
 });
 
 export { hookArgs } from "./args.js";


### PR DESCRIPTION
Related to https://github.com/graphile/crystal/issues/1921

Could not reproduce issue, so this is a guess.