### PR TITLE
Introduce concept of SQL-able to pg-sql2

### DIFF
--- a/.changeset/flat-dingos-explain.md
+++ b/.changeset/flat-dingos-explain.md
@@ -1,0 +1,9 @@
+---
+"graphile-build-pg": patch
+"postgraphile": patch
+"@dataplan/pg": patch
+"pg-sql2": patch
+---
+
+Introduce `interface SQLable {[$$toSQL](): SQL}` to `pg-sql2` and use it to
+simplify SQL fragments in various places.

--- a/grafast/dataplan-pg/src/examples/exampleSchema.ts
+++ b/grafast/dataplan-pg/src/examples/exampleSchema.ts
@@ -1988,7 +1988,7 @@ export function makeExampleSchema(
               (TYPES, sql) => (step: PgSelectStep<typeof messageResource>) => {
                 step.orderBy({
                   codec: TYPES.text,
-                  fragment: sql`${step.alias}.body`,
+                  fragment: sql`${step}.body`,
                   direction: "ASC",
                 });
               },
@@ -2004,7 +2004,7 @@ export function makeExampleSchema(
               (TYPES, sql) => (step: PgSelectStep<typeof messageResource>) => {
                 step.orderBy({
                   codec: TYPES.text,
-                  fragment: sql`${step.alias}.body`,
+                  fragment: sql`${step}.body`,
                   direction: "DESC",
                 });
               },
@@ -2218,7 +2218,7 @@ export function makeExampleSchema(
             if ($value.evalIs("YES")) {
               // No restriction
             } else if ($value.evalIs("EXCLUSIVELY")) {
-              $messages.where(sql`${$messages.alias}.archived_at is not null`);
+              $messages.where(sql`${$messages}.archived_at is not null`);
             } else if (
               $value.evalIs("INHERIT") &&
               // INHERIT only works if the parent has an archived_at attribute.
@@ -2234,7 +2234,7 @@ export function makeExampleSchema(
                 )} is null)`,
               );
             } else {
-              $messages.where(sql`${$messages.alias}.archived_at is null`);
+              $messages.where(sql`${$messages}.archived_at is null`);
             }
           },
         [PgSelectSingleStep, TYPES, getClassStep, sql],
@@ -2256,10 +2256,10 @@ export function makeExampleSchema(
             function plan($condition: PgConditionStep<any>, val) {
               const $value = val.getRaw();
               if ($value.evalIs(null)) {
-                $condition.where(sql`${$condition.alias}.featured is null`);
+                $condition.where(sql`${$condition}.featured is null`);
               } else {
                 $condition.where(
-                  sql`${$condition.alias}.featured = ${$condition.placeholder(
+                  sql`${$condition}.featured = ${$condition.placeholder(
                     $value,
                     TYPES.boolean,
                   )}`,
@@ -2338,7 +2338,7 @@ export function makeExampleSchema(
               } else {
                 const plan = new BooleanFilterStep(
                   $messageFilter,
-                  sql`${$messageFilter.alias}.featured`,
+                  sql`${$messageFilter}.featured`,
                 );
                 arg.apply(plan);
               }
@@ -2362,10 +2362,10 @@ export function makeExampleSchema(
             function plan($condition: PgConditionStep<any>, arg) {
               const $value = arg.getRaw();
               if ($value.evalIs(null)) {
-                $condition.where(sql`${$condition.alias}.name is null`);
+                $condition.where(sql`${$condition}.name is null`);
               } else {
                 $condition.where(
-                  sql`${$condition.alias}.name = ${$condition.placeholder(
+                  sql`${$condition}.name = ${$condition.placeholder(
                     $value,
                     TYPES.text,
                   )}`,

--- a/grafast/dataplan-pg/src/filters/pgBooleanFilter.ts
+++ b/grafast/dataplan-pg/src/filters/pgBooleanFilter.ts
@@ -1,10 +1,14 @@
 import type { ExecutableStep } from "grafast";
 import { ModifierStep } from "grafast";
-import type { SQL } from "pg-sql2";
+import type { SQL, SQLable } from "pg-sql2";
+import { $$toSQL } from "pg-sql2";
 
 import type { PgCodec, PgConditionLikeStep } from "../interfaces.js";
 
-export class PgBooleanFilterStep extends ModifierStep<PgConditionLikeStep> {
+export class PgBooleanFilterStep
+  extends ModifierStep<PgConditionLikeStep>
+  implements SQLable
+{
   static $$export = {
     moduleName: "@dataplan/pg",
     exportName: "PgBooleanFilterStep",
@@ -39,5 +43,8 @@ export class PgBooleanFilterStep extends ModifierStep<PgConditionLikeStep> {
     this.havingConditions.forEach((condition) =>
       this.$parent.having(condition),
     );
+  }
+  [$$toSQL]() {
+    return this.alias;
   }
 }

--- a/grafast/dataplan-pg/src/filters/pgClassFilter.ts
+++ b/grafast/dataplan-pg/src/filters/pgClassFilter.ts
@@ -1,6 +1,7 @@
 import type { ExecutableStep } from "grafast";
 import { ModifierStep } from "grafast";
-import type { SQL } from "pg-sql2";
+import type { SQL, SQLable } from "pg-sql2";
+import { $$toSQL } from "pg-sql2";
 
 import type { PgCodec } from "../interfaces.js";
 import type {
@@ -9,9 +10,12 @@ import type {
 } from "../steps/pgCondition.js";
 
 export class PgClassFilterStep<
-  TParentStep extends
-    PgConditionCapableParentStep = PgConditionCapableParentStep,
-> extends ModifierStep<PgConditionStep<TParentStep>> {
+    TParentStep extends
+      PgConditionCapableParentStep = PgConditionCapableParentStep,
+  >
+  extends ModifierStep<PgConditionStep<TParentStep>>
+  implements SQLable
+{
   static $$export = {
     moduleName: "@dataplan/pg",
     exportName: "PgClassFilterStep",
@@ -36,5 +40,9 @@ export class PgClassFilterStep<
 
   apply() {
     this.conditions.forEach((condition) => this.$parent.where(condition));
+  }
+
+  [$$toSQL]() {
+    return this.alias;
   }
 }

--- a/grafast/dataplan-pg/src/filters/pgOrFilter.ts
+++ b/grafast/dataplan-pg/src/filters/pgOrFilter.ts
@@ -1,11 +1,14 @@
 import type { ExecutableStep } from "grafast";
 import { ModifierStep } from "grafast";
-import type { SQL } from "pg-sql2";
-import { sql } from "pg-sql2";
+import type { SQL, SQLable } from "pg-sql2";
+import { $$toSQL, sql } from "pg-sql2";
 
 import type { PgCodec, PgConditionLikeStep } from "../interfaces.js";
 
-export class PgOrFilterStep extends ModifierStep<PgConditionLikeStep> {
+export class PgOrFilterStep
+  extends ModifierStep<PgConditionLikeStep>
+  implements SQLable
+{
   static $$export = {
     moduleName: "@dataplan/pg",
     exportName: "PgOrFilterStep",
@@ -49,5 +52,9 @@ export class PgOrFilterStep extends ModifierStep<PgConditionLikeStep> {
         )})`,
       );
     }
+  }
+
+  [$$toSQL]() {
+    return this.alias;
   }
 }

--- a/grafast/dataplan-pg/src/steps/pgCondition.ts
+++ b/grafast/dataplan-pg/src/steps/pgCondition.ts
@@ -1,7 +1,7 @@
 import type { BaseStep, ExecutableStep } from "grafast";
 import { ModifierStep } from "grafast";
-import type { SQL } from "pg-sql2";
-import { sql } from "pg-sql2";
+import type { SQL, SQLable } from "pg-sql2";
+import { $$toSQL, sql } from "pg-sql2";
 
 import { TYPES } from "../index.js";
 import type { PgCodec } from "../interfaces.js";
@@ -55,7 +55,7 @@ export class PgConditionStep<
       PgConditionCapableParentStep = PgConditionCapableParentStep,
   >
   extends ModifierStep<TParentStep>
-  implements PgConditionCapableParentStep
+  implements PgConditionCapableParentStep, SQLable
 {
   static $$export = {
     moduleName: "@dataplan/pg",
@@ -212,6 +212,9 @@ where ${sqlCondition}`})`;
         }
       }
     }
+  }
+  [$$toSQL]() {
+    return this.alias;
   }
 }
 

--- a/grafast/dataplan-pg/src/steps/pgInsertSingle.ts
+++ b/grafast/dataplan-pg/src/steps/pgInsertSingle.ts
@@ -6,8 +6,8 @@ import type {
   SetterStep,
 } from "grafast";
 import { ExecutableStep, exportAs, isDev, setter } from "grafast";
-import type { SQL, SQLRawValue } from "pg-sql2";
-import sql from "pg-sql2";
+import type { SQL, SQLable, SQLRawValue } from "pg-sql2";
+import sql, { $$toSQL } from "pg-sql2";
 
 import type { PgCodecAttribute } from "../codecs.js";
 import type { PgResource } from "../index.js";
@@ -52,7 +52,8 @@ export class PgInsertSingleStep<
     SetterCapableStep<{
       [key in keyof GetPgResourceAttributes<TResource> &
         string]: ExecutableStep;
-    }>
+    }>,
+    SQLable
 {
   static $$export = {
     moduleName: "@dataplan/pg",
@@ -403,6 +404,9 @@ export class PgInsertSingleStep<
     }
 
     super.finalize();
+  }
+  [$$toSQL]() {
+    return this.alias;
   }
 }
 

