### PR TITLE
Clarify amber preset behavior in nodeId documentation

### DIFF
--- a/postgraphile/website/postgraphile/node-id.md
+++ b/postgraphile/website/postgraphile/node-id.md
@@ -20,18 +20,18 @@ preset but you do not like this behavior, you have several options:
 
 1. You can use the `postgraphile/presets/relay` preset which makes several changes
     including removing `rowId` entirely.
-2. You can use a V4 preset that mimics the behavior and settings of Postgraphile V4
+2. You can use a V4 preset that mimics the behavior and settings of PostGraphile V4
     which used `nodeId` to represent the unique identifier.
 3. You can create your plugin similar to the following:
 
 ```ts
-const RevertToNodeIdPlugin: GraphileConfig.Plugin = {
-    name: 'RevertToNodeIdPlugin',
+const IdToNodeIdPlugin: GraphileConfig.Plugin = {
+    name: 'IdToNodeIdPlugin',
     version: '1.0.0',
     inflection: {
         replace: {
             nodeIdFieldName: (): string => 'nodeId',
-            attribute: (previous: any, options: any, details: any) => {
+            attribute(previous, options, details) {
                 const name = previous!.call(this, details)
                 if (name === 'rowId') {
                     return 'id'
@@ -54,6 +54,8 @@ import { InMemoryCache } from "apollo-cache-inmemory";
 const cache = new InMemoryCache({
   // highlight-next-line
   dataIdFromObject: (object) => object.id || null,
+  // Or if you renamed 'id' to 'nodeId' then:
+  //   dataIdFromObject: (object) => object.nodeId || null,
 });
 
 export const client = new ApolloClient({

--- a/postgraphile/website/postgraphile/node-id.md
+++ b/postgraphile/website/postgraphile/node-id.md
@@ -1,53 +1,28 @@
 ---
 layout: page
 path: /postgraphile/node-id/
-title: Globally Unique Object Identification ("nodeId" / "id")
+title: Globally Unique Object Identification ("id" / "nodeId")
 ---
 
 The [GraphQL Global Object Identification
 Specification](https://facebook.github.io/relay/graphql/objectidentification.htm)
-is one of the best practices in GraphQL, it gives clients a way to uniquely identify each object in the schema
-and to fetch these objects by their IDs.
+is one of the best practices in GraphQL, it gives clients a way to uniquely identify
+each object in the schema and to fetch these objects by their IDs.
 
-By default, PostGraphile implements this specification, assigning the unique
-identifier to every table with a primary key, but with a minor tweak - it uses
-the field name `nodeId` rather than the specified `id`. This change is to avoid
-clashing with the `id` field that is commonly the name of primary keys in
-database design. If you wish to call the Global Object Identifier field `id`
-instead (as is mandated by the specification), you can do so by overriding the
-`nodeIdFieldName` inflector, or you can use the `postgraphile/presets/relay`
-preset which does this (and a lot more) for you.
+By default, the `postgraphile/presets/amber` preset implements this specification.
+The amber preset assigns the unique identifier to every table with a primary key.
+The preset exposes the unique identifier as an attribute named `id`.
 
-If you choose to override the `nodeIdFieldName` inflector and you have database
-fields called `id` then you may want to override the `attribute` inflector too:
+It is common in database design to use the column name `id` for primary keys. For
+this reason, if there is an attribute named `id` that is already on the GraphQL type,
+the amber preset renames that attribute to `rowId`. If you want to use the amber
+preset but you do not like this behavior, you have several options:
 
-```ts {7-9,12}
-const IdPlugin: GraphileConfig.Plugin = {
-  name: "IdPlugin",
-  version: "0.0.0",
-
-  inflection: {
-    replace: {
-      nodeIdFieldName() {
-        return "id";
-      },
-      attribute(previous, options, details) {
-        const name = previous!.call(this, details);
-        if (name === "id") return "rowId";
-        return name;
-      },
-    },
-  },
-};
-```
-
-Similarly to the `postgraphile/presets/relay` preset, the
-`postgraphile/presets/amber` preset also sets nodeIdFieldName to `id` with
-`graphile-build`'s `NodePlugin`. The amber preset also mirrors the relay preset
-in renaming `id` columns in database tables to `rowId` with `graphile-build-pg`'s
-`PgAttributesPlugin`. If you are using the amber preset and you want to revert to
-using `nodeId` for the unique identifier and `id` attribute name for any `id`
-columns in your database, you can add something like the following plugin:
+1. You can use the `postgraphile/presets/relay` preset which makes several changes
+    including removing `rowId` entirely.
+2. You can use a V4 preset that mimics the behavior and settings of Postgraphile V4
+    which used `nodeId` to represent the unique identifier.
+3. You can create your plugin similar to the following:
 
 ```ts
 const RevertToNodeIdPlugin: GraphileConfig.Plugin = {
@@ -68,8 +43,8 @@ const RevertToNodeIdPlugin: GraphileConfig.Plugin = {
 }
 ```
 
-One common use case for the `nodeId` (or `id`) field is as the cache key for
-your client library, e.g. with Apollo Client's `dataIdFromObject`:
+One common use case for the unique `id` field is as the cache key for your client
+library, e.g. with Apollo Client's `dataIdFromObject`:
 
 ```ts
 import ApolloClient from "apollo-client";
@@ -78,7 +53,7 @@ import { InMemoryCache } from "apollo-cache-inmemory";
 
 const cache = new InMemoryCache({
   // highlight-next-line
-  dataIdFromObject: (object) => object.nodeId || null,
+  dataIdFromObject: (object) => object.id || null,
 });
 
 export const client = new ApolloClient({
@@ -89,7 +64,8 @@ export const client = new ApolloClient({
 
 ### Disabling the Global Object Identifier
 
-You can disable the global object identifier throughout your API by disabling `NodePlugin`:
+You can disable the global object identifier throughout your API by disabling
+`NodePlugin`:
 
 ```ts title="graphile.config.mjs"
 export default {
@@ -103,12 +79,12 @@ Ensure that you have a good way of generating cache identifiers for your GraphQL
 client though!
 
 (Note: the GraphQL Global Object Identification Specification was previously
-known as the Relay Global Object Identification Specification, but it's not
+known as the Relay Global Object Identification Specification, but it is not
 specific to Relay and is a general best practice for GraphQL APIs.)
 
-### Recommended: remove redundant fields
+### More On the Relay Preset
 
-If having both `nodeId: ID!` and `id: Int!` in your schema bothers you (as it
+If having both `id: ID!` and `rowId: Int!` in your schema bothers you (as it
 should!), you should consider using the `postgraphile/presets/relay` preset.
 This preset will hide raw primary keys from most of the schema, and will use
 global object identifiers instead - not just in the query schema but also in
@@ -130,21 +106,20 @@ export default {
 };
 ```
 
-### Node ID structure
+### Globally Unique ID Structure
 
-In GraphQL an `ID` should be treated as an "opaque" value - you should not
-extract values from inside it in your application. Though the Node ID is stable
-for the same object, when new objects are created there's no guarantee that
-their new ID will conform to the same encoding.
+In GraphQL a globally unique ID should be treated as an "opaque" value: you should
+not extract values from inside it in your application. Though the globally unique
+ID is stable for the same object, when new objects are created there is no guarantee
+that their new ID will conform to the same encoding.
 
-That said, it's generally easy to extract details from PostGraphile's IDs. Take
-for example the Node ID `WyJQb3N0IiwxXQ==`, by base64 decoding this value we
-can see the data in it is `["Post",1]`. This states that it's for the `Post`
-GraphQL type, and the associated primary key value is `1`. (If you're using the
-V4 preset then node IDs will use the table name (or a derivative thereof)
+That said, it is generally easy to extract details from PostGraphile's globally
+unique IDs. Take for example the Unique ID `WyJQb3N0IiwxXQ==`. By base64 decoding
+this value, we can see the data in it is `["Post",1]`. This states that it is for
+the `Post` GraphQL type, and the associated primary key value is `1`. (If you are
+using the V4 preset then `nodeId`s will use the table name (or a derivative thereof)
 rather than the GraphQL type name.)
 
-Thus using node IDs **does not** make your primary keys unobtainable, and doing
-so is not a goal of Node IDs. Should you need your primary keys to be
-meaningless, one choice is UUIDv4, and another is to use something like a
-Feistel cipher.
+Thus, using globally unique IDs **does not** make your primary keys unobtainable, and
+doing so is not a goal of globally unique IDs. Should you need your primary keys to
+be meaningless, you should use an approach like UUIDv4 or a Feistel cipher.

--- a/postgraphile/website/postgraphile/node-id.md
+++ b/postgraphile/website/postgraphile/node-id.md
@@ -34,7 +34,10 @@ const IdToNodeIdPlugin: GraphileConfig.Plugin = {
         return "nodeId";
       },
       attribute(previous, options, details) {
-        const name = previous!.call(this, details);
+        if (!previous) {
+          throw new Error("There was no 'attribute' inflector to replace?!");
+        }
+        const name = previous.call(this, details);
         if (name === "rowId") {
           return "id";
         }

--- a/postgraphile/website/postgraphile/node-id.md
+++ b/postgraphile/website/postgraphile/node-id.md
@@ -19,28 +19,30 @@ the amber preset renames that attribute to `rowId`. If you want to use the amber
 preset but you do not like this behavior, you have several options:
 
 1. You can use the `postgraphile/presets/relay` preset which makes several changes
-    including removing `rowId` entirely.
+   including removing `rowId` entirely.
 2. You can use a V4 preset that mimics the behavior and settings of PostGraphile V4
-    which used `nodeId` to represent the unique identifier.
+   which used `nodeId` to represent the unique identifier.
 3. You can create your plugin similar to the following:
 
 ```ts
 const IdToNodeIdPlugin: GraphileConfig.Plugin = {
-    name: 'IdToNodeIdPlugin',
-    version: '1.0.0',
-    inflection: {
-        replace: {
-            nodeIdFieldName(){ return 'nodeId'; },
-            attribute(previous, options, details) {
-                const name = previous!.call(this, details)
-                if (name === 'rowId') {
-                    return 'id'
-                }
-                return name
-            },
-        },
+  name: "IdToNodeIdPlugin",
+  version: "1.0.0",
+  inflection: {
+    replace: {
+      nodeIdFieldName() {
+        return "nodeId";
+      },
+      attribute(previous, options, details) {
+        const name = previous!.call(this, details);
+        if (name === "rowId") {
+          return "id";
+        }
+        return name;
+      },
     },
-}
+  },
+};
 ```
 
 One common use case for the unique `id` field is as the cache key for your client

--- a/postgraphile/website/postgraphile/node-id.md
+++ b/postgraphile/website/postgraphile/node-id.md
@@ -42,11 +42,11 @@ const IdPlugin: GraphileConfig.Plugin = {
 ```
 
 Like the `postgraphile/presets/relay` preset, the `postgraphile/presets/amber`
-preset also uses the field name `id` for the unique identifier and renames `id`
-columns in database tables to `rowId` via the NodePlugin and PgAttributesPlugin
-respectively. If you're using the amber preset and want to revert to using
-`nodeId` for the unique identifier and `id` for any `id` columns in your database,
-you can add something like the following plugin:
+preset also uses the field name `id` for the unique identifier with the
+`NodePlugin` and renames `id` columns in database tables to `rowId` with the
+PgAttributesPlugin respectively. If you're using the amber preset and want to
+revert to using `nodeId` for the unique identifier and `id` for any `id` columns
+in your database, you can add something like the following plugin:
 
 ```ts
 const RevertToNodeIdPlugin: GraphileConfig.Plugin = {

--- a/postgraphile/website/postgraphile/node-id.md
+++ b/postgraphile/website/postgraphile/node-id.md
@@ -64,8 +64,9 @@ export const client = new ApolloClient({
 
 ### Disabling the Global Object Identifier
 
-You can disable the global object identifier throughout your API by disabling
-`NodePlugin`:
+The global object identifier is added by the amber preset. If you use the amber
+preset but you want to disable the global object identifier throughout your API,
+you can do so by disabling `NodePlugin`:
 
 ```ts title="graphile.config.mjs"
 export default {
@@ -114,7 +115,7 @@ ID is stable for the same object, when new objects are created there is no guara
 that their new ID will conform to the same encoding.
 
 That said, it is generally easy to extract details from PostGraphile's globally
-unique IDs. Take for example the Unique ID `WyJQb3N0IiwxXQ==`. By base64 decoding
+unique IDs. Take for example the unique ID `WyJQb3N0IiwxXQ==`. By base64 decoding
 this value, we can see the data in it is `["Post",1]`. This states that it is for
 the `Post` GraphQL type, and the associated primary key value is `1`. (If you are
 using the V4 preset then `nodeId`s will use the table name (or a derivative thereof)

--- a/postgraphile/website/postgraphile/node-id.md
+++ b/postgraphile/website/postgraphile/node-id.md
@@ -41,6 +41,32 @@ const IdPlugin: GraphileConfig.Plugin = {
 };
 ```
 
+Like the `postgraphile/presets/relay` preset, the `postgraphile/presets/amber`
+preset also uses the field name `id` for the unique identifier and renames `id`
+columns in database tables to `rowId` via the NodePlugin and PgAttributesPlugin
+respectively. If you're using the amber preset and want to revert to using
+`nodeId` for the unique identifier and `id` for any `id` columns in your database,
+you can add something like the following plugin:
+
+```ts
+const RevertToNodeIdPlugin: GraphileConfig.Plugin = {
+    name: 'RevertToNodeIdPlugin',
+    version: '1.0.0',
+    inflection: {
+        replace: {
+            nodeIdFieldName: (): string => 'nodeId',
+            attribute: (previous: any, options: any, details: any) => {
+                const name = previous!.call(this, details)
+                if (name === 'rowId') {
+                    return 'id'
+                }
+                return name
+            },
+        },
+    },
+}
+```
+
 One common use case for the `nodeId` (or `id`) field is as the cache key for
 your client library, e.g. with Apollo Client's `dataIdFromObject`:
 

--- a/postgraphile/website/postgraphile/node-id.md
+++ b/postgraphile/website/postgraphile/node-id.md
@@ -30,7 +30,7 @@ const IdToNodeIdPlugin: GraphileConfig.Plugin = {
     version: '1.0.0',
     inflection: {
         replace: {
-            nodeIdFieldName: (): string => 'nodeId',
+            nodeIdFieldName(){ return 'nodeId'; },
             attribute(previous, options, details) {
                 const name = previous!.call(this, details)
                 if (name === 'rowId') {

--- a/postgraphile/website/postgraphile/node-id.md
+++ b/postgraphile/website/postgraphile/node-id.md
@@ -41,12 +41,13 @@ const IdPlugin: GraphileConfig.Plugin = {
 };
 ```
 
-Like the `postgraphile/presets/relay` preset, the `postgraphile/presets/amber`
-preset also uses the field name `id` for the unique identifier with the
-`NodePlugin` and renames `id` columns in database tables to `rowId` with the
-PgAttributesPlugin respectively. If you're using the amber preset and want to
-revert to using `nodeId` for the unique identifier and `id` for any `id` columns
-in your database, you can add something like the following plugin:
+Similarly to the `postgraphile/presets/relay` preset, the
+`postgraphile/presets/amber` preset also sets nodeIdFieldName to `id` with
+`graphile-build`'s `NodePlugin`. The amber preset also mirrors the relay preset
+in renaming `id` columns in database tables to `rowId` with `graphile-build-pg`'s
+`PgAttributesPlugin`. If you are using the amber preset and you want to revert to
+using `nodeId` for the unique identifier and `id` attribute name for any `id`
+columns in your database, you can add something like the following plugin:
 
 ```ts
 const RevertToNodeIdPlugin: GraphileConfig.Plugin = {


### PR DESCRIPTION
## Description

Added a section to nodeId/relay portion of documentation to clarify that the amber preset also overrides postgraphile's default.

Also included a plugin to revert that, though I can remove that if we think it is too verbose

Following up on discord thread: https://discord.com/channels/489127045289476126/489717163280826374/1220790554334334996

## Performance impact

None

## Security impact

None

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
