### PR TITLE
Make a public getDependencies method that other APIs may use

### DIFF
--- a/grafast/grafast/src/step.ts
+++ b/grafast/grafast/src/step.ts
@@ -206,9 +206,28 @@ export /* abstract */ class ExecutableStep<TData = any> extends BaseStep {
   public isSyncAndSafe!: boolean;
 
   /**
-   * The plan this plan will need data from in order to execute.
+   * The plan this plan will need data from in order to execute. For public
+   * access, use `getDependencies()`.
    */
   protected readonly dependencies: ReadonlyArray<ExecutableStep>;
+
+  /**
+   * Returns a copy of the dependencies of this step; not permitted during
+   * planning (only during optimize) in order to help you comply with the
+   * GraphQL specification.
+   *
+   * If a step is trying to access its own dependencies, it should instead
+   * use `this.dependencies`.
+   */
+  public getDependencies(): ReadonlyArray<ExecutableStep> {
+    if (this.operationPlan.phase !== "plan") {
+      return [...this.dependencies];
+    } else {
+      throw new Error(
+        `Accessing dependencies of a step during a plan resolver is forbidden; see: https://err.red/gprd`,
+      );
+    }
+  }
 
   /**
    * Just for mermaid

--- a/grafast/website/src/pages/errors/prd.md
+++ b/grafast/website/src/pages/errors/prd.md
@@ -1,0 +1,28 @@
+---
+title: Accessing Dependencies Forbidden in Plan Resolver
+---
+
+# Accessing Dependencies Forbidden in Plan Resolver
+
+You're probably here because you just received an error like:
+
+```
+Accessing dependencies of a step during a plan resolver is forbidden; see:
+https://err.red/gprd
+```
+
+This happens when one of your plan resolvers (or something that your plan
+resolver has called, including step methods) attempts to access the
+dependencies of another step. Typically this indicates you are attempting to
+interact with ancestor steps, which has a significant chance of making you
+non-compliant with the GraphQL specification; see: [Benjie's article on
+referencing ancestors](https://benjie.dev/graphql/ancestors) (which applies to
+any GraphQL schema using any technology, it is not specific to Gra*fast*).
+
+In Gra*fast*, access to ancestors is permitted under strictly controlled
+conditions to ensure compliance with the GraphQL specification. Most likely,
+your access should be placed in [the `optimize` lifecycle
+method](/grafast/step-classes#optimize).
+
+For more information on this, please reach out on Discord at
+https://discord.gg/graphile


### PR DESCRIPTION
## Description

I'm not sure about this... In fact... I don't think you should ever access another step's dependencies?
