### PR TITLE
Add example of maxRequestLength

### DIFF
--- a/grafast/website/grafserv/index.md
+++ b/grafast/website/grafserv/index.md
@@ -36,6 +36,7 @@ const preset = {
     graphiql: true,
     graphiqlPath: "/",
     websockets: true,
+    maxRequestLength: 100000,
   },
 };
 ```


### PR DESCRIPTION
## Description

I've checked that this option works, it is already documented in the postgraphile documentation. This adds it to the grafserv documentation

- Fixes #1918

## Performance impact

Documentation only

## Security impact

Documentation only

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
