### PR TITLE
Fix detection of pgSelect allowing merging

### DIFF
--- a/.changeset/good-monkeys-know.md
+++ b/.changeset/good-monkeys-know.md
@@ -1,0 +1,6 @@
+---
+"grafast": patch
+---
+
+Add `this.canAddDependency(step)` to determine if adding a given dependency
+would be allowed or not.

--- a/.changeset/slow-mangos-guess.md
+++ b/.changeset/slow-mangos-guess.md
@@ -1,0 +1,7 @@
+---
+"postgraphile": patch
+"@dataplan/pg": patch
+---
+
+Make it so that more pgSelect queries optimize themselves into parent queries
+via new step.canAddDependency helper.

--- a/grafast/grafast/src/step.ts
+++ b/grafast/grafast/src/step.ts
@@ -31,6 +31,7 @@ import type {
 import { $$subroutine } from "./interfaces.js";
 import type { __ItemStep } from "./steps/index.js";
 import { __ListTransformStep } from "./steps/index.js";
+import { stepAMayDependOnStepB } from "./utils.js";
 
 /**
  * @internal
@@ -336,6 +337,10 @@ export /* abstract */ class ExecutableStep<TData = any> extends BaseStep {
         },
       )}]`,
     );
+  }
+
+  protected canAddDependency(step: ExecutableStep): boolean {
+    return stepAMayDependOnStepB(this, step);
   }
 
   protected addDependency(

--- a/grafast/grafast/src/utils.ts
+++ b/grafast/grafast/src/utils.ts
@@ -964,9 +964,16 @@ export function stepAMayDependOnStepB(
   $a: ExecutableStep,
   $b: ExecutableStep,
 ): boolean {
-  return (
-    $a.layerPlan.ancestry.includes($b.layerPlan) && !stepADependsOnStepB($b, $a)
-  );
+  if ($a.isFinalized) {
+    return false;
+  }
+  if ($a._isUnaryLocked && $a._isUnary && !$b._isUnary) {
+    return false;
+  }
+  if (!$a.layerPlan.ancestry.includes($b.layerPlan)) {
+    return false;
+  }
+  return !stepADependsOnStepB($b, $a);
 }
 
 /**

--- a/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields.mermaid
@@ -92,19 +92,16 @@ graph TD
     PgClassExpression102{{"PgClassExpression[102∈9]<br />ᐸ”c”.”compo...nd_type__)ᐳ"}}:::plan
     PgSelectSingle98 --> PgClassExpression102
     PgSelect116[["PgSelect[116∈10]<br />ᐸpostᐳ"]]:::plan
-    Constant359{{"Constant[359∈10]<br />ᐸ15ᐳ"}}:::plan
-    Constant360{{"Constant[360∈10]<br />ᐸ20ᐳ"}}:::plan
-    Constant361{{"Constant[361∈10]<br />ᐸ'[...]'ᐳ"}}:::plan
+    Constant360{{"Constant[360∈10]<br />ᐸ15ᐳ"}}:::plan
+    Constant361{{"Constant[361∈10]<br />ᐸ20ᐳ"}}:::plan
+    Constant362{{"Constant[362∈10]<br />ᐸ'[...]'ᐳ"}}:::plan
     Constant146{{"Constant[146∈10]<br />ᐸnullᐳ"}}:::plan
-    Object18 & Connection115 & Constant359 & Constant360 & Constant361 & Constant359 & Constant360 & Constant361 & Constant360 & Constant361 & Constant359 & Constant146 --> PgSelect116
-    Constant377{{"Constant[377∈10]<br />ᐸ[Object: null prototype] {   a: 419,   b: 'easy cheesy bakedᐳ"}}:::plan
+    Constant378{{"Constant[378∈10]<br />ᐸ[Object: null prototype] {   a: 419,   b: 'easy cheesy bakedᐳ"}}:::plan
+    Object18 & Connection115 & Constant360 & Constant361 & Constant362 & Constant360 & Constant361 & Constant362 & Constant361 & Constant362 & Constant360 & Constant146 & Constant378 --> PgSelect116
     __Item117[/"__Item[117∈11]<br />ᐸ116ᐳ"\]:::itemplan
     PgSelect116 ==> __Item117
     PgSelectSingle118{{"PgSelectSingle[118∈11]<br />ᐸpostᐳ"}}:::plan
     __Item117 --> PgSelectSingle118
-    PgSelect185[["PgSelect[185∈12]<br />ᐸpost_computed_compound_type_arrayᐳ"]]:::plan
-    PgClassExpression184{{"PgClassExpression[184∈12]<br />ᐸ__post__ᐳ"}}:::plan
-    Object18 & PgClassExpression184 & Constant377 --> PgSelect185
     PgClassExpression119{{"PgClassExpression[119∈12]<br />ᐸ__post__.”headline”ᐳ"}}:::plan
     PgSelectSingle118 --> PgClassExpression119
     PgClassExpression123{{"PgClassExpression[123∈12]<br />ᐸ”a”.”post_...(__post__)ᐳ"}}:::plan
@@ -126,22 +123,21 @@ graph TD
     PgSelectSingle153 --> PgClassExpression155
     PgClassExpression159{{"PgClassExpression[159∈12]<br />ᐸ”a”.”post_...lder! */<br />)ᐳ"}}:::plan
     PgSelectSingle118 --> PgClassExpression159
-    PgSelectSingle183{{"PgSelectSingle[183∈12]<br />ᐸpostᐳ"}}:::plan
-    RemapKeys352{{"RemapKeys[352∈12]<br />ᐸ118:{”0”:3,”1”:4}ᐳ"}}:::plan
-    RemapKeys352 --> PgSelectSingle183
-    PgSelectSingle183 --> PgClassExpression184
     PgClassExpression203{{"PgClassExpression[203∈12]<br />ᐸ”a”.”post_...(__post__)ᐳ"}}:::plan
     PgSelectSingle118 --> PgClassExpression203
     PgClassExpression206{{"PgClassExpression[206∈12]<br />ᐸ”a”.”post_...(__post__)ᐳ"}}:::plan
     PgSelectSingle118 --> PgClassExpression206
     __ListTransform236[["__ListTransform[236∈12]<br />ᐸeach:235ᐳ"]]:::plan
-    Access354{{"Access[354∈12]<br />ᐸ117.5ᐳ"}}:::plan
-    Access354 --> __ListTransform236
+    Access355{{"Access[355∈12]<br />ᐸ117.4ᐳ"}}:::plan
+    Access355 --> __ListTransform236
     PgSelectSingle118 --> RemapKeys350
-    PgSelectSingle118 --> RemapKeys352
-    __Item117 --> Access354
-    __Item189[/"__Item[189∈13]<br />ᐸ185ᐳ"\]:::itemplan
-    PgSelect185 ==> __Item189
+    Access352{{"Access[352∈12]<br />ᐸ353.0ᐳ"}}:::plan
+    RemapKeys353{{"RemapKeys[353∈12]<br />ᐸ118:{”0”:3}ᐳ"}}:::plan
+    RemapKeys353 --> Access352
+    PgSelectSingle118 --> RemapKeys353
+    __Item117 --> Access355
+    __Item189[/"__Item[189∈13]<br />ᐸ352ᐳ"\]:::itemplan
+    Access352 ==> __Item189
     PgSelectSingle190{{"PgSelectSingle[190∈13]<br />ᐸpost_computed_compound_type_arrayᐳ"}}:::plan
     __Item189 --> PgSelectSingle190
     PgClassExpression191{{"PgClassExpression[191∈14]<br />ᐸ__post_com...rray__.”a”ᐳ"}}:::plan
@@ -164,14 +160,14 @@ graph TD
     PgClassExpression203 ==> __Item204
     __Item207[/"__Item[207∈17]<br />ᐸ206ᐳ"\]:::itemplan
     PgClassExpression206 ==> __Item207
-    __Item226[/"__Item[226∈19]<br />ᐸ354ᐳ"\]:::itemplan
-    Access354 ==> __Item226
+    __Item226[/"__Item[226∈19]<br />ᐸ355ᐳ"\]:::itemplan
+    Access355 ==> __Item226
     PgSelectSingle227{{"PgSelectSingle[227∈19]<br />ᐸpost_computed_interval_setᐳ"}}:::plan
     __Item226 --> PgSelectSingle227
     PgClassExpression228{{"PgClassExpression[228∈19]<br />ᐸ__post_com...al_set__.vᐳ"}}:::plan
     PgSelectSingle227 --> PgClassExpression228
-    __Item237[/"__Item[237∈21]<br />ᐸ354ᐳ"\]:::itemplan
-    Access354 -.-> __Item237
+    __Item237[/"__Item[237∈21]<br />ᐸ355ᐳ"\]:::itemplan
+    Access355 -.-> __Item237
     PgSelectSingle238{{"PgSelectSingle[238∈21]<br />ᐸpost_computed_interval_setᐳ"}}:::plan
     __Item237 --> PgSelectSingle238
     PgClassExpression239{{"PgClassExpression[239∈21]<br />ᐸ__post_com...al_set__.vᐳ"}}:::plan
@@ -193,8 +189,8 @@ graph TD
     PgSelect263[["PgSelect[263∈25]<br />ᐸpersonᐳ"]]:::plan
     Object18 & Connection262 --> PgSelect263
     Connection298{{"Connection[298∈25]<br />ᐸ294ᐳ"}}:::plan
-    Constant375{{"Constant[375∈25]<br />ᐸ1ᐳ"}}:::plan
-    Constant375 --> Connection298
+    Constant376{{"Constant[376∈25]<br />ᐸ1ᐳ"}}:::plan
+    Constant376 --> Connection298
     Connection280{{"Connection[280∈25]<br />ᐸ276ᐳ"}}:::plan
     __Item264[/"__Item[264∈26]<br />ᐸ263ᐳ"\]:::itemplan
     PgSelect263 ==> __Item264
@@ -205,23 +201,23 @@ graph TD
     PgClassExpression268{{"PgClassExpression[268∈27]<br />ᐸ”c”.”perso..._person__)ᐳ"}}:::plan
     PgSelectSingle265 --> PgClassExpression268
     PgSelectSingle311{{"PgSelectSingle[311∈27]<br />ᐸperson_first_postᐳ"}}:::plan
-    RemapKeys357{{"RemapKeys[357∈27]<br />ᐸ265:{”0”:2,”1”:3}ᐳ"}}:::plan
-    RemapKeys357 --> PgSelectSingle311
-    Access356{{"Access[356∈27]<br />ᐸ264.1ᐳ"}}:::plan
-    __Item264 --> Access356
-    PgSelectSingle265 --> RemapKeys357
-    __Item282[/"__Item[282∈28]<br />ᐸ356ᐳ"\]:::itemplan
-    Access356 ==> __Item282
+    RemapKeys358{{"RemapKeys[358∈27]<br />ᐸ265:{”0”:2,”1”:3}ᐳ"}}:::plan
+    RemapKeys358 --> PgSelectSingle311
+    Access357{{"Access[357∈27]<br />ᐸ264.1ᐳ"}}:::plan
+    __Item264 --> Access357
+    PgSelectSingle265 --> RemapKeys358
+    __Item282[/"__Item[282∈28]<br />ᐸ357ᐳ"\]:::itemplan
+    Access357 ==> __Item282
     PgSelectSingle283{{"PgSelectSingle[283∈28]<br />ᐸperson_friendsᐳ"}}:::plan
     __Item282 --> PgSelectSingle283
     PgClassExpression284{{"PgClassExpression[284∈29]<br />ᐸ__person_f...full_name”ᐳ"}}:::plan
     PgSelectSingle283 --> PgClassExpression284
     PgClassExpression286{{"PgClassExpression[286∈29]<br />ᐸ”c”.”perso...friends__)ᐳ"}}:::plan
     PgSelectSingle283 --> PgClassExpression286
-    Access355{{"Access[355∈29]<br />ᐸ282.1ᐳ"}}:::plan
-    __Item282 --> Access355
-    __Item300[/"__Item[300∈30]<br />ᐸ355ᐳ"\]:::itemplan
-    Access355 ==> __Item300
+    Access356{{"Access[356∈29]<br />ᐸ282.1ᐳ"}}:::plan
+    __Item282 --> Access356
+    __Item300[/"__Item[300∈30]<br />ᐸ356ᐳ"\]:::itemplan
+    Access356 ==> __Item300
     PgSelectSingle301{{"PgSelectSingle[301∈30]<br />ᐸperson_friendsᐳ"}}:::plan
     __Item300 --> PgSelectSingle301
     PgClassExpression302{{"PgClassExpression[302∈31]<br />ᐸ__person_f...full_name”ᐳ"}}:::plan
@@ -278,16 +274,16 @@ graph TD
     Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 98<br /><br />ROOT PgSelectSingle{7}ᐸfrmcdc_compoundTypeᐳ[98]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgClassExpression99,PgClassExpression100,PgClassExpression102 bucket9
-    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 18, 115, 224<br /><br />ROOT Connectionᐸ111ᐳ[115]<br />1: <br />ᐳ: 146, 359, 360, 361, 377<br />2: PgSelect[116]"):::bucket
+    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 18, 115, 224<br /><br />ROOT Connectionᐸ111ᐳ[115]<br />1: <br />ᐳ: 146, 360, 361, 362, 378<br />2: PgSelect[116]"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,PgSelect116,Constant146,Constant359,Constant360,Constant361,Constant377 bucket10
-    Bucket11("Bucket 11 (listItem)<br />Deps: 18, 377, 224<br /><br />ROOT __Item{11}ᐸ116ᐳ[117]"):::bucket
+    class Bucket10,PgSelect116,Constant146,Constant360,Constant361,Constant362,Constant378 bucket10
+    Bucket11("Bucket 11 (listItem)<br />Deps: 224<br /><br />ROOT __Item{11}ᐸ116ᐳ[117]"):::bucket
     classDef bucket11 stroke:#00ffff
     class Bucket11,__Item117,PgSelectSingle118 bucket11
-    Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 18, 377, 224, 118, 117<br /><br />ROOT PgSelectSingle{11}ᐸpostᐳ[118]<br />1: <br />ᐳ: 119, 123, 127, 131, 135, 139, 143, 159, 203, 206, 350, 352, 354, 153, 155, 183, 184<br />2: PgSelect[185], __ListTransform[236]"):::bucket
+    Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 224, 118, 117<br /><br />ROOT PgSelectSingle{11}ᐸpostᐳ[118]<br />1: <br />ᐳ: 119, 123, 127, 131, 135, 139, 143, 159, 203, 206, 350, 353, 355, 153, 155, 352<br />2: __ListTransform[236]"):::bucket
     classDef bucket12 stroke:#4169e1
-    class Bucket12,PgClassExpression119,PgClassExpression123,PgClassExpression127,PgClassExpression131,PgClassExpression135,PgClassExpression139,PgClassExpression143,PgSelectSingle153,PgClassExpression155,PgClassExpression159,PgSelectSingle183,PgClassExpression184,PgSelect185,PgClassExpression203,PgClassExpression206,__ListTransform236,RemapKeys350,RemapKeys352,Access354 bucket12
-    Bucket13("Bucket 13 (listItem)<br />ROOT __Item{13}ᐸ185ᐳ[189]"):::bucket
+    class Bucket12,PgClassExpression119,PgClassExpression123,PgClassExpression127,PgClassExpression131,PgClassExpression135,PgClassExpression139,PgClassExpression143,PgSelectSingle153,PgClassExpression155,PgClassExpression159,PgClassExpression203,PgClassExpression206,__ListTransform236,RemapKeys350,Access352,RemapKeys353,Access355 bucket12
+    Bucket13("Bucket 13 (listItem)<br />ROOT __Item{13}ᐸ352ᐳ[189]"):::bucket
     classDef bucket13 stroke:#3cb371
     class Bucket13,__Item189,PgSelectSingle190 bucket13
     Bucket14("Bucket 14 (nullableBoundary)<br />Deps: 190<br /><br />ROOT PgSelectSingle{13}ᐸpost_computed_compound_type_arrayᐳ[190]"):::bucket
@@ -305,7 +301,7 @@ graph TD
     Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 207<br /><br />ROOT __Item{17}ᐸ206ᐳ[207]"):::bucket
     classDef bucket18 stroke:#00bfff
     class Bucket18 bucket18
-    Bucket19("Bucket 19 (listItem)<br />ROOT __Item{19}ᐸ354ᐳ[226]"):::bucket
+    Bucket19("Bucket 19 (listItem)<br />ROOT __Item{19}ᐸ355ᐳ[226]"):::bucket
     classDef bucket19 stroke:#7f007f
     class Bucket19,__Item226,PgSelectSingle227,PgClassExpression228 bucket19
     Bucket20("Bucket 20 (nullableBoundary)<br />Deps: 228<br /><br />ROOT PgClassExpression{19}ᐸ__post_com...al_set__.vᐳ[228]"):::bucket
@@ -325,20 +321,20 @@ graph TD
     class Bucket24 bucket24
     Bucket25("Bucket 25 (nullableBoundary)<br />Deps: 18, 262<br /><br />ROOT Connectionᐸ258ᐳ[262]"):::bucket
     classDef bucket25 stroke:#dda0dd
-    class Bucket25,PgSelect263,Connection280,Connection298,Constant375 bucket25
+    class Bucket25,PgSelect263,Connection280,Connection298,Constant376 bucket25
     Bucket26("Bucket 26 (listItem)<br />Deps: 280, 298<br /><br />ROOT __Item{26}ᐸ263ᐳ[264]"):::bucket
     classDef bucket26 stroke:#ff0000
     class Bucket26,__Item264,PgSelectSingle265 bucket26
     Bucket27("Bucket 27 (nullableBoundary)<br />Deps: 280, 298, 265, 264<br /><br />ROOT PgSelectSingle{26}ᐸpersonᐳ[265]"):::bucket
     classDef bucket27 stroke:#ffff00
-    class Bucket27,PgClassExpression266,PgClassExpression268,PgSelectSingle311,Access356,RemapKeys357 bucket27
-    Bucket28("Bucket 28 (listItem)<br />Deps: 298<br /><br />ROOT __Item{28}ᐸ356ᐳ[282]"):::bucket
+    class Bucket27,PgClassExpression266,PgClassExpression268,PgSelectSingle311,Access357,RemapKeys358 bucket27
+    Bucket28("Bucket 28 (listItem)<br />Deps: 298<br /><br />ROOT __Item{28}ᐸ357ᐳ[282]"):::bucket
     classDef bucket28 stroke:#00ffff
     class Bucket28,__Item282,PgSelectSingle283 bucket28
     Bucket29("Bucket 29 (nullableBoundary)<br />Deps: 298, 283, 282<br /><br />ROOT PgSelectSingle{28}ᐸperson_friendsᐳ[283]"):::bucket
     classDef bucket29 stroke:#4169e1
-    class Bucket29,PgClassExpression284,PgClassExpression286,Access355 bucket29
-    Bucket30("Bucket 30 (listItem)<br />ROOT __Item{30}ᐸ355ᐳ[300]"):::bucket
+    class Bucket29,PgClassExpression284,PgClassExpression286,Access356 bucket29
+    Bucket30("Bucket 30 (listItem)<br />ROOT __Item{30}ᐸ356ᐳ[300]"):::bucket
     classDef bucket30 stroke:#3cb371
     class Bucket30,__Item300,PgSelectSingle301 bucket30
     Bucket31("Bucket 31 (nullableBoundary)<br />Deps: 301<br /><br />ROOT PgSelectSingle{30}ᐸperson_friendsᐳ[301]"):::bucket
@@ -379,5 +375,5 @@ graph TD
     Bucket33 --> Bucket34
     Bucket34 --> Bucket35
     classDef unary fill:#fafffa,borderWidth:8px
-    class Object18,Access16,Access17,__Value0,__Value3,__Value5,Connection19,Connection115,Connection224,Connection262,Connection326,PgSelect20,PgSelect116,Constant146,Constant359,Constant360,Constant361,Constant377,PgSelect263,Connection298,Connection280,Constant375,PgSelect327 unary
+    class Object18,Access16,Access17,__Value0,__Value3,__Value5,Connection19,Connection115,Connection224,Connection262,Connection326,PgSelect20,PgSelect116,Constant146,Constant360,Constant361,Constant362,Constant378,PgSelect263,Connection298,Connection280,Constant376,PgSelect327 unary
     end

--- a/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields.sql
+++ b/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields.sql
@@ -46,7 +46,7 @@ on TRUE
 order by __types__."id" asc;
 
 select __post_result__.*
-from (select 0 as idx, $1::"int4" as "id0", $2::"int4" as "id1", $3::"text" as "id2", $4::"int4" as "id3", $5::"int4" as "id4", $6::"text" as "id5", $7::"int4" as "id6", $8::"text" as "id7", $9::"int4" as "id8", $10::"text" as "id9") as __post_identifiers__,
+from (select 0 as idx, $1::"int4" as "id0", $2::"int4" as "id1", $3::"text" as "id2", $4::"int4" as "id3", $5::"int4" as "id4", $6::"text" as "id5", $7::"int4" as "id6", $8::"text" as "id7", $9::"int4" as "id8", $10::"text" as "id9", $11::"c"."compound_type" as "id10") as __post_identifiers__,
 lateral (
   select
     __post__."headline" as "0",
@@ -56,48 +56,59 @@ lateral (
       __post_identifiers__."id9"
     ) as "1",
     __post_2."id"::text as "2",
-    case when (__post_3) is not distinct from null then null::text else json_build_array((((__post_3)."id"))::text, ((__post_3)."headline"), ((__post_3)."body"), (((__post_3)."author_id"))::text, (((__post_3)."enums"))::text, (
-      select array_agg(case when (__comptype__) is not distinct from null then null::text else json_build_array(to_char(((__comptype__)."schedule"), 'YYYY-MM-DD"T"HH24:MI:SS.USTZH:TZM'::text), (((__comptype__)."is_optimised"))::text)::text end)
-      from unnest(((__post_3)."comptypes")) __comptype__
-    )::text)::text end as "3",
-    __post_3."id"::text as "4",
+    (select json_agg(s) from (
+      select
+        __post_computed_compound_type_array__."a"::text as "0",
+        __post_computed_compound_type_array__."b" as "1",
+        __post_computed_compound_type_array__."c"::text as "2",
+        __post_computed_compound_type_array__."d" as "3",
+        __post_computed_compound_type_array__."e"::text as "4",
+        __post_computed_compound_type_array__."f"::text as "5",
+        to_char(__post_computed_compound_type_array__."g", 'YYYY_MM_DD_HH24_MI_SS.US'::text) as "6",
+        __post_computed_compound_type_array__."foo_bar"::text as "7",
+        (not (__post_computed_compound_type_array__ is null))::text as "8"
+      from unnest("a"."post_computed_compound_type_array"(
+        __post_3,
+        __post_identifiers__."id10"
+      )) as __post_computed_compound_type_array__
+    ) s) as "3",
     (select json_agg(s) from (
       select
         to_char(__post_computed_interval_set__.v, 'YYYY_MM_DD_HH24_MI_SS.US'::text) as "0",
         (row_number() over (partition by 1))::text as "1"
       from "a"."post_computed_interval_set"(__post__) as __post_computed_interval_set__(v)
-    ) s) as "5",
-    "a"."post_headline_trimmed"(__post__) as "6",
+    ) s) as "4",
+    "a"."post_headline_trimmed"(__post__) as "5",
     "a"."post_headline_trimmed"(
       __post__,
       __post_identifiers__."id0"
-    ) as "7",
+    ) as "6",
     "a"."post_headline_trimmed"(
       __post__,
       __post_identifiers__."id1",
       __post_identifiers__."id2"
-    ) as "8",
-    "a"."post_headline_trimmed_strict"(__post__) as "9",
+    ) as "7",
+    "a"."post_headline_trimmed_strict"(__post__) as "8",
     "a"."post_headline_trimmed_strict"(
       __post__,
       __post_identifiers__."id3"
-    ) as "10",
+    ) as "9",
     "a"."post_headline_trimmed_strict"(
       __post__,
       __post_identifiers__."id4",
       __post_identifiers__."id5"
-    ) as "11",
+    ) as "10",
     "a"."post_headline_trimmed_no_defaults"(
       __post__,
       __post_identifiers__."id6",
       __post_identifiers__."id7"
-    ) as "12",
-    ("a"."post_computed_text_array"(__post__))::text as "13",
+    ) as "11",
+    ("a"."post_computed_text_array"(__post__))::text as "12",
     (
       select array_agg(to_char(__entry__, 'YYYY_MM_DD_HH24_MI_SS.US'::text))
       from unnest("a"."post_computed_interval_array"(__post__)) __entry__
-    )::text as "14",
-    __post_identifiers__.idx as "15"
+    )::text as "13",
+    __post_identifiers__.idx as "14"
   from "a"."post" as __post__
   left outer join lateral (select (__post__).*) as __post_2
   on TRUE
@@ -134,23 +145,3 @@ select
   __edge_case__."wont_cast_easy"::text as "1",
   "c"."edge_case_computed"(__edge_case__) as "2"
 from "c"."edge_case" as __edge_case__;
-
-select __post_computed_compound_type_array_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"a"."post" as "id0", (ids.value->>1)::"c"."compound_type" as "id1" from json_array_elements($1::json) with ordinality as ids) as __post_computed_compound_type_array_identifiers__,
-lateral (
-  select
-    __post_computed_compound_type_array__."a"::text as "0",
-    __post_computed_compound_type_array__."b" as "1",
-    __post_computed_compound_type_array__."c"::text as "2",
-    __post_computed_compound_type_array__."d" as "3",
-    __post_computed_compound_type_array__."e"::text as "4",
-    __post_computed_compound_type_array__."f"::text as "5",
-    to_char(__post_computed_compound_type_array__."g", 'YYYY_MM_DD_HH24_MI_SS.US'::text) as "6",
-    __post_computed_compound_type_array__."foo_bar"::text as "7",
-    (not (__post_computed_compound_type_array__ is null))::text as "8",
-    __post_computed_compound_type_array_identifiers__.idx as "9"
-  from unnest("a"."post_computed_compound_type_array"(
-    __post_computed_compound_type_array_identifiers__."id0",
-    __post_computed_compound_type_array_identifiers__."id1"
-  )) as __post_computed_compound_type_array__
-) as __post_computed_compound_type_array_result__;

--- a/postgraphile/postgraphile/__tests__/queries/v4/space.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/space.mermaid
@@ -9,37 +9,33 @@ graph TD
 
 
     %% plan dependencies
-    Object18{{"Object[18∈0]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Access16{{"Access[16∈0]<br />ᐸ3.pgSettingsᐳ"}}:::plan
-    Access17{{"Access[17∈0]<br />ᐸ3.withPgClientᐳ"}}:::plan
-    Access16 & Access17 --> Object18
-    __Value3["__Value[3∈0]<br />ᐸcontextᐳ"]:::plan
-    __Value3 --> Access16
-    __Value3 --> Access17
     __Value0["__Value[0∈0]"]:::plan
+    __Value3["__Value[3∈0]<br />ᐸcontextᐳ"]:::plan
     __Value5["__Value[5∈0]<br />ᐸrootValueᐳ"]:::plan
     Connection19{{"Connection[19∈0]<br />ᐸ15ᐳ"}}:::plan
     PgSelect20[["PgSelect[20∈1]<br />ᐸspacecraftᐳ"]]:::plan
-    Object18 & Connection19 --> PgSelect20
-    Constant46{{"Constant[46∈1]<br />ᐸ[Object: null prototype] { id: '1', type: 'MOBILE' }ᐳ"}}:::plan
+    Object18{{"Object[18∈1]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Constant48{{"Constant[48∈1]<br />ᐸ[Object: null prototype] { id: '1', type: 'MOBILE' }ᐳ"}}:::plan
+    Object18 & Connection19 & Constant48 --> PgSelect20
+    Access16{{"Access[16∈1]<br />ᐸ3.pgSettingsᐳ"}}:::plan
+    Access17{{"Access[17∈1]<br />ᐸ3.withPgClientᐳ"}}:::plan
+    Access16 & Access17 --> Object18
+    __Value3 --> Access16
+    __Value3 --> Access17
     __Item21[/"__Item[21∈2]<br />ᐸ20ᐳ"\]:::itemplan
     PgSelect20 ==> __Item21
     PgSelectSingle22{{"PgSelectSingle[22∈2]<br />ᐸspacecraftᐳ"}}:::plan
     __Item21 --> PgSelectSingle22
-    PgSelect30[["PgSelect[30∈3]<br />ᐸspacecraftᐳ"]]:::plan
-    PgClassExpression29{{"PgClassExpression[29∈3]<br />ᐸ__spacecraft__ᐳ"}}:::plan
-    Object18 & PgClassExpression29 & Constant46 --> PgSelect30
     PgClassExpression23{{"PgClassExpression[23∈3]<br />ᐸ__spacecraft__.”id”ᐳ"}}:::plan
     PgSelectSingle22 --> PgClassExpression23
     PgClassExpression24{{"PgClassExpression[24∈3]<br />ᐸ__spacecraft__.”name”ᐳ"}}:::plan
     PgSelectSingle22 --> PgClassExpression24
-    PgSelectSingle22 --> PgClassExpression29
-    First34{{"First[34∈3]"}}:::plan
-    PgSelect30 --> First34
     PgSelectSingle35{{"PgSelectSingle[35∈3]<br />ᐸspacecraftᐳ"}}:::plan
-    First34 --> PgSelectSingle35
+    RemapKeys44{{"RemapKeys[44∈3]<br />ᐸ22:{”0”:2,”1”:3}ᐳ"}}:::plan
+    RemapKeys44 --> PgSelectSingle35
     PgClassExpression37{{"PgClassExpression[37∈3]<br />ᐸ”space”.”s...lder! */<br />)ᐳ"}}:::plan
     PgSelectSingle35 --> PgClassExpression37
+    PgSelectSingle22 --> RemapKeys44
     Access38{{"Access[38∈4]<br />ᐸ37.startᐳ"}}:::plan
     PgClassExpression37 --> Access38
     Access41{{"Access[41∈4]<br />ᐸ37.endᐳ"}}:::plan
@@ -50,16 +46,16 @@ graph TD
     subgraph "Buckets for queries/v4/space"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value3,__Value5,Access16,Access17,Object18,Connection19 bucket0
-    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 18, 19<br /><br />ROOT Connectionᐸ15ᐳ[19]"):::bucket
+    class Bucket0,__Value0,__Value3,__Value5,Connection19 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 3, 19<br /><br />ROOT Connectionᐸ15ᐳ[19]<br />1: <br />ᐳ: 16, 17, 48, 18<br />2: PgSelect[20]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgSelect20,Constant46 bucket1
-    Bucket2("Bucket 2 (listItem)<br />Deps: 18, 46<br /><br />ROOT __Item{2}ᐸ20ᐳ[21]"):::bucket
+    class Bucket1,Access16,Access17,Object18,PgSelect20,Constant48 bucket1
+    Bucket2("Bucket 2 (listItem)<br />ROOT __Item{2}ᐸ20ᐳ[21]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2,__Item21,PgSelectSingle22 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 18, 46, 22<br /><br />ROOT PgSelectSingle{2}ᐸspacecraftᐳ[22]<br />1: <br />ᐳ: 23, 24, 29<br />2: PgSelect[30]<br />ᐳ: 34, 35, 37"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 22<br /><br />ROOT PgSelectSingle{2}ᐸspacecraftᐳ[22]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgClassExpression23,PgClassExpression24,PgClassExpression29,PgSelect30,First34,PgSelectSingle35,PgClassExpression37 bucket3
+    class Bucket3,PgClassExpression23,PgClassExpression24,PgSelectSingle35,PgClassExpression37,RemapKeys44 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 37<br /><br />ROOT PgClassExpression{3}ᐸ”space”.”s...lder! */<br />)ᐳ[37]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,Access38,Access41 bucket4
@@ -75,5 +71,5 @@ graph TD
     Bucket3 --> Bucket4
     Bucket4 --> Bucket5 & Bucket6
     classDef unary fill:#fafffa,borderWidth:8px
-    class Object18,Access16,Access17,__Value0,__Value3,__Value5,Connection19,PgSelect20,Constant46 unary
+    class __Value0,__Value3,__Value5,Connection19,PgSelect20,Object18,Access16,Access17,Constant48 unary
     end

--- a/postgraphile/postgraphile/__tests__/queries/v4/space.sql
+++ b/postgraphile/postgraphile/__tests__/queries/v4/space.sql
@@ -1,38 +1,31 @@
-select
-  __spacecraft__."id"::text as "0",
-  __spacecraft__."name" as "1",
-  case when (__spacecraft__) is not distinct from null then null::text else json_build_array((((__spacecraft__)."id"))::text, ((__spacecraft__)."name"), json_build_array(
-    lower_inc(((__spacecraft__)."return_to_earth")),
-    to_char(lower(((__spacecraft__)."return_to_earth")), 'YYYY-MM-DD"T"HH24:MI:SS.US'::text),
-    to_char(upper(((__spacecraft__)."return_to_earth")), 'YYYY-MM-DD"T"HH24:MI:SS.US'::text),
-    upper_inc(((__spacecraft__)."return_to_earth"))
-  )::text)::text end as "2"
-from "space"."spacecraft" as __spacecraft__
-order by __spacecraft__."id" asc;
-
 select __spacecraft_result__.*
-from (select ids.ordinality - 1 as idx, (ids.value->>0)::"space"."spacecraft" as "id0", (ids.value->>1)::"space"."launch_pad" as "id1" from json_array_elements($1::json) with ordinality as ids) as __spacecraft_identifiers__,
+from (select 0 as idx, $1::"space"."launch_pad" as "id0") as __spacecraft_identifiers__,
 lateral (
   select
+    __spacecraft__."id"::text as "0",
+    __spacecraft__."name" as "1",
     json_build_array(
       lower_inc("space"."spacecraft_eta"(
-        __spacecraft__,
-        __spacecraft_identifiers__."id1"
+        __spacecraft_2,
+        __spacecraft_identifiers__."id0"
       )),
       to_char(lower("space"."spacecraft_eta"(
-        __spacecraft__,
-        __spacecraft_identifiers__."id1"
+        __spacecraft_2,
+        __spacecraft_identifiers__."id0"
       )), 'YYYY-MM-DD"T"HH24:MI:SS.US'::text),
       to_char(upper("space"."spacecraft_eta"(
-        __spacecraft__,
-        __spacecraft_identifiers__."id1"
+        __spacecraft_2,
+        __spacecraft_identifiers__."id0"
       )), 'YYYY-MM-DD"T"HH24:MI:SS.US'::text),
       upper_inc("space"."spacecraft_eta"(
-        __spacecraft__,
-        __spacecraft_identifiers__."id1"
+        __spacecraft_2,
+        __spacecraft_identifiers__."id0"
       ))
-    )::text as "0",
-    __spacecraft__."id"::text as "1",
-    __spacecraft_identifiers__.idx as "2"
-  from (select (__spacecraft_identifiers__."id0").*) as __spacecraft__
+    )::text as "2",
+    __spacecraft_2."id"::text as "3",
+    __spacecraft_identifiers__.idx as "4"
+  from "space"."spacecraft" as __spacecraft__
+  left outer join lateral (select (__spacecraft__).*) as __spacecraft_2
+  on TRUE
+  order by __spacecraft__."id" asc
 ) as __spacecraft_result__;


### PR DESCRIPTION
## Description

#1987 was only an issue because the function wasn't optimized and was being called via a second SQL query. This was undesirable. It turns out to be due to the dependency checking in `pgSelect`'s `optimize` method. Really we just want to know that the dependencies can be pushed onto the new parent... so I've rewritten the code to do this instead.

## Performance impact

Significant improvement in some cases.

## Security impact

Helps avoid DOS I guess?

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
