### PR TITLE
graphile-export now detects invalid exports

### DIFF
--- a/.changeset/six-parents-collect.md
+++ b/.changeset/six-parents-collect.md
@@ -1,0 +1,7 @@
+---
+"postgraphile": patch
+"graphile-export": patch
+---
+
+Automatically detect when a `graphile-export` export is invalid, and throw an
+error indicating which method needs to have `EXPORTABLE` added around it.

--- a/.changeset/spicy-boats-learn.md
+++ b/.changeset/spicy-boats-learn.md
@@ -4,4 +4,5 @@
 "eslint-plugin-graphile-export": patch
 ---
 
-`eslint-plugin-graphile-export` now spots instances of `inputPlan`, `applyPlan` and `assertStep` so they can be checked - thanks @mattiarossi!
+`eslint-plugin-graphile-export` now spots instances of `inputPlan`, `applyPlan`
+and `assertStep` so they can be checked - thanks @mattiarossi!

--- a/postgraphile/postgraphile/graphile.config.ts
+++ b/postgraphile/postgraphile/graphile.config.ts
@@ -260,13 +260,16 @@ const preset: GraphileConfig.Preset = {
         },
         Subscription: {
           // Test via SQL: `NOTIFY test, '{"a":40}';`
-          sub: EXPORTABLE((context, jsonParse, listen, object) => (_$root, args) => {
-            const $topic = args.get("topic");
-            const $pgSubscriber = context().get("pgSubscriber");
-            return listen($pgSubscriber, $topic, ($payload) =>
-              object({ sub: jsonParse($payload).get("a" as never) }),
-            );
-          }, [context, jsonParse, listen, object]),
+          sub: EXPORTABLE(
+            (context, jsonParse, listen, object) => (_$root, args) => {
+              const $topic = args.get("topic");
+              const $pgSubscriber = context().get("pgSubscriber");
+              return listen($pgSubscriber, $topic, ($payload) =>
+                object({ sub: jsonParse($payload).get("a" as never) }),
+              );
+            },
+            [context, jsonParse, listen, object],
+          ),
           gql: {
             resolve: EXPORTABLE(
               () =>

--- a/postgraphile/postgraphile/graphile.config.ts
+++ b/postgraphile/postgraphile/graphile.config.ts
@@ -214,17 +214,27 @@ const preset: GraphileConfig.Preset = {
         `,
         plans: {
           Person: {
-            greet($user: PgSelectSingleStep, { $greeting }) {
-              const placeholderSql = $user.placeholder($greeting, TYPES.text);
-              const alias = $user.getClassStep().alias;
-              return $user.select(
-                sql`${placeholderSql} || ', ' || ${alias}.name`,
-                TYPES.text,
-              );
-            },
-            query() {
-              return constant(true);
-            },
+            greet: EXPORTABLE(
+              (TYPES, sql) =>
+                ($user: PgSelectSingleStep, { $greeting }) => {
+                  const placeholderSql = $user.placeholder(
+                    $greeting,
+                    TYPES.text,
+                  );
+                  const alias = $user.getClassStep().alias;
+                  return $user.select(
+                    sql`${placeholderSql} || ', ' || ${alias}.name`,
+                    TYPES.text,
+                  );
+                },
+              [TYPES, sql],
+            ),
+            query: EXPORTABLE(
+              (constant) => () => {
+                return constant(true);
+              },
+              [constant],
+            ),
           },
         },
       };
@@ -241,19 +251,22 @@ const preset: GraphileConfig.Preset = {
       `,
       plans: {
         Query: {
-          mol() {
-            return context().get("mol");
-          },
+          mol: EXPORTABLE(
+            (context) => () => {
+              return context().get("mol");
+            },
+            [context],
+          ),
         },
         Subscription: {
           // Test via SQL: `NOTIFY test, '{"a":40}';`
-          sub(_$root, args) {
+          sub: EXPORTABLE((context, jsonParse, listen, object) => (_$root, args) => {
             const $topic = args.get("topic");
             const $pgSubscriber = context().get("pgSubscriber");
             return listen($pgSubscriber, $topic, ($payload) =>
               object({ sub: jsonParse($payload).get("a" as never) }),
             );
-          },
+          }, [context, jsonParse, listen, object]),
           gql: {
             resolve: EXPORTABLE(
               () =>

--- a/postgraphile/postgraphile/src/plugins/PgV4SimpleSubscriptionsPlugin.ts
+++ b/postgraphile/postgraphile/src/plugins/PgV4SimpleSubscriptionsPlugin.ts
@@ -53,18 +53,28 @@ export const PgV4SimpleSubscriptionsPlugin = makeExtendSchemaPlugin((build) => {
         },
       },
       ListenPayload: {
-        event: EXPORTABLE(() => ($event) => {
-          return $event.get("event");
-        }, []),
+        event: EXPORTABLE(
+          () => ($event) => {
+            return $event.get("event");
+          },
+          [],
+        ),
         ...(nodeIdHandlerByTypeName
           ? {
-              relatedNodeId: EXPORTABLE((nodeIdFromEvent) => ($event) => {
-                return nodeIdFromEvent($event);
-              }, [nodeIdFromEvent]),
-              relatedNode: EXPORTABLE((node, nodeIdFromEvent, nodeIdHandlerByTypeName) => ($event) => {
-                const $nodeId = nodeIdFromEvent($event);
-                return node(nodeIdHandlerByTypeName, $nodeId);
-              }, [node, nodeIdFromEvent, nodeIdHandlerByTypeName]),
+              relatedNodeId: EXPORTABLE(
+                (nodeIdFromEvent) => ($event) => {
+                  return nodeIdFromEvent($event);
+                },
+                [nodeIdFromEvent],
+              ),
+              relatedNode: EXPORTABLE(
+                (node, nodeIdFromEvent, nodeIdHandlerByTypeName) =>
+                  ($event) => {
+                    const $nodeId = nodeIdFromEvent($event);
+                    return node(nodeIdHandlerByTypeName, $nodeId);
+                  },
+                [node, nodeIdFromEvent, nodeIdHandlerByTypeName],
+              ),
             }
           : null),
       },
@@ -73,15 +83,22 @@ export const PgV4SimpleSubscriptionsPlugin = makeExtendSchemaPlugin((build) => {
 }, "PgV4SimpleSubscriptionsPlugin");
 
 // base64JSON codec copy
-const nodeObjToNodeId = EXPORTABLE(() => function nodeObjToNodeId(obj: any[] | undefined): string | null {
-  if (!obj) return null;
-  return Buffer.from(JSON.stringify(obj), "utf8").toString("base64");
-}, []);
+const nodeObjToNodeId = EXPORTABLE(
+  () =>
+    function nodeObjToNodeId(obj: any[] | undefined): string | null {
+      if (!obj) return null;
+      return Buffer.from(JSON.stringify(obj), "utf8").toString("base64");
+    },
+  [],
+);
 
 // WARNING: this function assumes that you're using the `base64JSON` NodeID codec, which was the case for PostGraphile V4. If you are not doing so, YMMV.
-const nodeIdFromEvent = EXPORTABLE((lambda, nodeObjToNodeId) => function nodeIdFromEvent($event: JSONParseStep<{ __node__?: any[] }>) {
-  const $nodeObj = $event.get("__node__");
-  const $nodeId = lambda($nodeObj, nodeObjToNodeId);
-  return $nodeId;
-}, [lambda, nodeObjToNodeId]);
-
+const nodeIdFromEvent = EXPORTABLE(
+  (lambda, nodeObjToNodeId) =>
+    function nodeIdFromEvent($event: JSONParseStep<{ __node__?: any[] }>) {
+      const $nodeObj = $event.get("__node__");
+      const $nodeId = lambda($nodeObj, nodeObjToNodeId);
+      return $nodeId;
+    },
+  [lambda, nodeObjToNodeId],
+);

--- a/utils/graphile-export/src/exportSchema.ts
+++ b/utils/graphile-export/src/exportSchema.ts
@@ -3,7 +3,6 @@ import type { URL } from "node:url";
 import { inspect } from "node:util";
 
 import generate from "@babel/generator";
-import type { ParseResult } from "@babel/parser";
 import { parse } from "@babel/parser";
 import type { TemplateBuilderOptions } from "@babel/template";
 import template from "@babel/template";


### PR DESCRIPTION
## Description

- Fixes #1785 

When we're exporting functions, we now scan the function to ensure that it doesn't reference any variables outside of its scope. If it does, we'll abort the export with information about where the function was that failed, so that it can be wrapped in `EXPORTABLE()` (or have it's `EXPORTABLE` fixed).

:rotating_light: If your exports were previously invalid, they will now throw an error, preventing progress. This is safer, but it might break your existing `graphile-export` flows. We see this as a bugfix.

## Performance impact

Makes `graphile-export` slower; but that's a one-time cost (per export...)

## Security impact

Improves security by reducing the chances of referencing unexpected globals.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~~I've added tests for the new feature, and `yarn test` passes.~~
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
