### PR TITLE
Mark getDep as protected to avoid abuse

### DIFF
--- a/.changeset/chatty-dodos-melt.md
+++ b/.changeset/chatty-dodos-melt.md
@@ -1,0 +1,6 @@
+---
+"@dataplan/pg": patch
+"grafast": patch
+---
+
+Mark `ExecutableStep::getDep` as `protected` to avoid abuse.

--- a/grafast/dataplan-pg/src/steps/pgSelect.ts
+++ b/grafast/dataplan-pg/src/steps/pgSelect.ts
@@ -2496,7 +2496,6 @@ ${lateralText};`;
         } else if (dep instanceof ConnectionStep) {
           // We only have this to detect errors, it's an empty object. Safe.
         } else if (dep instanceof PgClassExpressionStep) {
-          const p2 = dep.getDep(dep.rowDependencyId);
           const t2Parent = dep.getParentStep();
           if (!(t2Parent instanceof PgSelectSingleStep)) {
             continue;
@@ -2527,7 +2526,7 @@ ${lateralText};`;
           */
 
           if (t === undefined && p === undefined) {
-            p = p2;
+            p = t2Parent;
             t = t2;
           } else if (t2 !== t) {
             debugPlanVerbose(
@@ -2539,11 +2538,11 @@ ${lateralText};`;
             );
             t = null;
             break;
-          } else if (p2 !== p) {
+          } else if (t2Parent !== p) {
             debugPlanVerbose(
               "Refusing to optimise %c due to parent dependency mismatch: %c != %c",
               this,
-              p2,
+              t2Parent,
               p,
             );
             t = null;
@@ -2688,7 +2687,7 @@ ${lateralText};`;
           parent instanceof PgSelectSingleStep &&
           parent.getClassStep().mode !== "aggregate"
         ) {
-          const parent2 = parent.getDep(parent.itemStepId);
+          const parent2 = parent.getItemStep();
           this.identifierMatches.forEach((identifierMatch, i) => {
             const { dependencyIndex, codec } = this.queryValues[i];
             const step = this.getDep(dependencyIndex);

--- a/grafast/dataplan-pg/src/steps/pgSelectSingle.ts
+++ b/grafast/dataplan-pg/src/steps/pgSelectSingle.ts
@@ -126,7 +126,8 @@ export class PgSelectSingleStep<
     return plan;
   }
 
-  private getItemStep(): ExecutableStep<unknown[]> {
+  /** @internal */
+  public getItemStep(): ExecutableStep<unknown[]> {
     const plan = this.getDep(this.itemStepId);
     return plan;
   }

--- a/grafast/grafast/src/step.ts
+++ b/grafast/grafast/src/step.ts
@@ -286,7 +286,7 @@ export /* abstract */ class ExecutableStep<TData = any> extends BaseStep {
     return this.layerPlan.getStep(id, this);
   }
 
-  public getDep(depId: number): ExecutableStep {
+  protected getDep(depId: number): ExecutableStep {
     return this.dependencies[depId];
   }
 

--- a/grafast/grafast/src/steps/__item.ts
+++ b/grafast/grafast/src/steps/__item.ts
@@ -40,6 +40,9 @@ export class __ItemStep<TData> extends UnbatchedExecutableStep<TData> {
     };
   }
 
+  getParentStep(): ExecutableStep {
+    return this.getDep(0);
+  }
   [$$deepDepSkip](): ExecutableStep {
     return this.getDep(0);
   }

--- a/grafast/grafast/src/steps/each.ts
+++ b/grafast/grafast/src/steps/each.ts
@@ -64,7 +64,7 @@ export function each<
       const rootStep = layerPlan.rootStep;
       if (
         rootStep instanceof __ItemStep &&
-        rootStep.getDep(0).layerPlan !== layerPlan
+        rootStep.getParentStep().layerPlan !== layerPlan
       ) {
         // We don't do anything; replace ourself with our parent
         return this.getListStep();


### PR DESCRIPTION
## Description

`getDep` is an internal API for use within the class only; should other step classes need access to a step's dependencies they should do so via public APIs that the step exposes.

:rotating_light: If you were previously using `getDep` on a different class, you'll now need to use the public interfaces instead. There's a significant chance that what you were doing may not have been safe, and may have led to GraphQL spec non-compliance.

Fixes #1939

## Performance impact

Negligible.

## Security impact

None known.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~~I've added tests for the new feature, and `yarn test` passes.~~
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
