### PR TITLE
Add ability to export values via graphile-export

### DIFF
--- a/.changeset/empty-numbers-act.md
+++ b/.changeset/empty-numbers-act.md
@@ -1,0 +1,5 @@
+---
+"graphile-export": patch
+---
+
+Ability to export values from graphile-export (e.g. the registry)

--- a/utils/graphile-export/src/exportSchema.ts
+++ b/utils/graphile-export/src/exportSchema.ts
@@ -1852,12 +1852,38 @@ export async function exportSchemaAsString(
     exportSchemaGraphQLJS(schemaExportDetails);
   }
 
+  return exportFile(file);
+}
+
+function exportFile(file: CodegenFile) {
   const ast = file.toAST();
 
   const optimizedAst = optimize(ast);
 
   const { code } = reallyGenerate(optimizedAst, {});
   return { code };
+}
+
+export async function exportValueAsString(
+  name: string,
+  value: any,
+  options: ExportOptions,
+): Promise<{ code: string }> {
+  const file = new CodegenFile(options);
+
+  const exportName = file.makeVariable(name);
+
+  const valueAST = convertToIdentifierViaAST(file, value, name, name);
+
+  file.addStatements(
+    t.exportNamedDeclaration(
+      t.variableDeclaration("const", [
+        t.variableDeclarator(exportName, valueAST),
+      ]),
+    ),
+  );
+
+  return exportFile(file);
 }
 
 async function loadESLint() {

--- a/utils/graphile-export/src/index.ts
+++ b/utils/graphile-export/src/index.ts
@@ -1,3 +1,7 @@
-export { exportSchema, exportSchemaAsString } from "./exportSchema.js";
+export {
+  exportSchema,
+  exportSchemaAsString,
+  exportValueAsString,
+} from "./exportSchema.js";
 export { EXPORTABLE } from "./helpers.js";
 export type { ExportOptions } from "./interfaces.js";


### PR DESCRIPTION
## Description

We want people to be able to export the result of the gather phase, this adds that functionality (though it's far from optimal right now, for example the resulting file doesn't have good type safety for registry due to `Object.assign(Object.create(null), ...)`

## Performance impact

Export only.

## Security impact

Export only.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~~I've added tests for the new feature, and `yarn test` passes.~~
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] ~~If this is a breaking change I've explained why.~~

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
