### PR TITLE
Allow loadOne/loadMany to support unary steps

### DIFF
--- a/.changeset/stale-schools-press.md
+++ b/.changeset/stale-schools-press.md
@@ -1,0 +1,6 @@
+---
+"grafast": patch
+---
+
+Add unary-step enhanced loadOne and loadMany usage to avoid manual grouping in
+callbacks.

--- a/grafast/grafast/src/steps/load.ts
+++ b/grafast/grafast/src/steps/load.ts
@@ -317,7 +317,7 @@ export class LoadStep<
       meta.cache = cache;
     }
     const batch = new Map<TSpec, number[]>();
-    const unary = values1 && values1.isBatch ? values1.value : undefined;
+    const unary = values1?.isBatch === false ? values1.value : undefined;
 
     const results: Array<PromiseOrDirect<Maybe<TData>>> = [];
     for (let i = 0; i < count; i++) {

--- a/grafast/grafast/src/steps/load.ts
+++ b/grafast/grafast/src/steps/load.ts
@@ -657,7 +657,7 @@ export function loadOne<
       $spec,
       null,
       loadCallbackOrIoEquivalenceOrUnarySpec,
-      loadCallbackOrIoEquivalenceOrUnarySpec as LoadOneCallback<
+      loadCallbackOrIoEquivalence as LoadOneCallback<
         TSpec,
         TItem,
         TParams,

--- a/grafast/grafast/src/steps/load.ts
+++ b/grafast/grafast/src/steps/load.ts
@@ -194,11 +194,11 @@ export class LoadStep<
   constructor(
     $spec: ExecutableStep<TSpec>,
     $unarySpec: ExecutableStep<TUnarySpec> | null,
-    private load: LoadCallback<TSpec, TItem, TData, TParams, TUnarySpec>,
-    private ioEquivalence?:
+    private ioEquivalence:
       | null
       | string
       | { [key in keyof TSpec]?: string | null },
+    private load: LoadCallback<TSpec, TItem, TData, TParams, TUnarySpec>,
   ) {
     super();
     this.addDependency($spec);
@@ -434,7 +434,7 @@ function load<
   ioEquivalence: null | string | { [key in keyof TSpec]?: string | null },
   loadCallback: LoadCallback<TSpec, TItem, TData, TParams, TUnarySpec>,
 ) {
-  return new LoadStep($spec, $unarySpec, loadCallback, ioEquivalence);
+  return new LoadStep($spec, $unarySpec, ioEquivalence, loadCallback);
 }
 
 export function loadMany<

--- a/grafast/grafast/src/steps/load.ts
+++ b/grafast/grafast/src/steps/load.ts
@@ -1,5 +1,5 @@
 import type { __ItemStep, Deferred, ExecutionDetails } from "../index.js";
-import { defer } from "../index.js";
+import { defer, isExecutableStep } from "../index.js";
 import type {
   GrafastResultsList,
   Maybe,
@@ -9,7 +9,12 @@ import { ExecutableStep, isListLikeStep, isObjectLikeStep } from "../step.js";
 import { arrayOfLength, canonicalJSONStringify } from "../utils.js";
 import { access } from "./access.js";
 
-export interface LoadOptions<TItem, TParams extends Record<string, any>> {
+export interface LoadOptions<
+  TItem,
+  TParams extends Record<string, any>,
+  TUnarySpec = never,
+> {
+  unary: TUnarySpec;
   attributes: ReadonlyArray<keyof TItem>;
   params: Partial<TParams>;
 }
@@ -19,10 +24,11 @@ type LoadCallback<
   TItem,
   TData extends TItem | ReadonlyArray<TItem>,
   TParams extends Record<string, any>,
+  TUnarySpec = never,
 > = {
   (
     specs: ReadonlyArray<TSpec>,
-    options: LoadOptions<TItem, TParams>,
+    options: LoadOptions<TItem, TParams, TUnarySpec>,
   ): PromiseOrDirect<ReadonlyArray<Maybe<TData>>>;
   displayName?: string;
 };
@@ -31,12 +37,14 @@ export type LoadOneCallback<
   TSpec,
   TItem,
   TParams extends Record<string, any>,
-> = LoadCallback<TSpec, TItem, TItem, TParams>;
+  TUnarySpec = never,
+> = LoadCallback<TSpec, TItem, TItem, TParams, TUnarySpec>;
 export type LoadManyCallback<
   TSpec,
   TItem,
   TParams extends Record<string, any>,
-> = LoadCallback<TSpec, TItem, ReadonlyArray<TItem>, TParams>;
+  TUnarySpec = never,
+> = LoadCallback<TSpec, TItem, ReadonlyArray<TItem>, TParams, TUnarySpec>;
 
 /**
  * A TypeScript Identity Function to help you strongly type your
@@ -46,9 +54,10 @@ export function loadOneCallback<
   TSpec,
   TItem,
   TParams extends Record<string, any>,
+  TUnarySpec = never,
 >(
-  callback: LoadOneCallback<TSpec, TItem, TParams>,
-): LoadOneCallback<TSpec, TItem, TParams> {
+  callback: LoadOneCallback<TSpec, TItem, TParams, TUnarySpec>,
+): LoadOneCallback<TSpec, TItem, TParams, TUnarySpec> {
   return callback;
 }
 /**
@@ -59,9 +68,10 @@ export function loadManyCallback<
   TSpec,
   TItem,
   TParams extends Record<string, any>,
+  TUnarySpec = never,
 >(
-  callback: LoadManyCallback<TSpec, TItem, TParams>,
-): LoadManyCallback<TSpec, TItem, TParams> {
+  callback: LoadManyCallback<TSpec, TItem, TParams, TUnarySpec>,
+): LoadManyCallback<TSpec, TItem, TParams, TUnarySpec> {
   return callback;
 }
 
@@ -167,20 +177,24 @@ export class LoadStep<
   TItem,
   TData extends TItem | ReadonlyArray<TItem>,
   TParams extends Record<string, any>,
+  TUnarySpec = never,
 > extends ExecutableStep {
   /* implements ListCapableStep<TItem, LoadedRecordStep<TItem, TParams>> */
   static $$export = { moduleName: "grafast", exportName: "LoadStep" };
 
   public isSyncAndSafe = false;
 
-  loadOptions: LoadOptions<TItem, TParams> | null = null;
+  loadOptions: Omit<LoadOptions<TItem, TParams, TUnarySpec>, "unary"> | null =
+    null;
   loadOptionsKey = "";
 
   attributes = new Set<keyof TItem>();
   params: Partial<TParams> = Object.create(null);
+  unaryDepId: number | null = null;
   constructor(
     $spec: ExecutableStep<TSpec>,
-    private load: LoadCallback<TSpec, TItem, TData, TParams>,
+    $unarySpec: ExecutableStep<TUnarySpec> | null,
+    private load: LoadCallback<TSpec, TItem, TData, TParams, TUnarySpec>,
     private ioEquivalence?:
       | null
       | string
@@ -188,6 +202,9 @@ export class LoadStep<
   ) {
     super();
     this.addDependency($spec);
+    if ($unarySpec) {
+      this.unaryDepId = this.addUnaryDependency($unarySpec);
+    }
   }
   toStringMeta() {
     return this.load.displayName || this.load.name;
@@ -288,9 +305,9 @@ export class LoadStep<
 
   execute({
     count,
-    values: [values0],
+    values: [values0, values1],
     extra,
-  }: ExecutionDetails<[TSpec]>): PromiseOrDirect<
+  }: ExecutionDetails<[TSpec, TUnarySpec]>): PromiseOrDirect<
     GrafastResultsList<Maybe<TData>>
   > {
     const meta = extra.meta as LoadMeta;
@@ -300,6 +317,7 @@ export class LoadStep<
       meta.cache = cache;
     }
     const batch = new Map<TSpec, number[]>();
+    const unary = values1 && values1.isBatch ? values1.value : undefined;
 
     const results: Array<PromiseOrDirect<Maybe<TData>>> = [];
     for (let i = 0; i < count; i++) {
@@ -338,7 +356,10 @@ export class LoadStep<
         setTimeout(() => {
           // Don't allow adding anything else to the batch
           meta.loadBatchesByLoad!.delete(this.load);
-          executeBatches(loadBatches!, this.load, loadOptions);
+          executeBatches(loadBatches!, this.load, {
+            ...loadOptions,
+            unary: unary as TUnarySpec,
+          });
         }, 0);
       }
       return (async () => {
@@ -365,8 +386,8 @@ export class LoadStep<
 
 async function executeBatches(
   loadBatches: readonly LoadBatch[],
-  load: LoadCallback<any, any, any, any>,
-  loadOptions: LoadOptions<any, any>,
+  load: LoadCallback<any, any, any, any, any>,
+  loadOptions: LoadOptions<any, any, any>,
 ) {
   try {
     const numberOfBatches = loadBatches.length;
@@ -406,26 +427,30 @@ function load<
   TItem,
   TData extends TItem | ReadonlyArray<TItem>,
   TParams extends Record<string, any>,
+  TUnarySpec = never,
 >(
   $spec: ExecutableStep<TSpec>,
+  $unarySpec: ExecutableStep<TUnarySpec> | null,
   ioEquivalence: null | string | { [key in keyof TSpec]?: string | null },
-  loadCallback: LoadCallback<TSpec, TItem, TData, TParams>,
+  loadCallback: LoadCallback<TSpec, TItem, TData, TParams, TUnarySpec>,
 ) {
-  return new LoadStep($spec, loadCallback, ioEquivalence);
+  return new LoadStep($spec, $unarySpec, loadCallback, ioEquivalence);
 }
 
 export function loadMany<
   TSpec,
   TItem,
   TParams extends Record<string, any> = Record<string, any>,
+  TUnarySpec = never,
 >(
   $spec: ExecutableStep<TSpec>,
-  loadCallback: LoadManyCallback<TSpec, TItem, TParams>,
-): LoadStep<TSpec, TItem, ReadonlyArray<TItem>, TParams>;
+  loadCallback: LoadManyCallback<TSpec, TItem, TParams, TUnarySpec>,
+): LoadStep<TSpec, TItem, ReadonlyArray<TItem>, TParams, TUnarySpec>;
 export function loadMany<
   TSpec,
   TItem,
   TParams extends Record<string, any> = Record<string, any>,
+  TUnarySpec = never,
 >(
   $spec: ExecutableStep<TSpec>,
   ioEquivalence:
@@ -436,83 +461,220 @@ export function loadMany<
         : TSpec extends Record<string, any>
         ? { [key in keyof TSpec]?: string | null }
         : never),
-  loadCallback: LoadManyCallback<TSpec, TItem, TParams>,
-): LoadStep<TSpec, TItem, ReadonlyArray<TItem>, TParams>;
+  loadCallback: LoadManyCallback<TSpec, TItem, TParams, TUnarySpec>,
+): LoadStep<TSpec, TItem, ReadonlyArray<TItem>, TParams, TUnarySpec>;
 export function loadMany<
   TSpec,
   TItem,
   TParams extends Record<string, any> = Record<string, any>,
+  TUnarySpec = never,
 >(
   $spec: ExecutableStep<TSpec>,
-  loadCallbackOrIoEquivalence:
+  $unarySpec: ExecutableStep<TUnarySpec> | null,
+  loadCallback: LoadManyCallback<TSpec, TItem, TParams, TUnarySpec>,
+): LoadStep<TSpec, TItem, ReadonlyArray<TItem>, TParams, TUnarySpec>;
+export function loadMany<
+  TSpec,
+  TItem,
+  TParams extends Record<string, any> = Record<string, any>,
+  TUnarySpec = never,
+>(
+  $spec: ExecutableStep<TSpec>,
+  $unarySpec: ExecutableStep<TUnarySpec> | null,
+  ioEquivalence:
+    | null
+    | string
+    | (TSpec extends [...any[]]
+        ? { [key in keyof TSpec]: string | null }
+        : TSpec extends Record<string, any>
+        ? { [key in keyof TSpec]?: string | null }
+        : never),
+  loadCallback: LoadManyCallback<TSpec, TItem, TParams, TUnarySpec>,
+): LoadStep<TSpec, TItem, ReadonlyArray<TItem>, TParams, TUnarySpec>;
+export function loadMany<
+  TSpec,
+  TItem,
+  TParams extends Record<string, any> = Record<string, any>,
+  TUnarySpec = never,
+>(
+  $spec: ExecutableStep<TSpec>,
+  loadCallbackOrIoEquivalenceOrUnarySpec:
+    | LoadManyCallback<TSpec, TItem, TParams, TUnarySpec>
+    | null
+    | string
+    | { [key in keyof TSpec]?: string | null }
+    | ExecutableStep<TUnarySpec>,
+  loadCallbackOrIoEquivalence?:
     | LoadManyCallback<TSpec, TItem, TParams>
     | null
     | string
     | { [key in keyof TSpec]?: string | null },
-  loadCallbackOnly?: LoadManyCallback<TSpec, TItem, TParams>,
-): LoadStep<TSpec, TItem, ReadonlyArray<TItem>, TParams> {
+  loadCallbackOnly?: LoadManyCallback<TSpec, TItem, TParams, TUnarySpec>,
+): LoadStep<TSpec, TItem, ReadonlyArray<TItem>, TParams, TUnarySpec> {
   if (loadCallbackOnly) {
     return load(
       $spec,
+      loadCallbackOrIoEquivalenceOrUnarySpec as ExecutableStep<TUnarySpec> | null,
       loadCallbackOrIoEquivalence as
         | null
         | string
         | { [key in keyof TSpec]?: string | null },
-      loadCallbackOnly as LoadManyCallback<TSpec, TItem, TParams>,
-    ) as LoadStep<TSpec, TItem, ReadonlyArray<TItem>, TParams>;
-  } else {
+      loadCallbackOnly as LoadManyCallback<TSpec, TItem, TParams, TUnarySpec>,
+    ) as LoadStep<TSpec, TItem, ReadonlyArray<TItem>, TParams, TUnarySpec>;
+  }
+  // At most 3 arguments
+  else if (isExecutableStep(loadCallbackOrIoEquivalenceOrUnarySpec)) {
+    return load(
+      $spec,
+      loadCallbackOrIoEquivalenceOrUnarySpec,
+      null,
+      loadCallbackOrIoEquivalence as LoadManyCallback<
+        TSpec,
+        TItem,
+        TParams,
+        TUnarySpec
+      >,
+    ) as LoadStep<TSpec, TItem, ReadonlyArray<TItem>, TParams, TUnarySpec>;
+  }
+  // Unary step is definitely null; 3 arguments
+  else if (loadCallbackOrIoEquivalence) {
     return load(
       $spec,
       null,
-      loadCallbackOrIoEquivalence as LoadManyCallback<TSpec, TItem, TParams>,
-    ) as LoadStep<TSpec, TItem, ReadonlyArray<TItem>, TParams>;
+      loadCallbackOrIoEquivalenceOrUnarySpec,
+      loadCallbackOrIoEquivalence as LoadManyCallback<
+        TSpec,
+        TItem,
+        TParams,
+        TUnarySpec
+      >,
+    ) as LoadStep<TSpec, TItem, ReadonlyArray<TItem>, TParams, TUnarySpec>;
+  }
+  // 2 arguments
+  else {
+    return load(
+      $spec,
+      null,
+      null,
+      loadCallbackOrIoEquivalenceOrUnarySpec as LoadManyCallback<
+        TSpec,
+        TItem,
+        TParams,
+        TUnarySpec
+      >,
+    ) as LoadStep<TSpec, TItem, ReadonlyArray<TItem>, TParams, TUnarySpec>;
   }
 }
 
 export function loadOne<
-  TSpec,
+  const TSpec,
   TItem,
   TParams extends Record<string, any> = Record<string, any>,
+  TUnarySpec = never,
 >(
   $spec: ExecutableStep<TSpec>,
-  loadCallback: LoadOneCallback<TSpec, TItem, TParams>,
+  loadCallback: LoadOneCallback<TSpec, TItem, TParams, TUnarySpec>,
 ): LoadedRecordStep<TItem, TParams>;
 export function loadOne<
   const TSpec,
   TItem,
   TParams extends Record<string, any> = Record<string, any>,
+  TUnarySpec = never,
 >(
   $spec: ExecutableStep<TSpec>,
   ioEquivalence: null | string | { [key in keyof TSpec]?: string | null },
-  loadCallback: LoadOneCallback<TSpec, TItem, TParams>,
+  loadCallback: LoadOneCallback<TSpec, TItem, TParams, TUnarySpec>,
+): LoadedRecordStep<TItem, TParams>;
+export function loadOne<
+  const TSpec,
+  TItem,
+  TParams extends Record<string, any> = Record<string, any>,
+  const TUnarySpec = never,
+>(
+  $spec: ExecutableStep<TSpec>,
+  $unarySpec: ExecutableStep<TUnarySpec> | null,
+  loadCallback: LoadOneCallback<TSpec, TItem, TParams, TUnarySpec>,
+): LoadedRecordStep<TItem, TParams>;
+export function loadOne<
+  const TSpec,
+  TItem,
+  TParams extends Record<string, any> = Record<string, any>,
+  const TUnarySpec = never,
+>(
+  $spec: ExecutableStep<TSpec>,
+  $unarySpec: ExecutableStep<TUnarySpec> | null,
+  ioEquivalence: null | string | { [key in keyof TSpec]?: string | null },
+  loadCallback: LoadOneCallback<TSpec, TItem, TParams, TUnarySpec>,
 ): LoadedRecordStep<TItem, TParams>;
 export function loadOne<
   TSpec,
   TItem,
   TParams extends Record<string, any> = Record<string, any>,
+  TUnarySpec = never,
 >(
   $spec: ExecutableStep<TSpec>,
-  loadCallbackOrIoEquivalence:
-    | LoadOneCallback<TSpec, TItem, TParams>
+  loadCallbackOrIoEquivalenceOrUnarySpec:
+    | LoadOneCallback<TSpec, TItem, TParams, TUnarySpec>
+    | null
+    | string
+    | { [key in keyof TSpec]?: string | null }
+    | ExecutableStep<TUnarySpec>,
+  loadCallbackOrIoEquivalence?:
+    | LoadOneCallback<TSpec, TItem, TParams, TUnarySpec>
     | null
     | string
     | { [key in keyof TSpec]?: string | null },
-  loadCallbackOnly?: LoadOneCallback<TSpec, TItem, TParams>,
+  loadCallbackOnly?: LoadOneCallback<TSpec, TItem, TParams, TUnarySpec>,
 ): LoadedRecordStep<TItem, TParams> {
   if (loadCallbackOnly) {
     return load(
       $spec,
+      loadCallbackOrIoEquivalenceOrUnarySpec as ExecutableStep<TUnarySpec> | null,
       loadCallbackOrIoEquivalence as
         | null
         | string
         | { [key in keyof TSpec]?: string | null },
-      loadCallbackOnly as LoadOneCallback<TSpec, TItem, TParams>,
+      loadCallbackOnly as LoadOneCallback<TSpec, TItem, TParams, TUnarySpec>,
+    ).single();
+  }
+  // At most 3 arguments
+  else if (isExecutableStep(loadCallbackOrIoEquivalenceOrUnarySpec)) {
+    return load(
+      $spec,
+      loadCallbackOrIoEquivalenceOrUnarySpec,
+      null,
+      loadCallbackOrIoEquivalence as LoadOneCallback<
+        TSpec,
+        TItem,
+        TParams,
+        TUnarySpec
+      >,
+    ).single();
+  }
+  // Unary step is definitely null; 3 arguments
+  else if (loadCallbackOrIoEquivalence) {
+    return load(
+      $spec,
+      null,
+      loadCallbackOrIoEquivalenceOrUnarySpec,
+      loadCallbackOrIoEquivalenceOrUnarySpec as LoadOneCallback<
+        TSpec,
+        TItem,
+        TParams,
+        TUnarySpec
+      >,
     ).single();
   } else {
     return load(
       $spec,
       null,
-      loadCallbackOrIoEquivalence as LoadOneCallback<TSpec, TItem, TParams>,
+      null,
+      loadCallbackOrIoEquivalenceOrUnarySpec as LoadOneCallback<
+        TSpec,
+        TItem,
+        TParams,
+        TUnarySpec
+      >,
     ).single();
   }
 }

--- a/grafast/website/grafast/step-library/standard-steps/loadMany.md
+++ b/grafast/website/grafast/step-library/standard-steps/loadMany.md
@@ -1,3 +1,7 @@
+---
+toc_max_heading_level: 4
+---
+
 import Mermaid from "@theme/Mermaid";
 
 # loadMany
@@ -111,17 +115,19 @@ stateDiagram
 
 ## Usage
 
+### Basic usage
+
 ```ts
 const $userId = $user.get("id");
 const $friendships = loadMany($userId, getFriendshipsByUserIds);
 ```
 
-`loadMany` accepts two or three arguments, the first is the step that specifies
-which records to load, and the last is the callback function called with these
-specs responsible for loading them.
+`loadMany` accepts two to four arguments, the first is the step that specifies
+which records to load (the _specifier step_), and the last is the callback
+function called with these specs responsible for loading them.
 
 The callback function is called with two arguments, the first is a list of the
-values from the specifier step and the second is options that may affect the
+values from the _specifier step_ and the second is options that may affect the
 fetching of the records.
 
 :::tip
@@ -145,7 +151,8 @@ const friendshipsByUserIdCallback = (ids, { attributes }) => {
 
 [dataloader]: https://github.com/graphql/dataloader
 
-Optionally a middle argument can indicate the input/output equivalence - this can be:
+Optionally a penultimate argument (2nd of 3 arguments, or 3rd of 4 arguments)
+can indicate the input/output equivalence - this can be:
 
 - `null` to indicate no input/output equivalence
 - a string to indicate that the same named property on the output is equivalent
@@ -173,10 +180,30 @@ const $posts = loadMany(
 );
 ```
 
+### Advanced usage
+
+```ts
+const $userId = $user.get("id");
+const $dbClient = context().get("dbClient");
+const $friendships = loadMany($userId, $dbClient, getFriendshipsByUserIds);
+```
+
+In addition to the forms seen in "Basic usage" above, you can pass a second
+step to `loadMany`. This second step must be a [**unary
+step**](../../step-classes.md#addUnaryDependency), meaning that it must represent
+exactly one value across the entire request (not a batch of values like most
+steps). Since we know it will have exactly one value, we can pass it into the
+callback as a single value and our callback will be able to use it directly
+without having to perform any manual grouping.
+
+This unary dependency is useful for fixed values (for example, those from
+GraphQL field arguments) and values on the GraphQL context such as clients to
+various APIs and other data sources.
+
 ## Multiple steps
 
-The [`list()`](./list) step can be used if you need to pass the value of more
-than one step into your callback:
+The [`list()`](./list) or [`object()`](./object) step can be used if you need
+to pass the value of more than one step into your callback:
 
 ```ts
 const $result = loadMany(list([$a, $b, $c]), callback);


### PR DESCRIPTION
## Description

Following [this discussion in Discord](https://discord.com/channels/489127045289476126/498852330754801666/1217421837206552689) I felt rather motivated to add support for unary steps to loadOne/loadMany.

### Before

```ts
const $executorContext = executor.context();
const $id = ...;
const $result = loadOne(list([$executorContext, $id]), async (tuples) => {
  // Batch the values by their executor context; probably there will only be one batch entry. (Highly technical note: unary values have been added to `main` recently but not yet shipped; we may be able to get rid of this later by changing the signature of loadOne and declaring $executorContext as a unary value so that you know there will be exactly one value of it - then you will just have `executorContext` and `ids` without this batching overhead.)
  const idAndIndexesByExecutorContext = new Map();
  for (let i = 0; i < tuples.length; i++) {
    const [executorContext, id] = tuples[i];
    const list = idAndIndexesByExecutorContext.get(executorContext) || [];
    if (list.length === 0) {
      idAndIndexesByExecutorContext.set(executorContext, list);
    }
    list.push([id, i]);
  }

  // Prepare the results array
  const results = new Array(tuples.length);

  // Now execute these batches, and write to the results array
  for (const [executorContext, idsAndIndexes] of idAndIndexesByExecutorContext) {
    const ids = idsAndIndexes.map(t => t[0]);
    const { withPgClient, pgSettings } = executorContext;
    const data = await withPgClient(pgSettings, (client) => getTheRecordsByIdsOrWhatever(client, ids));
    // Write the results back to the results array
    for (const entry of data) {
      // Find the index of this result from the DB
      const idx = ids.indexOf(entry.id);
      if (idx >= 0) {
        // Find the corresponding index in the input tuples list
        const resultIdx = idAndIndexes[idx][1];
        // Store the result in this index
        results[resultIdx] = entry;
      }
    }
  }

  // Finally return the results
  return results;
});
```

^ Note that we pass executorContext and id through as a tuple, so we get a list of tuples as input and then we must loop over these, group them by executorContext, then execute each group, and finally figure out where in the results to write the result for each `id` back to.

### After

```ts
const $executorContext = executor.context();
const $id = ...;
const $result = loadOne($id, $executorContext, async (ids, { unary: executorContext }) => {
  const { withPgClient, pgSettings } = executorContext;
  const data = await withPgClient(pgSettings, (client) => getTheRecordsByIdsOrWhatever(client, ids));
  return ids.map(id => data.find(d => d.id === id));
});
```

^ Note that here we pass `$executorContext` as a separate, unary, step. Because it's in the unary position we know it will have exactly one value, so we do not need to group by it. Removing the grouping code **massively** simplifies the remaining code, and we end up with the above much shorter plan resolver which does effectively the same thing.

## Performance impact

Unknown.

## Security impact

None known.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
