### PR TITLE
Use ESLint on export to see if it might be invalid

### DIFF
--- a/.changeset/weak-items-type.md
+++ b/.changeset/weak-items-type.md
@@ -1,0 +1,9 @@
+---
+"graphile-build": patch
+"graphile-export": patch
+"postgraphile": patch
+---
+
+Exporting a schema now performs ESLint 'no-use-before-define' check to catch
+even more invalid export conditions. Fix `registerNodeIdCodec` calls caught by
+this.

--- a/graphile-build/graphile-build/src/plugins/NodeIdCodecBase64JSONPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/NodeIdCodecBase64JSONPlugin.ts
@@ -19,11 +19,17 @@ export const NodeIdCodecBase64JSONPlugin: GraphileConfig.Plugin = {
         if (!build.registerNodeIdCodec) {
           return _;
         }
-        build.registerNodeIdCodec({
-          name: "base64JSON",
-          encode: base64JSONEncode,
-          decode: base64JSONDecode,
-        });
+        const { EXPORTABLE } = build;
+        build.registerNodeIdCodec(
+          EXPORTABLE(
+            (base64JSONDecode, base64JSONEncode) => ({
+              name: "base64JSON",
+              encode: base64JSONEncode,
+              decode: base64JSONDecode,
+            }),
+            [base64JSONDecode, base64JSONEncode],
+          ),
+        );
         return _;
       },
     },

--- a/graphile-build/graphile-build/src/plugins/NodeIdCodecPipeStringPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/NodeIdCodecPipeStringPlugin.ts
@@ -20,11 +20,17 @@ export const NodeIdCodecPipeStringPlugin: GraphileConfig.Plugin = {
         if (!build.registerNodeIdCodec) {
           return _;
         }
-        build.registerNodeIdCodec({
-          name: "pipeString",
-          encode: pipeStringEncode,
-          decode: pipeStringDecode,
-        });
+        const { EXPORTABLE } = build;
+        build.registerNodeIdCodec(
+          EXPORTABLE(
+            (pipeStringDecode, pipeStringEncode) => ({
+              name: "pipeString",
+              encode: pipeStringEncode,
+              decode: pipeStringDecode,
+            }),
+            [pipeStringDecode, pipeStringEncode],
+          ),
+        );
         return _;
       },
     },

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -8984,7 +8989,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Input: {
     typeName: "Input",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("inputs", false), $record.get("id")]);
@@ -9003,7 +9008,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Patch: {
     typeName: "Patch",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("patchs", false), $record.get("id")]);
@@ -9022,7 +9027,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Reserved: {
     typeName: "Reserved",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("reserveds", false), $record.get("id")]);
@@ -9041,7 +9046,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   ReservedPatchRecord: {
     typeName: "ReservedPatchRecord",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("reservedPatchs", false), $record.get("id")]);
@@ -9060,7 +9065,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   ReservedInputRecord: {
     typeName: "ReservedInputRecord",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("reserved_inputs", false), $record.get("id")]);
@@ -9079,7 +9084,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   DefaultValue: {
     typeName: "DefaultValue",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("default_values", false), $record.get("id")]);
@@ -9098,7 +9103,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   MyTable: {
     typeName: "MyTable",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("my_tables", false), $record.get("id")]);
@@ -9117,7 +9122,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   PersonSecret: {
     typeName: "PersonSecret",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: "This is deprecated (comment on table c.person_secret).",
     plan($record) {
       return list([constant("person_secrets", false), $record.get("person_id")]);
@@ -9136,7 +9141,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   ViewTable: {
     typeName: "ViewTable",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("view_tables", false), $record.get("id")]);
@@ -9155,7 +9160,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   CompoundKey: {
     typeName: "CompoundKey",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("compound_keys", false), $record.get("person_id_1"), $record.get("person_id_2")]);
@@ -9175,7 +9180,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   SimilarTable1: {
     typeName: "SimilarTable1",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("similar_table_1S", false), $record.get("id")]);
@@ -9194,7 +9199,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   SimilarTable2: {
     typeName: "SimilarTable2",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("similar_table_2S", false), $record.get("id")]);
@@ -9213,7 +9218,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   NullTestRecord: {
     typeName: "NullTestRecord",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("null_test_records", false), $record.get("id")]);
@@ -9232,7 +9237,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Issue756: {
     typeName: "Issue756",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("issue756S", false), $record.get("id")]);
@@ -9251,7 +9256,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   LeftArm: {
     typeName: "LeftArm",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("left_arms", false), $record.get("id")]);
@@ -9270,7 +9275,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Post: {
     typeName: "Post",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("posts", false), $record.get("id")]);
@@ -9289,7 +9294,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -9308,7 +9313,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Type: {
     typeName: "Type",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("types", false), $record.get("id")]);
