### PR TITLE
Grafserv Node Server - Skip processing request if response is already finished

### DIFF
--- a/grafast/grafserv/src/servers/node/index.ts
+++ b/grafast/grafserv/src/servers/node/index.ts
@@ -109,6 +109,16 @@ export class NodeGrafservBase extends GrafservBase {
     const dynamicOptions = this.dynamicOptions;
     return async (req, res, next) => {
       try {
+        // If middleware prior to this has already finished the response,
+        // then skip processing the request.
+        if (res.writableFinished) {
+          if (typeof next === "function") {
+            next();
+          } 
+
+          return;
+        }
+
         const request = this.getDigest(dynamicOptions, req, res, isHTTPS);
         const result = await this.processRequest(request);
 


### PR DESCRIPTION
Grafserv's node server has a bug where it attempts to handle responses that have already been sent by prior middleware, causing the classic `Error [ERR_HTTP_HEADERS_SENT]: Cannot write headers after they are sent to the client`

Example server:
```ts
const serv = pgl.createServ(grafserv);
const server = createServer();
server.on('error', console.error);

server.on('request', (req, res) => {
  // Set CORS headers
	res.setHeader('Access-Control-Allow-Origin', req.headers.origin || '*');
	res.setHeader('Access-Control-Allow-Methods', 'OPTIONS, POST');
	res.setHeader('Access-Control-Allow-Headers', '*');

  // Respond to CORS preflight requests
  if (req.method === 'OPTIONS') {
    res.writeHead(200);
    res.end();
  }
});

serv.addTo(server).catch((e) => {
  console.error(e);
});
```