### PR TITLE
pg-introspection additions

### DIFF
--- a/.changeset/friendly-meals-bow.md
+++ b/.changeset/friendly-meals-bow.md
@@ -1,0 +1,7 @@
+---
+"postgraphile": patch
+"pg-introspection": patch
+---
+
+Excludes table constraints on tables from extensions if configured to not
+include extensions.

--- a/.changeset/loud-carpets-pump.md
+++ b/.changeset/loud-carpets-pump.md
@@ -1,0 +1,6 @@
+---
+"postgraphile": patch
+"pg-introspection": patch
+---
+
+Add pg_am to pg-introspection to enable determining index access method

--- a/utils/pg-introspection/src/augmentIntrospection.ts
+++ b/utils/pg-introspection/src/augmentIntrospection.ts
@@ -91,6 +91,8 @@ export function augmentIntrospection(
     del(extensionProcOids, introspection.procs, "_id");
     del(extensionClassOids, introspection.classes, "_id");
     del(extensionClassOids, introspection.attributes, "attrelid");
+    del(extensionClassOids, introspection.constraints, "conrelid");
+    del(extensionClassOids, introspection.constraints, "confrelid");
     del(extensionClassOids, introspection.types, "typrelid");
   }
 

--- a/utils/pg-introspection/src/augmentIntrospection.ts
+++ b/utils/pg-introspection/src/augmentIntrospection.ts
@@ -297,6 +297,11 @@ export function augmentIntrospection(
     entity.getInherited = memo(() =>
       introspection.inherits.filter((inh) => inh.inhrelid === entity._id),
     );
+    entity.getAccessMethod = memo(() =>
+      entity.relam != null
+        ? introspection.am.find((am) => am._id === entity.relam)
+        : undefined,
+    );
   });
   introspection.indexes.forEach((entity) => {
     entity._type = "PgIndex";

--- a/utils/pg-introspection/src/augmentIntrospection.ts
+++ b/utils/pg-introspection/src/augmentIntrospection.ts
@@ -45,7 +45,7 @@ function del<T extends Record<string, any>, TKey extends keyof T>(
 ) {
   for (let i = collection.length - 1; i >= 0; i--) {
     const entry = collection[i];
-    if (toDelete.has(entry[attr])) {
+    if (entry[attr] != null && toDelete.has(entry[attr])) {
       collection.splice(i, 1);
     }
   }

--- a/utils/pg-introspection/src/index.ts
+++ b/utils/pg-introspection/src/index.ts
@@ -140,6 +140,7 @@ declare module "./introspection" {
     getTags(): PgSmartTagsDict;
     getACL(): AclObject[];
     getInherited(): PgInherits[];
+    getAccessMethod(): PgAm | undefined;
   }
   interface PgIndex {
     _type: "PgIndex";


### PR DESCRIPTION
## Description

`pg_am` now added; so you can get the access method (e.g. `btree`) of an index:

```ts
const indexes = pgClass.getIndexes();
if (indexes.length > 0) {
  const idx = indexes[0];
  const indClass = idx.getIndexClass();
  console.log(`Table ${pgClass.relname} index ${indClass?.relname}, method ${indClass?.getAccessMethod()?.amname}`);
}
```

- Fixes #1925 

Correctly excludes constraints on (or to) tables from extensions.

- Fixes #1750

## Performance impact

Slightly more expensive introspection.

## Security impact

None known.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~~I've added tests for the new feature, and `yarn test` passes.~~
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] ~~If this is a breaking change I've explained why.~~

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