@@ -49012,7 +49017,7 @@ export const plans = {
     deletedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Input.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteInputPayload_queryPlan,
     inputEdge: {
@@ -49066,7 +49071,7 @@ export const plans = {
     deletedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Patch.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePatchPayload_queryPlan,
     patchEdge: {
@@ -49120,7 +49125,7 @@ export const plans = {
     deletedReservedId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Reserved.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteReservedPayload_queryPlan,
     reservedEdge: {
@@ -49174,7 +49179,7 @@ export const plans = {
     deletedReservedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedPatchRecord.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteReservedPatchRecordPayload_queryPlan,
     reservedPatchRecordEdge: {
@@ -49228,7 +49233,7 @@ export const plans = {
     deletedReservedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedInputRecord.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteReservedInputRecordPayload_queryPlan,
     reservedInputRecordEdge: {
@@ -49282,7 +49287,7 @@ export const plans = {
     deletedDefaultValueId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.DefaultValue.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteDefaultValuePayload_queryPlan,
     defaultValueEdge: {
@@ -49348,7 +49353,7 @@ export const plans = {
     deletedMyTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.MyTable.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteMyTablePayload_queryPlan,
     myTableEdge: {
@@ -49402,7 +49407,7 @@ export const plans = {
     deletedPersonSecretId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.PersonSecret.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonSecretPayload_queryPlan,
     personSecretEdge: {
@@ -49461,7 +49466,7 @@ export const plans = {
     deletedViewTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ViewTable.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteViewTablePayload_queryPlan,
     viewTableEdge: {
@@ -49515,7 +49520,7 @@ export const plans = {
     deletedCompoundKeyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.CompoundKey.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteCompoundKeyPayload_queryPlan,
     compoundKeyEdge: {
@@ -49580,7 +49585,7 @@ export const plans = {
     deletedSimilarTable1Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable1.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteSimilarTable1Payload_queryPlan,
     similarTable1Edge: {
@@ -49634,7 +49639,7 @@ export const plans = {
     deletedSimilarTable2Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable2.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteSimilarTable2Payload_queryPlan,
     similarTable2Edge: {
@@ -49688,7 +49693,7 @@ export const plans = {
     deletedNullTestRecordId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.NullTestRecord.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteNullTestRecordPayload_queryPlan,
     nullTestRecordEdge: {
@@ -49742,7 +49747,7 @@ export const plans = {
     deletedIssue756Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Issue756.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteIssue756Payload_queryPlan,
     issue756Edge: {
@@ -49796,7 +49801,7 @@ export const plans = {
     deletedLeftArmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.LeftArm.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteLeftArmPayload_queryPlan,
     leftArmEdge: {
@@ -49861,7 +49866,7 @@ export const plans = {
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePostPayload_queryPlan,
     postEdge: {
@@ -49920,7 +49925,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {
@@ -49980,7 +49985,7 @@ export const plans = {
     deletedTypeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Type.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTypePayload_queryPlan,
     typeEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.inheritence.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.inheritence.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const attributes = Object.assign(Object.create(null), {
@@ -331,7 +336,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   File: {
     typeName: "File",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("files", false), $record.get("id")]);
@@ -350,7 +355,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   User: {
     typeName: "User",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("users", false), $record.get("id")]);
@@ -369,7 +374,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   UserFile: {
     typeName: "UserFile",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("user_files", false), $record.get("id")]);
@@ -3277,7 +3282,7 @@ export const plans = {
     deletedFileId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.File.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteFilePayload_queryPlan,
     fileEdge: {
@@ -3331,7 +3336,7 @@ export const plans = {
     deletedUserId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.User.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteUserPayload_queryPlan,
     userEdge: {
@@ -3385,7 +3390,7 @@ export const plans = {
     deletedUserFileId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.UserFile.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteUserFilePayload_queryPlan,
     userFileEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -8984,7 +8989,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Input: {
     typeName: "Input",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("inputs", false), $record.get("id")]);
@@ -9003,7 +9008,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Patch: {
     typeName: "Patch",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("patchs", false), $record.get("id")]);
@@ -9022,7 +9027,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Reserved: {
     typeName: "Reserved",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("reserveds", false), $record.get("id")]);
@@ -9041,7 +9046,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   ReservedPatchRecord: {
     typeName: "ReservedPatchRecord",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("reservedPatchs", false), $record.get("id")]);
@@ -9060,7 +9065,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   ReservedInputRecord: {
     typeName: "ReservedInputRecord",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("reserved_inputs", false), $record.get("id")]);
@@ -9079,7 +9084,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   DefaultValue: {
     typeName: "DefaultValue",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("default_values", false), $record.get("id")]);
@@ -9098,7 +9103,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   MyTable: {
     typeName: "MyTable",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("my_tables", false), $record.get("id")]);
@@ -9117,7 +9122,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   PersonSecret: {
     typeName: "PersonSecret",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: "This is deprecated (comment on table c.person_secret).",
     plan($record) {
       return list([constant("person_secrets", false), $record.get("person_id")]);
@@ -9136,7 +9141,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   ViewTable: {
     typeName: "ViewTable",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("view_tables", false), $record.get("id")]);
@@ -9155,7 +9160,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   CompoundKey: {
     typeName: "CompoundKey",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("compound_keys", false), $record.get("person_id_1"), $record.get("person_id_2")]);
@@ -9175,7 +9180,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   SimilarTable1: {
     typeName: "SimilarTable1",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("similar_table_1S", false), $record.get("id")]);
@@ -9194,7 +9199,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   SimilarTable2: {
     typeName: "SimilarTable2",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("similar_table_2S", false), $record.get("id")]);
@@ -9213,7 +9218,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   NullTestRecord: {
     typeName: "NullTestRecord",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("null_test_records", false), $record.get("id")]);
@@ -9232,7 +9237,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Issue756: {
     typeName: "Issue756",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("issue756S", false), $record.get("id")]);
@@ -9251,7 +9256,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   LeftArm: {
     typeName: "LeftArm",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("left_arms", false), $record.get("id")]);
@@ -9270,7 +9275,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Post: {
     typeName: "Post",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("posts", false), $record.get("id")]);
@@ -9289,7 +9294,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -9308,7 +9313,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Type: {
     typeName: "Type",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("types", false), $record.get("id")]);
@@ -49012,7 +49017,7 @@ export const plans = {
     deletedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Input.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteInputPayload_queryPlan,
     inputEdge: {
@@ -49066,7 +49071,7 @@ export const plans = {
     deletedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Patch.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePatchPayload_queryPlan,
     patchEdge: {
@@ -49120,7 +49125,7 @@ export const plans = {
     deletedReservedId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Reserved.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteReservedPayload_queryPlan,
     reservedEdge: {
@@ -49174,7 +49179,7 @@ export const plans = {
     deletedReservedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedPatchRecord.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteReservedPatchRecordPayload_queryPlan,
     reservedPatchRecordEdge: {
@@ -49228,7 +49233,7 @@ export const plans = {
     deletedReservedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedInputRecord.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteReservedInputRecordPayload_queryPlan,
     reservedInputRecordEdge: {
@@ -49282,7 +49287,7 @@ export const plans = {
     deletedDefaultValueId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.DefaultValue.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteDefaultValuePayload_queryPlan,
     defaultValueEdge: {
@@ -49348,7 +49353,7 @@ export const plans = {
     deletedMyTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.MyTable.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteMyTablePayload_queryPlan,
     myTableEdge: {
@@ -49402,7 +49407,7 @@ export const plans = {
     deletedPersonSecretId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.PersonSecret.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonSecretPayload_queryPlan,
     personSecretEdge: {
@@ -49461,7 +49466,7 @@ export const plans = {
     deletedViewTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ViewTable.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteViewTablePayload_queryPlan,
     viewTableEdge: {
@@ -49515,7 +49520,7 @@ export const plans = {
     deletedCompoundKeyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.CompoundKey.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteCompoundKeyPayload_queryPlan,
     compoundKeyEdge: {
@@ -49580,7 +49585,7 @@ export const plans = {
     deletedSimilarTable1Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable1.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteSimilarTable1Payload_queryPlan,
     similarTable1Edge: {
@@ -49634,7 +49639,7 @@ export const plans = {
     deletedSimilarTable2Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable2.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteSimilarTable2Payload_queryPlan,
     similarTable2Edge: {
@@ -49688,7 +49693,7 @@ export const plans = {
     deletedNullTestRecordId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.NullTestRecord.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteNullTestRecordPayload_queryPlan,
     nullTestRecordEdge: {
@@ -49742,7 +49747,7 @@ export const plans = {
     deletedIssue756Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Issue756.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteIssue756Payload_queryPlan,
     issue756Edge: {
@@ -49796,7 +49801,7 @@ export const plans = {
     deletedLeftArmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.LeftArm.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteLeftArmPayload_queryPlan,
     leftArmEdge: {
@@ -49861,7 +49866,7 @@ export const plans = {
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePostPayload_queryPlan,
     postEdge: {
@@ -49920,7 +49925,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {
@@ -49980,7 +49985,7 @@ export const plans = {
     deletedTypeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Type.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTypePayload_queryPlan,
     typeEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/enum_tables.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/enum_tables.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -1048,7 +1053,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   LetterDescription: {
     typeName: "LetterDescription",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("letter_descriptions", false), $record.get("id")]);
@@ -1067,7 +1072,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   ReferencingTable: {
     typeName: "ReferencingTable",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("referencing_tables", false), $record.get("id")]);
@@ -3833,7 +3838,7 @@ export const plans = {
     deletedLetterDescriptionId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.LetterDescription.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteLetterDescriptionPayload_queryPlan,
     letterDescriptionEdge: {
@@ -3899,7 +3904,7 @@ export const plans = {
     deletedReferencingTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReferencingTable.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteReferencingTablePayload_queryPlan,
     referencingTableEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -5311,7 +5316,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   MyTable: {
     typeName: "MyTable",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("my_tables", false), $record.get("id")]);
@@ -5330,7 +5335,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   PersonSecret: {
     typeName: "PersonSecret",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: "This is deprecated (comment on table c.person_secret).",
     plan($record) {
       return list([constant("person_secrets", false), $record.get("person_id")]);
@@ -5349,7 +5354,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   CompoundKey: {
     typeName: "CompoundKey",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("compound_keys", false), $record.get("person_id_1"), $record.get("person_id_2")]);
@@ -5369,7 +5374,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   NullTestRecord: {
     typeName: "NullTestRecord",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("null_test_records", false), $record.get("id")]);
@@ -5388,7 +5393,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   LeftArm: {
     typeName: "LeftArm",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("left_arms", false), $record.get("id")]);
@@ -5407,7 +5412,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Issue756: {
     typeName: "Issue756",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("issue756S", false), $record.get("id")]);
@@ -5426,7 +5431,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -23152,7 +23157,7 @@ export const plans = {
     deletedMyTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.MyTable.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteMyTablePayload_queryPlan,
     myTableEdge: {
@@ -23206,7 +23211,7 @@ export const plans = {
     deletedPersonSecretId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.PersonSecret.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonSecretPayload_queryPlan,
     personSecretEdge: {
@@ -23270,7 +23275,7 @@ export const plans = {
     deletedCompoundKeyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.CompoundKey.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteCompoundKeyPayload_queryPlan,
     compoundKeyEdge: {
@@ -23335,7 +23340,7 @@ export const plans = {
     deletedNullTestRecordId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.NullTestRecord.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteNullTestRecordPayload_queryPlan,
     nullTestRecordEdge: {
@@ -23389,7 +23394,7 @@ export const plans = {
     deletedLeftArmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.LeftArm.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteLeftArmPayload_queryPlan,
     leftArmEdge: {
@@ -23454,7 +23459,7 @@ export const plans = {
     deletedIssue756Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Issue756.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteIssue756Payload_queryPlan,
     issue756Edge: {
@@ -23508,7 +23513,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-good.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-good.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -5309,7 +5314,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   MyTable: {
     typeName: "MyTable",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("my_tables", false), $record.get("id")]);
@@ -5328,7 +5333,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   PersonSecret: {
     typeName: "PersonSecret",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: "This is deprecated (comment on table c.person_secret).",
     plan($record) {
       return list([constant("person_secrets", false), $record.get("person_id")]);
@@ -5347,7 +5352,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   CompoundKey: {
     typeName: "CompoundKey",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("compound_keys", false), $record.get("person_id_1"), $record.get("person_id_2")]);
@@ -5367,7 +5372,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   NullTestRecord: {
     typeName: "NullTestRecord",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("null_test_records", false), $record.get("id")]);
@@ -5386,7 +5391,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   LeftArm: {
     typeName: "LeftArm",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("left_arms", false), $record.get("id")]);
@@ -5405,7 +5410,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Issue756: {
     typeName: "Issue756",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("issue756S", false), $record.get("id")]);
@@ -5424,7 +5429,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -23261,7 +23266,7 @@ export const plans = {
     deletedMyTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.MyTable.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteMyTablePayload_queryPlan,
     myTableEdge: {
@@ -23315,7 +23320,7 @@ export const plans = {
     deletedPersonSecretId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.PersonSecret.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonSecretPayload_queryPlan,
     personSecretEdge: {
@@ -23379,7 +23384,7 @@ export const plans = {
     deletedCompoundKeyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.CompoundKey.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteCompoundKeyPayload_queryPlan,
     compoundKeyEdge: {
@@ -23444,7 +23449,7 @@ export const plans = {
     deletedNullTestRecordId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.NullTestRecord.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteNullTestRecordPayload_queryPlan,
     nullTestRecordEdge: {
@@ -23498,7 +23503,7 @@ export const plans = {
     deletedLeftArmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.LeftArm.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteLeftArmPayload_queryPlan,
     leftArmEdge: {
@@ -23563,7 +23568,7 @@ export const plans = {
     deletedIssue756Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Issue756.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteIssue756Payload_queryPlan,
     issue756Edge: {
@@ -23617,7 +23622,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -9020,7 +9025,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Input: {
     typeName: "Input",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("inputs", false), $record.get("id")]);
@@ -9039,7 +9044,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Patch: {
     typeName: "Patch",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("patchs", false), $record.get("id")]);
@@ -9058,7 +9063,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Reserved: {
     typeName: "Reserved",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("reserveds", false), $record.get("id")]);
@@ -9077,7 +9082,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   ReservedPatchRecord: {
     typeName: "ReservedPatchRecord",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("reservedPatchs", false), $record.get("id")]);
@@ -9096,7 +9101,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   ReservedInputRecord: {
     typeName: "ReservedInputRecord",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("reserved_inputs", false), $record.get("id")]);
@@ -9115,7 +9120,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   DefaultValue: {
     typeName: "DefaultValue",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("default_values", false), $record.get("id")]);
@@ -9134,7 +9139,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   MyTable: {
     typeName: "MyTable",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("my_tables", false), $record.get("id")]);
@@ -9153,7 +9158,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   PersonSecret: {
     typeName: "PersonSecret",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: "This is deprecated (comment on table c.person_secret).",
     plan($record) {
       return list([constant("person_secrets", false), $record.get("person_id")]);
@@ -9172,7 +9177,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   ViewTable: {
     typeName: "ViewTable",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("view_tables", false), $record.get("id")]);
@@ -9191,7 +9196,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   CompoundKey: {
     typeName: "CompoundKey",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("compound_keys", false), $record.get("person_id_1"), $record.get("person_id_2")]);
@@ -9211,7 +9216,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   SimilarTable1: {
     typeName: "SimilarTable1",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("similar_table_1S", false), $record.get("id")]);
@@ -9230,7 +9235,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   SimilarTable2: {
     typeName: "SimilarTable2",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("similar_table_2S", false), $record.get("id")]);
@@ -9249,7 +9254,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   NullTestRecord: {
     typeName: "NullTestRecord",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("null_test_records", false), $record.get("id")]);
@@ -9268,7 +9273,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Issue756: {
     typeName: "Issue756",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("issue756S", false), $record.get("id")]);
@@ -9287,7 +9292,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   LeftArm: {
     typeName: "LeftArm",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("left_arms", false), $record.get("id")]);
@@ -9306,7 +9311,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Post: {
     typeName: "Post",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("posts", false), $record.get("id")]);
@@ -9325,7 +9330,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -9344,7 +9349,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Type: {
     typeName: "Type",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("types", false), $record.get("id")]);
@@ -48729,7 +48734,7 @@ export const plans = {
     deletedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Input.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteInputPayload_queryPlan,
     inputEdge: {
@@ -48783,7 +48788,7 @@ export const plans = {
     deletedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Patch.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePatchPayload_queryPlan,
     patchEdge: {
@@ -48837,7 +48842,7 @@ export const plans = {
     deletedReservedId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Reserved.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteReservedPayload_queryPlan,
     reservedEdge: {
@@ -48891,7 +48896,7 @@ export const plans = {
     deletedReservedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedPatchRecord.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteReservedPatchRecordPayload_queryPlan,
     reservedPatchRecordEdge: {
@@ -48945,7 +48950,7 @@ export const plans = {
     deletedReservedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedInputRecord.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteReservedInputRecordPayload_queryPlan,
     reservedInputRecordEdge: {
@@ -48999,7 +49004,7 @@ export const plans = {
     deletedDefaultValueId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.DefaultValue.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteDefaultValuePayload_queryPlan,
     defaultValueEdge: {
@@ -49065,7 +49070,7 @@ export const plans = {
     deletedMyTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.MyTable.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteMyTablePayload_queryPlan,
     myTableEdge: {
@@ -49119,7 +49124,7 @@ export const plans = {
     deletedPersonSecretId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.PersonSecret.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonSecretPayload_queryPlan,
     personSecretEdge: {
@@ -49178,7 +49183,7 @@ export const plans = {
     deletedViewTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ViewTable.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteViewTablePayload_queryPlan,
     viewTableEdge: {
@@ -49232,7 +49237,7 @@ export const plans = {
     deletedCompoundKeyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.CompoundKey.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteCompoundKeyPayload_queryPlan,
     compoundKeyEdge: {
@@ -49297,7 +49302,7 @@ export const plans = {
     deletedSimilarTable1Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable1.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteSimilarTable1Payload_queryPlan,
     similarTable1Edge: {
@@ -49351,7 +49356,7 @@ export const plans = {
     deletedSimilarTable2Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable2.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteSimilarTable2Payload_queryPlan,
     similarTable2Edge: {
@@ -49405,7 +49410,7 @@ export const plans = {
     deletedNullTestRecordId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.NullTestRecord.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteNullTestRecordPayload_queryPlan,
     nullTestRecordEdge: {
@@ -49459,7 +49464,7 @@ export const plans = {
     deletedIssue756Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Issue756.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteIssue756Payload_queryPlan,
     issue756Edge: {
@@ -49513,7 +49518,7 @@ export const plans = {
     deletedLeftArmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.LeftArm.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteLeftArmPayload_queryPlan,
     leftArmEdge: {
@@ -49578,7 +49583,7 @@ export const plans = {
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePostPayload_queryPlan,
     postEdge: {
@@ -49637,7 +49642,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {
@@ -49697,7 +49702,7 @@ export const plans = {
     deletedTypeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Type.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTypePayload_queryPlan,
     typeEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -9014,7 +9019,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Input: {
     typeName: "Input",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("inputs", false), $record.get("id")]);
@@ -9033,7 +9038,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Patch: {
     typeName: "Patch",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("patchs", false), $record.get("id")]);
@@ -9052,7 +9057,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Reserved: {
     typeName: "Reserved",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("reserveds", false), $record.get("id")]);
@@ -9071,7 +9076,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   ReservedPatchRecord: {
     typeName: "ReservedPatchRecord",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("reservedPatchs", false), $record.get("id")]);
@@ -9090,7 +9095,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   ReservedInputRecord: {
     typeName: "ReservedInputRecord",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("reserved_inputs", false), $record.get("id")]);
@@ -9109,7 +9114,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   DefaultValue: {
     typeName: "DefaultValue",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("default_values", false), $record.get("id")]);
@@ -9128,7 +9133,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   MyTable: {
     typeName: "MyTable",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("my_tables", false), $record.get("id")]);
@@ -9147,7 +9152,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   PersonSecret: {
     typeName: "PersonSecret",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: "This is deprecated (comment on table c.person_secret).",
     plan($record) {
       return list([constant("person_secrets", false), $record.get("person_id")]);
@@ -9166,7 +9171,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   ViewTable: {
     typeName: "ViewTable",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("view_tables", false), $record.get("id")]);
@@ -9185,7 +9190,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   CompoundKey: {
     typeName: "CompoundKey",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("compound_keys", false), $record.get("person_id_1"), $record.get("person_id_2")]);
@@ -9205,7 +9210,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   SimilarTable1: {
     typeName: "SimilarTable1",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("similar_table_1S", false), $record.get("id")]);
@@ -9224,7 +9229,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   SimilarTable2: {
     typeName: "SimilarTable2",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("similar_table_2S", false), $record.get("id")]);
@@ -9243,7 +9248,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   NullTestRecord: {
     typeName: "NullTestRecord",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("null_test_records", false), $record.get("id")]);
@@ -9262,7 +9267,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Issue756: {
     typeName: "Issue756",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("issue756S", false), $record.get("id")]);
@@ -9281,7 +9286,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   LeftArm: {
     typeName: "LeftArm",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("left_arms", false), $record.get("id")]);
@@ -9300,7 +9305,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Post: {
     typeName: "Post",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("posts", false), $record.get("id")]);
@@ -9319,7 +9324,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -9338,7 +9343,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Type: {
     typeName: "Type",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("types", false), $record.get("id")]);
@@ -49042,7 +49047,7 @@ export const plans = {
     deletedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Input.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteInputPayload_queryPlan,
     inputEdge: {
@@ -49096,7 +49101,7 @@ export const plans = {
     deletedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Patch.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePatchPayload_queryPlan,
     patchEdge: {
@@ -49150,7 +49155,7 @@ export const plans = {
     deletedReservedId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Reserved.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteReservedPayload_queryPlan,
     reservedEdge: {
@@ -49204,7 +49209,7 @@ export const plans = {
     deletedReservedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedPatchRecord.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteReservedPatchRecordPayload_queryPlan,
     reservedPatchRecordEdge: {
@@ -49258,7 +49263,7 @@ export const plans = {
     deletedReservedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedInputRecord.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteReservedInputRecordPayload_queryPlan,
     reservedInputRecordEdge: {
@@ -49312,7 +49317,7 @@ export const plans = {
     deletedDefaultValueId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.DefaultValue.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteDefaultValuePayload_queryPlan,
     defaultValueEdge: {
@@ -49378,7 +49383,7 @@ export const plans = {
     deletedMyTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.MyTable.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteMyTablePayload_queryPlan,
     myTableEdge: {
@@ -49432,7 +49437,7 @@ export const plans = {
     deletedPersonSecretId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.PersonSecret.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonSecretPayload_queryPlan,
     personSecretEdge: {
@@ -49491,7 +49496,7 @@ export const plans = {
     deletedViewTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ViewTable.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteViewTablePayload_queryPlan,
     viewTableEdge: {
@@ -49545,7 +49550,7 @@ export const plans = {
     deletedCompoundKeyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.CompoundKey.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteCompoundKeyPayload_queryPlan,
     compoundKeyEdge: {
@@ -49610,7 +49615,7 @@ export const plans = {
     deletedSimilarTable1Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable1.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteSimilarTable1Payload_queryPlan,
     similarTable1Edge: {
@@ -49664,7 +49669,7 @@ export const plans = {
     deletedSimilarTable2Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable2.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteSimilarTable2Payload_queryPlan,
     similarTable2Edge: {
@@ -49718,7 +49723,7 @@ export const plans = {
     deletedNullTestRecordId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.NullTestRecord.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteNullTestRecordPayload_queryPlan,
     nullTestRecordEdge: {
@@ -49772,7 +49777,7 @@ export const plans = {
     deletedIssue756Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Issue756.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteIssue756Payload_queryPlan,
     issue756Edge: {
@@ -49826,7 +49831,7 @@ export const plans = {
     deletedLeftArmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.LeftArm.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteLeftArmPayload_queryPlan,
     leftArmEdge: {
@@ -49891,7 +49896,7 @@ export const plans = {
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePostPayload_queryPlan,
     postEdge: {
@@ -49950,7 +49955,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {
@@ -50010,7 +50015,7 @@ export const plans = {
     deletedTypeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Type.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTypePayload_queryPlan,
     typeEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/geometry.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/geometry.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const attributes = Object.assign(Object.create(null), {
@@ -212,7 +217,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Geom: {
     typeName: "Geom",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("geoms", false), $record.get("id")]);
@@ -1908,7 +1913,7 @@ export const plans = {
     deletedGeomId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Geom.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteGeomPayload_queryPlan,
     geomEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -9237,7 +9242,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Input: {
     typeName: "Input",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("inputs", false), $record.get("id")]);
@@ -9256,7 +9261,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Patch: {
     typeName: "Patch",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("patchs", false), $record.get("id")]);
@@ -9275,7 +9280,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Reserved: {
     typeName: "Reserved",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("reserveds", false), $record.get("id")]);
@@ -9294,7 +9299,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   ReservedPatchRecord: {
     typeName: "ReservedPatchRecord",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("reservedPatchs", false), $record.get("id")]);
@@ -9313,7 +9318,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   ReservedInputRecord: {
     typeName: "ReservedInputRecord",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("reserved_inputs", false), $record.get("id")]);
@@ -9332,7 +9337,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   DefaultValue: {
     typeName: "DefaultValue",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("default_values", false), $record.get("id")]);
@@ -9351,7 +9356,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   MyTable: {
     typeName: "MyTable",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("my_tables", false), $record.get("id")]);
@@ -9370,7 +9375,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   PersonSecret: {
     typeName: "PersonSecret",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: "This is deprecated (comment on table c.person_secret).",
     plan($record) {
       return list([constant("person_secrets", false), $record.get("person_id")]);
@@ -9389,7 +9394,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   ViewTable: {
     typeName: "ViewTable",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("view_tables", false), $record.get("id")]);
@@ -9408,7 +9413,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   CompoundKey: {
     typeName: "CompoundKey",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("compound_keys", false), $record.get("person_id_1"), $record.get("person_id_2")]);
@@ -9428,7 +9433,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   SimilarTable1: {
     typeName: "SimilarTable1",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("similar_table_1S", false), $record.get("id")]);
@@ -9447,7 +9452,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   SimilarTable2: {
     typeName: "SimilarTable2",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("similar_table_2S", false), $record.get("id")]);
@@ -9466,7 +9471,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   NullTestRecord: {
     typeName: "NullTestRecord",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("null_test_records", false), $record.get("id")]);
@@ -9485,7 +9490,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Issue756: {
     typeName: "Issue756",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("issue756S", false), $record.get("id")]);
@@ -9504,7 +9509,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   LeftArm: {
     typeName: "LeftArm",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("left_arms", false), $record.get("id")]);
@@ -9523,7 +9528,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Post: {
     typeName: "Post",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("posts", false), $record.get("id")]);
@@ -9542,7 +9547,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -9561,7 +9566,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Type: {
     typeName: "Type",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("types", false), $record.get("id")]);
@@ -43682,7 +43687,7 @@ export const plans = {
     deletedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Input.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteInputPayload_queryPlan,
     inputEdge: {
@@ -43736,7 +43741,7 @@ export const plans = {
     deletedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Patch.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePatchPayload_queryPlan,
     patchEdge: {
@@ -43790,7 +43795,7 @@ export const plans = {
     deletedReservedId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Reserved.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteReservedPayload_queryPlan,
     reservedEdge: {
@@ -43844,7 +43849,7 @@ export const plans = {
     deletedReservedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedPatchRecord.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteReservedPatchRecordPayload_queryPlan,
     reservedPatchRecordEdge: {
@@ -43898,7 +43903,7 @@ export const plans = {
     deletedReservedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedInputRecord.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteReservedInputRecordPayload_queryPlan,
     reservedInputRecordEdge: {
@@ -43952,7 +43957,7 @@ export const plans = {
     deletedDefaultValueId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.DefaultValue.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteDefaultValuePayload_queryPlan,
     defaultValueEdge: {
@@ -44018,7 +44023,7 @@ export const plans = {
     deletedMyTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.MyTable.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteMyTablePayload_queryPlan,
     myTableEdge: {
@@ -44072,7 +44077,7 @@ export const plans = {
     deletedPersonSecretId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.PersonSecret.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonSecretPayload_queryPlan,
     personSecretEdge: {
@@ -44131,7 +44136,7 @@ export const plans = {
     deletedViewTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ViewTable.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteViewTablePayload_queryPlan,
     viewTableEdge: {
@@ -44185,7 +44190,7 @@ export const plans = {
     deletedCompoundKeyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.CompoundKey.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteCompoundKeyPayload_queryPlan,
     compoundKeyEdge: {
@@ -44250,7 +44255,7 @@ export const plans = {
     deletedSimilarTable1Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable1.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteSimilarTable1Payload_queryPlan,
     similarTable1Edge: {
@@ -44304,7 +44309,7 @@ export const plans = {
     deletedSimilarTable2Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable2.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteSimilarTable2Payload_queryPlan,
     similarTable2Edge: {
@@ -44358,7 +44363,7 @@ export const plans = {
     deletedNullTestRecordId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.NullTestRecord.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteNullTestRecordPayload_queryPlan,
     nullTestRecordEdge: {
@@ -44412,7 +44417,7 @@ export const plans = {
     deletedIssue756Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Issue756.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteIssue756Payload_queryPlan,
     issue756Edge: {
@@ -44466,7 +44471,7 @@ export const plans = {
     deletedLeftArmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.LeftArm.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteLeftArmPayload_queryPlan,
     leftArmEdge: {
@@ -44531,7 +44536,7 @@ export const plans = {
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePostPayload_queryPlan,
     postEdge: {
@@ -44590,7 +44595,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {
@@ -44650,7 +44655,7 @@ export const plans = {
     deletedTypeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Type.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTypePayload_queryPlan,
     typeEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/indexes.index_expressions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/indexes.index_expressions.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const attributes = Object.assign(Object.create(null), {
@@ -151,7 +156,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Employee: {
     typeName: "Employee",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("employees", false), $record.get("id")]);

--- a/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -8984,7 +8989,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Q: handler,
   Input: {
     typeName: "Input",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("inputs", false), $record.get("id")]);
@@ -9003,7 +9008,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Patch: {
     typeName: "Patch",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("patchs", false), $record.get("id")]);
@@ -9022,7 +9027,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Reserved: {
     typeName: "Reserved",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("reserveds", false), $record.get("id")]);
@@ -9041,7 +9046,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   ReservedPatchRecord: {
     typeName: "ReservedPatchRecord",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("reservedPatchs", false), $record.get("id")]);
@@ -9060,7 +9065,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   ReservedInputRecord: {
     typeName: "ReservedInputRecord",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("reserved_inputs", false), $record.get("id")]);
@@ -9079,7 +9084,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   DefaultValue: {
     typeName: "DefaultValue",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("default_values", false), $record.get("id")]);
@@ -9098,7 +9103,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   MyTable: {
     typeName: "MyTable",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("my_tables", false), $record.get("id")]);
@@ -9117,7 +9122,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   PersonSecret: {
     typeName: "PersonSecret",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: "This is deprecated (comment on table c.person_secret).",
     plan($record) {
       return list([constant("person_secrets", false), $record.get("person_id")]);
@@ -9136,7 +9141,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   ViewTable: {
     typeName: "ViewTable",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("view_tables", false), $record.get("id")]);
@@ -9155,7 +9160,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   CompoundKey: {
     typeName: "CompoundKey",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("compound_keys", false), $record.get("person_id_1"), $record.get("person_id_2")]);
@@ -9175,7 +9180,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   SimilarTable1: {
     typeName: "SimilarTable1",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("similar_table_1S", false), $record.get("id")]);
@@ -9194,7 +9199,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   SimilarTable2: {
     typeName: "SimilarTable2",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("similar_table_2S", false), $record.get("id")]);
@@ -9213,7 +9218,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   NullTestRecord: {
     typeName: "NullTestRecord",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("null_test_records", false), $record.get("id")]);
@@ -9232,7 +9237,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Issue756: {
     typeName: "Issue756",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("issue756S", false), $record.get("id")]);
@@ -9251,7 +9256,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   LeftArm: {
     typeName: "LeftArm",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("left_arms", false), $record.get("id")]);
@@ -9270,7 +9275,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Post: {
     typeName: "Post",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("posts", false), $record.get("id")]);
@@ -9289,7 +9294,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -9308,7 +9313,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Type: {
     typeName: "Type",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("types", false), $record.get("id")]);
@@ -49017,7 +49022,7 @@ export const plans = {
     deletedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Input.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteInputPayload_queryPlan,
     inputEdge: {
@@ -49071,7 +49076,7 @@ export const plans = {
     deletedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Patch.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePatchPayload_queryPlan,
     patchEdge: {
@@ -49125,7 +49130,7 @@ export const plans = {
     deletedReservedId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Reserved.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteReservedPayload_queryPlan,
     reservedEdge: {
@@ -49179,7 +49184,7 @@ export const plans = {
     deletedReservedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedPatchRecord.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteReservedPatchRecordPayload_queryPlan,
     reservedPatchRecordEdge: {
@@ -49233,7 +49238,7 @@ export const plans = {
     deletedReservedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedInputRecord.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteReservedInputRecordPayload_queryPlan,
     reservedInputRecordEdge: {
@@ -49287,7 +49292,7 @@ export const plans = {
     deletedDefaultValueId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.DefaultValue.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteDefaultValuePayload_queryPlan,
     defaultValueEdge: {
@@ -49353,7 +49358,7 @@ export const plans = {
     deletedMyTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.MyTable.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteMyTablePayload_queryPlan,
     myTableEdge: {
@@ -49407,7 +49412,7 @@ export const plans = {
     deletedPersonSecretId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.PersonSecret.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonSecretPayload_queryPlan,
     personSecretEdge: {
@@ -49466,7 +49471,7 @@ export const plans = {
     deletedViewTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ViewTable.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteViewTablePayload_queryPlan,
     viewTableEdge: {
@@ -49520,7 +49525,7 @@ export const plans = {
     deletedCompoundKeyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.CompoundKey.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteCompoundKeyPayload_queryPlan,
     compoundKeyEdge: {
@@ -49585,7 +49590,7 @@ export const plans = {
     deletedSimilarTable1Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable1.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteSimilarTable1Payload_queryPlan,
     similarTable1Edge: {
@@ -49639,7 +49644,7 @@ export const plans = {
     deletedSimilarTable2Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable2.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteSimilarTable2Payload_queryPlan,
     similarTable2Edge: {
@@ -49693,7 +49698,7 @@ export const plans = {
     deletedNullTestRecordId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.NullTestRecord.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteNullTestRecordPayload_queryPlan,
     nullTestRecordEdge: {
@@ -49747,7 +49752,7 @@ export const plans = {
     deletedIssue756Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Issue756.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteIssue756Payload_queryPlan,
     issue756Edge: {
@@ -49801,7 +49806,7 @@ export const plans = {
     deletedLeftArmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.LeftArm.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteLeftArmPayload_queryPlan,
     leftArmEdge: {
@@ -49866,7 +49871,7 @@ export const plans = {
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePostPayload_queryPlan,
     postEdge: {
@@ -49925,7 +49930,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {
@@ -49985,7 +49990,7 @@ export const plans = {
     deletedTypeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Type.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTypePayload_queryPlan,
     typeEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/js-reserved.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/js-reserved.1.export.mjs
@@ -2,6 +2,17 @@ import { PgDeleteSingleStep, PgExecutor, PgSelectSingleStep, PgSelectStep, PgUni
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const handler_codec_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
 const attributes_type_codec_itemType = enumCodec({
   name: "itemType",
   identifier: sql.identifier(...["js_reserved", "item_type"]),
@@ -1510,15 +1521,7 @@ const registry = makeRegistry(registryConfig);
 const pgResource_relational_topicsPgResource = registry.pgResources["relational_topics"];
 const handler = {
   typeName: "RelationalTopic",
-  codec: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  codec: handler_codec_base64JSON,
   deprecationReason: undefined,
   plan($record) {
     return list([constant("relational_topics", false), $record.get("id")]);
@@ -1535,6 +1538,12 @@ const handler = {
     return obj[0] === "relational_topics";
   }
 };
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: {
     name: "raw",
@@ -1545,15 +1554,11 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
       return typeof value === "string" ? value : null;
     }
   },
-  base64JSON: handler.codec,
+  base64JSON: handler_codec_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const building_buildingPgResource = registry.pgResources["building"];
@@ -1561,7 +1566,7 @@ const relational_items_relational_itemsPgResource = registry.pgResources["relati
 const relational_status_relational_statusPgResource = registry.pgResources["relational_status"];
 const handler2 = {
   typeName: "Building",
-  codec: handler.codec,
+  codec: handler_codec_base64JSON,
   deprecationReason: undefined,
   plan($record) {
     return list([constant("buildings", false), $record.get("id")]);
@@ -1663,7 +1668,7 @@ function MachinesConnection_pageInfoPlan($connection) {
 }
 const handler3 = {
   typeName: "Machine",
-  codec: handler.codec,
+  codec: handler_codec_base64JSON,
   deprecationReason: undefined,
   plan($record) {
     return list([constant("machines", false), $record.get("id")]);
@@ -1704,7 +1709,7 @@ function RelationalItemsConnection_pageInfoPlan($connection) {
 }
 const handler4 = {
   typeName: "RelationalStatus",
-  codec: handler.codec,
+  codec: handler_codec_base64JSON,
   deprecationReason: undefined,
   plan($record) {
     return list([constant("relational_statuses", false), $record.get("id")]);
@@ -1753,7 +1758,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   RelationalTopic: handler,
   _Proto__: {
     typeName: "_Proto__",
-    codec: handler.codec,
+    codec: handler_codec_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("__proto__S", false), ...uniques2[0].attributes.map(attribute => $record.get(attribute))]);
@@ -1775,7 +1780,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Building: handler2,
   Constructor: {
     typeName: "Constructor",
-    codec: handler.codec,
+    codec: handler_codec_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("constructors", false), $record.get("id")]);
@@ -1794,7 +1799,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Crop: {
     typeName: "Crop",
-    codec: handler.codec,
+    codec: handler_codec_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("crops", false), $record.get("id")]);
@@ -1814,7 +1819,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Machine: handler3,
   Material: {
     typeName: "Material",
-    codec: handler.codec,
+    codec: handler_codec_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("materials", false), $record.get("id")]);
@@ -1833,7 +1838,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Null: {
     typeName: "Null",
-    codec: handler.codec,
+    codec: handler_codec_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("nulls", false), $record.get("id")]);
@@ -1852,7 +1857,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Project: {
     typeName: "Project",
-    codec: handler.codec,
+    codec: handler_codec_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("projects", false), $record.get("id")]);
@@ -1872,7 +1877,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   RelationalStatus: handler4,
   Yield: {
     typeName: "Yield",
-    codec: handler.codec,
+    codec: handler_codec_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("yields", false), $record.get("id")]);
@@ -1891,7 +1896,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Reserved: {
     typeName: "Reserved",
-    codec: handler.codec,
+    codec: handler_codec_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("reserveds", false), $record.get("id")]);
@@ -15981,7 +15986,7 @@ export const plans = {
     deletedProtoId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName._Proto__.plan($record);
-      return lambda(specifier, handler.codec.encode);
+      return lambda(specifier, handler_codec_base64JSON.encode);
     },
     query: DeleteProtoPayload_queryPlan,
     _protoEdge: {
@@ -16041,7 +16046,7 @@ export const plans = {
     deletedBuildingId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = handler2.plan($record);
-      return lambda(specifier, handler2.codec.encode);
+      return lambda(specifier, handler_codec_base64JSON.encode);
     },
     query: DeleteBuildingPayload_queryPlan,
     buildingEdge: {
@@ -16101,7 +16106,7 @@ export const plans = {
     deletedConstructorId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Constructor.plan($record);
-      return lambda(specifier, handler.codec.encode);
+      return lambda(specifier, handler_codec_base64JSON.encode);
     },
     query: DeleteConstructorPayload_queryPlan,
     constructorEdge: {
@@ -16167,7 +16172,7 @@ export const plans = {
     deletedCropId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Crop.plan($record);
-      return lambda(specifier, handler.codec.encode);
+      return lambda(specifier, handler_codec_base64JSON.encode);
     },
     query: DeleteCropPayload_queryPlan,
     cropEdge: {
@@ -16227,7 +16232,7 @@ export const plans = {
     deletedMachineId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = handler3.plan($record);
-      return lambda(specifier, handler3.codec.encode);
+      return lambda(specifier, handler_codec_base64JSON.encode);
     },
     query: DeleteMachinePayload_queryPlan,
     machineEdge: {
@@ -16285,7 +16290,7 @@ export const plans = {
     deletedMaterialId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Material.plan($record);
-      return lambda(specifier, handler.codec.encode);
+      return lambda(specifier, handler_codec_base64JSON.encode);
     },
     query: DeleteMaterialPayload_queryPlan,
     materialEdge: {
@@ -16351,7 +16356,7 @@ export const plans = {
     deletedNullId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Null.plan($record);
-      return lambda(specifier, handler.codec.encode);
+      return lambda(specifier, handler_codec_base64JSON.encode);
     },
     query: DeleteNullPayload_queryPlan,
     nullEdge: {
@@ -16417,7 +16422,7 @@ export const plans = {
     deletedProjectId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Project.plan($record);
-      return lambda(specifier, handler.codec.encode);
+      return lambda(specifier, handler_codec_base64JSON.encode);
     },
     query: DeleteProjectPayload_queryPlan,
     projectEdge: {
@@ -16477,7 +16482,7 @@ export const plans = {
     deletedYieldId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Yield.plan($record);
-      return lambda(specifier, handler.codec.encode);
+      return lambda(specifier, handler_codec_base64JSON.encode);
     },
     query: DeleteYieldPayload_queryPlan,
     yieldEdge: {
@@ -16537,7 +16542,7 @@ export const plans = {
     deletedReservedId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Reserved.plan($record);
-      return lambda(specifier, handler.codec.encode);
+      return lambda(specifier, handler_codec_base64JSON.encode);
     },
     query: DeleteReservedPayload_queryPlan,
     reservedEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/jwt.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/jwt.1.export.mjs
@@ -31,25 +31,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const sqlIdent = sql.identifier(...["b", "guid"]);
@@ -2074,7 +2079,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Type: {
     typeName: "Type",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("types", false), $record.get("id")]);
@@ -9978,7 +9983,7 @@ export const plans = {
     deletedTypeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Type.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTypePayload_queryPlan,
     typeEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/network_types.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/network_types.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const attributes = Object.assign(Object.create(null), {
@@ -163,7 +168,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Network: {
     typeName: "Network",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("networks", false), $record.get("id")]);
@@ -1334,7 +1339,7 @@ export const plans = {
     deletedNetworkId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Network.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteNetworkPayload_queryPlan,
     networkEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/network_types.custom.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/network_types.custom.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const attributes = Object.assign(Object.create(null), {
@@ -163,7 +168,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Network: {
     typeName: "Network",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("networks", false), $record.get("id")]);
@@ -1340,7 +1345,7 @@ export const plans = {
     deletedNetworkId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Network.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteNetworkPayload_queryPlan,
     networkEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -5270,7 +5275,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   MyTable: {
     typeName: "MyTable",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("my_tables", false), $record.get("id")]);
@@ -5289,7 +5294,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   PersonSecret: {
     typeName: "PersonSecret",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: "This is deprecated (comment on table c.person_secret).",
     plan($record) {
       return list([constant("person_secrets", false), $record.get("person_id")]);
@@ -5308,7 +5313,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   CompoundKey: {
     typeName: "CompoundKey",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("compound_keys", false), $record.get("person_id_1"), $record.get("person_id_2")]);
@@ -5328,7 +5333,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   NullTestRecord: {
     typeName: "NullTestRecord",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("null_test_records", false), $record.get("id")]);
@@ -5347,7 +5352,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   LeftArm: {
     typeName: "LeftArm",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("left_arms", false), $record.get("id")]);
@@ -5366,7 +5371,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Issue756: {
     typeName: "Issue756",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("issue756S", false), $record.get("id")]);
@@ -5385,7 +5390,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -1074,7 +1079,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Film: {
     typeName: "Film",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("films", false), $record.get("code")]);
@@ -1093,7 +1098,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Studio: {
     typeName: "Studio",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("studios", false), $record.get("id")]);
@@ -1112,7 +1117,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Post: {
     typeName: "Post",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("posts", false), $record.get("id")]);
@@ -1131,7 +1136,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   TvEpisode: {
     typeName: "TvEpisode",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("tv_episodes", false), $record.get("code")]);
@@ -1150,7 +1155,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   TvShow: {
     typeName: "TvShow",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("tv_shows", false), $record.get("code")]);
@@ -1169,7 +1174,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -8371,7 +8376,7 @@ export const plans = {
     deletedFilmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Film.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteFilmPayload_queryPlan,
     filmEdge: {
@@ -8425,7 +8430,7 @@ export const plans = {
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteStudioPayload_queryPlan,
     studioEdge: {
@@ -8479,7 +8484,7 @@ export const plans = {
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePostPayload_queryPlan,
     postEdge: {
@@ -8538,7 +8543,7 @@ export const plans = {
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTvEpisodePayload_queryPlan,
     tvEpisodeEdge: {
@@ -8597,7 +8602,7 @@ export const plans = {
     deletedTvShowId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvShow.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTvShowPayload_queryPlan,
     tvShowEdge: {
@@ -8656,7 +8661,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -1077,7 +1082,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Film: {
     typeName: "Film",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("films", false), $record.get("code")]);
@@ -1096,7 +1101,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Studio: {
     typeName: "Studio",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("studios", false), $record.get("id")]);
@@ -1115,7 +1120,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Post: {
     typeName: "Post",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("posts", false), $record.get("id")]);
@@ -1134,7 +1139,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   TvEpisode: {
     typeName: "TvEpisode",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("tv_episodes", false), $record.get("code")]);
@@ -1153,7 +1158,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   TvShow: {
     typeName: "TvShow",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("tv_shows", false), $record.get("code")]);
@@ -1172,7 +1177,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -8366,7 +8371,7 @@ export const plans = {
     deletedFilmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Film.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteFilmPayload_queryPlan,
     filmEdge: {
@@ -8420,7 +8425,7 @@ export const plans = {
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteStudioPayload_queryPlan,
     studioEdge: {
@@ -8474,7 +8479,7 @@ export const plans = {
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePostPayload_queryPlan,
     postEdge: {
@@ -8533,7 +8538,7 @@ export const plans = {
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTvEpisodePayload_queryPlan,
     tvEpisodeEdge: {
@@ -8592,7 +8597,7 @@ export const plans = {
     deletedTvShowId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvShow.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTvShowPayload_queryPlan,
     tvShowEdge: {
@@ -8651,7 +8656,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.execute.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.execute.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -1070,7 +1075,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Film: {
     typeName: "Film",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("films", false), $record.get("code")]);
@@ -1089,7 +1094,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Studio: {
     typeName: "Studio",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("studios", false), $record.get("id")]);
@@ -1108,7 +1113,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Post: {
     typeName: "Post",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("posts", false), $record.get("id")]);
@@ -1127,7 +1132,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   TvEpisode: {
     typeName: "TvEpisode",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("tv_episodes", false), $record.get("code")]);
@@ -1146,7 +1151,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   TvShow: {
     typeName: "TvShow",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("tv_shows", false), $record.get("code")]);
@@ -1165,7 +1170,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -8214,7 +8219,7 @@ export const plans = {
     deletedFilmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Film.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteFilmPayload_queryPlan,
     filmEdge: {
@@ -8268,7 +8273,7 @@ export const plans = {
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteStudioPayload_queryPlan,
     studioEdge: {
@@ -8322,7 +8327,7 @@ export const plans = {
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePostPayload_queryPlan,
     postEdge: {
@@ -8381,7 +8386,7 @@ export const plans = {
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTvEpisodePayload_queryPlan,
     tvEpisodeEdge: {
@@ -8440,7 +8445,7 @@ export const plans = {
     deletedTvShowId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvShow.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTvShowPayload_queryPlan,
     tvShowEdge: {
@@ -8499,7 +8504,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.loads-title.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.loads-title.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -1077,7 +1082,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Film: {
     typeName: "Film",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("films", false), $record.get("code")]);
@@ -1096,7 +1101,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Studio: {
     typeName: "Studio",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("studios", false), $record.get("id")]);
@@ -1115,7 +1120,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Post: {
     typeName: "Post",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("posts", false), $record.get("id")]);
@@ -1134,7 +1139,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   TvEpisode: {
     typeName: "TvEpisode",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("tv_episodes", false), $record.get("code")]);
@@ -1153,7 +1158,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   TvShow: {
     typeName: "TvShow",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("tv_shows", false), $record.get("code")]);
@@ -1172,7 +1177,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -8354,7 +8359,7 @@ export const plans = {
     deletedFilmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Film.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteFilmPayload_queryPlan,
     filmEdge: {
@@ -8408,7 +8413,7 @@ export const plans = {
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteStudioPayload_queryPlan,
     studioEdge: {
@@ -8462,7 +8467,7 @@ export const plans = {
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePostPayload_queryPlan,
     postEdge: {
@@ -8521,7 +8526,7 @@ export const plans = {
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTvEpisodePayload_queryPlan,
     tvEpisodeEdge: {
@@ -8580,7 +8585,7 @@ export const plans = {
     deletedTvShowId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvShow.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTvShowPayload_queryPlan,
     tvShowEdge: {
@@ -8639,7 +8644,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.shows-title-asterisk.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.shows-title-asterisk.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -1080,7 +1085,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Film: {
     typeName: "Film",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("films", false), $record.get("code")]);
@@ -1099,7 +1104,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Studio: {
     typeName: "Studio",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("studios", false), $record.get("id")]);
@@ -1118,7 +1123,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Post: {
     typeName: "Post",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("posts", false), $record.get("id")]);
@@ -1137,7 +1142,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   TvEpisode: {
     typeName: "TvEpisode",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("tv_episodes", false), $record.get("code")]);
@@ -1156,7 +1161,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   TvShow: {
     typeName: "TvShow",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("tv_shows", false), $record.get("code")]);
@@ -1175,7 +1180,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -8213,7 +8218,7 @@ export const plans = {
     deletedFilmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Film.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteFilmPayload_queryPlan,
     filmEdge: {
@@ -8267,7 +8272,7 @@ export const plans = {
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteStudioPayload_queryPlan,
     studioEdge: {
@@ -8321,7 +8326,7 @@ export const plans = {
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePostPayload_queryPlan,
     postEdge: {
@@ -8380,7 +8385,7 @@ export const plans = {
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTvEpisodePayload_queryPlan,
     tvEpisodeEdge: {
@@ -8439,7 +8444,7 @@ export const plans = {
     deletedTvShowId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvShow.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTvShowPayload_queryPlan,
     tvShowEdge: {
@@ -8498,7 +8503,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.title-order.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.title-order.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -1077,7 +1082,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Film: {
     typeName: "Film",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("films", false), $record.get("code")]);
@@ -1096,7 +1101,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Studio: {
     typeName: "Studio",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("studios", false), $record.get("id")]);
@@ -1115,7 +1120,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Post: {
     typeName: "Post",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("posts", false), $record.get("id")]);
@@ -1134,7 +1139,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   TvEpisode: {
     typeName: "TvEpisode",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("tv_episodes", false), $record.get("code")]);
@@ -1153,7 +1158,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   TvShow: {
     typeName: "TvShow",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("tv_shows", false), $record.get("code")]);
@@ -1172,7 +1177,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -8338,7 +8343,7 @@ export const plans = {
     deletedFilmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Film.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteFilmPayload_queryPlan,
     filmEdge: {
@@ -8392,7 +8397,7 @@ export const plans = {
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteStudioPayload_queryPlan,
     studioEdge: {
@@ -8446,7 +8451,7 @@ export const plans = {
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePostPayload_queryPlan,
     postEdge: {
@@ -8505,7 +8510,7 @@ export const plans = {
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTvEpisodePayload_queryPlan,
     tvEpisodeEdge: {
@@ -8564,7 +8569,7 @@ export const plans = {
     deletedTvShowId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvShow.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTvShowPayload_queryPlan,
     tvShowEdge: {
@@ -8623,7 +8628,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.update-title.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.update-title.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -1077,7 +1082,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Film: {
     typeName: "Film",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("films", false), $record.get("code")]);
@@ -1096,7 +1101,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Studio: {
     typeName: "Studio",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("studios", false), $record.get("id")]);
@@ -1115,7 +1120,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Post: {
     typeName: "Post",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("posts", false), $record.get("id")]);
@@ -1134,7 +1139,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   TvEpisode: {
     typeName: "TvEpisode",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("tv_episodes", false), $record.get("code")]);
@@ -1153,7 +1158,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   TvShow: {
     typeName: "TvShow",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("tv_shows", false), $record.get("code")]);
@@ -1172,7 +1177,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -8366,7 +8371,7 @@ export const plans = {
     deletedFilmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Film.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteFilmPayload_queryPlan,
     filmEdge: {
@@ -8420,7 +8425,7 @@ export const plans = {
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteStudioPayload_queryPlan,
     studioEdge: {
@@ -8474,7 +8479,7 @@ export const plans = {
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePostPayload_queryPlan,
     postEdge: {
@@ -8533,7 +8538,7 @@ export const plans = {
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTvEpisodePayload_queryPlan,
     tvEpisodeEdge: {
@@ -8592,7 +8597,7 @@ export const plans = {
     deletedTvShowId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvShow.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTvShowPayload_queryPlan,
     tvShowEdge: {
@@ -8651,7 +8656,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -1080,7 +1085,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Film: {
     typeName: "Film",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("films", false), $record.get("code")]);
@@ -1099,7 +1104,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Studio: {
     typeName: "Studio",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("studios", false), $record.get("id")]);
@@ -1118,7 +1123,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Post: {
     typeName: "Post",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("posts", false), $record.get("id")]);
@@ -1137,7 +1142,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   TvEpisode: {
     typeName: "TvEpisode",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("tv_episodes", false), $record.get("code")]);
@@ -1156,7 +1161,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   TvShow: {
     typeName: "TvShow",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("tv_shows", false), $record.get("code")]);
@@ -1175,7 +1180,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -7899,7 +7904,7 @@ export const plans = {
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteStudioPayload_queryPlan,
     studioEdge: {
@@ -7953,7 +7958,7 @@ export const plans = {
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePostPayload_queryPlan,
     postEdge: {
@@ -8012,7 +8017,7 @@ export const plans = {
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTvEpisodePayload_queryPlan,
     tvEpisodeEdge: {
@@ -8071,7 +8076,7 @@ export const plans = {
     deletedTvShowId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvShow.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTvShowPayload_queryPlan,
     tvShowEdge: {
@@ -8130,7 +8135,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.constraints.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.constraints.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -1082,7 +1087,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Film: {
     typeName: "Film",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("films", false), $record.get("code")]);
@@ -1101,7 +1106,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Studio: {
     typeName: "Studio",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("studios", false), $record.get("id")]);
@@ -1120,7 +1125,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Post: {
     typeName: "Post",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("posts", false), $record.get("id")]);
@@ -1139,7 +1144,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   TvEpisode: {
     typeName: "TvEpisode",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("tv_episodes", false), $record.get("code")]);
@@ -1158,7 +1163,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   TvShow: {
     typeName: "TvShow",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("tv_shows", false), $record.get("code")]);
@@ -1177,7 +1182,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -8109,7 +8114,7 @@ export const plans = {
     deletedFilmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Film.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteFilmPayload_queryPlan,
     filmEdge: {
@@ -8163,7 +8168,7 @@ export const plans = {
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteStudioPayload_queryPlan,
     studioEdge: {
@@ -8217,7 +8222,7 @@ export const plans = {
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePostPayload_queryPlan,
     postEdge: {
@@ -8276,7 +8281,7 @@ export const plans = {
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTvEpisodePayload_queryPlan,
     tvEpisodeEdge: {
@@ -8335,7 +8340,7 @@ export const plans = {
     deletedTvShowId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvShow.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTvShowPayload_queryPlan,
     tvShowEdge: {
@@ -8394,7 +8399,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-asterisk.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-asterisk.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -1084,7 +1089,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Studio: {
     typeName: "Studio",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("studios", false), $record.get("id")]);
@@ -1103,7 +1108,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Post: {
     typeName: "Post",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("posts", false), $record.get("id")]);
@@ -1122,7 +1127,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   TvEpisode: {
     typeName: "TvEpisode",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("tv_episodes", false), $record.get("code")]);
@@ -1141,7 +1146,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -6321,7 +6326,7 @@ export const plans = {
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteStudioPayload_queryPlan,
     studioEdge: {
@@ -6375,7 +6380,7 @@ export const plans = {
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePostPayload_queryPlan,
     postEdge: {
@@ -6434,7 +6439,7 @@ export const plans = {
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTvEpisodePayload_queryPlan,
     tvEpisodeEdge: {
@@ -6488,7 +6493,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-create.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-create.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -1080,7 +1085,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Film: {
     typeName: "Film",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("films", false), $record.get("code")]);
@@ -1099,7 +1104,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Studio: {
     typeName: "Studio",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("studios", false), $record.get("id")]);
@@ -1118,7 +1123,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Post: {
     typeName: "Post",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("posts", false), $record.get("id")]);
@@ -1137,7 +1142,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   TvEpisode: {
     typeName: "TvEpisode",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("tv_episodes", false), $record.get("code")]);
@@ -1156,7 +1161,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   TvShow: {
     typeName: "TvShow",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("tv_shows", false), $record.get("code")]);
@@ -1175,7 +1180,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -8231,7 +8236,7 @@ export const plans = {
     deletedFilmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Film.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteFilmPayload_queryPlan,
     filmEdge: {
@@ -8285,7 +8290,7 @@ export const plans = {
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteStudioPayload_queryPlan,
     studioEdge: {
@@ -8339,7 +8344,7 @@ export const plans = {
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePostPayload_queryPlan,
     postEdge: {
@@ -8398,7 +8403,7 @@ export const plans = {
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTvEpisodePayload_queryPlan,
     tvEpisodeEdge: {
@@ -8457,7 +8462,7 @@ export const plans = {
     deletedTvShowId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvShow.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTvShowPayload_queryPlan,
     tvShowEdge: {
@@ -8516,7 +8521,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-delete.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-delete.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -1080,7 +1085,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Film: {
     typeName: "Film",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("films", false), $record.get("code")]);
@@ -1099,7 +1104,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Studio: {
     typeName: "Studio",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("studios", false), $record.get("id")]);
@@ -1118,7 +1123,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Post: {
     typeName: "Post",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("posts", false), $record.get("id")]);
@@ -1137,7 +1142,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   TvEpisode: {
     typeName: "TvEpisode",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("tv_episodes", false), $record.get("code")]);
@@ -1156,7 +1161,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   TvShow: {
     typeName: "TvShow",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("tv_shows", false), $record.get("code")]);
@@ -1175,7 +1180,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -8258,7 +8263,7 @@ export const plans = {
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteStudioPayload_queryPlan,
     studioEdge: {
@@ -8312,7 +8317,7 @@ export const plans = {
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePostPayload_queryPlan,
     postEdge: {
@@ -8371,7 +8376,7 @@ export const plans = {
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTvEpisodePayload_queryPlan,
     tvEpisodeEdge: {
@@ -8430,7 +8435,7 @@ export const plans = {
     deletedTvShowId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvShow.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTvShowPayload_queryPlan,
     tvShowEdge: {
@@ -8489,7 +8494,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-loads.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-loads.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -1079,7 +1084,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Studio: {
     typeName: "Studio",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("studios", false), $record.get("id")]);
@@ -1098,7 +1103,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Post: {
     typeName: "Post",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("posts", false), $record.get("id")]);
@@ -1117,7 +1122,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   TvEpisode: {
     typeName: "TvEpisode",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("tv_episodes", false), $record.get("code")]);
@@ -1136,7 +1141,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   TvShow: {
     typeName: "TvShow",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("tv_shows", false), $record.get("code")]);
@@ -1155,7 +1160,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -7505,7 +7510,7 @@ export const plans = {
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteStudioPayload_queryPlan,
     studioEdge: {
@@ -7559,7 +7564,7 @@ export const plans = {
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePostPayload_queryPlan,
     postEdge: {
@@ -7618,7 +7623,7 @@ export const plans = {
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTvEpisodePayload_queryPlan,
     tvEpisodeEdge: {
@@ -7677,7 +7682,7 @@ export const plans = {
     deletedTvShowId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvShow.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTvShowPayload_queryPlan,
     tvShowEdge: {
@@ -7736,7 +7741,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-update.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-update.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -1080,7 +1085,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Film: {
     typeName: "Film",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("films", false), $record.get("code")]);
@@ -1099,7 +1104,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Studio: {
     typeName: "Studio",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("studios", false), $record.get("id")]);
@@ -1118,7 +1123,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Post: {
     typeName: "Post",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("posts", false), $record.get("id")]);
@@ -1137,7 +1142,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   TvEpisode: {
     typeName: "TvEpisode",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("tv_episodes", false), $record.get("code")]);
@@ -1156,7 +1161,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   TvShow: {
     typeName: "TvShow",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("tv_shows", false), $record.get("code")]);
@@ -1175,7 +1180,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -8164,7 +8169,7 @@ export const plans = {
     deletedFilmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Film.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteFilmPayload_queryPlan,
     filmEdge: {
@@ -8218,7 +8223,7 @@ export const plans = {
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteStudioPayload_queryPlan,
     studioEdge: {
@@ -8272,7 +8277,7 @@ export const plans = {
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePostPayload_queryPlan,
     postEdge: {
@@ -8331,7 +8336,7 @@ export const plans = {
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTvEpisodePayload_queryPlan,
     tvEpisodeEdge: {
@@ -8390,7 +8395,7 @@ export const plans = {
     deletedTvShowId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvShow.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTvShowPayload_queryPlan,
     tvShowEdge: {
@@ -8449,7 +8454,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.shows-order.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.shows-order.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -1080,7 +1085,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Film: {
     typeName: "Film",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("films", false), $record.get("code")]);
@@ -1099,7 +1104,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Studio: {
     typeName: "Studio",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("studios", false), $record.get("id")]);
@@ -1118,7 +1123,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Post: {
     typeName: "Post",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("posts", false), $record.get("id")]);
@@ -1137,7 +1142,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   TvEpisode: {
     typeName: "TvEpisode",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("tv_episodes", false), $record.get("code")]);
@@ -1156,7 +1161,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   TvShow: {
     typeName: "TvShow",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("tv_shows", false), $record.get("code")]);
@@ -1175,7 +1180,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -8121,7 +8126,7 @@ export const plans = {
     deletedFilmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Film.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteFilmPayload_queryPlan,
     filmEdge: {
@@ -8175,7 +8180,7 @@ export const plans = {
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteStudioPayload_queryPlan,
     studioEdge: {
@@ -8229,7 +8234,7 @@ export const plans = {
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePostPayload_queryPlan,
     postEdge: {
@@ -8288,7 +8293,7 @@ export const plans = {
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTvEpisodePayload_queryPlan,
     tvEpisodeEdge: {
@@ -8347,7 +8352,7 @@ export const plans = {
     deletedTvShowId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvShow.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTvShowPayload_queryPlan,
     studioByStudioId($record) {
@@ -8375,7 +8380,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/partitions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/partitions.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const attributes_object_Object_ = Object.assign(Object.create(null), {
@@ -271,7 +276,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   User: {
     typeName: "User",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("users", false), $record.get("id")]);
@@ -290,7 +295,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Measurement: {
     typeName: "Measurement",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("measurements", false), $record.get("timestamp"), $record.get("key")]);
@@ -2449,7 +2454,7 @@ export const plans = {
     deletedUserId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.User.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteUserPayload_queryPlan,
     userEdge: {
@@ -2503,7 +2508,7 @@ export const plans = {
     deletedMeasurementId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Measurement.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteMeasurementPayload_queryPlan,
     measurementEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/pg11.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/pg11.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const attributes = Object.assign(Object.create(null), {
@@ -643,7 +648,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   AlwaysAsIdentity: {
     typeName: "AlwaysAsIdentity",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("always_as_identities", false), $record.get("id")]);
@@ -662,7 +667,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   ByDefaultAsIdentity: {
     typeName: "ByDefaultAsIdentity",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("by_default_as_identities", false), $record.get("id")]);
@@ -681,7 +686,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Network: {
     typeName: "Network",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("networks", false), $record.get("id")]);
@@ -700,7 +705,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Type: {
     typeName: "Type",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("types", false), $record.get("id")]);
@@ -4986,7 +4991,7 @@ export const plans = {
     deletedAlwaysAsIdentityId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.AlwaysAsIdentity.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteAlwaysAsIdentityPayload_queryPlan,
     alwaysAsIdentityEdge: {
@@ -5040,7 +5045,7 @@ export const plans = {
     deletedByDefaultAsIdentityId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ByDefaultAsIdentity.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteByDefaultAsIdentityPayload_queryPlan,
     byDefaultAsIdentityEdge: {
@@ -5094,7 +5099,7 @@ export const plans = {
     deletedNetworkId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Network.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteNetworkPayload_queryPlan,
     networkEdge: {
@@ -5148,7 +5153,7 @@ export const plans = {
     deletedTypeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Type.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTypePayload_queryPlan,
     typeEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/pg11.custom.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/pg11.custom.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const attributes = Object.assign(Object.create(null), {
@@ -643,7 +648,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   AlwaysAsIdentity: {
     typeName: "AlwaysAsIdentity",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("always_as_identities", false), $record.get("id")]);
@@ -662,7 +667,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   ByDefaultAsIdentity: {
     typeName: "ByDefaultAsIdentity",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("by_default_as_identities", false), $record.get("id")]);
@@ -681,7 +686,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Network: {
     typeName: "Network",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("networks", false), $record.get("id")]);
@@ -700,7 +705,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Type: {
     typeName: "Type",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("types", false), $record.get("id")]);
@@ -4995,7 +5000,7 @@ export const plans = {
     deletedAlwaysAsIdentityId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.AlwaysAsIdentity.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteAlwaysAsIdentityPayload_queryPlan,
     alwaysAsIdentityEdge: {
@@ -5049,7 +5054,7 @@ export const plans = {
     deletedByDefaultAsIdentityId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ByDefaultAsIdentity.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteByDefaultAsIdentityPayload_queryPlan,
     byDefaultAsIdentityEdge: {
@@ -5103,7 +5108,7 @@ export const plans = {
     deletedNetworkId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Network.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteNetworkPayload_queryPlan,
     networkEdge: {
@@ -5157,7 +5162,7 @@ export const plans = {
     deletedTypeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Type.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTypePayload_queryPlan,
     typeEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/polymorphic.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/polymorphic.1.export.mjs
@@ -2,6 +2,17 @@ import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectStep, PgUnionAllSte
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, lambda, list, makeDecodeNodeId, makeGrafastSchema, node, object, rootValue, specFromNodeId } from "grafast";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const handler_codec_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
 const executor_mainPgExecutor = new PgExecutor({
   name: "main",
   context() {
@@ -4243,15 +4254,7 @@ const registry = makeRegistry(registryConfig);
 const resource_single_table_itemsPgResource = registry.pgResources["single_table_items"];
 const handler = {
   typeName: "SingleTableTopic",
-  codec: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  codec: handler_codec_base64JSON,
   deprecationReason: undefined,
   plan($record) {
     return list([constant("SingleTableTopic", false), $record.get("id")]);
@@ -4268,6 +4271,12 @@ const handler = {
     return obj[0] === "SingleTableTopic";
   }
 };
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: {
     name: "raw",
@@ -4278,15 +4287,11 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
       return typeof value === "string" ? value : null;
     }
   },
-  base64JSON: handler.codec,
+  base64JSON: handler_codec_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const otherSource_peoplePgResource = registry.pgResources["people"];
@@ -4387,7 +4392,7 @@ function SingleTableTopic_singleTableItemRelationCompositePksByParentId_after_ap
 }
 const handler2 = {
   typeName: "Person",
-  codec: handler.codec,
+  codec: handler_codec_base64JSON,
   deprecationReason: undefined,
   plan($record) {
     return list([constant("people", false), $record.get("person_id")]);
@@ -4546,7 +4551,7 @@ function LogEntriesConnection_pageInfoPlan($connection) {
 }
 const handler3 = {
   typeName: "LogEntry",
-  codec: handler.codec,
+  codec: handler_codec_base64JSON,
   deprecationReason: undefined,
   plan($record) {
     return list([constant("log_entries", false), $record.get("id")]);
@@ -4603,7 +4608,7 @@ const resourceByTypeName2 = Object.assign(Object.create(null), {
 });
 const handler4 = {
   typeName: "Organization",
-  codec: handler.codec,
+  codec: handler_codec_base64JSON,
   deprecationReason: undefined,
   plan($record) {
     return list([constant("organizations", false), $record.get("organization_id")]);
@@ -4677,7 +4682,7 @@ function AwsApplicationsConnection_pageInfoPlan($connection) {
 }
 const handler5 = {
   typeName: "AwsApplication",
-  codec: handler.codec,
+  codec: handler_codec_base64JSON,
   deprecationReason: undefined,
   plan($record) {
     return list([constant("aws_applications", false), $record.get("id")]);
@@ -4850,7 +4855,7 @@ function GcpApplicationsConnection_pageInfoPlan($connection) {
 }
 const handler6 = {
   typeName: "GcpApplication",
-  codec: handler.codec,
+  codec: handler_codec_base64JSON,
   deprecationReason: undefined,
   plan($record) {
     return list([constant("gcp_applications", false), $record.get("id")]);
@@ -5006,7 +5011,7 @@ function RelationalItemRelationsConnection_pageInfoPlan($connection) {
 const pgResource_relational_item_relationsPgResource = registry.pgResources["relational_item_relations"];
 const handler7 = {
   typeName: "RelationalItemRelation",
-  codec: handler.codec,
+  codec: handler_codec_base64JSON,
   deprecationReason: undefined,
   plan($record) {
     return list([constant("relational_item_relations", false), $record.get("id")]);
@@ -5036,7 +5041,7 @@ function RelationalItemRelationCompositePksConnection_pageInfoPlan($connection) 
 const pgResource_relational_item_relation_composite_pksPgResource = registry.pgResources["relational_item_relation_composite_pks"];
 const handler8 = {
   typeName: "RelationalItemRelationCompositePk",
-  codec: handler.codec,
+  codec: handler_codec_base64JSON,
   deprecationReason: undefined,
   plan($record) {
     return list([constant("relational_item_relation_composite_pks", false), $record.get("parent_id"), $record.get("child_id")]);
@@ -5066,7 +5071,7 @@ function SingleTableItemRelationsConnection_pageInfoPlan($connection) {
 }
 const handler9 = {
   typeName: "SingleTableItemRelation",
-  codec: handler.codec,
+  codec: handler_codec_base64JSON,
   deprecationReason: undefined,
   plan($record) {
     return list([constant("single_table_item_relations", false), $record.get("id")]);
@@ -5095,7 +5100,7 @@ function SingleTableItemRelationCompositePksConnection_pageInfoPlan($connection)
 }
 const handler10 = {
   typeName: "SingleTableItemRelationCompositePk",
-  codec: handler.codec,
+  codec: handler_codec_base64JSON,
   deprecationReason: undefined,
   plan($record) {
     return list([constant("single_table_item_relation_composite_pks", false), $record.get("parent_id"), $record.get("child_id")]);
@@ -5115,7 +5120,7 @@ const handler10 = {
 };
 const handler11 = {
   typeName: "SingleTablePost",
-  codec: handler.codec,
+  codec: handler_codec_base64JSON,
   deprecationReason: undefined,
   plan($record) {
     return list([constant("SingleTablePost", false), $record.get("id")]);
@@ -5210,7 +5215,7 @@ function SingleTablePost_singleTableItemRelationCompositePksByParentId_after_app
 }
 const handler12 = {
   typeName: "Priority",
-  codec: handler.codec,
+  codec: handler_codec_base64JSON,
   deprecationReason: undefined,
   plan($record) {
     return list([constant("priorities", false), $record.get("id")]);
@@ -5244,7 +5249,7 @@ function Priority_singleTableItemsByPriorityId_after_applyPlan(_, $connection, v
 }
 const handler13 = {
   typeName: "SingleTableDivider",
-  codec: handler.codec,
+  codec: handler_codec_base64JSON,
   deprecationReason: undefined,
   plan($record) {
     return list([constant("SingleTableDivider", false), $record.get("id")]);
@@ -5338,7 +5343,7 @@ function SingleTableDivider_singleTableItemRelationCompositePksByParentId_after_
 }
 const handler14 = {
   typeName: "SingleTableChecklist",
-  codec: handler.codec,
+  codec: handler_codec_base64JSON,
   deprecationReason: undefined,
   plan($record) {
     return list([constant("SingleTableChecklist", false), $record.get("id")]);
@@ -5432,7 +5437,7 @@ function SingleTableChecklist_singleTableItemRelationCompositePksByParentId_afte
 }
 const handler15 = {
   typeName: "SingleTableChecklistItem",
-  codec: handler.codec,
+  codec: handler_codec_base64JSON,
   deprecationReason: undefined,
   plan($record) {
     return list([constant("SingleTableChecklistItem", false), $record.get("id")]);
@@ -5527,7 +5532,7 @@ function SingleTableChecklistItem_singleTableItemRelationCompositePksByParentId_
 const pgResource_relational_topicsPgResource = registry.pgResources["relational_topics"];
 const handler16 = {
   typeName: "RelationalTopic",
-  codec: handler.codec,
+  codec: handler_codec_base64JSON,
   deprecationReason: undefined,
   plan($record) {
     return list([constant("relational_topics", false), $record.get("topic_item_id")]);
@@ -5640,7 +5645,7 @@ function RelationalTopic_relationalItemRelationCompositePksByParentId_after_appl
 }
 const handler17 = {
   typeName: "RelationalPost",
-  codec: handler.codec,
+  codec: handler_codec_base64JSON,
   deprecationReason: undefined,
   plan($record) {
     return list([constant("relational_posts", false), $record.get("post_item_id")]);
@@ -5734,7 +5739,7 @@ function RelationalPost_relationalItemRelationCompositePksByParentId_after_apply
 }
 const handler18 = {
   typeName: "RelationalDivider",
-  codec: handler.codec,
+  codec: handler_codec_base64JSON,
   deprecationReason: undefined,
   plan($record) {
     return list([constant("relational_dividers", false), $record.get("divider_item_id")]);
@@ -5828,7 +5833,7 @@ function RelationalDivider_relationalItemRelationCompositePksByParentId_after_ap
 }
 const handler19 = {
   typeName: "RelationalChecklist",
-  codec: handler.codec,
+  codec: handler_codec_base64JSON,
   deprecationReason: undefined,
   plan($record) {
     return list([constant("relational_checklists", false), $record.get("checklist_item_id")]);
@@ -5922,7 +5927,7 @@ function RelationalChecklist_relationalItemRelationCompositePksByParentId_after_
 }
 const handler20 = {
   typeName: "RelationalChecklistItem",
-  codec: handler.codec,
+  codec: handler_codec_base64JSON,
   deprecationReason: undefined,
   plan($record) {
     return list([constant("relational_checklist_items", false), $record.get("checklist_item_item_id")]);
@@ -6055,7 +6060,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   RelationalPost: handler17,
   FirstPartyVulnerability: {
     typeName: "FirstPartyVulnerability",
-    codec: handler.codec,
+    codec: handler_codec_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("first_party_vulnerabilities", false), $record.get("id")]);
@@ -6074,7 +6079,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   ThirdPartyVulnerability: {
     typeName: "ThirdPartyVulnerability",
-    codec: handler.codec,
+    codec: handler_codec_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("third_party_vulnerabilities", false), $record.get("id")]);
@@ -33871,7 +33876,7 @@ export const plans = {
     deletedOrganizationId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = handler4.plan($record);
-      return lambda(specifier, handler4.codec.encode);
+      return lambda(specifier, handler_codec_base64JSON.encode);
     },
     query: DeleteOrganizationPayload_queryPlan,
     organizationEdge: {
@@ -33931,7 +33936,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = handler2.plan($record);
-      return lambda(specifier, handler2.codec.encode);
+      return lambda(specifier, handler_codec_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {
@@ -33991,7 +33996,7 @@ export const plans = {
     deletedRelationalItemRelationCompositePkId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = handler8.plan($record);
-      return lambda(specifier, handler8.codec.encode);
+      return lambda(specifier, handler_codec_base64JSON.encode);
     },
     query: DeleteRelationalItemRelationCompositePkPayload_queryPlan,
     relationalItemRelationCompositePkEdge: {
@@ -34056,7 +34061,7 @@ export const plans = {
     deletedSingleTableItemRelationCompositePkId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = handler10.plan($record);
-      return lambda(specifier, handler10.codec.encode);
+      return lambda(specifier, handler_codec_base64JSON.encode);
     },
     query: DeleteSingleTableItemRelationCompositePkPayload_queryPlan,
     singleTableItemRelationCompositePkEdge: {
@@ -34121,7 +34126,7 @@ export const plans = {
     deletedRelationalItemRelationId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = handler7.plan($record);
-      return lambda(specifier, handler7.codec.encode);
+      return lambda(specifier, handler_codec_base64JSON.encode);
     },
     query: DeleteRelationalItemRelationPayload_queryPlan,
     relationalItemRelationEdge: {
@@ -34192,7 +34197,7 @@ export const plans = {
     deletedSingleTableItemRelationId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = handler9.plan($record);
-      return lambda(specifier, handler9.codec.encode);
+      return lambda(specifier, handler_codec_base64JSON.encode);
     },
     query: DeleteSingleTableItemRelationPayload_queryPlan,
     singleTableItemRelationEdge: {
@@ -34263,7 +34268,7 @@ export const plans = {
     deletedLogEntryId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = handler3.plan($record);
-      return lambda(specifier, handler3.codec.encode);
+      return lambda(specifier, handler_codec_base64JSON.encode);
     },
     query: DeleteLogEntryPayload_queryPlan,
     logEntryEdge: {
@@ -34327,7 +34332,7 @@ export const plans = {
     deletedFirstPartyVulnerabilityId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.FirstPartyVulnerability.plan($record);
-      return lambda(specifier, handler.codec.encode);
+      return lambda(specifier, handler_codec_base64JSON.encode);
     },
     query: DeleteFirstPartyVulnerabilityPayload_queryPlan,
     firstPartyVulnerabilityEdge: {
@@ -34381,7 +34386,7 @@ export const plans = {
     deletedThirdPartyVulnerabilityId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ThirdPartyVulnerability.plan($record);
-      return lambda(specifier, handler.codec.encode);
+      return lambda(specifier, handler_codec_base64JSON.encode);
     },
     query: DeleteThirdPartyVulnerabilityPayload_queryPlan,
     thirdPartyVulnerabilityEdge: {
@@ -34435,7 +34440,7 @@ export const plans = {
     deletedAwsApplicationId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = handler5.plan($record);
-      return lambda(specifier, handler5.codec.encode);
+      return lambda(specifier, handler_codec_base64JSON.encode);
     },
     query: DeleteAwsApplicationPayload_queryPlan,
     awsApplicationEdge: {
@@ -34499,7 +34504,7 @@ export const plans = {
     deletedGcpApplicationId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = handler6.plan($record);
-      return lambda(specifier, handler6.codec.encode);
+      return lambda(specifier, handler_codec_base64JSON.encode);
     },
     query: DeleteGcpApplicationPayload_queryPlan,
     gcpApplicationEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/rbac.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/rbac.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -9232,7 +9237,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   PersonSecret: {
     typeName: "PersonSecret",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: "This is deprecated (comment on table c.person_secret).",
     plan($record) {
       return list([constant("person_secrets", false), $record.get("person_id")]);
@@ -9251,7 +9256,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   LeftArm: {
     typeName: "LeftArm",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("left_arms", false), $record.get("id")]);
@@ -9270,7 +9275,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Post: {
     typeName: "Post",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("posts", false), $record.get("id")]);
@@ -9289,7 +9294,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -13804,7 +13809,7 @@ export const plans = {
     deletedPersonSecretId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.PersonSecret.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonSecretPayload_queryPlan,
     personSecretEdge: {
@@ -13863,7 +13868,7 @@ export const plans = {
     deletedLeftArmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.LeftArm.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteLeftArmPayload_queryPlan,
     leftArmEdge: {
@@ -13928,7 +13933,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -8984,7 +8989,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Input: {
     typeName: "Input",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("inputs", false), $record.get("id")]);
@@ -9003,7 +9008,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Patch: {
     typeName: "Patch",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("patchs", false), $record.get("id")]);
@@ -9022,7 +9027,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Reserved: {
     typeName: "Reserved",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("reserveds", false), $record.get("id")]);
@@ -9041,7 +9046,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   ReservedPatchRecord: {
     typeName: "ReservedPatchRecord",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("reservedPatchs", false), $record.get("id")]);
@@ -9060,7 +9065,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   ReservedInputRecord: {
     typeName: "ReservedInputRecord",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("reserved_inputs", false), $record.get("id")]);
@@ -9079,7 +9084,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   DefaultValue: {
     typeName: "DefaultValue",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("default_values", false), $record.get("id")]);
@@ -9098,7 +9103,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   MyTable: {
     typeName: "MyTable",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("my_tables", false), $record.get("id")]);
@@ -9117,7 +9122,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   PersonSecret: {
     typeName: "PersonSecret",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: "This is deprecated (comment on table c.person_secret).",
     plan($record) {
       return list([constant("person_secrets", false), $record.get("person_id")]);
@@ -9136,7 +9141,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   ViewTable: {
     typeName: "ViewTable",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("view_tables", false), $record.get("id")]);
@@ -9155,7 +9160,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   CompoundKey: {
     typeName: "CompoundKey",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("compound_keys", false), $record.get("person_id_1"), $record.get("person_id_2")]);
@@ -9175,7 +9180,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   SimilarTable1: {
     typeName: "SimilarTable1",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("similar_table_1S", false), $record.get("id")]);
@@ -9194,7 +9199,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   SimilarTable2: {
     typeName: "SimilarTable2",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("similar_table_2S", false), $record.get("id")]);
@@ -9213,7 +9218,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   NullTestRecord: {
     typeName: "NullTestRecord",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("null_test_records", false), $record.get("id")]);
@@ -9232,7 +9237,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Issue756: {
     typeName: "Issue756",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("issue756S", false), $record.get("id")]);
@@ -9251,7 +9256,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   LeftArm: {
     typeName: "LeftArm",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("left_arms", false), $record.get("id")]);
@@ -9270,7 +9275,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Post: {
     typeName: "Post",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("posts", false), $record.get("id")]);
@@ -9289,7 +9294,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -9308,7 +9313,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Type: {
     typeName: "Type",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("types", false), $record.get("id")]);
@@ -49012,7 +49017,7 @@ export const plans = {
     deletedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Input.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteInputPayload_queryPlan,
     inputEdge: {
@@ -49066,7 +49071,7 @@ export const plans = {
     deletedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Patch.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePatchPayload_queryPlan,
     patchEdge: {
@@ -49120,7 +49125,7 @@ export const plans = {
     deletedReservedId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Reserved.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteReservedPayload_queryPlan,
     reservedEdge: {
@@ -49174,7 +49179,7 @@ export const plans = {
     deletedReservedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedPatchRecord.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteReservedPatchRecordPayload_queryPlan,
     reservedPatchRecordEdge: {
@@ -49228,7 +49233,7 @@ export const plans = {
     deletedReservedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedInputRecord.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteReservedInputRecordPayload_queryPlan,
     reservedInputRecordEdge: {
@@ -49282,7 +49287,7 @@ export const plans = {
     deletedDefaultValueId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.DefaultValue.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteDefaultValuePayload_queryPlan,
     defaultValueEdge: {
@@ -49348,7 +49353,7 @@ export const plans = {
     deletedMyTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.MyTable.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteMyTablePayload_queryPlan,
     myTableEdge: {
@@ -49402,7 +49407,7 @@ export const plans = {
     deletedPersonSecretId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.PersonSecret.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonSecretPayload_queryPlan,
     personSecretEdge: {
@@ -49461,7 +49466,7 @@ export const plans = {
     deletedViewTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ViewTable.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteViewTablePayload_queryPlan,
     viewTableEdge: {
@@ -49515,7 +49520,7 @@ export const plans = {
     deletedCompoundKeyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.CompoundKey.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteCompoundKeyPayload_queryPlan,
     compoundKeyEdge: {
@@ -49580,7 +49585,7 @@ export const plans = {
     deletedSimilarTable1Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable1.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteSimilarTable1Payload_queryPlan,
     similarTable1Edge: {
@@ -49634,7 +49639,7 @@ export const plans = {
     deletedSimilarTable2Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable2.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteSimilarTable2Payload_queryPlan,
     similarTable2Edge: {
@@ -49688,7 +49693,7 @@ export const plans = {
     deletedNullTestRecordId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.NullTestRecord.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteNullTestRecordPayload_queryPlan,
     nullTestRecordEdge: {
@@ -49742,7 +49747,7 @@ export const plans = {
     deletedIssue756Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Issue756.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteIssue756Payload_queryPlan,
     issue756Edge: {
@@ -49796,7 +49801,7 @@ export const plans = {
     deletedLeftArmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.LeftArm.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteLeftArmPayload_queryPlan,
     leftArmEdge: {
@@ -49861,7 +49866,7 @@ export const plans = {
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePostPayload_queryPlan,
     postEdge: {
@@ -49920,7 +49925,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {
@@ -49980,7 +49985,7 @@ export const plans = {
     deletedTypeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Type.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTypePayload_queryPlan,
     typeEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/refs.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/refs.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const attributes_object_Object_ = Object.assign(Object.create(null), {
@@ -273,7 +278,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -292,7 +297,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Post: {
     typeName: "Post",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("posts", false), $record.get("id")]);

--- a/postgraphile/postgraphile/__tests__/schema/v4/relay.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/relay.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -1075,7 +1080,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Film: {
     typeName: "Film",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("films", false), $record.get("code")]);
@@ -1094,7 +1099,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Studio: {
     typeName: "Studio",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("studios", false), $record.get("id")]);
@@ -1113,7 +1118,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Post: {
     typeName: "Post",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("posts", false), $record.get("id")]);
@@ -1132,7 +1137,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   TvEpisode: {
     typeName: "TvEpisode",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("tv_episodes", false), $record.get("code")]);
@@ -1151,7 +1156,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   TvShow: {
     typeName: "TvShow",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("tv_shows", false), $record.get("code")]);
@@ -1170,7 +1175,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -7199,7 +7204,7 @@ export const plans = {
     deletedFilmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Film.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteFilmPayload_queryPlan,
     filmEdge: {
@@ -7247,7 +7252,7 @@ export const plans = {
     deletedStudioId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Studio.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteStudioPayload_queryPlan,
     studioEdge: {
@@ -7295,7 +7300,7 @@ export const plans = {
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePostPayload_queryPlan,
     postEdge: {
@@ -7343,7 +7348,7 @@ export const plans = {
     deletedTvEpisodeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvEpisode.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTvEpisodePayload_queryPlan,
     tvEpisodeEdge: {
@@ -7391,7 +7396,7 @@ export const plans = {
     deletedTvShowId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.TvShow.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTvShowPayload_queryPlan,
     tvShowEdge: {
@@ -7439,7 +7444,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -5270,7 +5275,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   MyTable: {
     typeName: "MyTable",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("my_tables", false), $record.get("id")]);
@@ -5289,7 +5294,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   PersonSecret: {
     typeName: "PersonSecret",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: "This is deprecated (comment on table c.person_secret).",
     plan($record) {
       return list([constant("person_secrets", false), $record.get("person_id")]);
@@ -5308,7 +5313,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   CompoundKey: {
     typeName: "CompoundKey",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("compound_keys", false), $record.get("person_id_1"), $record.get("person_id_2")]);
@@ -5328,7 +5333,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   NullTestRecord: {
     typeName: "NullTestRecord",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("null_test_records", false), $record.get("id")]);
@@ -5347,7 +5352,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   LeftArm: {
     typeName: "LeftArm",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("left_arms", false), $record.get("id")]);
@@ -5366,7 +5371,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Issue756: {
     typeName: "Issue756",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("issue756S", false), $record.get("id")]);
@@ -5385,7 +5390,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -22994,7 +22999,7 @@ export const plans = {
     deletedMyTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.MyTable.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteMyTablePayload_queryPlan,
     myTableEdge: {
@@ -23048,7 +23053,7 @@ export const plans = {
     deletedPersonSecretId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.PersonSecret.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonSecretPayload_queryPlan,
     personSecretEdge: {
@@ -23107,7 +23112,7 @@ export const plans = {
     deletedCompoundKeyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.CompoundKey.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteCompoundKeyPayload_queryPlan,
     compoundKeyEdge: {
@@ -23172,7 +23177,7 @@ export const plans = {
     deletedNullTestRecordId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.NullTestRecord.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteNullTestRecordPayload_queryPlan,
     nullTestRecordEdge: {
@@ -23226,7 +23231,7 @@ export const plans = {
     deletedLeftArmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.LeftArm.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteLeftArmPayload_queryPlan,
     leftArmEdge: {
@@ -23291,7 +23296,7 @@ export const plans = {
     deletedIssue756Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Issue756.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteIssue756Payload_queryPlan,
     issue756Edge: {
@@ -23345,7 +23350,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -5270,7 +5275,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   MyTable: {
     typeName: "MyTable",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("my_tables", false), $record.get("id")]);
@@ -5289,7 +5294,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   PersonSecret: {
     typeName: "PersonSecret",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: "This is deprecated (comment on table c.person_secret).",
     plan($record) {
       return list([constant("person_secrets", false), $record.get("person_id")]);
@@ -5308,7 +5313,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   CompoundKey: {
     typeName: "CompoundKey",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("compound_keys", false), $record.get("person_id_1"), $record.get("person_id_2")]);
@@ -5328,7 +5333,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   NullTestRecord: {
     typeName: "NullTestRecord",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("null_test_records", false), $record.get("id")]);
@@ -5347,7 +5352,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   LeftArm: {
     typeName: "LeftArm",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("left_arms", false), $record.get("id")]);
@@ -5366,7 +5371,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Issue756: {
     typeName: "Issue756",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("issue756S", false), $record.get("id")]);
@@ -5385,7 +5390,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -23907,7 +23912,7 @@ export const plans = {
     deletedMyTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.MyTable.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteMyTablePayload_queryPlan,
     myTableEdge: {
@@ -23961,7 +23966,7 @@ export const plans = {
     deletedPersonSecretId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.PersonSecret.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonSecretPayload_queryPlan,
     personSecretEdge: {
@@ -24020,7 +24025,7 @@ export const plans = {
     deletedCompoundKeyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.CompoundKey.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteCompoundKeyPayload_queryPlan,
     compoundKeyEdge: {
@@ -24085,7 +24090,7 @@ export const plans = {
     deletedNullTestRecordId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.NullTestRecord.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteNullTestRecordPayload_queryPlan,
     nullTestRecordEdge: {
@@ -24139,7 +24144,7 @@ export const plans = {
     deletedLeftArmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.LeftArm.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteLeftArmPayload_queryPlan,
     leftArmEdge: {
@@ -24204,7 +24209,7 @@ export const plans = {
     deletedIssue756Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Issue756.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteIssue756Payload_queryPlan,
     issue756Edge: {
@@ -24258,7 +24263,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.omit-pets-simple.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.omit-pets-simple.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const attributes_object_Object_ = Object.assign(Object.create(null), {
@@ -291,7 +296,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -310,7 +315,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Pet: {
     typeName: "Pet",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("pets", false), $record.get("id")]);
@@ -2473,7 +2478,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {
@@ -2527,7 +2532,7 @@ export const plans = {
     deletedPetId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Pet.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePetPayload_queryPlan,
     petEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only-people-omit.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only-people-omit.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const attributes_object_Object_ = Object.assign(Object.create(null), {
@@ -297,7 +302,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -316,7 +321,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Pet: {
     typeName: "Pet",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("pets", false), $record.get("id")]);
@@ -2274,7 +2279,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {
@@ -2328,7 +2333,7 @@ export const plans = {
     deletedPetId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Pet.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePetPayload_queryPlan,
     personByOwnerId($record) {

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -5270,7 +5275,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   MyTable: {
     typeName: "MyTable",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("my_tables", false), $record.get("id")]);
@@ -5289,7 +5294,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   PersonSecret: {
     typeName: "PersonSecret",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: "This is deprecated (comment on table c.person_secret).",
     plan($record) {
       return list([constant("person_secrets", false), $record.get("person_id")]);
@@ -5308,7 +5313,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   CompoundKey: {
     typeName: "CompoundKey",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("compound_keys", false), $record.get("person_id_1"), $record.get("person_id_2")]);
@@ -5328,7 +5333,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   NullTestRecord: {
     typeName: "NullTestRecord",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("null_test_records", false), $record.get("id")]);
@@ -5347,7 +5352,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   LeftArm: {
     typeName: "LeftArm",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("left_arms", false), $record.get("id")]);
@@ -5366,7 +5371,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Issue756: {
     typeName: "Issue756",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("issue756S", false), $record.get("id")]);
@@ -5385,7 +5390,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -20551,7 +20556,7 @@ export const plans = {
     deletedMyTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.MyTable.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteMyTablePayload_queryPlan
   },
@@ -20574,7 +20579,7 @@ export const plans = {
     deletedPersonSecretId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.PersonSecret.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonSecretPayload_queryPlan,
     personByPersonId($record) {
@@ -20602,7 +20607,7 @@ export const plans = {
     deletedCompoundKeyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.CompoundKey.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteCompoundKeyPayload_queryPlan,
     personByPersonId1($record) {
@@ -20636,7 +20641,7 @@ export const plans = {
     deletedNullTestRecordId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.NullTestRecord.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteNullTestRecordPayload_queryPlan
   },
@@ -20659,7 +20664,7 @@ export const plans = {
     deletedLeftArmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.LeftArm.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteLeftArmPayload_queryPlan,
     personByPersonId($record) {
@@ -20693,7 +20698,7 @@ export const plans = {
     deletedIssue756Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Issue756.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteIssue756Payload_queryPlan
   },
@@ -20716,7 +20721,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan
   },

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.pets-simple.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.pets-simple.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const attributes_object_Object_ = Object.assign(Object.create(null), {
@@ -292,7 +297,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -311,7 +316,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Pet: {
     typeName: "Pet",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("pets", false), $record.get("id")]);
@@ -2478,7 +2483,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {
@@ -2532,7 +2537,7 @@ export const plans = {
     deletedPetId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Pet.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePetPayload_queryPlan,
     petEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -8984,7 +8989,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Input: {
     typeName: "Input",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("inputs", false), $record.get("id")]);
@@ -9003,7 +9008,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Patch: {
     typeName: "Patch",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("patchs", false), $record.get("id")]);
@@ -9022,7 +9027,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Reserved: {
     typeName: "Reserved",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("reserveds", false), $record.get("id")]);
@@ -9041,7 +9046,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   ReservedPatchRecord: {
     typeName: "ReservedPatchRecord",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("reservedPatchs", false), $record.get("id")]);
@@ -9060,7 +9065,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   ReservedInputRecord: {
     typeName: "ReservedInputRecord",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("reserved_inputs", false), $record.get("id")]);
@@ -9079,7 +9084,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   DefaultValue: {
     typeName: "DefaultValue",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("default_values", false), $record.get("id")]);
@@ -9098,7 +9103,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   MyTable: {
     typeName: "MyTable",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("my_tables", false), $record.get("id")]);
@@ -9117,7 +9122,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   PersonSecret: {
     typeName: "PersonSecret",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: "This is deprecated (comment on table c.person_secret).",
     plan($record) {
       return list([constant("person_secrets", false), $record.get("person_id")]);
@@ -9136,7 +9141,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   ViewTable: {
     typeName: "ViewTable",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("view_tables", false), $record.get("id")]);
@@ -9155,7 +9160,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   CompoundKey: {
     typeName: "CompoundKey",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("compound_keys", false), $record.get("person_id_1"), $record.get("person_id_2")]);
@@ -9175,7 +9180,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   SimilarTable1: {
     typeName: "SimilarTable1",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("similar_table_1S", false), $record.get("id")]);
@@ -9194,7 +9199,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   SimilarTable2: {
     typeName: "SimilarTable2",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("similar_table_2S", false), $record.get("id")]);
@@ -9213,7 +9218,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   NullTestRecord: {
     typeName: "NullTestRecord",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("null_test_records", false), $record.get("id")]);
@@ -9232,7 +9237,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Issue756: {
     typeName: "Issue756",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("issue756S", false), $record.get("id")]);
@@ -9251,7 +9256,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   LeftArm: {
     typeName: "LeftArm",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("left_arms", false), $record.get("id")]);
@@ -9270,7 +9275,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Post: {
     typeName: "Post",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("posts", false), $record.get("id")]);
@@ -9289,7 +9294,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Person: {
     typeName: "Person",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("people", false), $record.get("id")]);
@@ -9308,7 +9313,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Type: {
     typeName: "Type",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("types", false), $record.get("id")]);
@@ -49012,7 +49017,7 @@ export const plans = {
     deletedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Input.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteInputPayload_queryPlan,
     inputEdge: {
@@ -49066,7 +49071,7 @@ export const plans = {
     deletedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Patch.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePatchPayload_queryPlan,
     patchEdge: {
@@ -49120,7 +49125,7 @@ export const plans = {
     deletedReservedId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Reserved.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteReservedPayload_queryPlan,
     reservedEdge: {
@@ -49174,7 +49179,7 @@ export const plans = {
     deletedReservedPatchId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedPatchRecord.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteReservedPatchRecordPayload_queryPlan,
     reservedPatchRecordEdge: {
@@ -49228,7 +49233,7 @@ export const plans = {
     deletedReservedInputId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ReservedInputRecord.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteReservedInputRecordPayload_queryPlan,
     reservedInputRecordEdge: {
@@ -49282,7 +49287,7 @@ export const plans = {
     deletedDefaultValueId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.DefaultValue.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteDefaultValuePayload_queryPlan,
     defaultValueEdge: {
@@ -49348,7 +49353,7 @@ export const plans = {
     deletedMyTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.MyTable.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteMyTablePayload_queryPlan,
     myTableEdge: {
@@ -49402,7 +49407,7 @@ export const plans = {
     deletedPersonSecretId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.PersonSecret.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonSecretPayload_queryPlan,
     personSecretEdge: {
@@ -49461,7 +49466,7 @@ export const plans = {
     deletedViewTableId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.ViewTable.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteViewTablePayload_queryPlan,
     viewTableEdge: {
@@ -49515,7 +49520,7 @@ export const plans = {
     deletedCompoundKeyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.CompoundKey.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteCompoundKeyPayload_queryPlan,
     compoundKeyEdge: {
@@ -49580,7 +49585,7 @@ export const plans = {
     deletedSimilarTable1Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable1.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteSimilarTable1Payload_queryPlan,
     similarTable1Edge: {
@@ -49634,7 +49639,7 @@ export const plans = {
     deletedSimilarTable2Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.SimilarTable2.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteSimilarTable2Payload_queryPlan,
     similarTable2Edge: {
@@ -49688,7 +49693,7 @@ export const plans = {
     deletedNullTestRecordId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.NullTestRecord.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteNullTestRecordPayload_queryPlan,
     nullTestRecordEdge: {
@@ -49742,7 +49747,7 @@ export const plans = {
     deletedIssue756Id($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Issue756.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteIssue756Payload_queryPlan,
     issue756Edge: {
@@ -49796,7 +49801,7 @@ export const plans = {
     deletedLeftArmId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.LeftArm.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteLeftArmPayload_queryPlan,
     leftArmEdge: {
@@ -49861,7 +49866,7 @@ export const plans = {
     deletedPostId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePostPayload_queryPlan,
     postEdge: {
@@ -49920,7 +49925,7 @@ export const plans = {
     deletedPersonId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Person.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePersonPayload_queryPlan,
     personEdge: {
@@ -49980,7 +49985,7 @@ export const plans = {
     deletedTypeId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Type.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteTypePayload_queryPlan,
     typeEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -1201,7 +1206,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Post: {
     typeName: "Post",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("post_views", false), $record.get("id")]);
@@ -1220,7 +1225,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Offer: {
     typeName: "Offer",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("offer_views", false), $record.get("id")]);
@@ -1239,7 +1244,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Street: {
     typeName: "Street",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("streets", false), $record.get("id")]);
@@ -1258,7 +1263,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Property: {
     typeName: "Property",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("properties", false), $record.get("id")]);
@@ -1277,7 +1282,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   StreetProperty: {
     typeName: "StreetProperty",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("street_properties", false), $record.get("str_id"), $record.get("prop_id")]);
@@ -1297,7 +1302,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   House: {
     typeName: "House",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("houses", false), $record.get("street_id"), $record.get("property_id")]);
@@ -1317,7 +1322,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Building: {
     typeName: "Building",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("buildings", false), $record.get("id")]);
@@ -8762,7 +8767,7 @@ export const plans = {
     deletedPostViewId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePostPayload_queryPlan,
     postEdge: {
@@ -8816,7 +8821,7 @@ export const plans = {
     deletedOfferViewId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Offer.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteOfferPayload_queryPlan,
     offerEdge: {
@@ -8875,7 +8880,7 @@ export const plans = {
     deletedStreetId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Street.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteStreetPayload_queryPlan,
     streetEdge: {
@@ -8935,7 +8940,7 @@ export const plans = {
     deletedPropertyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Property.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePropertyPayload_queryPlan,
     propertyEdge: {
@@ -8994,7 +8999,7 @@ export const plans = {
     deletedStreetPropertyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.StreetProperty.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteStreetPropertyPayload_queryPlan,
     streetPropertyEdge: {
@@ -9059,7 +9064,7 @@ export const plans = {
     deletedBuildingId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Building.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteBuildingPayload_queryPlan,
     buildingEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -1198,7 +1203,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Post: {
     typeName: "Post",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("post_views", false), $record.get("id")]);
@@ -1217,7 +1222,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Offer: {
     typeName: "Offer",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("offer_views", false), $record.get("id")]);
@@ -1236,7 +1241,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Street: {
     typeName: "Street",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("streets", false), $record.get("id")]);
@@ -1255,7 +1260,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Property: {
     typeName: "Property",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("properties", false), $record.get("id")]);
@@ -1274,7 +1279,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   StreetProperty: {
     typeName: "StreetProperty",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("street_properties", false), $record.get("str_id"), $record.get("prop_id")]);
@@ -1294,7 +1299,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   House: {
     typeName: "House",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("houses", false), $record.get("street_id"), $record.get("property_id")]);
@@ -1314,7 +1319,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Building: {
     typeName: "Building",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("buildings", false), $record.get("id")]);
@@ -8642,7 +8647,7 @@ export const plans = {
     deletedPostViewId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePostPayload_queryPlan,
     postEdge: {
@@ -8696,7 +8701,7 @@ export const plans = {
     deletedOfferViewId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Offer.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteOfferPayload_queryPlan,
     offerEdge: {
@@ -8750,7 +8755,7 @@ export const plans = {
     deletedStreetId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Street.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteStreetPayload_queryPlan,
     streetEdge: {
@@ -8810,7 +8815,7 @@ export const plans = {
     deletedPropertyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Property.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePropertyPayload_queryPlan,
     propertyEdge: {
@@ -8869,7 +8874,7 @@ export const plans = {
     deletedStreetPropertyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.StreetProperty.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteStreetPropertyPayload_queryPlan,
     streetPropertyEdge: {
@@ -8934,7 +8939,7 @@ export const plans = {
     deletedBuildingId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Building.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteBuildingPayload_queryPlan,
     buildingEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post_view.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post_view.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -1201,7 +1206,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Post: {
     typeName: "Post",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("post_views", false), $record.get("id")]);
@@ -1220,7 +1225,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Offer: {
     typeName: "Offer",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("offer_views", false), $record.get("id")]);
@@ -1239,7 +1244,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Street: {
     typeName: "Street",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("streets", false), $record.get("id")]);
@@ -1258,7 +1263,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Property: {
     typeName: "Property",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("properties", false), $record.get("id")]);
@@ -1277,7 +1282,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   StreetProperty: {
     typeName: "StreetProperty",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("street_properties", false), $record.get("str_id"), $record.get("prop_id")]);
@@ -1297,7 +1302,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   House: {
     typeName: "House",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("houses", false), $record.get("street_id"), $record.get("property_id")]);
@@ -1317,7 +1322,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Building: {
     typeName: "Building",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("buildings", false), $record.get("id")]);
@@ -8762,7 +8767,7 @@ export const plans = {
     deletedPostViewId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePostPayload_queryPlan,
     postEdge: {
@@ -8816,7 +8821,7 @@ export const plans = {
     deletedOfferViewId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Offer.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteOfferPayload_queryPlan,
     offerEdge: {
@@ -8875,7 +8880,7 @@ export const plans = {
     deletedStreetId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Street.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteStreetPayload_queryPlan,
     streetEdge: {
@@ -8935,7 +8940,7 @@ export const plans = {
     deletedPropertyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Property.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePropertyPayload_queryPlan,
     propertyEdge: {
@@ -8994,7 +8999,7 @@ export const plans = {
     deletedStreetPropertyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.StreetProperty.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteStreetPropertyPayload_queryPlan,
     streetPropertyEdge: {
@@ -9059,7 +9064,7 @@ export const plans = {
     deletedBuildingId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Building.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteBuildingPayload_queryPlan,
     buildingEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post_view_no_pk.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post_view_no_pk.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -1204,7 +1209,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Offer: {
     typeName: "Offer",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("offer_views", false), $record.get("id")]);
@@ -1223,7 +1228,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Street: {
     typeName: "Street",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("streets", false), $record.get("id")]);
@@ -1242,7 +1247,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Property: {
     typeName: "Property",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("properties", false), $record.get("id")]);
@@ -1261,7 +1266,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   StreetProperty: {
     typeName: "StreetProperty",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("street_properties", false), $record.get("str_id"), $record.get("prop_id")]);
@@ -1281,7 +1286,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   House: {
     typeName: "House",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("houses", false), $record.get("street_id"), $record.get("property_id")]);
@@ -1301,7 +1306,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Building: {
     typeName: "Building",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("buildings", false), $record.get("id")]);
@@ -8308,7 +8313,7 @@ export const plans = {
     deletedOfferViewId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Offer.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteOfferPayload_queryPlan,
     offerEdge: {
@@ -8367,7 +8372,7 @@ export const plans = {
     deletedStreetId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Street.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteStreetPayload_queryPlan,
     streetEdge: {
@@ -8427,7 +8432,7 @@ export const plans = {
     deletedPropertyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Property.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePropertyPayload_queryPlan,
     propertyEdge: {
@@ -8486,7 +8491,7 @@ export const plans = {
     deletedStreetPropertyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.StreetProperty.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteStreetPropertyPayload_queryPlan,
     streetPropertyEdge: {
@@ -8551,7 +8556,7 @@ export const plans = {
     deletedBuildingId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Building.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteBuildingPayload_queryPlan,
     buildingEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.view_fake_unique.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.view_fake_unique.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -1200,7 +1205,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Offer: {
     typeName: "Offer",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("offer_views", false), $record.get("id")]);
@@ -1219,7 +1224,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Street: {
     typeName: "Street",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("streets", false), $record.get("id")]);
@@ -1238,7 +1243,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Property: {
     typeName: "Property",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("properties", false), $record.get("id")]);
@@ -1257,7 +1262,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   StreetProperty: {
     typeName: "StreetProperty",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("street_properties", false), $record.get("str_id"), $record.get("prop_id")]);
@@ -1277,7 +1282,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   House: {
     typeName: "House",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("houses", false), $record.get("street_id"), $record.get("property_id")]);
@@ -1297,7 +1302,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Building: {
     typeName: "Building",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("buildings", false), $record.get("id")]);
@@ -8499,7 +8504,7 @@ export const plans = {
     deletedOfferViewId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Offer.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteOfferPayload_queryPlan,
     offerEdge: {
@@ -8558,7 +8563,7 @@ export const plans = {
     deletedStreetId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Street.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteStreetPayload_queryPlan,
     streetEdge: {
@@ -8618,7 +8623,7 @@ export const plans = {
     deletedPropertyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Property.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePropertyPayload_queryPlan,
     propertyEdge: {
@@ -8677,7 +8682,7 @@ export const plans = {
     deletedStreetPropertyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.StreetProperty.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteStreetPropertyPayload_queryPlan,
     streetPropertyEdge: {
@@ -8742,7 +8747,7 @@ export const plans = {
     deletedBuildingId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Building.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteBuildingPayload_queryPlan,
     buildingEdge: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.view_fake_unique_pk.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.view_fake_unique_pk.1.export.mjs
@@ -29,25 +29,30 @@ const handler = {
     return constant`query`;
   }
 };
+function base64JSONDecode(value) {
+  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+}
+function base64JSONEncode(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+const nodeIdCodecs_base64JSON_base64JSON = {
+  name: "base64JSON",
+  encode: base64JSONEncode,
+  decode: base64JSONDecode
+};
+function pipeStringDecode(value) {
+  return typeof value === "string" ? value.split("|") : null;
+}
+function pipeStringEncode(value) {
+  return Array.isArray(value) ? value.join("|") : null;
+}
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
-  base64JSON: {
-    name: "base64JSON",
-    encode(value) {
-      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-    },
-    decode(value) {
-      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-    }
-  },
+  base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
-      return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
-      return typeof value === "string" ? value.split("|") : null;
-    }
+    encode: pipeStringEncode,
+    decode: pipeStringDecode
   }
 });
 const executor_mainPgExecutor = new PgExecutor({
@@ -1101,7 +1106,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   Query: handler,
   Post: {
     typeName: "Post",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("post_views", false), $record.get("id")]);
@@ -1120,7 +1125,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Offer: {
     typeName: "Offer",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("offer_views", false), $record.get("id")]);
@@ -1139,7 +1144,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Street: {
     typeName: "Street",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("streets", false), $record.get("id")]);
@@ -1158,7 +1163,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Property: {
     typeName: "Property",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("properties", false), $record.get("id")]);
@@ -1177,7 +1182,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   StreetProperty: {
     typeName: "StreetProperty",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("street_properties", false), $record.get("str_id"), $record.get("prop_id")]);
@@ -1197,7 +1202,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   House: {
     typeName: "House",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("houses", false), $record.get("street_id"), $record.get("property_id")]);
@@ -1217,7 +1222,7 @@ const nodeIdHandlerByTypeName = Object.assign(Object.create(null), {
   },
   Building: {
     typeName: "Building",
-    codec: nodeIdCodecs.base64JSON,
+    codec: nodeIdCodecs_base64JSON_base64JSON,
     deprecationReason: undefined,
     plan($record) {
       return list([constant("buildings", false), $record.get("id")]);
@@ -8395,7 +8400,7 @@ export const plans = {
     deletedPostViewId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Post.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePostPayload_queryPlan,
     postEdge: {
@@ -8449,7 +8454,7 @@ export const plans = {
     deletedOfferViewId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Offer.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteOfferPayload_queryPlan,
     offerEdge: {
@@ -8508,7 +8513,7 @@ export const plans = {
     deletedStreetId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Street.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteStreetPayload_queryPlan,
     streetEdge: {
@@ -8568,7 +8573,7 @@ export const plans = {
     deletedPropertyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Property.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeletePropertyPayload_queryPlan,
     propertyEdge: {
@@ -8627,7 +8632,7 @@ export const plans = {
     deletedStreetPropertyId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.StreetProperty.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteStreetPropertyPayload_queryPlan,
     streetPropertyEdge: {
@@ -8692,7 +8697,7 @@ export const plans = {
     deletedBuildingId($object) {
       const $record = $object.getStepForKey("result");
       const specifier = nodeIdHandlerByTypeName.Building.plan($record);
-      return lambda(specifier, nodeIdCodecs.base64JSON.encode);
+      return lambda(specifier, nodeIdCodecs_base64JSON_base64JSON.encode);
     },
     query: DeleteBuildingPayload_queryPlan,
     buildingEdge: {

--- a/utils/graphile-export/package.json
+++ b/utils/graphile-export/package.json
@@ -53,10 +53,14 @@
     "node": ">=16"
   },
   "peerDependencies": {
+    "eslint": "^8.48.0",
     "grafast": "workspace:^",
     "pg-sql2": "workspace:^5.0.0-beta.5"
   },
   "peerDependenciesMeta": {
+    "eslint": {
+      "optional": true
+    },
     "pg-sql2": {
       "optional": true
     }

--- a/utils/graphile-export/src/exportSchema.ts
+++ b/utils/graphile-export/src/exportSchema.ts
@@ -1882,7 +1882,16 @@ async function lint(code: string, rawFilePath: string | URL) {
         sourceType: "module",
       },
       rules: {
-        "no-use-before-define": "error",
+        "no-use-before-define": [
+          "error",
+          {
+            functions: false,
+            classes: false,
+            // We often have cyclic dependencies between types, this is handled via callbacks, so we don't care about that.
+            variables: false,
+            allowNamedExports: false,
+          },
+        ],
       },
     },
   });

--- a/utils/graphile-export/src/optimize/index.ts
+++ b/utils/graphile-export/src/optimize/index.ts
@@ -36,7 +36,7 @@ function isSimpleParam(param: t.Node): param is t.Identifier {
   return t.isIdentifier(param);
 }
 
-export const optimize = (ast: t.Node, runs = 1): t.Node => {
+export const optimize = (ast: t.File, runs = 1): t.File => {
   traverse(ast, {
     VariableDeclaration: {
       enter(path) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12078,9 +12078,12 @@ __metadata:
     tslib: "npm:^2.6.2"
     typescript: "npm:^5.2.2"
   peerDependencies:
+    eslint: ^8.48.0
     grafast: "workspace:^"
     pg-sql2: "workspace:^5.0.0-beta.5"
   peerDependenciesMeta:
+    eslint:
+      optional: true
     pg-sql2:
       optional: true
   languageName: unknown


### PR DESCRIPTION
## Description

Specifically we're looking to catch situations where we use variables before they're defined (aka Temporal Dead Zone (TDZ)); however we know that GraphQL types often references each other (`Author` has many `Post`s, `Post` has `Author`), so the linting is limited to the current scope only. We'll only run these extra checks if ESLint is available.

:rotating_light: This will spot more invalid exports, so yet more people might get errors when exporting if there are bugs.

- Fixes #1787
- Fixes #1938

## Performance impact

Export of a schema takes longer due to linting.

## Security impact

None known.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~~I've added tests for the new feature, and `yarn test` passes.~~ Covered by existing tests.
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
