### PR TITLE
eslint-plugin-graphile-export, Add inputPlan,applyPlan as methods that can be generated as exportable - Fix #1932

### DIFF
--- a/.changeset/spicy-boats-learn.md
+++ b/.changeset/spicy-boats-learn.md
@@ -1,0 +1,7 @@
+---
+"graphile-build-pg": patch
+"graphile-build": patch
+"eslint-plugin-graphile-export": patch
+---
+
+`eslint-plugin-graphile-export` now spots instances of `inputPlan`, `applyPlan` and `assertStep` so they can be checked - thanks @mattiarossi!

--- a/graphile-build/graphile-build-pg/src/plugins/PgTablesPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgTablesPlugin.ts
@@ -663,9 +663,13 @@ export const PgTablesPlugin: GraphileConfig.Plugin = {
                   description: `An input for mutations affecting \`${tableTypeName}\``,
                   extensions: {
                     grafast: {
-                      inputPlan() {
-                        return object(Object.create(null));
-                      },
+                      inputPlan: EXPORTABLE(
+                        (object) =>
+                          function inputPlan() {
+                            return object(Object.create(null));
+                          },
+                        [object],
+                      ),
                     },
                   },
                 }),
@@ -692,9 +696,13 @@ export const PgTablesPlugin: GraphileConfig.Plugin = {
                   description: `Represents an update to a \`${tableTypeName}\`. Fields that are set will be updated.`,
                   extensions: {
                     grafast: {
-                      inputPlan() {
-                        return object(Object.create(null));
-                      },
+                      inputPlan: EXPORTABLE(
+                        (object) =>
+                          function inputPlan() {
+                            return object(Object.create(null));
+                          },
+                        [object],
+                      ),
                     },
                   },
                 }),
@@ -717,9 +725,13 @@ export const PgTablesPlugin: GraphileConfig.Plugin = {
                   description: `An input representation of \`${tableTypeName}\` with nullable fields.`,
                   extensions: {
                     grafast: {
-                      inputPlan() {
-                        return object(Object.create(null));
-                      },
+                      inputPlan: EXPORTABLE(
+                        (object) =>
+                          function inputPlan() {
+                            return object(Object.create(null));
+                          },
+                        [object],
+                      ),
                     },
                   },
                 }),

--- a/graphile-build/graphile-build/src/plugins/QueryPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/QueryPlugin.ts
@@ -25,7 +25,7 @@ export const QueryPlugin: GraphileConfig.Plugin = {
     hooks: {
       init: {
         callback: (_, build, _context) => {
-          const { registerObjectType, inflection } = build;
+          const { registerObjectType, inflection, EXPORTABLE } = build;
           registerObjectType(
             inflection.builtin("Query"),
             {

--- a/graphile-build/graphile-build/src/plugins/QueryPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/QueryPlugin.ts
@@ -37,7 +37,7 @@ export const QueryPlugin: GraphileConfig.Plugin = {
               // but only because of the check on interfaces that all
               // consistituent types either expect a step or don't (which is an
               // arbitrary constraint we've added that can be removed).
-              assertStep: () => true,
+              assertStep: EXPORTABLE(() => () => true, []),
               description:
                 "The root query type which gives access points into the data universe.",
             }),

--- a/utils/eslint-plugin-graphile-export/src/ExportMethods.ts
+++ b/utils/eslint-plugin-graphile-export/src/ExportMethods.ts
@@ -49,6 +49,9 @@ const ALLOWED_SIBLING_KEYS: string[] = [
   "assertStep",
   "autoApplyAfterParentInputPlan",
   "autoApplyAfterParentApplyPlan",
+  "autoApplyAfterParentPlan",
+  "autoApplyAfterParentSubscribePlan",
+  "idempotent",
   "inputPlan",
   "applyPlan",
 ];
@@ -97,6 +100,7 @@ export const ExportMethods: Rule.RuleModule = {
       "parseLiteral",
       "inputPlan",
       "applyPlan",
+      "assertStep",
     ];
 
     const options: CommonOptions = {

--- a/utils/eslint-plugin-graphile-export/src/ExportMethods.ts
+++ b/utils/eslint-plugin-graphile-export/src/ExportMethods.ts
@@ -45,6 +45,12 @@ const ALLOWED_SIBLING_KEYS: string[] = [
 
   // pgSelect args
   "name",
+
+  "assertStep",
+  "autoApplyAfterParentInputPlan",
+  "autoApplyAfterParentApplyPlan",
+  "inputPlan",
+  "applyPlan",
 ];
 
 export const ExportMethods: Rule.RuleModule = {
@@ -89,6 +95,8 @@ export const ExportMethods: Rule.RuleModule = {
       "serialize",
       "parseValue",
       "parseLiteral",
+      "inputPlan",
+      "applyPlan",
     ];
 
     const options: CommonOptions = {

--- a/utils/eslint-plugin-graphile-export/src/index.ts
+++ b/utils/eslint-plugin-graphile-export/src/index.ts
@@ -31,6 +31,8 @@ export const configs = {
             "serialize",
             "parseValue",
             "parseLiteral",
+            "inputPlan",
+            "applyPlan",
           ],
         },
       ],

--- a/utils/eslint-plugin-graphile-export/src/index.ts
+++ b/utils/eslint-plugin-graphile-export/src/index.ts
@@ -33,6 +33,7 @@ export const configs = {
             "parseLiteral",
             "inputPlan",
             "applyPlan",
+            "assertStep",
           ],
         },
       ],


### PR DESCRIPTION
Added

* inputPlan
* applyPlan

to the list of exportable methods in eslint-plugin-graphile-export, applied lint:fix to the codebase, should Fix #1932 and allow proper export of a schema that has custom record types as function parameters