--- a/grafast/dataplan-pg/src/steps/pgSelect.ts
+++ b/grafast/dataplan-pg/src/steps/pgSelect.ts
@@ -40,7 +40,7 @@ import {
   stepsAreInSamePhase,
 } from "grafast";
 import type { SQL, SQLRawValue } from "pg-sql2";
-import sql, { $$symbolToIdentifier, arraysMatch } from "pg-sql2";
+import sql, { $$symbolToIdentifier, $$toSQL, arraysMatch } from "pg-sql2";
 
 import type { PgCodecAttributes } from "../codecs.js";
 import { listOfCodec, TYPES } from "../codecs.js";
@@ -2854,6 +2854,10 @@ ${lateralText};`;
     const $single = new PgSelectSingleStep(this, itemPlan);
     const isScalar = !this.resource.codec.attributes;
     return (isScalar ? $single.getSelfNamed() : $single) as any;
+  }
+
+  [$$toSQL]() {
+    return this.alias;
   }
 
   // --------------------

--- a/grafast/dataplan-pg/src/steps/pgSelectSingle.ts
+++ b/grafast/dataplan-pg/src/steps/pgSelectSingle.ts
@@ -10,8 +10,8 @@ import {
   UnbatchedExecutableStep,
 } from "grafast";
 import type { GraphQLObjectType } from "grafast/graphql";
-import type { SQL } from "pg-sql2";
-import sql from "pg-sql2";
+import type { SQL, SQLable } from "pg-sql2";
+import sql, { $$toSQL } from "pg-sql2";
 
 import type {
   ObjectFromPgCodecAttributes,
@@ -79,7 +79,8 @@ export class PgSelectSingleStep<
         ? UCodec
         : never
     >,
-    EdgeCapableStep<any>
+    EdgeCapableStep<any>,
+    SQLable
 {
   static $$export = {
     moduleName: "@dataplan/pg",
@@ -550,9 +551,7 @@ export class PgSelectSingleStep<
           attribute: { codec },
           attr,
         } = nonNullAttribute;
-        const expression = sql`${this.getClassStep().alias}.${sql.identifier(
-          attr,
-        )}`;
+        const expression = sql`${this}.${sql.identifier(attr)}`;
         this.nullCheckAttributeIndex = this.getClassStep().selectAndReturnIndex(
           codec.castFromPg
             ? codec.castFromPg(expression)
@@ -605,6 +604,10 @@ export class PgSelectSingleStep<
       }
     }
     return this.handlePolymorphism ? this.handlePolymorphism(result) : result;
+  }
+
+  [$$toSQL]() {
+    return this.getClassStep().alias;
   }
 }
 

--- a/grafast/dataplan-pg/src/steps/pgUpdateSingle.ts
+++ b/grafast/dataplan-pg/src/steps/pgUpdateSingle.ts
@@ -1,7 +1,7 @@
 import type { ExecutionDetails, GrafastResultsList, SetterStep } from "grafast";
 import { ExecutableStep, exportAs, isDev, SafeError, setter } from "grafast";
-import type { SQL, SQLRawValue } from "pg-sql2";
-import sql from "pg-sql2";
+import type { SQL, SQLRawValue, SQLable } from "pg-sql2";
+import sql, { $$toSQL } from "pg-sql2";
 
 import type { PgCodecAttribute } from "../codecs.js";
 import type { PgResource, PgResourceUnique } from "../index.js";
@@ -36,8 +36,11 @@ interface PgUpdatePlanFinalizeResults {
  * Update a single row identified by the 'getBy' argument.
  */
 export class PgUpdateSingleStep<
-  TResource extends PgResource<any, any, any, any, any> = PgResource,
-> extends ExecutableStep<unknown[]> {
+    TResource extends PgResource<any, any, any, any, any> = PgResource,
+  >
+  extends ExecutableStep<unknown[]>
+  implements SQLable
+{
   static $$export = {
     moduleName: "@dataplan/pg",
     exportName: "PgUpdateSingleStep",
@@ -442,6 +445,9 @@ export class PgUpdateSingleStep<
     }
 
     super.finalize();
+  }
+  [$$toSQL]() {
+    return this.alias;
   }
 }
 

--- a/grafast/dataplan-pg/src/steps/pgUpdateSingle.ts
+++ b/grafast/dataplan-pg/src/steps/pgUpdateSingle.ts
@@ -1,6 +1,6 @@
 import type { ExecutionDetails, GrafastResultsList, SetterStep } from "grafast";
 import { ExecutableStep, exportAs, isDev, SafeError, setter } from "grafast";
-import type { SQL, SQLRawValue, SQLable } from "pg-sql2";
+import type { SQL, SQLable, SQLRawValue } from "pg-sql2";
 import sql, { $$toSQL } from "pg-sql2";
 
 import type { PgCodecAttribute } from "../codecs.js";

--- a/graphile-build/graphile-build-pg/src/plugins/PgOrderByPrimaryKeyPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgOrderByPrimaryKeyPlugin.ts
@@ -69,7 +69,7 @@ export const PgOrderByPrimaryKeyPlugin: GraphileConfig.Plugin = {
                           const attribute = pgCodec.attributes[attributeName];
                           step.orderBy({
                             codec: attribute.codec,
-                            fragment: sql`${step.alias}.${sql.identifier(
+                            fragment: sql`${step}.${sql.identifier(
                               attributeName,
                             )}`,
                             direction: "ASC",
@@ -97,7 +97,7 @@ export const PgOrderByPrimaryKeyPlugin: GraphileConfig.Plugin = {
                           const attribute = pgCodec.attributes[attributeName];
                           step.orderBy({
                             codec: attribute.codec,
-                            fragment: sql`${step.alias}.${sql.identifier(
+                            fragment: sql`${step}.${sql.identifier(
                               attributeName,
                             )}`,
                             direction: "DESC",

--- a/postgraphile/postgraphile/__tests__/kitchen-sink-data.sql
+++ b/postgraphile/postgraphile/__tests__/kitchen-sink-data.sql
@@ -928,4 +928,4 @@ truncate space.mobile_pad restart identity;
 insert into space.mobile_pad(name) select i::text from generate_series(1, 10) i;
 insert into space.static_pad(name) select i::text from generate_series(1, 10) i;
 insert into space.temp_pad(name) select i::text from generate_series(1, 10) i;
-insert into space.spacecraft(name, return_to_earth) select i::text, tsrange((date_trunc('day', now()) - (i+1) * interval '1 day')::timestamp, (date_trunc('day', now()) - (i) * interval '1 day')::timestamp, '[)') from generate_series(1, 10) i;
+insert into space.spacecraft(name, return_to_earth) select i::text, tsrange((date_trunc('day', '2024-03-13T12:00:00Z'::timestamptz) - (i+1) * interval '1 day')::timestamp, (date_trunc('day', '2024-03-13T12:00:00Z'::timestamptz) - (i) * interval '1 day')::timestamp, '[)') from generate_series(1, 10) i;

--- a/postgraphile/postgraphile/graphile.config.ts
+++ b/postgraphile/postgraphile/graphile.config.ts
@@ -250,9 +250,8 @@ const preset: GraphileConfig.Preset = {
                     $greeting,
                     TYPES.text,
                   );
-                  const alias = $user.getClassStep().alias;
                   return $user.select(
-                    sql`${placeholderSql} || ', ' || ${alias}.name`,
+                    sql`${placeholderSql} || ', ' || ${$user}.name`,
                     TYPES.text,
                   );
                 },


### PR DESCRIPTION
## Description

Writing `` sql`${$user.getClassStep().alias}.is_admin is true` `` is a chore; this change makes it so that `sql` can recognize embedded values that can be turned natively into SQL, for example `pgSelect` and `pgSelectSingle` can now be used like: `` sql`${$user}.is_admin is true` `` which is much simpler and easier to read.

Note: this is only useful for aliases, you cannot use this for placeholders.

## Performance impact

Negligible, planning only.

## Security impact

I guess you could argue that it's slightly more magic, and thus slightly riskier that the coder might do the wrong thing? I can't see how this would turn into a vulnerability that would get past testing though.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
