### PR TITLE
Move authorization checks to deduplicate to fix query planning issue

### DIFF
--- a/.changeset/green-flowers-knock.md
+++ b/.changeset/green-flowers-knock.md
@@ -1,0 +1,6 @@
+---
+"@dataplan/pg": patch
+---
+
+Fix authorization check so it can call other steps (e.g. reading from
+`context()`)

--- a/grafast/dataplan-pg/src/steps/pgSelect.ts
+++ b/grafast/dataplan-pg/src/steps/pgSelect.ts
@@ -1813,10 +1813,6 @@ and ${sql.indent(sql.parens(condition(i + 1)))}`}
     sql: SQL;
     extraSelectIndexes: number[];
   } {
-    if (!this.isTrusted) {
-      this.resource.applyAuthorizationChecksToPlan(this);
-    }
-
     const reverse = this.shouldReverseOrder();
 
     const { sql: select, extraSelectIndexes } = this.buildSelect(options);
@@ -2187,6 +2183,11 @@ ${lateralText};`;
   }
 
   deduplicate(peers: PgSelectStep<any>[]): PgSelectStep<TResource>[] {
+    if (!this.isTrusted) {
+      this.resource.applyAuthorizationChecksToPlan(this);
+      this.isTrusted = true;
+    }
+
     this.locker.lockAllParameters();
     return peers.filter(($p): $p is PgSelectStep<TResource> => {
       if ($p === this) {


### PR DESCRIPTION
Ports this patch into core: https://github.com/benjie/v5-auth-poc/blob/main/patches/%40dataplan%2Bpg%2B0.0.1-beta.17.patch