### PR TITLE
Add TypeScript config note to Grafast website

### DIFF
--- a/grafast/website/grafast/getting-started/index.mdx
+++ b/grafast/website/grafast/getting-started/index.mdx
@@ -24,6 +24,36 @@ the <grafast /> execution strategy, but for now <grafast /> is JavaScript/TypeSc
 If you have an existing GraphQL.js schema, you can run it through <grafast /> ─ see
 [using with an existing schema](./existing-schema).
 
+## TypeScript v5.0.0+ (optional)
+
+We recommend that you use TypeScript for the best experience - auto-completion,
+inline documentation, etc.
+
+You do not need to use TypeScript to use <grafast />, but if you do then you
+must use a version from TypeScript v5.0.0 upward and configure it to support
+the `exports` property in `package.json`, you can do so by adding this to your
+TypeScript configuration:
+
+```
+    "moduleResolution": "node16", // Or "nodenext"
+```
+
+:::note
+
+Our adherence to semver **does not cover types** - we _may_ make breaking
+changes to TypeScript types in patch-level updates. The reason for this is that
+TypeScript itself is ever-changing, and the libraries we depend on often make
+breaking type changes, forcing us to do so too. Further, improvements to types
+are generally a good thing for developer experience, even if it might mean you
+have to spend a couple minutes after updating to address any issues.
+
+However, we try and keep the TypeScript types as stable as possible, only
+making breaking changes when their benefits outweigh the costs (as determined
+by our maintainer), and we do our best to detail in the release notes how to
+deal with these changes (if any action is necessary).
+
+:::
+
 ## My first plan
 
 Let's build a simple GraphQL schema powered by <grafast /> plans and query it.


### PR DESCRIPTION
## Description

Adds a section on TypeScript configuration under getting started in Grafast

- Fixes #1856

## Performance impact

Documentation only

## Security impact

Documentation only

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
