### PR TITLE
Add example global behavior to disable everything by default

### DIFF
--- a/postgraphile/website/postgraphile/behavior.md
+++ b/postgraphile/website/postgraphile/behavior.md
@@ -76,6 +76,11 @@ These global defaults can still be overridden by each entity, so they're a
 good way of making wide ranging "default" behaviors without locking yourself in
 too hard.
 
+For example, if you want to run postgraphile with all behaviors disabled by default,
+you can start your defaultBehavior string with `-*`. This would allow you to take the
+approach of requiring intentional engineer decisions on how database schema additions
+are reflected in your GraphQL schema.
+
 :::info
 
 If you're authoring a preset that is not the final configuration for a schema


### PR DESCRIPTION
## Description

This is a small addition to the documentation for something that took me several minutes to figure out. It is something I suspect will be useful for others who want to take the same disabled-by-default approach that I am taking with postgraphile

## Performance impact

None - just docs

## Security impact

None - just docs

## Checklist

- [x] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).

@benjie, I imagine we don't need release notes for documentation tweaks?
