### PR TITLE
Render flagged dependencies in mermaid

### DIFF
--- a/grafast/grafast/src/engine/OperationPlan.ts
+++ b/grafast/grafast/src/engine/OperationPlan.ts
@@ -3369,7 +3369,9 @@ export class OperationPlan {
         bucketId: step.layerPlan.id,
         dependencyIds: sstep.dependencies.map((d) => d.id),
         dependencyForbiddenFlags: sstep.dependencyForbiddenFlags.slice(),
-        dependencyOnReject: sstep.dependencyOnReject.map(String),
+        dependencyOnReject: sstep.dependencyOnReject.map((or) =>
+          or ? String(or) : or,
+        ),
         polymorphicPaths: step.polymorphicPaths
           ? [...step.polymorphicPaths]
           : undefined,

--- a/grafast/grafast/src/engine/OperationPlan.ts
+++ b/grafast/grafast/src/engine/OperationPlan.ts
@@ -3360,13 +3360,16 @@ export class OperationPlan {
   generatePlanJSON(): GrafastPlanJSON {
     function printStep(step: ExecutableStep): GrafastPlanStepJSONv1 {
       const metaString = step.toStringMeta();
+      const sstep = sudo(step);
       return {
         id: step.id,
         stepClass: step.constructor.name,
         metaString: metaString ? stripAnsi(metaString) : metaString,
         isUnary: step._isUnary,
         bucketId: step.layerPlan.id,
-        dependencyIds: sudo(step).dependencies.map((d) => d.id),
+        dependencyIds: sstep.dependencies.map((d) => d.id),
+        dependencyForbiddenFlags: sstep.dependencyForbiddenFlags.slice(),
+        dependencyOnReject: sstep.dependencyOnReject.map(String),
         polymorphicPaths: step.polymorphicPaths
           ? [...step.polymorphicPaths]
           : undefined,

--- a/grafast/grafast/src/planJSONInterfaces.ts
+++ b/grafast/grafast/src/planJSONInterfaces.ts
@@ -12,7 +12,7 @@ export interface GrafastPlanStepJSONv1 {
   bucketId: string | number;
   dependencyIds: ReadonlyArray<string | number>;
   dependencyForbiddenFlags: ReadonlyArray<ExecutionEntryFlags>;
-  dependencyOnReject: ReadonlyArray<string>;
+  dependencyOnReject: ReadonlyArray<string | null | undefined>;
   polymorphicPaths: readonly string[] | undefined;
   isSyncAndSafe: boolean | undefined;
   supportsUnbatched: boolean | undefined;

--- a/grafast/grafast/src/planJSONInterfaces.ts
+++ b/grafast/grafast/src/planJSONInterfaces.ts
@@ -1,3 +1,5 @@
+import type { ExecutionEntryFlags } from "./interfaces";
+
 export interface GrafastPlanJSON {
   version: "v1" | "v2";
 }
@@ -9,6 +11,8 @@ export interface GrafastPlanStepJSONv1 {
   isUnary: boolean;
   bucketId: string | number;
   dependencyIds: ReadonlyArray<string | number>;
+  dependencyForbiddenFlags: ReadonlyArray<ExecutionEntryFlags>;
+  dependencyOnReject: ReadonlyArray<string>;
   polymorphicPaths: readonly string[] | undefined;
   isSyncAndSafe: boolean | undefined;
   supportsUnbatched: boolean | undefined;

--- a/grafast/grafast/src/steps/__flag.ts
+++ b/grafast/grafast/src/steps/__flag.ts
@@ -180,8 +180,8 @@ export class __FlagStep<TData> extends ExecutableStep<TData> {
  * Example use case: get user by id, but id is null: no need to fetch the user
  * since we know they won't exist.
  */
-export function inhibitOnNull($step: ExecutableStep) {
-  return new __FlagStep($step, {
+export function inhibitOnNull<T>($step: ExecutableStep<T>) {
+  return new __FlagStep<T>($step, {
     acceptFlags: DEFAULT_ACCEPT_FLAGS & ~FLAG_NULL,
   });
 }
@@ -191,20 +191,23 @@ export function inhibitOnNull($step: ExecutableStep) {
  * that represents a Post instead: throw error to tell user they've sent invalid
  * data.
  */
-export function assertNotNull(
-  $step: ExecutableStep,
+export function assertNotNull<T>(
+  $step: ExecutableStep<T>,
   message: string,
   options?: { if?: FlagStepOptions["if"] },
 ) {
-  return new __FlagStep($step, {
+  return new __FlagStep<T>($step, {
     ...options,
     acceptFlags: DEFAULT_ACCEPT_FLAGS & ~FLAG_NULL,
     onReject: newGrafastError(new SafeError(message), $step.id),
   });
 }
 
-export function trap($step: ExecutableStep, acceptFlags: ExecutionEntryFlags) {
-  return new __FlagStep($step, {
+export function trap<T>(
+  $step: ExecutableStep<T>,
+  acceptFlags: ExecutionEntryFlags,
+) {
+  return new __FlagStep<T>($step, {
     acceptFlags: (acceptFlags & TRAPPABLE_FLAGS) | FLAG_NULL,
   });
 }

--- a/graphile-build/graphile-build-pg/src/plugins/PgIntrospectionPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgIntrospectionPlugin.ts
@@ -359,6 +359,14 @@ export const PgIntrospectionPlugin: GraphileConfig.Plugin = {
                       ? ctx.get(pgSettingsKey)
                       : constant(null),
                   withPgClient: ctx.get(withPgClientKey),
+                  /* TODO: consider doing:
+                  ```
+                  withPgClient: assertNotNull(
+                    ctx.get(withPgClientKey),
+                    `Server is misconfigured; unable to find '${withPgClientKey}' in context.`,
+                  ),
+                  ```
+                  */
                 } as PgExecutorContextPlans<any>);
               },
             }),

--- a/graphile-build/graphile-build-pg/src/plugins/PgIntrospectionPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgIntrospectionPlugin.ts
@@ -339,6 +339,14 @@ export const PgIntrospectionPlugin: GraphileConfig.Plugin = {
           throw new Error(`Database '${serviceName}' not found`);
         }
         const { pgSettingsKey, withPgClientKey } = pgService;
+        /* TODO: consider replacing the `withPgClient` with:
+           ```
+           withPgClient: assertNotNull(
+             ctx.get(withPgClientKey),
+             `Server is misconfigured; unable to find '${withPgClientKey}' in context.`,
+           ),
+           ```
+        */
         const executor = EXPORTABLE(
           (
             PgExecutor,
@@ -359,14 +367,6 @@ export const PgIntrospectionPlugin: GraphileConfig.Plugin = {
                       ? ctx.get(pgSettingsKey)
                       : constant(null),
                   withPgClient: ctx.get(withPgClientKey),
-                  /* TODO: consider doing:
-                  ```
-                  withPgClient: assertNotNull(
-                    ctx.get(withPgClientKey),
-                    `Server is misconfigured; unable to find '${withPgClientKey}' in context.`,
-                  ),
-                  ```
-                  */
                 } as PgExecutorContextPlans<any>);
               },
             }),

--- a/postgraphile/postgraphile/__tests__/mutations/v4/mutation-delete.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/mutation-delete.mermaid
@@ -40,7 +40,8 @@ graph TD
     Constant406{{"Constant[406∈0]<br />ᐸ'graphile-build.issue.27.exists@example.com'ᐳ"}}:::plan
     Constant408{{"Constant[408∈0]<br />ᐸ1ᐳ"}}:::plan
     PgDeleteSingle13[["PgDeleteSingle[13∈1]<br />ᐸpost(id)ᐳ"]]:::sideeffectplan
-    Object16 & Access11 --> PgDeleteSingle13
+    Object16 -->|rejectNull| PgDeleteSingle13
+    Access11 --> PgDeleteSingle13
     Object17{{"Object[17∈1]<br />ᐸ{result}ᐳ"}}:::plan
     PgDeleteSingle13 --> Object17
     List21{{"List[21∈2]<br />ᐸ19,20ᐳ"}}:::plan
@@ -61,7 +62,8 @@ graph TD
     PgDeleteSingle38[["PgDeleteSingle[38∈5]<br />ᐸpost(id)ᐳ"]]:::sideeffectplan
     Object41{{"Object[41∈5]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access36{{"Access[36∈5]<br />ᐸ35.1ᐳ"}}:::plan
-    Object41 & Access36 --> PgDeleteSingle38
+    Object41 -->|rejectNull| PgDeleteSingle38
+    Access36 --> PgDeleteSingle38
     Access39{{"Access[39∈5]<br />ᐸ3.pgSettingsᐳ"}}:::plan
     Access40{{"Access[40∈5]<br />ᐸ3.withPgClientᐳ"}}:::plan
     Access39 & Access40 --> Object41
@@ -89,7 +91,8 @@ graph TD
     PgDeleteSingle62[["PgDeleteSingle[62∈9]<br />ᐸpost(id)ᐳ"]]:::sideeffectplan
     Object65{{"Object[65∈9]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access60{{"Access[60∈9]<br />ᐸ59.1ᐳ"}}:::plan
-    Object65 & Access60 --> PgDeleteSingle62
+    Object65 -->|rejectNull| PgDeleteSingle62
+    Access60 --> PgDeleteSingle62
     Access63{{"Access[63∈9]<br />ᐸ3.pgSettingsᐳ"}}:::plan
     Access64{{"Access[64∈9]<br />ᐸ3.withPgClientᐳ"}}:::plan
     Access63 & Access64 --> Object65
@@ -118,7 +121,8 @@ graph TD
     PgDeleteSingle87[["PgDeleteSingle[87∈13]<br />ᐸpost(id)ᐳ"]]:::sideeffectplan
     Object90{{"Object[90∈13]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access85{{"Access[85∈13]<br />ᐸ84.1ᐳ"}}:::plan
-    Object90 & Access85 --> PgDeleteSingle87
+    Object90 -->|rejectNull| PgDeleteSingle87
+    Access85 --> PgDeleteSingle87
     Access88{{"Access[88∈13]<br />ᐸ3.pgSettingsᐳ"}}:::plan
     Access89{{"Access[89∈13]<br />ᐸ3.withPgClientᐳ"}}:::plan
     Access88 & Access89 --> Object90
@@ -262,7 +266,9 @@ graph TD
     Object214{{"Object[214∈35]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access207{{"Access[207∈35]<br />ᐸ206.1ᐳ"}}:::plan
     Access209{{"Access[209∈35]<br />ᐸ206.2ᐳ"}}:::plan
-    Object214 & Access207 & Access209 --> PgDeleteSingle211
+    Object214 -->|rejectNull| PgDeleteSingle211
+    Access207 -->|rejectNull| PgDeleteSingle211
+    Access209 --> PgDeleteSingle211
     Access212{{"Access[212∈35]<br />ᐸ3.pgSettingsᐳ"}}:::plan
     Access213{{"Access[213∈35]<br />ᐸ3.withPgClientᐳ"}}:::plan
     Access212 & Access213 --> Object214

--- a/postgraphile/postgraphile/__tests__/mutations/v4/mutation-update.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/mutation-update.mermaid
@@ -47,7 +47,8 @@ graph TD
     Constant629{{"Constant[629∈0]<br />ᐸ1ᐳ"}}:::plan
     Constant632{{"Constant[632∈0]<br />ᐸ'New String'ᐳ"}}:::plan
     PgUpdateSingle25[["PgUpdateSingle[25∈1]<br />ᐸperson(id;person_full_name,about)ᐳ"]]:::sideeffectplan
-    Object28 & Access23 & Constant592 & Constant593 --> PgUpdateSingle25
+    Object28 -->|rejectNull| PgUpdateSingle25
+    Access23 & Constant592 & Constant593 --> PgUpdateSingle25
     Object29{{"Object[29∈1]<br />ᐸ{result}ᐳ"}}:::plan
     PgUpdateSingle25 --> Object29
     Edge59{{"Edge[59∈2]"}}:::plan
@@ -99,7 +100,8 @@ graph TD
     PgUpdateSingle88[["PgUpdateSingle[88∈7]<br />ᐸperson(id;person_full_name,email)ᐳ"]]:::sideeffectplan
     Object91{{"Object[91∈7]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access86{{"Access[86∈7]<br />ᐸ85.1ᐳ"}}:::plan
-    Object91 & Access86 & Constant597 & Constant598 --> PgUpdateSingle88
+    Object91 -->|rejectNull| PgUpdateSingle88
+    Access86 & Constant597 & Constant598 --> PgUpdateSingle88
     Access89{{"Access[89∈7]<br />ᐸ3.pgSettingsᐳ"}}:::plan
     Access90{{"Access[90∈7]<br />ᐸ3.withPgClientᐳ"}}:::plan
     Access89 & Access90 --> Object91
@@ -158,7 +160,8 @@ graph TD
     PgUpdateSingle150[["PgUpdateSingle[150∈13]<br />ᐸperson(id;about)ᐳ"]]:::sideeffectplan
     Object153{{"Object[153∈13]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access148{{"Access[148∈13]<br />ᐸ147.1ᐳ"}}:::plan
-    Object153 & Access148 & Constant602 --> PgUpdateSingle150
+    Object153 -->|rejectNull| PgUpdateSingle150
+    Access148 & Constant602 --> PgUpdateSingle150
     Access151{{"Access[151∈13]<br />ᐸ3.pgSettingsᐳ"}}:::plan
     Access152{{"Access[152∈13]<br />ᐸ3.withPgClientᐳ"}}:::plan
     Access151 & Access152 --> Object153
@@ -217,7 +220,8 @@ graph TD
     PgUpdateSingle212[["PgUpdateSingle[212∈19]<br />ᐸperson(id;about)ᐳ"]]:::sideeffectplan
     Object215{{"Object[215∈19]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access210{{"Access[210∈19]<br />ᐸ209.1ᐳ"}}:::plan
-    Object215 & Access210 & Constant605 --> PgUpdateSingle212
+    Object215 -->|rejectNull| PgUpdateSingle212
+    Access210 & Constant605 --> PgUpdateSingle212
     Access213{{"Access[213∈19]<br />ᐸ3.pgSettingsᐳ"}}:::plan
     Access214{{"Access[214∈19]<br />ᐸ3.withPgClientᐳ"}}:::plan
     Access213 & Access214 --> Object215
@@ -390,7 +394,9 @@ graph TD
     Object392{{"Object[392∈37]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access385{{"Access[385∈37]<br />ᐸ384.1ᐳ"}}:::plan
     Access387{{"Access[387∈37]<br />ᐸ384.2ᐳ"}}:::plan
-    Object392 & Access385 & Access387 & Constant615 & Constant616 --> PgUpdateSingle389
+    Object392 -->|rejectNull| PgUpdateSingle389
+    Access385 -->|rejectNull| PgUpdateSingle389
+    Access387 & Constant615 & Constant616 --> PgUpdateSingle389
     Access390{{"Access[390∈37]<br />ᐸ3.pgSettingsᐳ"}}:::plan
     Access391{{"Access[391∈37]<br />ᐸ3.withPgClientᐳ"}}:::plan
     Access390 & Access391 --> Object392

--- a/postgraphile/postgraphile/__tests__/mutations/v4/relay.createLeftArm.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/relay.createLeftArm.mermaid
@@ -25,7 +25,8 @@ graph TD
     __Value5["__Value[5∈0]<br />ᐸrootValueᐳ"]:::plan
     Constant39{{"Constant[39∈0]<br />ᐸ0.69ᐳ"}}:::plan
     PgInsertSingle14[["PgInsertSingle[14∈1]<br />ᐸleft_arm(length_in_metres,person_id)ᐳ"]]:::sideeffectplan
-    Object17 & Constant39 & Access20 --> PgInsertSingle14
+    Constant39 -->|rejectNull| PgInsertSingle14
+    Object17 & Access20 --> PgInsertSingle14
     Object18{{"Object[18∈1]<br />ᐸ{result}ᐳ"}}:::plan
     PgInsertSingle14 --> Object18
     List24{{"List[24∈3]<br />ᐸ22,23ᐳ"}}:::plan

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/simple-single-table-items-root-topic.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/simple-single-table-items-root-topic.mermaid
@@ -15,7 +15,8 @@ graph TD
     Access16 & Access17 --> Object18
     PgSelect107[["PgSelect[107∈0]<br />ᐸsingle_table_itemsᐳ"]]:::plan
     Access105{{"Access[105∈0]<br />ᐸ104.1ᐳ"}}:::plan
-    Object18 & Access105 --> PgSelect107
+    Object18 -->|rejectNull| PgSelect107
+    Access105 --> PgSelect107
     __Value3["__Value[3∈0]<br />ᐸcontextᐳ"]:::plan
     __Value3 --> Access16
     __Value3 --> Access17
@@ -103,45 +104,65 @@ graph TD
     PgSelect200[["PgSelect[200∈7]<br />ᐸrelational_item_relation_composite_pksᐳ<br />ᐳRelationalItemRelationCompositePk"]]:::plan
     Access377{{"Access[377∈7]<br />ᐸ131.base64JSON.1ᐳ<br />ᐳSingleTableTopic<br />ᐳPerson<br />ᐳLogEntry<br />ᐳOrganization<br />ᐳAwsApplication<br />ᐳGcpApplication<br />ᐳRelationalItemRelation<br />ᐳRelationalItemRelationCompositePk<br />ᐳSingleTableItemRelation<br />ᐳSingleTableItemRelationCompositePk<br />ᐳSingleTablePost<br />ᐳPriority<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem<br />ᐳFirstPartyVulnerability<br />ᐳThirdPartyVulnerability"}}:::plan
     Access378{{"Access[378∈7]<br />ᐸ131.base64JSON.2ᐳ<br />ᐳRelationalItemRelationCompositePk<br />ᐳSingleTableItemRelationCompositePk"}}:::plan
-    Object18 & Access377 & Access378 --> PgSelect200
+    Object18 -->|rejectNull| PgSelect200
+    Access377 -->|rejectNull| PgSelect200
+    Access378 --> PgSelect200
     PgSelect220[["PgSelect[220∈7]<br />ᐸsingle_table_item_relation_composite_pksᐳ<br />ᐳSingleTableItemRelationCompositePk"]]:::plan
-    Object18 & Access377 & Access378 --> PgSelect220
+    Object18 -->|rejectNull| PgSelect220
+    Access377 -->|rejectNull| PgSelect220
+    Access378 --> PgSelect220
     PgSelect135[["PgSelect[135∈7]<br />ᐸsingle_table_itemsᐳ<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"]]:::plan
-    Object18 & Access377 --> PgSelect135
+    Object18 -->|rejectNull| PgSelect135
+    Access377 --> PgSelect135
     PgSelect144[["PgSelect[144∈7]<br />ᐸpeopleᐳ<br />ᐳPerson"]]:::plan
-    Object18 & Access377 --> PgSelect144
+    Object18 -->|rejectNull| PgSelect144
+    Access377 --> PgSelect144
     PgSelect153[["PgSelect[153∈7]<br />ᐸlog_entriesᐳ<br />ᐳLogEntry"]]:::plan
-    Object18 & Access377 --> PgSelect153
+    Object18 -->|rejectNull| PgSelect153
+    Access377 --> PgSelect153
     PgSelect162[["PgSelect[162∈7]<br />ᐸorganizationsᐳ<br />ᐳOrganization"]]:::plan
-    Object18 & Access377 --> PgSelect162
+    Object18 -->|rejectNull| PgSelect162
+    Access377 --> PgSelect162
     PgSelect171[["PgSelect[171∈7]<br />ᐸaws_applicationsᐳ<br />ᐳAwsApplication"]]:::plan
-    Object18 & Access377 --> PgSelect171
+    Object18 -->|rejectNull| PgSelect171
+    Access377 --> PgSelect171
     PgSelect180[["PgSelect[180∈7]<br />ᐸgcp_applicationsᐳ<br />ᐳGcpApplication"]]:::plan
-    Object18 & Access377 --> PgSelect180
+    Object18 -->|rejectNull| PgSelect180
+    Access377 --> PgSelect180
     PgSelect189[["PgSelect[189∈7]<br />ᐸrelational_item_relationsᐳ<br />ᐳRelationalItemRelation"]]:::plan
-    Object18 & Access377 --> PgSelect189
+    Object18 -->|rejectNull| PgSelect189
+    Access377 --> PgSelect189
     PgSelect209[["PgSelect[209∈7]<br />ᐸsingle_table_item_relationsᐳ<br />ᐳSingleTableItemRelation"]]:::plan
-    Object18 & Access377 --> PgSelect209
+    Object18 -->|rejectNull| PgSelect209
+    Access377 --> PgSelect209
     PgSelect238[["PgSelect[238∈7]<br />ᐸprioritiesᐳ<br />ᐳPriority"]]:::plan
-    Object18 & Access377 --> PgSelect238
+    Object18 -->|rejectNull| PgSelect238
+    Access377 --> PgSelect238
     List256{{"List[256∈7]<br />ᐸ254,253ᐳ<br />ᐳSingleTableDivider"}}:::plan
     Constant254{{"Constant[254∈7]<br />ᐸ'SingleTableDivider'ᐳ<br />ᐳSingleTableDivider"}}:::plan
     PgClassExpression253{{"PgClassExpression[253∈7]<br />ᐸ__single_t...ems__.”id”ᐳ<br />ᐳSingleTableDivider"}}:::plan
     Constant254 & PgClassExpression253 --> List256
     PgSelect290[["PgSelect[290∈7]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    Object18 & Access377 --> PgSelect290
+    Object18 -->|rejectNull| PgSelect290
+    Access377 --> PgSelect290
     PgSelect299[["PgSelect[299∈7]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object18 & Access377 --> PgSelect299
+    Object18 -->|rejectNull| PgSelect299
+    Access377 --> PgSelect299
     PgSelect308[["PgSelect[308∈7]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object18 & Access377 --> PgSelect308
+    Object18 -->|rejectNull| PgSelect308
+    Access377 --> PgSelect308
     PgSelect317[["PgSelect[317∈7]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object18 & Access377 --> PgSelect317
+    Object18 -->|rejectNull| PgSelect317
+    Access377 --> PgSelect317
     PgSelect326[["PgSelect[326∈7]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object18 & Access377 --> PgSelect326
+    Object18 -->|rejectNull| PgSelect326
+    Access377 --> PgSelect326
     PgSelect336[["PgSelect[336∈7]<br />ᐸfirst_party_vulnerabilitiesᐳ<br />ᐳFirstPartyVulnerability"]]:::plan
-    Object18 & Access377 --> PgSelect336
+    Object18 -->|rejectNull| PgSelect336
+    Access377 --> PgSelect336
     PgSelect345[["PgSelect[345∈7]<br />ᐸthird_party_vulnerabilitiesᐳ<br />ᐳThirdPartyVulnerability"]]:::plan
-    Object18 & Access377 --> PgSelect345
+    Object18 -->|rejectNull| PgSelect345
+    Access377 --> PgSelect345
     First139{{"First[139∈7]"}}:::plan
     PgSelect135 --> First139
     PgSelectSingle140{{"PgSelectSingle[140∈7]<br />ᐸsingle_table_itemsᐳ"}}:::plan

--- a/postgraphile/postgraphile/__tests__/queries/v4/large_bigint.issue491.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/large_bigint.issue491.mermaid
@@ -15,10 +15,12 @@ graph TD
     Access16 & Access17 --> Object18
     PgSelect33[["PgSelect[33∈0]<br />ᐸlarge_node_idᐳ"]]:::plan
     Access31{{"Access[31∈0]<br />ᐸ30.1ᐳ"}}:::plan
-    Object18 & Access31 --> PgSelect33
+    Object18 -->|rejectNull| PgSelect33
+    Access31 --> PgSelect33
     PgSelect49[["PgSelect[49∈0]<br />ᐸlarge_node_idᐳ"]]:::plan
     Access47{{"Access[47∈0]<br />ᐸ46.1ᐳ"}}:::plan
-    Object18 & Access47 --> PgSelect49
+    Object18 -->|rejectNull| PgSelect49
+    Access47 --> PgSelect49
     __Value3["__Value[3∈0]<br />ᐸcontextᐳ"]:::plan
     __Value3 --> Access16
     __Value3 --> Access17

--- a/postgraphile/postgraphile/__tests__/queries/v4/node.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/node.mermaid
@@ -13,33 +13,44 @@ graph TD
     Object18{{"Object[18∈0]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Access1632{{"Access[1632∈0]<br />ᐸ1631.1ᐳ"}}:::plan
     Access1634{{"Access[1634∈0]<br />ᐸ1631.2ᐳ"}}:::plan
-    Object18 & Access1632 & Access1634 --> PgSelect1636
+    Object18 -->|rejectNull| PgSelect1636
+    Access1632 -->|rejectNull| PgSelect1636
+    Access1634 --> PgSelect1636
     PgSelect1655[["PgSelect[1655∈0]<br />ᐸcompound_keyᐳ"]]:::plan
     Access1651{{"Access[1651∈0]<br />ᐸ1650.1ᐳ"}}:::plan
     Access1653{{"Access[1653∈0]<br />ᐸ1650.2ᐳ"}}:::plan
-    Object18 & Access1651 & Access1653 --> PgSelect1655
+    Object18 -->|rejectNull| PgSelect1655
+    Access1651 -->|rejectNull| PgSelect1655
+    Access1653 --> PgSelect1655
     PgSelect1674[["PgSelect[1674∈0]<br />ᐸcompound_keyᐳ"]]:::plan
     Access1670{{"Access[1670∈0]<br />ᐸ1669.1ᐳ"}}:::plan
     Access1672{{"Access[1672∈0]<br />ᐸ1669.2ᐳ"}}:::plan
-    Object18 & Access1670 & Access1672 --> PgSelect1674
+    Object18 -->|rejectNull| PgSelect1674
+    Access1670 -->|rejectNull| PgSelect1674
+    Access1672 --> PgSelect1674
     Access16{{"Access[16∈0]<br />ᐸ3.pgSettingsᐳ"}}:::plan
     Access17{{"Access[17∈0]<br />ᐸ3.withPgClientᐳ"}}:::plan
     Access16 & Access17 --> Object18
     PgSelect1586[["PgSelect[1586∈0]<br />ᐸpersonᐳ"]]:::plan
     Access1584{{"Access[1584∈0]<br />ᐸ1583.1ᐳ"}}:::plan
-    Object18 & Access1584 --> PgSelect1586
+    Object18 -->|rejectNull| PgSelect1586
+    Access1584 --> PgSelect1586
     PgSelect1602[["PgSelect[1602∈0]<br />ᐸpersonᐳ"]]:::plan
     Access1600{{"Access[1600∈0]<br />ᐸ1599.1ᐳ"}}:::plan
-    Object18 & Access1600 --> PgSelect1602
+    Object18 -->|rejectNull| PgSelect1602
+    Access1600 --> PgSelect1602
     PgSelect1618[["PgSelect[1618∈0]<br />ᐸpersonᐳ"]]:::plan
     Access1616{{"Access[1616∈0]<br />ᐸ1615.1ᐳ"}}:::plan
-    Object18 & Access1616 --> PgSelect1618
+    Object18 -->|rejectNull| PgSelect1618
+    Access1616 --> PgSelect1618
     PgSelect2201[["PgSelect[2201∈0]<br />ᐸsimilar_table_1ᐳ"]]:::plan
     Access2199{{"Access[2199∈0]<br />ᐸ2198.1ᐳ"}}:::plan
-    Object18 & Access2199 --> PgSelect2201
+    Object18 -->|rejectNull| PgSelect2201
+    Access2199 --> PgSelect2201
     PgSelect2219[["PgSelect[2219∈0]<br />ᐸsimilar_table_2ᐳ"]]:::plan
     Access2217{{"Access[2217∈0]<br />ᐸ2216.1ᐳ"}}:::plan
-    Object18 & Access2217 --> PgSelect2219
+    Object18 -->|rejectNull| PgSelect2219
+    Access2217 --> PgSelect2219
     __Value3["__Value[3∈0]<br />ᐸcontextᐳ"]:::plan
     __Value3 --> Access16
     __Value3 --> Access17
@@ -179,110 +190,129 @@ graph TD
     PgSelect141[["PgSelect[141∈7]<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
     Access2396{{"Access[2396∈7]<br />ᐸ54.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access2397{{"Access[2397∈7]<br />ᐸ54.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
-    Object18 & Access2396 & Access2397 --> PgSelect141
+    Object18 -->|rejectNull| PgSelect141
+    Access2396 -->|rejectNull| PgSelect141
+    Access2397 --> PgSelect141
     List150{{"List[150∈7]<br />ᐸ147,148,149ᐳ<br />ᐳCompoundKey"}}:::plan
     Constant147{{"Constant[147∈7]<br />ᐸ'compound_keys'ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression148{{"PgClassExpression[148∈7]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression149{{"PgClassExpression[149∈7]<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     Constant147 & PgClassExpression148 & PgClassExpression149 --> List150
     PgSelect61[["PgSelect[61∈7]<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
-    Object18 & Access2396 --> PgSelect61
+    Object18 -->|rejectNull| PgSelect61
+    Access2396 --> PgSelect61
     List69{{"List[69∈7]<br />ᐸ67,68ᐳ<br />ᐳInput"}}:::plan
     Constant67{{"Constant[67∈7]<br />ᐸ'inputs'ᐳ<br />ᐳInput"}}:::plan
     PgClassExpression68{{"PgClassExpression[68∈7]<br />ᐸ__inputs__.”id”ᐳ"}}:::plan
     Constant67 & PgClassExpression68 --> List69
     PgSelect74[["PgSelect[74∈7]<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
-    Object18 & Access2396 --> PgSelect74
+    Object18 -->|rejectNull| PgSelect74
+    Access2396 --> PgSelect74
     List82{{"List[82∈7]<br />ᐸ80,81ᐳ<br />ᐳPatch"}}:::plan
     Constant80{{"Constant[80∈7]<br />ᐸ'patchs'ᐳ<br />ᐳPatch"}}:::plan
     PgClassExpression81{{"PgClassExpression[81∈7]<br />ᐸ__patchs__.”id”ᐳ"}}:::plan
     Constant80 & PgClassExpression81 --> List82
     PgSelect87[["PgSelect[87∈7]<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
-    Object18 & Access2396 --> PgSelect87
+    Object18 -->|rejectNull| PgSelect87
+    Access2396 --> PgSelect87
     List95{{"List[95∈7]<br />ᐸ93,94ᐳ<br />ᐳReserved"}}:::plan
     Constant93{{"Constant[93∈7]<br />ᐸ'reserveds'ᐳ<br />ᐳReserved"}}:::plan
     PgClassExpression94{{"PgClassExpression[94∈7]<br />ᐸ__reserved__.”id”ᐳ"}}:::plan
     Constant93 & PgClassExpression94 --> List95
     PgSelect100[["PgSelect[100∈7]<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
-    Object18 & Access2396 --> PgSelect100
+    Object18 -->|rejectNull| PgSelect100
+    Access2396 --> PgSelect100
     List108{{"List[108∈7]<br />ᐸ106,107ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     Constant106{{"Constant[106∈7]<br />ᐸ'reservedPatchs'ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     PgClassExpression107{{"PgClassExpression[107∈7]<br />ᐸ__reserved...chs__.”id”ᐳ"}}:::plan
     Constant106 & PgClassExpression107 --> List108
     PgSelect113[["PgSelect[113∈7]<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
-    Object18 & Access2396 --> PgSelect113
+    Object18 -->|rejectNull| PgSelect113
+    Access2396 --> PgSelect113
     List121{{"List[121∈7]<br />ᐸ119,120ᐳ<br />ᐳReservedInputRecord"}}:::plan
     Constant119{{"Constant[119∈7]<br />ᐸ'reserved_inputs'ᐳ<br />ᐳReservedInputRecord"}}:::plan
     PgClassExpression120{{"PgClassExpression[120∈7]<br />ᐸ__reserved_input__.”id”ᐳ"}}:::plan
     Constant119 & PgClassExpression120 --> List121
     PgSelect126[["PgSelect[126∈7]<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
-    Object18 & Access2396 --> PgSelect126
+    Object18 -->|rejectNull| PgSelect126
+    Access2396 --> PgSelect126
     List134{{"List[134∈7]<br />ᐸ132,133ᐳ<br />ᐳDefaultValue"}}:::plan
     Constant132{{"Constant[132∈7]<br />ᐸ'default_values'ᐳ<br />ᐳDefaultValue"}}:::plan
     PgClassExpression133{{"PgClassExpression[133∈7]<br />ᐸ__default_value__.”id”ᐳ"}}:::plan
     Constant132 & PgClassExpression133 --> List134
     PgSelect157[["PgSelect[157∈7]<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
-    Object18 & Access2396 --> PgSelect157
+    Object18 -->|rejectNull| PgSelect157
+    Access2396 --> PgSelect157
     List165{{"List[165∈7]<br />ᐸ163,164ᐳ<br />ᐳPerson"}}:::plan
     Constant163{{"Constant[163∈7]<br />ᐸ'people'ᐳ<br />ᐳPerson"}}:::plan
     PgClassExpression164{{"PgClassExpression[164∈7]<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant163 & PgClassExpression164 --> List165
     PgSelect172[["PgSelect[172∈7]<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
-    Object18 & Access2396 --> PgSelect172
+    Object18 -->|rejectNull| PgSelect172
+    Access2396 --> PgSelect172
     List180{{"List[180∈7]<br />ᐸ178,179ᐳ<br />ᐳPost"}}:::plan
     Constant178{{"Constant[178∈7]<br />ᐸ'posts'ᐳ<br />ᐳPost"}}:::plan
     PgClassExpression179{{"PgClassExpression[179∈7]<br />ᐸ__post__.”id”ᐳ"}}:::plan
     Constant178 & PgClassExpression179 --> List180
     PgSelect185[["PgSelect[185∈7]<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
-    Object18 & Access2396 --> PgSelect185
+    Object18 -->|rejectNull| PgSelect185
+    Access2396 --> PgSelect185
     List193{{"List[193∈7]<br />ᐸ191,192ᐳ<br />ᐳType"}}:::plan
     Constant191{{"Constant[191∈7]<br />ᐸ'types'ᐳ<br />ᐳType"}}:::plan
     PgClassExpression192{{"PgClassExpression[192∈7]<br />ᐸ__types__.”id”ᐳ"}}:::plan
     Constant191 & PgClassExpression192 --> List193
     PgSelect198[["PgSelect[198∈7]<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
-    Object18 & Access2396 --> PgSelect198
+    Object18 -->|rejectNull| PgSelect198
+    Access2396 --> PgSelect198
     List206{{"List[206∈7]<br />ᐸ204,205ᐳ<br />ᐳPersonSecret"}}:::plan
     Constant204{{"Constant[204∈7]<br />ᐸ'person_secrets'ᐳ<br />ᐳPersonSecret"}}:::plan
     PgClassExpression205{{"PgClassExpression[205∈7]<br />ᐸ__person_s...person_id”ᐳ"}}:::plan
     Constant204 & PgClassExpression205 --> List206
     PgSelect211[["PgSelect[211∈7]<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
-    Object18 & Access2396 --> PgSelect211
+    Object18 -->|rejectNull| PgSelect211
+    Access2396 --> PgSelect211
     List219{{"List[219∈7]<br />ᐸ217,218ᐳ<br />ᐳLeftArm"}}:::plan
     Constant217{{"Constant[217∈7]<br />ᐸ'left_arms'ᐳ<br />ᐳLeftArm"}}:::plan
     PgClassExpression218{{"PgClassExpression[218∈7]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
     Constant217 & PgClassExpression218 --> List219
     PgSelect224[["PgSelect[224∈7]<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
-    Object18 & Access2396 --> PgSelect224
+    Object18 -->|rejectNull| PgSelect224
+    Access2396 --> PgSelect224
     List232{{"List[232∈7]<br />ᐸ230,231ᐳ<br />ᐳMyTable"}}:::plan
     Constant230{{"Constant[230∈7]<br />ᐸ'my_tables'ᐳ<br />ᐳMyTable"}}:::plan
     PgClassExpression231{{"PgClassExpression[231∈7]<br />ᐸ__my_table__.”id”ᐳ"}}:::plan
     Constant230 & PgClassExpression231 --> List232
     PgSelect237[["PgSelect[237∈7]<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
-    Object18 & Access2396 --> PgSelect237
+    Object18 -->|rejectNull| PgSelect237
+    Access2396 --> PgSelect237
     List245{{"List[245∈7]<br />ᐸ243,244ᐳ<br />ᐳViewTable"}}:::plan
     Constant243{{"Constant[243∈7]<br />ᐸ'view_tables'ᐳ<br />ᐳViewTable"}}:::plan
     PgClassExpression244{{"PgClassExpression[244∈7]<br />ᐸ__view_table__.”id”ᐳ"}}:::plan
     Constant243 & PgClassExpression244 --> List245
     PgSelect250[["PgSelect[250∈7]<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
-    Object18 & Access2396 --> PgSelect250
+    Object18 -->|rejectNull| PgSelect250
+    Access2396 --> PgSelect250
     List258{{"List[258∈7]<br />ᐸ256,257ᐳ<br />ᐳSimilarTable1"}}:::plan
     Constant256{{"Constant[256∈7]<br />ᐸ'similar_table_1S'ᐳ<br />ᐳSimilarTable1"}}:::plan
     PgClassExpression257{{"PgClassExpression[257∈7]<br />ᐸ__similar_...e_1__.”id”ᐳ"}}:::plan
     Constant256 & PgClassExpression257 --> List258
     PgSelect267[["PgSelect[267∈7]<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
-    Object18 & Access2396 --> PgSelect267
+    Object18 -->|rejectNull| PgSelect267
+    Access2396 --> PgSelect267
     List275{{"List[275∈7]<br />ᐸ273,274ᐳ<br />ᐳSimilarTable2"}}:::plan
     Constant273{{"Constant[273∈7]<br />ᐸ'similar_table_2S'ᐳ<br />ᐳSimilarTable2"}}:::plan
     PgClassExpression274{{"PgClassExpression[274∈7]<br />ᐸ__similar_...e_2__.”id”ᐳ"}}:::plan
     Constant273 & PgClassExpression274 --> List275
     PgSelect284[["PgSelect[284∈7]<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
-    Object18 & Access2396 --> PgSelect284
+    Object18 -->|rejectNull| PgSelect284
+    Access2396 --> PgSelect284
     List292{{"List[292∈7]<br />ᐸ290,291ᐳ<br />ᐳNullTestRecord"}}:::plan
     Constant290{{"Constant[290∈7]<br />ᐸ'null_test_records'ᐳ<br />ᐳNullTestRecord"}}:::plan
     PgClassExpression291{{"PgClassExpression[291∈7]<br />ᐸ__null_tes...ord__.”id”ᐳ"}}:::plan
     Constant290 & PgClassExpression291 --> List292
     PgSelect297[["PgSelect[297∈7]<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
-    Object18 & Access2396 --> PgSelect297
+    Object18 -->|rejectNull| PgSelect297
+    Access2396 --> PgSelect297
     List305{{"List[305∈7]<br />ᐸ303,304ᐳ<br />ᐳIssue756"}}:::plan
     Constant303{{"Constant[303∈7]<br />ᐸ'issue756S'ᐳ<br />ᐳIssue756"}}:::plan
     PgClassExpression304{{"PgClassExpression[304∈7]<br />ᐸ__issue756__.”id”ᐳ"}}:::plan
@@ -436,110 +466,129 @@ graph TD
     PgSelect396[["PgSelect[396∈8]<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
     Access2399{{"Access[2399∈8]<br />ᐸ309.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access2400{{"Access[2400∈8]<br />ᐸ309.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
-    Object18 & Access2399 & Access2400 --> PgSelect396
+    Object18 -->|rejectNull| PgSelect396
+    Access2399 -->|rejectNull| PgSelect396
+    Access2400 --> PgSelect396
     List405{{"List[405∈8]<br />ᐸ402,403,404ᐳ<br />ᐳCompoundKey"}}:::plan
     Constant402{{"Constant[402∈8]<br />ᐸ'compound_keys'ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression403{{"PgClassExpression[403∈8]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression404{{"PgClassExpression[404∈8]<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     Constant402 & PgClassExpression403 & PgClassExpression404 --> List405
     PgSelect316[["PgSelect[316∈8]<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
-    Object18 & Access2399 --> PgSelect316
+    Object18 -->|rejectNull| PgSelect316
+    Access2399 --> PgSelect316
     List324{{"List[324∈8]<br />ᐸ322,323ᐳ<br />ᐳInput"}}:::plan
     Constant322{{"Constant[322∈8]<br />ᐸ'inputs'ᐳ<br />ᐳInput"}}:::plan
     PgClassExpression323{{"PgClassExpression[323∈8]<br />ᐸ__inputs__.”id”ᐳ"}}:::plan
     Constant322 & PgClassExpression323 --> List324
     PgSelect329[["PgSelect[329∈8]<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
-    Object18 & Access2399 --> PgSelect329
+    Object18 -->|rejectNull| PgSelect329
+    Access2399 --> PgSelect329
     List337{{"List[337∈8]<br />ᐸ335,336ᐳ<br />ᐳPatch"}}:::plan
     Constant335{{"Constant[335∈8]<br />ᐸ'patchs'ᐳ<br />ᐳPatch"}}:::plan
     PgClassExpression336{{"PgClassExpression[336∈8]<br />ᐸ__patchs__.”id”ᐳ"}}:::plan
     Constant335 & PgClassExpression336 --> List337
     PgSelect342[["PgSelect[342∈8]<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
-    Object18 & Access2399 --> PgSelect342
+    Object18 -->|rejectNull| PgSelect342
+    Access2399 --> PgSelect342
     List350{{"List[350∈8]<br />ᐸ348,349ᐳ<br />ᐳReserved"}}:::plan
     Constant348{{"Constant[348∈8]<br />ᐸ'reserveds'ᐳ<br />ᐳReserved"}}:::plan
     PgClassExpression349{{"PgClassExpression[349∈8]<br />ᐸ__reserved__.”id”ᐳ"}}:::plan
     Constant348 & PgClassExpression349 --> List350
     PgSelect355[["PgSelect[355∈8]<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
-    Object18 & Access2399 --> PgSelect355
+    Object18 -->|rejectNull| PgSelect355
+    Access2399 --> PgSelect355
     List363{{"List[363∈8]<br />ᐸ361,362ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     Constant361{{"Constant[361∈8]<br />ᐸ'reservedPatchs'ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     PgClassExpression362{{"PgClassExpression[362∈8]<br />ᐸ__reserved...chs__.”id”ᐳ"}}:::plan
     Constant361 & PgClassExpression362 --> List363
     PgSelect368[["PgSelect[368∈8]<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
-    Object18 & Access2399 --> PgSelect368
+    Object18 -->|rejectNull| PgSelect368
+    Access2399 --> PgSelect368
     List376{{"List[376∈8]<br />ᐸ374,375ᐳ<br />ᐳReservedInputRecord"}}:::plan
     Constant374{{"Constant[374∈8]<br />ᐸ'reserved_inputs'ᐳ<br />ᐳReservedInputRecord"}}:::plan
     PgClassExpression375{{"PgClassExpression[375∈8]<br />ᐸ__reserved_input__.”id”ᐳ"}}:::plan
     Constant374 & PgClassExpression375 --> List376
     PgSelect381[["PgSelect[381∈8]<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
-    Object18 & Access2399 --> PgSelect381
+    Object18 -->|rejectNull| PgSelect381
+    Access2399 --> PgSelect381
     List389{{"List[389∈8]<br />ᐸ387,388ᐳ<br />ᐳDefaultValue"}}:::plan
     Constant387{{"Constant[387∈8]<br />ᐸ'default_values'ᐳ<br />ᐳDefaultValue"}}:::plan
     PgClassExpression388{{"PgClassExpression[388∈8]<br />ᐸ__default_value__.”id”ᐳ"}}:::plan
     Constant387 & PgClassExpression388 --> List389
     PgSelect412[["PgSelect[412∈8]<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
-    Object18 & Access2399 --> PgSelect412
+    Object18 -->|rejectNull| PgSelect412
+    Access2399 --> PgSelect412
     List420{{"List[420∈8]<br />ᐸ418,419ᐳ<br />ᐳPerson"}}:::plan
     Constant418{{"Constant[418∈8]<br />ᐸ'people'ᐳ<br />ᐳPerson"}}:::plan
     PgClassExpression419{{"PgClassExpression[419∈8]<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant418 & PgClassExpression419 --> List420
     PgSelect427[["PgSelect[427∈8]<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
-    Object18 & Access2399 --> PgSelect427
+    Object18 -->|rejectNull| PgSelect427
+    Access2399 --> PgSelect427
     List435{{"List[435∈8]<br />ᐸ433,434ᐳ<br />ᐳPost"}}:::plan
     Constant433{{"Constant[433∈8]<br />ᐸ'posts'ᐳ<br />ᐳPost"}}:::plan
     PgClassExpression434{{"PgClassExpression[434∈8]<br />ᐸ__post__.”id”ᐳ"}}:::plan
     Constant433 & PgClassExpression434 --> List435
     PgSelect440[["PgSelect[440∈8]<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
-    Object18 & Access2399 --> PgSelect440
+    Object18 -->|rejectNull| PgSelect440
+    Access2399 --> PgSelect440
     List448{{"List[448∈8]<br />ᐸ446,447ᐳ<br />ᐳType"}}:::plan
     Constant446{{"Constant[446∈8]<br />ᐸ'types'ᐳ<br />ᐳType"}}:::plan
     PgClassExpression447{{"PgClassExpression[447∈8]<br />ᐸ__types__.”id”ᐳ"}}:::plan
     Constant446 & PgClassExpression447 --> List448
     PgSelect453[["PgSelect[453∈8]<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
-    Object18 & Access2399 --> PgSelect453
+    Object18 -->|rejectNull| PgSelect453
+    Access2399 --> PgSelect453
     List461{{"List[461∈8]<br />ᐸ459,460ᐳ<br />ᐳPersonSecret"}}:::plan
     Constant459{{"Constant[459∈8]<br />ᐸ'person_secrets'ᐳ<br />ᐳPersonSecret"}}:::plan
     PgClassExpression460{{"PgClassExpression[460∈8]<br />ᐸ__person_s...person_id”ᐳ"}}:::plan
     Constant459 & PgClassExpression460 --> List461
     PgSelect466[["PgSelect[466∈8]<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
-    Object18 & Access2399 --> PgSelect466
+    Object18 -->|rejectNull| PgSelect466
+    Access2399 --> PgSelect466
     List474{{"List[474∈8]<br />ᐸ472,473ᐳ<br />ᐳLeftArm"}}:::plan
     Constant472{{"Constant[472∈8]<br />ᐸ'left_arms'ᐳ<br />ᐳLeftArm"}}:::plan
     PgClassExpression473{{"PgClassExpression[473∈8]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
     Constant472 & PgClassExpression473 --> List474
     PgSelect479[["PgSelect[479∈8]<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
-    Object18 & Access2399 --> PgSelect479
+    Object18 -->|rejectNull| PgSelect479
+    Access2399 --> PgSelect479
     List487{{"List[487∈8]<br />ᐸ485,486ᐳ<br />ᐳMyTable"}}:::plan
     Constant485{{"Constant[485∈8]<br />ᐸ'my_tables'ᐳ<br />ᐳMyTable"}}:::plan
     PgClassExpression486{{"PgClassExpression[486∈8]<br />ᐸ__my_table__.”id”ᐳ"}}:::plan
     Constant485 & PgClassExpression486 --> List487
     PgSelect492[["PgSelect[492∈8]<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
-    Object18 & Access2399 --> PgSelect492
+    Object18 -->|rejectNull| PgSelect492
+    Access2399 --> PgSelect492
     List500{{"List[500∈8]<br />ᐸ498,499ᐳ<br />ᐳViewTable"}}:::plan
     Constant498{{"Constant[498∈8]<br />ᐸ'view_tables'ᐳ<br />ᐳViewTable"}}:::plan
     PgClassExpression499{{"PgClassExpression[499∈8]<br />ᐸ__view_table__.”id”ᐳ"}}:::plan
     Constant498 & PgClassExpression499 --> List500
     PgSelect505[["PgSelect[505∈8]<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
-    Object18 & Access2399 --> PgSelect505
+    Object18 -->|rejectNull| PgSelect505
+    Access2399 --> PgSelect505
     List513{{"List[513∈8]<br />ᐸ511,512ᐳ<br />ᐳSimilarTable1"}}:::plan
     Constant511{{"Constant[511∈8]<br />ᐸ'similar_table_1S'ᐳ<br />ᐳSimilarTable1"}}:::plan
     PgClassExpression512{{"PgClassExpression[512∈8]<br />ᐸ__similar_...e_1__.”id”ᐳ"}}:::plan
     Constant511 & PgClassExpression512 --> List513
     PgSelect522[["PgSelect[522∈8]<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
-    Object18 & Access2399 --> PgSelect522
+    Object18 -->|rejectNull| PgSelect522
+    Access2399 --> PgSelect522
     List530{{"List[530∈8]<br />ᐸ528,529ᐳ<br />ᐳSimilarTable2"}}:::plan
     Constant528{{"Constant[528∈8]<br />ᐸ'similar_table_2S'ᐳ<br />ᐳSimilarTable2"}}:::plan
     PgClassExpression529{{"PgClassExpression[529∈8]<br />ᐸ__similar_...e_2__.”id”ᐳ"}}:::plan
     Constant528 & PgClassExpression529 --> List530
     PgSelect539[["PgSelect[539∈8]<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
-    Object18 & Access2399 --> PgSelect539
+    Object18 -->|rejectNull| PgSelect539
+    Access2399 --> PgSelect539
     List547{{"List[547∈8]<br />ᐸ545,546ᐳ<br />ᐳNullTestRecord"}}:::plan
     Constant545{{"Constant[545∈8]<br />ᐸ'null_test_records'ᐳ<br />ᐳNullTestRecord"}}:::plan
     PgClassExpression546{{"PgClassExpression[546∈8]<br />ᐸ__null_tes...ord__.”id”ᐳ"}}:::plan
     Constant545 & PgClassExpression546 --> List547
     PgSelect552[["PgSelect[552∈8]<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
-    Object18 & Access2399 --> PgSelect552
+    Object18 -->|rejectNull| PgSelect552
+    Access2399 --> PgSelect552
     List560{{"List[560∈8]<br />ᐸ558,559ᐳ<br />ᐳIssue756"}}:::plan
     Constant558{{"Constant[558∈8]<br />ᐸ'issue756S'ᐳ<br />ᐳIssue756"}}:::plan
     PgClassExpression559{{"PgClassExpression[559∈8]<br />ᐸ__issue756__.”id”ᐳ"}}:::plan
@@ -693,110 +742,129 @@ graph TD
     PgSelect651[["PgSelect[651∈9]<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
     Access2402{{"Access[2402∈9]<br />ᐸ564.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access2403{{"Access[2403∈9]<br />ᐸ564.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
-    Object18 & Access2402 & Access2403 --> PgSelect651
+    Object18 -->|rejectNull| PgSelect651
+    Access2402 -->|rejectNull| PgSelect651
+    Access2403 --> PgSelect651
     List660{{"List[660∈9]<br />ᐸ657,658,659ᐳ<br />ᐳCompoundKey"}}:::plan
     Constant657{{"Constant[657∈9]<br />ᐸ'compound_keys'ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression658{{"PgClassExpression[658∈9]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression659{{"PgClassExpression[659∈9]<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     Constant657 & PgClassExpression658 & PgClassExpression659 --> List660
     PgSelect571[["PgSelect[571∈9]<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
-    Object18 & Access2402 --> PgSelect571
+    Object18 -->|rejectNull| PgSelect571
+    Access2402 --> PgSelect571
     List579{{"List[579∈9]<br />ᐸ577,578ᐳ<br />ᐳInput"}}:::plan
     Constant577{{"Constant[577∈9]<br />ᐸ'inputs'ᐳ<br />ᐳInput"}}:::plan
     PgClassExpression578{{"PgClassExpression[578∈9]<br />ᐸ__inputs__.”id”ᐳ"}}:::plan
     Constant577 & PgClassExpression578 --> List579
     PgSelect584[["PgSelect[584∈9]<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
-    Object18 & Access2402 --> PgSelect584
+    Object18 -->|rejectNull| PgSelect584
+    Access2402 --> PgSelect584
     List592{{"List[592∈9]<br />ᐸ590,591ᐳ<br />ᐳPatch"}}:::plan
     Constant590{{"Constant[590∈9]<br />ᐸ'patchs'ᐳ<br />ᐳPatch"}}:::plan
     PgClassExpression591{{"PgClassExpression[591∈9]<br />ᐸ__patchs__.”id”ᐳ"}}:::plan
     Constant590 & PgClassExpression591 --> List592
     PgSelect597[["PgSelect[597∈9]<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
-    Object18 & Access2402 --> PgSelect597
+    Object18 -->|rejectNull| PgSelect597
+    Access2402 --> PgSelect597
     List605{{"List[605∈9]<br />ᐸ603,604ᐳ<br />ᐳReserved"}}:::plan
     Constant603{{"Constant[603∈9]<br />ᐸ'reserveds'ᐳ<br />ᐳReserved"}}:::plan
     PgClassExpression604{{"PgClassExpression[604∈9]<br />ᐸ__reserved__.”id”ᐳ"}}:::plan
     Constant603 & PgClassExpression604 --> List605
     PgSelect610[["PgSelect[610∈9]<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
-    Object18 & Access2402 --> PgSelect610
+    Object18 -->|rejectNull| PgSelect610
+    Access2402 --> PgSelect610
     List618{{"List[618∈9]<br />ᐸ616,617ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     Constant616{{"Constant[616∈9]<br />ᐸ'reservedPatchs'ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     PgClassExpression617{{"PgClassExpression[617∈9]<br />ᐸ__reserved...chs__.”id”ᐳ"}}:::plan
     Constant616 & PgClassExpression617 --> List618
     PgSelect623[["PgSelect[623∈9]<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
-    Object18 & Access2402 --> PgSelect623
+    Object18 -->|rejectNull| PgSelect623
+    Access2402 --> PgSelect623
     List631{{"List[631∈9]<br />ᐸ629,630ᐳ<br />ᐳReservedInputRecord"}}:::plan
     Constant629{{"Constant[629∈9]<br />ᐸ'reserved_inputs'ᐳ<br />ᐳReservedInputRecord"}}:::plan
     PgClassExpression630{{"PgClassExpression[630∈9]<br />ᐸ__reserved_input__.”id”ᐳ"}}:::plan
     Constant629 & PgClassExpression630 --> List631
     PgSelect636[["PgSelect[636∈9]<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
-    Object18 & Access2402 --> PgSelect636
+    Object18 -->|rejectNull| PgSelect636
+    Access2402 --> PgSelect636
     List644{{"List[644∈9]<br />ᐸ642,643ᐳ<br />ᐳDefaultValue"}}:::plan
     Constant642{{"Constant[642∈9]<br />ᐸ'default_values'ᐳ<br />ᐳDefaultValue"}}:::plan
     PgClassExpression643{{"PgClassExpression[643∈9]<br />ᐸ__default_value__.”id”ᐳ"}}:::plan
     Constant642 & PgClassExpression643 --> List644
     PgSelect667[["PgSelect[667∈9]<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
-    Object18 & Access2402 --> PgSelect667
+    Object18 -->|rejectNull| PgSelect667
+    Access2402 --> PgSelect667
     List675{{"List[675∈9]<br />ᐸ673,674ᐳ<br />ᐳPerson"}}:::plan
     Constant673{{"Constant[673∈9]<br />ᐸ'people'ᐳ<br />ᐳPerson"}}:::plan
     PgClassExpression674{{"PgClassExpression[674∈9]<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant673 & PgClassExpression674 --> List675
     PgSelect682[["PgSelect[682∈9]<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
-    Object18 & Access2402 --> PgSelect682
+    Object18 -->|rejectNull| PgSelect682
+    Access2402 --> PgSelect682
     List690{{"List[690∈9]<br />ᐸ688,689ᐳ<br />ᐳPost"}}:::plan
     Constant688{{"Constant[688∈9]<br />ᐸ'posts'ᐳ<br />ᐳPost"}}:::plan
     PgClassExpression689{{"PgClassExpression[689∈9]<br />ᐸ__post__.”id”ᐳ"}}:::plan
     Constant688 & PgClassExpression689 --> List690
     PgSelect695[["PgSelect[695∈9]<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
-    Object18 & Access2402 --> PgSelect695
+    Object18 -->|rejectNull| PgSelect695
+    Access2402 --> PgSelect695
     List703{{"List[703∈9]<br />ᐸ701,702ᐳ<br />ᐳType"}}:::plan
     Constant701{{"Constant[701∈9]<br />ᐸ'types'ᐳ<br />ᐳType"}}:::plan
     PgClassExpression702{{"PgClassExpression[702∈9]<br />ᐸ__types__.”id”ᐳ"}}:::plan
     Constant701 & PgClassExpression702 --> List703
     PgSelect708[["PgSelect[708∈9]<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
-    Object18 & Access2402 --> PgSelect708
+    Object18 -->|rejectNull| PgSelect708
+    Access2402 --> PgSelect708
     List716{{"List[716∈9]<br />ᐸ714,715ᐳ<br />ᐳPersonSecret"}}:::plan
     Constant714{{"Constant[714∈9]<br />ᐸ'person_secrets'ᐳ<br />ᐳPersonSecret"}}:::plan
     PgClassExpression715{{"PgClassExpression[715∈9]<br />ᐸ__person_s...person_id”ᐳ"}}:::plan
     Constant714 & PgClassExpression715 --> List716
     PgSelect721[["PgSelect[721∈9]<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
-    Object18 & Access2402 --> PgSelect721
+    Object18 -->|rejectNull| PgSelect721
+    Access2402 --> PgSelect721
     List729{{"List[729∈9]<br />ᐸ727,728ᐳ<br />ᐳLeftArm"}}:::plan
     Constant727{{"Constant[727∈9]<br />ᐸ'left_arms'ᐳ<br />ᐳLeftArm"}}:::plan
     PgClassExpression728{{"PgClassExpression[728∈9]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
     Constant727 & PgClassExpression728 --> List729
     PgSelect734[["PgSelect[734∈9]<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
-    Object18 & Access2402 --> PgSelect734
+    Object18 -->|rejectNull| PgSelect734
+    Access2402 --> PgSelect734
     List742{{"List[742∈9]<br />ᐸ740,741ᐳ<br />ᐳMyTable"}}:::plan
     Constant740{{"Constant[740∈9]<br />ᐸ'my_tables'ᐳ<br />ᐳMyTable"}}:::plan
     PgClassExpression741{{"PgClassExpression[741∈9]<br />ᐸ__my_table__.”id”ᐳ"}}:::plan
     Constant740 & PgClassExpression741 --> List742
     PgSelect747[["PgSelect[747∈9]<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
-    Object18 & Access2402 --> PgSelect747
+    Object18 -->|rejectNull| PgSelect747
+    Access2402 --> PgSelect747
     List755{{"List[755∈9]<br />ᐸ753,754ᐳ<br />ᐳViewTable"}}:::plan
     Constant753{{"Constant[753∈9]<br />ᐸ'view_tables'ᐳ<br />ᐳViewTable"}}:::plan
     PgClassExpression754{{"PgClassExpression[754∈9]<br />ᐸ__view_table__.”id”ᐳ"}}:::plan
     Constant753 & PgClassExpression754 --> List755
     PgSelect760[["PgSelect[760∈9]<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
-    Object18 & Access2402 --> PgSelect760
+    Object18 -->|rejectNull| PgSelect760
+    Access2402 --> PgSelect760
     List768{{"List[768∈9]<br />ᐸ766,767ᐳ<br />ᐳSimilarTable1"}}:::plan
     Constant766{{"Constant[766∈9]<br />ᐸ'similar_table_1S'ᐳ<br />ᐳSimilarTable1"}}:::plan
     PgClassExpression767{{"PgClassExpression[767∈9]<br />ᐸ__similar_...e_1__.”id”ᐳ"}}:::plan
     Constant766 & PgClassExpression767 --> List768
     PgSelect777[["PgSelect[777∈9]<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
-    Object18 & Access2402 --> PgSelect777
+    Object18 -->|rejectNull| PgSelect777
+    Access2402 --> PgSelect777
     List785{{"List[785∈9]<br />ᐸ783,784ᐳ<br />ᐳSimilarTable2"}}:::plan
     Constant783{{"Constant[783∈9]<br />ᐸ'similar_table_2S'ᐳ<br />ᐳSimilarTable2"}}:::plan
     PgClassExpression784{{"PgClassExpression[784∈9]<br />ᐸ__similar_...e_2__.”id”ᐳ"}}:::plan
     Constant783 & PgClassExpression784 --> List785
     PgSelect794[["PgSelect[794∈9]<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
-    Object18 & Access2402 --> PgSelect794
+    Object18 -->|rejectNull| PgSelect794
+    Access2402 --> PgSelect794
     List802{{"List[802∈9]<br />ᐸ800,801ᐳ<br />ᐳNullTestRecord"}}:::plan
     Constant800{{"Constant[800∈9]<br />ᐸ'null_test_records'ᐳ<br />ᐳNullTestRecord"}}:::plan
     PgClassExpression801{{"PgClassExpression[801∈9]<br />ᐸ__null_tes...ord__.”id”ᐳ"}}:::plan
     Constant800 & PgClassExpression801 --> List802
     PgSelect807[["PgSelect[807∈9]<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
-    Object18 & Access2402 --> PgSelect807
+    Object18 -->|rejectNull| PgSelect807
+    Access2402 --> PgSelect807
     List815{{"List[815∈9]<br />ᐸ813,814ᐳ<br />ᐳIssue756"}}:::plan
     Constant813{{"Constant[813∈9]<br />ᐸ'issue756S'ᐳ<br />ᐳIssue756"}}:::plan
     PgClassExpression814{{"PgClassExpression[814∈9]<br />ᐸ__issue756__.”id”ᐳ"}}:::plan
@@ -950,110 +1018,129 @@ graph TD
     PgSelect906[["PgSelect[906∈10]<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
     Access2405{{"Access[2405∈10]<br />ᐸ819.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access2406{{"Access[2406∈10]<br />ᐸ819.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
-    Object18 & Access2405 & Access2406 --> PgSelect906
+    Object18 -->|rejectNull| PgSelect906
+    Access2405 -->|rejectNull| PgSelect906
+    Access2406 --> PgSelect906
     List915{{"List[915∈10]<br />ᐸ912,913,914ᐳ<br />ᐳCompoundKey"}}:::plan
     Constant912{{"Constant[912∈10]<br />ᐸ'compound_keys'ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression913{{"PgClassExpression[913∈10]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression914{{"PgClassExpression[914∈10]<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     Constant912 & PgClassExpression913 & PgClassExpression914 --> List915
     PgSelect826[["PgSelect[826∈10]<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
-    Object18 & Access2405 --> PgSelect826
+    Object18 -->|rejectNull| PgSelect826
+    Access2405 --> PgSelect826
     List834{{"List[834∈10]<br />ᐸ832,833ᐳ<br />ᐳInput"}}:::plan
     Constant832{{"Constant[832∈10]<br />ᐸ'inputs'ᐳ<br />ᐳInput"}}:::plan
     PgClassExpression833{{"PgClassExpression[833∈10]<br />ᐸ__inputs__.”id”ᐳ"}}:::plan
     Constant832 & PgClassExpression833 --> List834
     PgSelect839[["PgSelect[839∈10]<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
-    Object18 & Access2405 --> PgSelect839
+    Object18 -->|rejectNull| PgSelect839
+    Access2405 --> PgSelect839
     List847{{"List[847∈10]<br />ᐸ845,846ᐳ<br />ᐳPatch"}}:::plan
     Constant845{{"Constant[845∈10]<br />ᐸ'patchs'ᐳ<br />ᐳPatch"}}:::plan
     PgClassExpression846{{"PgClassExpression[846∈10]<br />ᐸ__patchs__.”id”ᐳ"}}:::plan
     Constant845 & PgClassExpression846 --> List847
     PgSelect852[["PgSelect[852∈10]<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
-    Object18 & Access2405 --> PgSelect852
+    Object18 -->|rejectNull| PgSelect852
+    Access2405 --> PgSelect852
     List860{{"List[860∈10]<br />ᐸ858,859ᐳ<br />ᐳReserved"}}:::plan
     Constant858{{"Constant[858∈10]<br />ᐸ'reserveds'ᐳ<br />ᐳReserved"}}:::plan
     PgClassExpression859{{"PgClassExpression[859∈10]<br />ᐸ__reserved__.”id”ᐳ"}}:::plan
     Constant858 & PgClassExpression859 --> List860
     PgSelect865[["PgSelect[865∈10]<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
-    Object18 & Access2405 --> PgSelect865
+    Object18 -->|rejectNull| PgSelect865
+    Access2405 --> PgSelect865
     List873{{"List[873∈10]<br />ᐸ871,872ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     Constant871{{"Constant[871∈10]<br />ᐸ'reservedPatchs'ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     PgClassExpression872{{"PgClassExpression[872∈10]<br />ᐸ__reserved...chs__.”id”ᐳ"}}:::plan
     Constant871 & PgClassExpression872 --> List873
     PgSelect878[["PgSelect[878∈10]<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
-    Object18 & Access2405 --> PgSelect878
+    Object18 -->|rejectNull| PgSelect878
+    Access2405 --> PgSelect878
     List886{{"List[886∈10]<br />ᐸ884,885ᐳ<br />ᐳReservedInputRecord"}}:::plan
     Constant884{{"Constant[884∈10]<br />ᐸ'reserved_inputs'ᐳ<br />ᐳReservedInputRecord"}}:::plan
     PgClassExpression885{{"PgClassExpression[885∈10]<br />ᐸ__reserved_input__.”id”ᐳ"}}:::plan
     Constant884 & PgClassExpression885 --> List886
     PgSelect891[["PgSelect[891∈10]<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
-    Object18 & Access2405 --> PgSelect891
+    Object18 -->|rejectNull| PgSelect891
+    Access2405 --> PgSelect891
     List899{{"List[899∈10]<br />ᐸ897,898ᐳ<br />ᐳDefaultValue"}}:::plan
     Constant897{{"Constant[897∈10]<br />ᐸ'default_values'ᐳ<br />ᐳDefaultValue"}}:::plan
     PgClassExpression898{{"PgClassExpression[898∈10]<br />ᐸ__default_value__.”id”ᐳ"}}:::plan
     Constant897 & PgClassExpression898 --> List899
     PgSelect922[["PgSelect[922∈10]<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
-    Object18 & Access2405 --> PgSelect922
+    Object18 -->|rejectNull| PgSelect922
+    Access2405 --> PgSelect922
     List930{{"List[930∈10]<br />ᐸ928,929ᐳ<br />ᐳPerson"}}:::plan
     Constant928{{"Constant[928∈10]<br />ᐸ'people'ᐳ<br />ᐳPerson"}}:::plan
     PgClassExpression929{{"PgClassExpression[929∈10]<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant928 & PgClassExpression929 --> List930
     PgSelect937[["PgSelect[937∈10]<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
-    Object18 & Access2405 --> PgSelect937
+    Object18 -->|rejectNull| PgSelect937
+    Access2405 --> PgSelect937
     List945{{"List[945∈10]<br />ᐸ943,944ᐳ<br />ᐳPost"}}:::plan
     Constant943{{"Constant[943∈10]<br />ᐸ'posts'ᐳ<br />ᐳPost"}}:::plan
     PgClassExpression944{{"PgClassExpression[944∈10]<br />ᐸ__post__.”id”ᐳ"}}:::plan
     Constant943 & PgClassExpression944 --> List945
     PgSelect950[["PgSelect[950∈10]<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
-    Object18 & Access2405 --> PgSelect950
+    Object18 -->|rejectNull| PgSelect950
+    Access2405 --> PgSelect950
     List958{{"List[958∈10]<br />ᐸ956,957ᐳ<br />ᐳType"}}:::plan
     Constant956{{"Constant[956∈10]<br />ᐸ'types'ᐳ<br />ᐳType"}}:::plan
     PgClassExpression957{{"PgClassExpression[957∈10]<br />ᐸ__types__.”id”ᐳ"}}:::plan
     Constant956 & PgClassExpression957 --> List958
     PgSelect963[["PgSelect[963∈10]<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
-    Object18 & Access2405 --> PgSelect963
+    Object18 -->|rejectNull| PgSelect963
+    Access2405 --> PgSelect963
     List971{{"List[971∈10]<br />ᐸ969,970ᐳ<br />ᐳPersonSecret"}}:::plan
     Constant969{{"Constant[969∈10]<br />ᐸ'person_secrets'ᐳ<br />ᐳPersonSecret"}}:::plan
     PgClassExpression970{{"PgClassExpression[970∈10]<br />ᐸ__person_s...person_id”ᐳ"}}:::plan
     Constant969 & PgClassExpression970 --> List971
     PgSelect976[["PgSelect[976∈10]<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
-    Object18 & Access2405 --> PgSelect976
+    Object18 -->|rejectNull| PgSelect976
+    Access2405 --> PgSelect976
     List984{{"List[984∈10]<br />ᐸ982,983ᐳ<br />ᐳLeftArm"}}:::plan
     Constant982{{"Constant[982∈10]<br />ᐸ'left_arms'ᐳ<br />ᐳLeftArm"}}:::plan
     PgClassExpression983{{"PgClassExpression[983∈10]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
     Constant982 & PgClassExpression983 --> List984
     PgSelect989[["PgSelect[989∈10]<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
-    Object18 & Access2405 --> PgSelect989
+    Object18 -->|rejectNull| PgSelect989
+    Access2405 --> PgSelect989
     List997{{"List[997∈10]<br />ᐸ995,996ᐳ<br />ᐳMyTable"}}:::plan
     Constant995{{"Constant[995∈10]<br />ᐸ'my_tables'ᐳ<br />ᐳMyTable"}}:::plan
     PgClassExpression996{{"PgClassExpression[996∈10]<br />ᐸ__my_table__.”id”ᐳ"}}:::plan
     Constant995 & PgClassExpression996 --> List997
     PgSelect1002[["PgSelect[1002∈10]<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
-    Object18 & Access2405 --> PgSelect1002
+    Object18 -->|rejectNull| PgSelect1002
+    Access2405 --> PgSelect1002
     List1010{{"List[1010∈10]<br />ᐸ1008,1009ᐳ<br />ᐳViewTable"}}:::plan
     Constant1008{{"Constant[1008∈10]<br />ᐸ'view_tables'ᐳ<br />ᐳViewTable"}}:::plan
     PgClassExpression1009{{"PgClassExpression[1009∈10]<br />ᐸ__view_table__.”id”ᐳ"}}:::plan
     Constant1008 & PgClassExpression1009 --> List1010
     PgSelect1015[["PgSelect[1015∈10]<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
-    Object18 & Access2405 --> PgSelect1015
+    Object18 -->|rejectNull| PgSelect1015
+    Access2405 --> PgSelect1015
     List1023{{"List[1023∈10]<br />ᐸ1021,1022ᐳ<br />ᐳSimilarTable1"}}:::plan
     Constant1021{{"Constant[1021∈10]<br />ᐸ'similar_table_1S'ᐳ<br />ᐳSimilarTable1"}}:::plan
     PgClassExpression1022{{"PgClassExpression[1022∈10]<br />ᐸ__similar_...e_1__.”id”ᐳ"}}:::plan
     Constant1021 & PgClassExpression1022 --> List1023
     PgSelect1032[["PgSelect[1032∈10]<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
-    Object18 & Access2405 --> PgSelect1032
+    Object18 -->|rejectNull| PgSelect1032
+    Access2405 --> PgSelect1032
     List1040{{"List[1040∈10]<br />ᐸ1038,1039ᐳ<br />ᐳSimilarTable2"}}:::plan
     Constant1038{{"Constant[1038∈10]<br />ᐸ'similar_table_2S'ᐳ<br />ᐳSimilarTable2"}}:::plan
     PgClassExpression1039{{"PgClassExpression[1039∈10]<br />ᐸ__similar_...e_2__.”id”ᐳ"}}:::plan
     Constant1038 & PgClassExpression1039 --> List1040
     PgSelect1049[["PgSelect[1049∈10]<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
-    Object18 & Access2405 --> PgSelect1049
+    Object18 -->|rejectNull| PgSelect1049
+    Access2405 --> PgSelect1049
     List1057{{"List[1057∈10]<br />ᐸ1055,1056ᐳ<br />ᐳNullTestRecord"}}:::plan
     Constant1055{{"Constant[1055∈10]<br />ᐸ'null_test_records'ᐳ<br />ᐳNullTestRecord"}}:::plan
     PgClassExpression1056{{"PgClassExpression[1056∈10]<br />ᐸ__null_tes...ord__.”id”ᐳ"}}:::plan
     Constant1055 & PgClassExpression1056 --> List1057
     PgSelect1062[["PgSelect[1062∈10]<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
-    Object18 & Access2405 --> PgSelect1062
+    Object18 -->|rejectNull| PgSelect1062
+    Access2405 --> PgSelect1062
     List1070{{"List[1070∈10]<br />ᐸ1068,1069ᐳ<br />ᐳIssue756"}}:::plan
     Constant1068{{"Constant[1068∈10]<br />ᐸ'issue756S'ᐳ<br />ᐳIssue756"}}:::plan
     PgClassExpression1069{{"PgClassExpression[1069∈10]<br />ᐸ__issue756__.”id”ᐳ"}}:::plan
@@ -1207,110 +1294,129 @@ graph TD
     PgSelect1161[["PgSelect[1161∈11]<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
     Access2408{{"Access[2408∈11]<br />ᐸ1074.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access2409{{"Access[2409∈11]<br />ᐸ1074.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
-    Object18 & Access2408 & Access2409 --> PgSelect1161
+    Object18 -->|rejectNull| PgSelect1161
+    Access2408 -->|rejectNull| PgSelect1161
+    Access2409 --> PgSelect1161
     List1170{{"List[1170∈11]<br />ᐸ1167,1168,1169ᐳ<br />ᐳCompoundKey"}}:::plan
     Constant1167{{"Constant[1167∈11]<br />ᐸ'compound_keys'ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression1168{{"PgClassExpression[1168∈11]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression1169{{"PgClassExpression[1169∈11]<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     Constant1167 & PgClassExpression1168 & PgClassExpression1169 --> List1170
     PgSelect1081[["PgSelect[1081∈11]<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
-    Object18 & Access2408 --> PgSelect1081
+    Object18 -->|rejectNull| PgSelect1081
+    Access2408 --> PgSelect1081
     List1089{{"List[1089∈11]<br />ᐸ1087,1088ᐳ<br />ᐳInput"}}:::plan
     Constant1087{{"Constant[1087∈11]<br />ᐸ'inputs'ᐳ<br />ᐳInput"}}:::plan
     PgClassExpression1088{{"PgClassExpression[1088∈11]<br />ᐸ__inputs__.”id”ᐳ"}}:::plan
     Constant1087 & PgClassExpression1088 --> List1089
     PgSelect1094[["PgSelect[1094∈11]<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
-    Object18 & Access2408 --> PgSelect1094
+    Object18 -->|rejectNull| PgSelect1094
+    Access2408 --> PgSelect1094
     List1102{{"List[1102∈11]<br />ᐸ1100,1101ᐳ<br />ᐳPatch"}}:::plan
     Constant1100{{"Constant[1100∈11]<br />ᐸ'patchs'ᐳ<br />ᐳPatch"}}:::plan
     PgClassExpression1101{{"PgClassExpression[1101∈11]<br />ᐸ__patchs__.”id”ᐳ"}}:::plan
     Constant1100 & PgClassExpression1101 --> List1102
     PgSelect1107[["PgSelect[1107∈11]<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
-    Object18 & Access2408 --> PgSelect1107
+    Object18 -->|rejectNull| PgSelect1107
+    Access2408 --> PgSelect1107
     List1115{{"List[1115∈11]<br />ᐸ1113,1114ᐳ<br />ᐳReserved"}}:::plan
     Constant1113{{"Constant[1113∈11]<br />ᐸ'reserveds'ᐳ<br />ᐳReserved"}}:::plan
     PgClassExpression1114{{"PgClassExpression[1114∈11]<br />ᐸ__reserved__.”id”ᐳ"}}:::plan
     Constant1113 & PgClassExpression1114 --> List1115
     PgSelect1120[["PgSelect[1120∈11]<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
-    Object18 & Access2408 --> PgSelect1120
+    Object18 -->|rejectNull| PgSelect1120
+    Access2408 --> PgSelect1120
     List1128{{"List[1128∈11]<br />ᐸ1126,1127ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     Constant1126{{"Constant[1126∈11]<br />ᐸ'reservedPatchs'ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     PgClassExpression1127{{"PgClassExpression[1127∈11]<br />ᐸ__reserved...chs__.”id”ᐳ"}}:::plan
     Constant1126 & PgClassExpression1127 --> List1128
     PgSelect1133[["PgSelect[1133∈11]<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
-    Object18 & Access2408 --> PgSelect1133
+    Object18 -->|rejectNull| PgSelect1133
+    Access2408 --> PgSelect1133
     List1141{{"List[1141∈11]<br />ᐸ1139,1140ᐳ<br />ᐳReservedInputRecord"}}:::plan
     Constant1139{{"Constant[1139∈11]<br />ᐸ'reserved_inputs'ᐳ<br />ᐳReservedInputRecord"}}:::plan
     PgClassExpression1140{{"PgClassExpression[1140∈11]<br />ᐸ__reserved_input__.”id”ᐳ"}}:::plan
     Constant1139 & PgClassExpression1140 --> List1141
     PgSelect1146[["PgSelect[1146∈11]<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
-    Object18 & Access2408 --> PgSelect1146
+    Object18 -->|rejectNull| PgSelect1146
+    Access2408 --> PgSelect1146
     List1154{{"List[1154∈11]<br />ᐸ1152,1153ᐳ<br />ᐳDefaultValue"}}:::plan
     Constant1152{{"Constant[1152∈11]<br />ᐸ'default_values'ᐳ<br />ᐳDefaultValue"}}:::plan
     PgClassExpression1153{{"PgClassExpression[1153∈11]<br />ᐸ__default_value__.”id”ᐳ"}}:::plan
     Constant1152 & PgClassExpression1153 --> List1154
     PgSelect1177[["PgSelect[1177∈11]<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
-    Object18 & Access2408 --> PgSelect1177
+    Object18 -->|rejectNull| PgSelect1177
+    Access2408 --> PgSelect1177
     List1185{{"List[1185∈11]<br />ᐸ1183,1184ᐳ<br />ᐳPerson"}}:::plan
     Constant1183{{"Constant[1183∈11]<br />ᐸ'people'ᐳ<br />ᐳPerson"}}:::plan
     PgClassExpression1184{{"PgClassExpression[1184∈11]<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant1183 & PgClassExpression1184 --> List1185
     PgSelect1192[["PgSelect[1192∈11]<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
-    Object18 & Access2408 --> PgSelect1192
+    Object18 -->|rejectNull| PgSelect1192
+    Access2408 --> PgSelect1192
     List1200{{"List[1200∈11]<br />ᐸ1198,1199ᐳ<br />ᐳPost"}}:::plan
     Constant1198{{"Constant[1198∈11]<br />ᐸ'posts'ᐳ<br />ᐳPost"}}:::plan
     PgClassExpression1199{{"PgClassExpression[1199∈11]<br />ᐸ__post__.”id”ᐳ"}}:::plan
     Constant1198 & PgClassExpression1199 --> List1200
     PgSelect1205[["PgSelect[1205∈11]<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
-    Object18 & Access2408 --> PgSelect1205
+    Object18 -->|rejectNull| PgSelect1205
+    Access2408 --> PgSelect1205
     List1213{{"List[1213∈11]<br />ᐸ1211,1212ᐳ<br />ᐳType"}}:::plan
     Constant1211{{"Constant[1211∈11]<br />ᐸ'types'ᐳ<br />ᐳType"}}:::plan
     PgClassExpression1212{{"PgClassExpression[1212∈11]<br />ᐸ__types__.”id”ᐳ"}}:::plan
     Constant1211 & PgClassExpression1212 --> List1213
     PgSelect1218[["PgSelect[1218∈11]<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
-    Object18 & Access2408 --> PgSelect1218
+    Object18 -->|rejectNull| PgSelect1218
+    Access2408 --> PgSelect1218
     List1226{{"List[1226∈11]<br />ᐸ1224,1225ᐳ<br />ᐳPersonSecret"}}:::plan
     Constant1224{{"Constant[1224∈11]<br />ᐸ'person_secrets'ᐳ<br />ᐳPersonSecret"}}:::plan
     PgClassExpression1225{{"PgClassExpression[1225∈11]<br />ᐸ__person_s...person_id”ᐳ"}}:::plan
     Constant1224 & PgClassExpression1225 --> List1226
     PgSelect1231[["PgSelect[1231∈11]<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
-    Object18 & Access2408 --> PgSelect1231
+    Object18 -->|rejectNull| PgSelect1231
+    Access2408 --> PgSelect1231
     List1239{{"List[1239∈11]<br />ᐸ1237,1238ᐳ<br />ᐳLeftArm"}}:::plan
     Constant1237{{"Constant[1237∈11]<br />ᐸ'left_arms'ᐳ<br />ᐳLeftArm"}}:::plan
     PgClassExpression1238{{"PgClassExpression[1238∈11]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
     Constant1237 & PgClassExpression1238 --> List1239
     PgSelect1244[["PgSelect[1244∈11]<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
-    Object18 & Access2408 --> PgSelect1244
+    Object18 -->|rejectNull| PgSelect1244
+    Access2408 --> PgSelect1244
     List1252{{"List[1252∈11]<br />ᐸ1250,1251ᐳ<br />ᐳMyTable"}}:::plan
     Constant1250{{"Constant[1250∈11]<br />ᐸ'my_tables'ᐳ<br />ᐳMyTable"}}:::plan
     PgClassExpression1251{{"PgClassExpression[1251∈11]<br />ᐸ__my_table__.”id”ᐳ"}}:::plan
     Constant1250 & PgClassExpression1251 --> List1252
     PgSelect1257[["PgSelect[1257∈11]<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
-    Object18 & Access2408 --> PgSelect1257
+    Object18 -->|rejectNull| PgSelect1257
+    Access2408 --> PgSelect1257
     List1265{{"List[1265∈11]<br />ᐸ1263,1264ᐳ<br />ᐳViewTable"}}:::plan
     Constant1263{{"Constant[1263∈11]<br />ᐸ'view_tables'ᐳ<br />ᐳViewTable"}}:::plan
     PgClassExpression1264{{"PgClassExpression[1264∈11]<br />ᐸ__view_table__.”id”ᐳ"}}:::plan
     Constant1263 & PgClassExpression1264 --> List1265
     PgSelect1270[["PgSelect[1270∈11]<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
-    Object18 & Access2408 --> PgSelect1270
+    Object18 -->|rejectNull| PgSelect1270
+    Access2408 --> PgSelect1270
     List1278{{"List[1278∈11]<br />ᐸ1276,1277ᐳ<br />ᐳSimilarTable1"}}:::plan
     Constant1276{{"Constant[1276∈11]<br />ᐸ'similar_table_1S'ᐳ<br />ᐳSimilarTable1"}}:::plan
     PgClassExpression1277{{"PgClassExpression[1277∈11]<br />ᐸ__similar_...e_1__.”id”ᐳ"}}:::plan
     Constant1276 & PgClassExpression1277 --> List1278
     PgSelect1287[["PgSelect[1287∈11]<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
-    Object18 & Access2408 --> PgSelect1287
+    Object18 -->|rejectNull| PgSelect1287
+    Access2408 --> PgSelect1287
     List1295{{"List[1295∈11]<br />ᐸ1293,1294ᐳ<br />ᐳSimilarTable2"}}:::plan
     Constant1293{{"Constant[1293∈11]<br />ᐸ'similar_table_2S'ᐳ<br />ᐳSimilarTable2"}}:::plan
     PgClassExpression1294{{"PgClassExpression[1294∈11]<br />ᐸ__similar_...e_2__.”id”ᐳ"}}:::plan
     Constant1293 & PgClassExpression1294 --> List1295
     PgSelect1304[["PgSelect[1304∈11]<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
-    Object18 & Access2408 --> PgSelect1304
+    Object18 -->|rejectNull| PgSelect1304
+    Access2408 --> PgSelect1304
     List1312{{"List[1312∈11]<br />ᐸ1310,1311ᐳ<br />ᐳNullTestRecord"}}:::plan
     Constant1310{{"Constant[1310∈11]<br />ᐸ'null_test_records'ᐳ<br />ᐳNullTestRecord"}}:::plan
     PgClassExpression1311{{"PgClassExpression[1311∈11]<br />ᐸ__null_tes...ord__.”id”ᐳ"}}:::plan
     Constant1310 & PgClassExpression1311 --> List1312
     PgSelect1317[["PgSelect[1317∈11]<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
-    Object18 & Access2408 --> PgSelect1317
+    Object18 -->|rejectNull| PgSelect1317
+    Access2408 --> PgSelect1317
     List1325{{"List[1325∈11]<br />ᐸ1323,1324ᐳ<br />ᐳIssue756"}}:::plan
     Constant1323{{"Constant[1323∈11]<br />ᐸ'issue756S'ᐳ<br />ᐳIssue756"}}:::plan
     PgClassExpression1324{{"PgClassExpression[1324∈11]<br />ᐸ__issue756__.”id”ᐳ"}}:::plan
@@ -1464,110 +1570,129 @@ graph TD
     PgSelect1416[["PgSelect[1416∈12]<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
     Access2411{{"Access[2411∈12]<br />ᐸ1329.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access2412{{"Access[2412∈12]<br />ᐸ1329.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
-    Object18 & Access2411 & Access2412 --> PgSelect1416
+    Object18 -->|rejectNull| PgSelect1416
+    Access2411 -->|rejectNull| PgSelect1416
+    Access2412 --> PgSelect1416
     List1425{{"List[1425∈12]<br />ᐸ1422,1423,1424ᐳ<br />ᐳCompoundKey"}}:::plan
     Constant1422{{"Constant[1422∈12]<br />ᐸ'compound_keys'ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression1423{{"PgClassExpression[1423∈12]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression1424{{"PgClassExpression[1424∈12]<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     Constant1422 & PgClassExpression1423 & PgClassExpression1424 --> List1425
     PgSelect1336[["PgSelect[1336∈12]<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
-    Object18 & Access2411 --> PgSelect1336
+    Object18 -->|rejectNull| PgSelect1336
+    Access2411 --> PgSelect1336
     List1344{{"List[1344∈12]<br />ᐸ1342,1343ᐳ<br />ᐳInput"}}:::plan
     Constant1342{{"Constant[1342∈12]<br />ᐸ'inputs'ᐳ<br />ᐳInput"}}:::plan
     PgClassExpression1343{{"PgClassExpression[1343∈12]<br />ᐸ__inputs__.”id”ᐳ"}}:::plan
     Constant1342 & PgClassExpression1343 --> List1344
     PgSelect1349[["PgSelect[1349∈12]<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
-    Object18 & Access2411 --> PgSelect1349
+    Object18 -->|rejectNull| PgSelect1349
+    Access2411 --> PgSelect1349
     List1357{{"List[1357∈12]<br />ᐸ1355,1356ᐳ<br />ᐳPatch"}}:::plan
     Constant1355{{"Constant[1355∈12]<br />ᐸ'patchs'ᐳ<br />ᐳPatch"}}:::plan
     PgClassExpression1356{{"PgClassExpression[1356∈12]<br />ᐸ__patchs__.”id”ᐳ"}}:::plan
     Constant1355 & PgClassExpression1356 --> List1357
     PgSelect1362[["PgSelect[1362∈12]<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
-    Object18 & Access2411 --> PgSelect1362
+    Object18 -->|rejectNull| PgSelect1362
+    Access2411 --> PgSelect1362
     List1370{{"List[1370∈12]<br />ᐸ1368,1369ᐳ<br />ᐳReserved"}}:::plan
     Constant1368{{"Constant[1368∈12]<br />ᐸ'reserveds'ᐳ<br />ᐳReserved"}}:::plan
     PgClassExpression1369{{"PgClassExpression[1369∈12]<br />ᐸ__reserved__.”id”ᐳ"}}:::plan
     Constant1368 & PgClassExpression1369 --> List1370
     PgSelect1375[["PgSelect[1375∈12]<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
-    Object18 & Access2411 --> PgSelect1375
+    Object18 -->|rejectNull| PgSelect1375
+    Access2411 --> PgSelect1375
     List1383{{"List[1383∈12]<br />ᐸ1381,1382ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     Constant1381{{"Constant[1381∈12]<br />ᐸ'reservedPatchs'ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     PgClassExpression1382{{"PgClassExpression[1382∈12]<br />ᐸ__reserved...chs__.”id”ᐳ"}}:::plan
     Constant1381 & PgClassExpression1382 --> List1383
     PgSelect1388[["PgSelect[1388∈12]<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
-    Object18 & Access2411 --> PgSelect1388
+    Object18 -->|rejectNull| PgSelect1388
+    Access2411 --> PgSelect1388
     List1396{{"List[1396∈12]<br />ᐸ1394,1395ᐳ<br />ᐳReservedInputRecord"}}:::plan
     Constant1394{{"Constant[1394∈12]<br />ᐸ'reserved_inputs'ᐳ<br />ᐳReservedInputRecord"}}:::plan
     PgClassExpression1395{{"PgClassExpression[1395∈12]<br />ᐸ__reserved_input__.”id”ᐳ"}}:::plan
     Constant1394 & PgClassExpression1395 --> List1396
     PgSelect1401[["PgSelect[1401∈12]<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
-    Object18 & Access2411 --> PgSelect1401
+    Object18 -->|rejectNull| PgSelect1401
+    Access2411 --> PgSelect1401
     List1409{{"List[1409∈12]<br />ᐸ1407,1408ᐳ<br />ᐳDefaultValue"}}:::plan
     Constant1407{{"Constant[1407∈12]<br />ᐸ'default_values'ᐳ<br />ᐳDefaultValue"}}:::plan
     PgClassExpression1408{{"PgClassExpression[1408∈12]<br />ᐸ__default_value__.”id”ᐳ"}}:::plan
     Constant1407 & PgClassExpression1408 --> List1409
     PgSelect1432[["PgSelect[1432∈12]<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
-    Object18 & Access2411 --> PgSelect1432
+    Object18 -->|rejectNull| PgSelect1432
+    Access2411 --> PgSelect1432
     List1440{{"List[1440∈12]<br />ᐸ1438,1439ᐳ<br />ᐳPerson"}}:::plan
     Constant1438{{"Constant[1438∈12]<br />ᐸ'people'ᐳ<br />ᐳPerson"}}:::plan
     PgClassExpression1439{{"PgClassExpression[1439∈12]<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant1438 & PgClassExpression1439 --> List1440
     PgSelect1447[["PgSelect[1447∈12]<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
-    Object18 & Access2411 --> PgSelect1447
+    Object18 -->|rejectNull| PgSelect1447
+    Access2411 --> PgSelect1447
     List1455{{"List[1455∈12]<br />ᐸ1453,1454ᐳ<br />ᐳPost"}}:::plan
     Constant1453{{"Constant[1453∈12]<br />ᐸ'posts'ᐳ<br />ᐳPost"}}:::plan
     PgClassExpression1454{{"PgClassExpression[1454∈12]<br />ᐸ__post__.”id”ᐳ"}}:::plan
     Constant1453 & PgClassExpression1454 --> List1455
     PgSelect1460[["PgSelect[1460∈12]<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
-    Object18 & Access2411 --> PgSelect1460
+    Object18 -->|rejectNull| PgSelect1460
+    Access2411 --> PgSelect1460
     List1468{{"List[1468∈12]<br />ᐸ1466,1467ᐳ<br />ᐳType"}}:::plan
     Constant1466{{"Constant[1466∈12]<br />ᐸ'types'ᐳ<br />ᐳType"}}:::plan
     PgClassExpression1467{{"PgClassExpression[1467∈12]<br />ᐸ__types__.”id”ᐳ"}}:::plan
     Constant1466 & PgClassExpression1467 --> List1468
     PgSelect1473[["PgSelect[1473∈12]<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
-    Object18 & Access2411 --> PgSelect1473
+    Object18 -->|rejectNull| PgSelect1473
+    Access2411 --> PgSelect1473
     List1481{{"List[1481∈12]<br />ᐸ1479,1480ᐳ<br />ᐳPersonSecret"}}:::plan
     Constant1479{{"Constant[1479∈12]<br />ᐸ'person_secrets'ᐳ<br />ᐳPersonSecret"}}:::plan
     PgClassExpression1480{{"PgClassExpression[1480∈12]<br />ᐸ__person_s...person_id”ᐳ"}}:::plan
     Constant1479 & PgClassExpression1480 --> List1481
     PgSelect1486[["PgSelect[1486∈12]<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
-    Object18 & Access2411 --> PgSelect1486
+    Object18 -->|rejectNull| PgSelect1486
+    Access2411 --> PgSelect1486
     List1494{{"List[1494∈12]<br />ᐸ1492,1493ᐳ<br />ᐳLeftArm"}}:::plan
     Constant1492{{"Constant[1492∈12]<br />ᐸ'left_arms'ᐳ<br />ᐳLeftArm"}}:::plan
     PgClassExpression1493{{"PgClassExpression[1493∈12]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
     Constant1492 & PgClassExpression1493 --> List1494
     PgSelect1499[["PgSelect[1499∈12]<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
-    Object18 & Access2411 --> PgSelect1499
+    Object18 -->|rejectNull| PgSelect1499
+    Access2411 --> PgSelect1499
     List1507{{"List[1507∈12]<br />ᐸ1505,1506ᐳ<br />ᐳMyTable"}}:::plan
     Constant1505{{"Constant[1505∈12]<br />ᐸ'my_tables'ᐳ<br />ᐳMyTable"}}:::plan
     PgClassExpression1506{{"PgClassExpression[1506∈12]<br />ᐸ__my_table__.”id”ᐳ"}}:::plan
     Constant1505 & PgClassExpression1506 --> List1507
     PgSelect1512[["PgSelect[1512∈12]<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
-    Object18 & Access2411 --> PgSelect1512
+    Object18 -->|rejectNull| PgSelect1512
+    Access2411 --> PgSelect1512
     List1520{{"List[1520∈12]<br />ᐸ1518,1519ᐳ<br />ᐳViewTable"}}:::plan
     Constant1518{{"Constant[1518∈12]<br />ᐸ'view_tables'ᐳ<br />ᐳViewTable"}}:::plan
     PgClassExpression1519{{"PgClassExpression[1519∈12]<br />ᐸ__view_table__.”id”ᐳ"}}:::plan
     Constant1518 & PgClassExpression1519 --> List1520
     PgSelect1525[["PgSelect[1525∈12]<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
-    Object18 & Access2411 --> PgSelect1525
+    Object18 -->|rejectNull| PgSelect1525
+    Access2411 --> PgSelect1525
     List1533{{"List[1533∈12]<br />ᐸ1531,1532ᐳ<br />ᐳSimilarTable1"}}:::plan
     Constant1531{{"Constant[1531∈12]<br />ᐸ'similar_table_1S'ᐳ<br />ᐳSimilarTable1"}}:::plan
     PgClassExpression1532{{"PgClassExpression[1532∈12]<br />ᐸ__similar_...e_1__.”id”ᐳ"}}:::plan
     Constant1531 & PgClassExpression1532 --> List1533
     PgSelect1542[["PgSelect[1542∈12]<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
-    Object18 & Access2411 --> PgSelect1542
+    Object18 -->|rejectNull| PgSelect1542
+    Access2411 --> PgSelect1542
     List1550{{"List[1550∈12]<br />ᐸ1548,1549ᐳ<br />ᐳSimilarTable2"}}:::plan
     Constant1548{{"Constant[1548∈12]<br />ᐸ'similar_table_2S'ᐳ<br />ᐳSimilarTable2"}}:::plan
     PgClassExpression1549{{"PgClassExpression[1549∈12]<br />ᐸ__similar_...e_2__.”id”ᐳ"}}:::plan
     Constant1548 & PgClassExpression1549 --> List1550
     PgSelect1559[["PgSelect[1559∈12]<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
-    Object18 & Access2411 --> PgSelect1559
+    Object18 -->|rejectNull| PgSelect1559
+    Access2411 --> PgSelect1559
     List1567{{"List[1567∈12]<br />ᐸ1565,1566ᐳ<br />ᐳNullTestRecord"}}:::plan
     Constant1565{{"Constant[1565∈12]<br />ᐸ'null_test_records'ᐳ<br />ᐳNullTestRecord"}}:::plan
     PgClassExpression1566{{"PgClassExpression[1566∈12]<br />ᐸ__null_tes...ord__.”id”ᐳ"}}:::plan
     Constant1565 & PgClassExpression1566 --> List1567
     PgSelect1572[["PgSelect[1572∈12]<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
-    Object18 & Access2411 --> PgSelect1572
+    Object18 -->|rejectNull| PgSelect1572
+    Access2411 --> PgSelect1572
     List1580{{"List[1580∈12]<br />ᐸ1578,1579ᐳ<br />ᐳIssue756"}}:::plan
     Constant1578{{"Constant[1578∈12]<br />ᐸ'issue756S'ᐳ<br />ᐳIssue756"}}:::plan
     PgClassExpression1579{{"PgClassExpression[1579∈12]<br />ᐸ__issue756__.”id”ᐳ"}}:::plan
@@ -1769,110 +1894,129 @@ graph TD
     PgSelect1776[["PgSelect[1776∈19]<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
     Access2420{{"Access[2420∈19]<br />ᐸ1689.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access2421{{"Access[2421∈19]<br />ᐸ1689.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
-    Object18 & Access2420 & Access2421 --> PgSelect1776
+    Object18 -->|rejectNull| PgSelect1776
+    Access2420 -->|rejectNull| PgSelect1776
+    Access2421 --> PgSelect1776
     List1785{{"List[1785∈19]<br />ᐸ1782,1783,1784ᐳ<br />ᐳCompoundKey"}}:::plan
     Constant1782{{"Constant[1782∈19]<br />ᐸ'compound_keys'ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression1783{{"PgClassExpression[1783∈19]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression1784{{"PgClassExpression[1784∈19]<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     Constant1782 & PgClassExpression1783 & PgClassExpression1784 --> List1785
     PgSelect1696[["PgSelect[1696∈19]<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
-    Object18 & Access2420 --> PgSelect1696
+    Object18 -->|rejectNull| PgSelect1696
+    Access2420 --> PgSelect1696
     List1704{{"List[1704∈19]<br />ᐸ1702,1703ᐳ<br />ᐳInput"}}:::plan
     Constant1702{{"Constant[1702∈19]<br />ᐸ'inputs'ᐳ<br />ᐳInput"}}:::plan
     PgClassExpression1703{{"PgClassExpression[1703∈19]<br />ᐸ__inputs__.”id”ᐳ"}}:::plan
     Constant1702 & PgClassExpression1703 --> List1704
     PgSelect1709[["PgSelect[1709∈19]<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
-    Object18 & Access2420 --> PgSelect1709
+    Object18 -->|rejectNull| PgSelect1709
+    Access2420 --> PgSelect1709
     List1717{{"List[1717∈19]<br />ᐸ1715,1716ᐳ<br />ᐳPatch"}}:::plan
     Constant1715{{"Constant[1715∈19]<br />ᐸ'patchs'ᐳ<br />ᐳPatch"}}:::plan
     PgClassExpression1716{{"PgClassExpression[1716∈19]<br />ᐸ__patchs__.”id”ᐳ"}}:::plan
     Constant1715 & PgClassExpression1716 --> List1717
     PgSelect1722[["PgSelect[1722∈19]<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
-    Object18 & Access2420 --> PgSelect1722
+    Object18 -->|rejectNull| PgSelect1722
+    Access2420 --> PgSelect1722
     List1730{{"List[1730∈19]<br />ᐸ1728,1729ᐳ<br />ᐳReserved"}}:::plan
     Constant1728{{"Constant[1728∈19]<br />ᐸ'reserveds'ᐳ<br />ᐳReserved"}}:::plan
     PgClassExpression1729{{"PgClassExpression[1729∈19]<br />ᐸ__reserved__.”id”ᐳ"}}:::plan
     Constant1728 & PgClassExpression1729 --> List1730
     PgSelect1735[["PgSelect[1735∈19]<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
-    Object18 & Access2420 --> PgSelect1735
+    Object18 -->|rejectNull| PgSelect1735
+    Access2420 --> PgSelect1735
     List1743{{"List[1743∈19]<br />ᐸ1741,1742ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     Constant1741{{"Constant[1741∈19]<br />ᐸ'reservedPatchs'ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     PgClassExpression1742{{"PgClassExpression[1742∈19]<br />ᐸ__reserved...chs__.”id”ᐳ"}}:::plan
     Constant1741 & PgClassExpression1742 --> List1743
     PgSelect1748[["PgSelect[1748∈19]<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
-    Object18 & Access2420 --> PgSelect1748
+    Object18 -->|rejectNull| PgSelect1748
+    Access2420 --> PgSelect1748
     List1756{{"List[1756∈19]<br />ᐸ1754,1755ᐳ<br />ᐳReservedInputRecord"}}:::plan
     Constant1754{{"Constant[1754∈19]<br />ᐸ'reserved_inputs'ᐳ<br />ᐳReservedInputRecord"}}:::plan
     PgClassExpression1755{{"PgClassExpression[1755∈19]<br />ᐸ__reserved_input__.”id”ᐳ"}}:::plan
     Constant1754 & PgClassExpression1755 --> List1756
     PgSelect1761[["PgSelect[1761∈19]<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
-    Object18 & Access2420 --> PgSelect1761
+    Object18 -->|rejectNull| PgSelect1761
+    Access2420 --> PgSelect1761
     List1769{{"List[1769∈19]<br />ᐸ1767,1768ᐳ<br />ᐳDefaultValue"}}:::plan
     Constant1767{{"Constant[1767∈19]<br />ᐸ'default_values'ᐳ<br />ᐳDefaultValue"}}:::plan
     PgClassExpression1768{{"PgClassExpression[1768∈19]<br />ᐸ__default_value__.”id”ᐳ"}}:::plan
     Constant1767 & PgClassExpression1768 --> List1769
     PgSelect1792[["PgSelect[1792∈19]<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
-    Object18 & Access2420 --> PgSelect1792
+    Object18 -->|rejectNull| PgSelect1792
+    Access2420 --> PgSelect1792
     List1800{{"List[1800∈19]<br />ᐸ1798,1799ᐳ<br />ᐳPerson"}}:::plan
     Constant1798{{"Constant[1798∈19]<br />ᐸ'people'ᐳ<br />ᐳPerson"}}:::plan
     PgClassExpression1799{{"PgClassExpression[1799∈19]<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant1798 & PgClassExpression1799 --> List1800
     PgSelect1807[["PgSelect[1807∈19]<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
-    Object18 & Access2420 --> PgSelect1807
+    Object18 -->|rejectNull| PgSelect1807
+    Access2420 --> PgSelect1807
     List1815{{"List[1815∈19]<br />ᐸ1813,1814ᐳ<br />ᐳPost"}}:::plan
     Constant1813{{"Constant[1813∈19]<br />ᐸ'posts'ᐳ<br />ᐳPost"}}:::plan
     PgClassExpression1814{{"PgClassExpression[1814∈19]<br />ᐸ__post__.”id”ᐳ"}}:::plan
     Constant1813 & PgClassExpression1814 --> List1815
     PgSelect1820[["PgSelect[1820∈19]<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
-    Object18 & Access2420 --> PgSelect1820
+    Object18 -->|rejectNull| PgSelect1820
+    Access2420 --> PgSelect1820
     List1828{{"List[1828∈19]<br />ᐸ1826,1827ᐳ<br />ᐳType"}}:::plan
     Constant1826{{"Constant[1826∈19]<br />ᐸ'types'ᐳ<br />ᐳType"}}:::plan
     PgClassExpression1827{{"PgClassExpression[1827∈19]<br />ᐸ__types__.”id”ᐳ"}}:::plan
     Constant1826 & PgClassExpression1827 --> List1828
     PgSelect1833[["PgSelect[1833∈19]<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
-    Object18 & Access2420 --> PgSelect1833
+    Object18 -->|rejectNull| PgSelect1833
+    Access2420 --> PgSelect1833
     List1841{{"List[1841∈19]<br />ᐸ1839,1840ᐳ<br />ᐳPersonSecret"}}:::plan
     Constant1839{{"Constant[1839∈19]<br />ᐸ'person_secrets'ᐳ<br />ᐳPersonSecret"}}:::plan
     PgClassExpression1840{{"PgClassExpression[1840∈19]<br />ᐸ__person_s...person_id”ᐳ"}}:::plan
     Constant1839 & PgClassExpression1840 --> List1841
     PgSelect1846[["PgSelect[1846∈19]<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
-    Object18 & Access2420 --> PgSelect1846
+    Object18 -->|rejectNull| PgSelect1846
+    Access2420 --> PgSelect1846
     List1854{{"List[1854∈19]<br />ᐸ1852,1853ᐳ<br />ᐳLeftArm"}}:::plan
     Constant1852{{"Constant[1852∈19]<br />ᐸ'left_arms'ᐳ<br />ᐳLeftArm"}}:::plan
     PgClassExpression1853{{"PgClassExpression[1853∈19]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
     Constant1852 & PgClassExpression1853 --> List1854
     PgSelect1859[["PgSelect[1859∈19]<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
-    Object18 & Access2420 --> PgSelect1859
+    Object18 -->|rejectNull| PgSelect1859
+    Access2420 --> PgSelect1859
     List1867{{"List[1867∈19]<br />ᐸ1865,1866ᐳ<br />ᐳMyTable"}}:::plan
     Constant1865{{"Constant[1865∈19]<br />ᐸ'my_tables'ᐳ<br />ᐳMyTable"}}:::plan
     PgClassExpression1866{{"PgClassExpression[1866∈19]<br />ᐸ__my_table__.”id”ᐳ"}}:::plan
     Constant1865 & PgClassExpression1866 --> List1867
     PgSelect1872[["PgSelect[1872∈19]<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
-    Object18 & Access2420 --> PgSelect1872
+    Object18 -->|rejectNull| PgSelect1872
+    Access2420 --> PgSelect1872
     List1880{{"List[1880∈19]<br />ᐸ1878,1879ᐳ<br />ᐳViewTable"}}:::plan
     Constant1878{{"Constant[1878∈19]<br />ᐸ'view_tables'ᐳ<br />ᐳViewTable"}}:::plan
     PgClassExpression1879{{"PgClassExpression[1879∈19]<br />ᐸ__view_table__.”id”ᐳ"}}:::plan
     Constant1878 & PgClassExpression1879 --> List1880
     PgSelect1885[["PgSelect[1885∈19]<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
-    Object18 & Access2420 --> PgSelect1885
+    Object18 -->|rejectNull| PgSelect1885
+    Access2420 --> PgSelect1885
     List1893{{"List[1893∈19]<br />ᐸ1891,1892ᐳ<br />ᐳSimilarTable1"}}:::plan
     Constant1891{{"Constant[1891∈19]<br />ᐸ'similar_table_1S'ᐳ<br />ᐳSimilarTable1"}}:::plan
     PgClassExpression1892{{"PgClassExpression[1892∈19]<br />ᐸ__similar_...e_1__.”id”ᐳ"}}:::plan
     Constant1891 & PgClassExpression1892 --> List1893
     PgSelect1902[["PgSelect[1902∈19]<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
-    Object18 & Access2420 --> PgSelect1902
+    Object18 -->|rejectNull| PgSelect1902
+    Access2420 --> PgSelect1902
     List1910{{"List[1910∈19]<br />ᐸ1908,1909ᐳ<br />ᐳSimilarTable2"}}:::plan
     Constant1908{{"Constant[1908∈19]<br />ᐸ'similar_table_2S'ᐳ<br />ᐳSimilarTable2"}}:::plan
     PgClassExpression1909{{"PgClassExpression[1909∈19]<br />ᐸ__similar_...e_2__.”id”ᐳ"}}:::plan
     Constant1908 & PgClassExpression1909 --> List1910
     PgSelect1919[["PgSelect[1919∈19]<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
-    Object18 & Access2420 --> PgSelect1919
+    Object18 -->|rejectNull| PgSelect1919
+    Access2420 --> PgSelect1919
     List1927{{"List[1927∈19]<br />ᐸ1925,1926ᐳ<br />ᐳNullTestRecord"}}:::plan
     Constant1925{{"Constant[1925∈19]<br />ᐸ'null_test_records'ᐳ<br />ᐳNullTestRecord"}}:::plan
     PgClassExpression1926{{"PgClassExpression[1926∈19]<br />ᐸ__null_tes...ord__.”id”ᐳ"}}:::plan
     Constant1925 & PgClassExpression1926 --> List1927
     PgSelect1932[["PgSelect[1932∈19]<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
-    Object18 & Access2420 --> PgSelect1932
+    Object18 -->|rejectNull| PgSelect1932
+    Access2420 --> PgSelect1932
     List1940{{"List[1940∈19]<br />ᐸ1938,1939ᐳ<br />ᐳIssue756"}}:::plan
     Constant1938{{"Constant[1938∈19]<br />ᐸ'issue756S'ᐳ<br />ᐳIssue756"}}:::plan
     PgClassExpression1939{{"PgClassExpression[1939∈19]<br />ᐸ__issue756__.”id”ᐳ"}}:::plan
@@ -2026,110 +2170,129 @@ graph TD
     PgSelect2031[["PgSelect[2031∈20]<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
     Access2423{{"Access[2423∈20]<br />ᐸ1944.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access2424{{"Access[2424∈20]<br />ᐸ1944.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
-    Object18 & Access2423 & Access2424 --> PgSelect2031
+    Object18 -->|rejectNull| PgSelect2031
+    Access2423 -->|rejectNull| PgSelect2031
+    Access2424 --> PgSelect2031
     List2040{{"List[2040∈20]<br />ᐸ2037,2038,2039ᐳ<br />ᐳCompoundKey"}}:::plan
     Constant2037{{"Constant[2037∈20]<br />ᐸ'compound_keys'ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression2038{{"PgClassExpression[2038∈20]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression2039{{"PgClassExpression[2039∈20]<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     Constant2037 & PgClassExpression2038 & PgClassExpression2039 --> List2040
     PgSelect1951[["PgSelect[1951∈20]<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
-    Object18 & Access2423 --> PgSelect1951
+    Object18 -->|rejectNull| PgSelect1951
+    Access2423 --> PgSelect1951
     List1959{{"List[1959∈20]<br />ᐸ1957,1958ᐳ<br />ᐳInput"}}:::plan
     Constant1957{{"Constant[1957∈20]<br />ᐸ'inputs'ᐳ<br />ᐳInput"}}:::plan
     PgClassExpression1958{{"PgClassExpression[1958∈20]<br />ᐸ__inputs__.”id”ᐳ"}}:::plan
     Constant1957 & PgClassExpression1958 --> List1959
     PgSelect1964[["PgSelect[1964∈20]<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
-    Object18 & Access2423 --> PgSelect1964
+    Object18 -->|rejectNull| PgSelect1964
+    Access2423 --> PgSelect1964
     List1972{{"List[1972∈20]<br />ᐸ1970,1971ᐳ<br />ᐳPatch"}}:::plan
     Constant1970{{"Constant[1970∈20]<br />ᐸ'patchs'ᐳ<br />ᐳPatch"}}:::plan
     PgClassExpression1971{{"PgClassExpression[1971∈20]<br />ᐸ__patchs__.”id”ᐳ"}}:::plan
     Constant1970 & PgClassExpression1971 --> List1972
     PgSelect1977[["PgSelect[1977∈20]<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
-    Object18 & Access2423 --> PgSelect1977
+    Object18 -->|rejectNull| PgSelect1977
+    Access2423 --> PgSelect1977
     List1985{{"List[1985∈20]<br />ᐸ1983,1984ᐳ<br />ᐳReserved"}}:::plan
     Constant1983{{"Constant[1983∈20]<br />ᐸ'reserveds'ᐳ<br />ᐳReserved"}}:::plan
     PgClassExpression1984{{"PgClassExpression[1984∈20]<br />ᐸ__reserved__.”id”ᐳ"}}:::plan
     Constant1983 & PgClassExpression1984 --> List1985
     PgSelect1990[["PgSelect[1990∈20]<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
-    Object18 & Access2423 --> PgSelect1990
+    Object18 -->|rejectNull| PgSelect1990
+    Access2423 --> PgSelect1990
     List1998{{"List[1998∈20]<br />ᐸ1996,1997ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     Constant1996{{"Constant[1996∈20]<br />ᐸ'reservedPatchs'ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     PgClassExpression1997{{"PgClassExpression[1997∈20]<br />ᐸ__reserved...chs__.”id”ᐳ"}}:::plan
     Constant1996 & PgClassExpression1997 --> List1998
     PgSelect2003[["PgSelect[2003∈20]<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
-    Object18 & Access2423 --> PgSelect2003
+    Object18 -->|rejectNull| PgSelect2003
+    Access2423 --> PgSelect2003
     List2011{{"List[2011∈20]<br />ᐸ2009,2010ᐳ<br />ᐳReservedInputRecord"}}:::plan
     Constant2009{{"Constant[2009∈20]<br />ᐸ'reserved_inputs'ᐳ<br />ᐳReservedInputRecord"}}:::plan
     PgClassExpression2010{{"PgClassExpression[2010∈20]<br />ᐸ__reserved_input__.”id”ᐳ"}}:::plan
     Constant2009 & PgClassExpression2010 --> List2011
     PgSelect2016[["PgSelect[2016∈20]<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
-    Object18 & Access2423 --> PgSelect2016
+    Object18 -->|rejectNull| PgSelect2016
+    Access2423 --> PgSelect2016
     List2024{{"List[2024∈20]<br />ᐸ2022,2023ᐳ<br />ᐳDefaultValue"}}:::plan
     Constant2022{{"Constant[2022∈20]<br />ᐸ'default_values'ᐳ<br />ᐳDefaultValue"}}:::plan
     PgClassExpression2023{{"PgClassExpression[2023∈20]<br />ᐸ__default_value__.”id”ᐳ"}}:::plan
     Constant2022 & PgClassExpression2023 --> List2024
     PgSelect2047[["PgSelect[2047∈20]<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
-    Object18 & Access2423 --> PgSelect2047
+    Object18 -->|rejectNull| PgSelect2047
+    Access2423 --> PgSelect2047
     List2055{{"List[2055∈20]<br />ᐸ2053,2054ᐳ<br />ᐳPerson"}}:::plan
     Constant2053{{"Constant[2053∈20]<br />ᐸ'people'ᐳ<br />ᐳPerson"}}:::plan
     PgClassExpression2054{{"PgClassExpression[2054∈20]<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant2053 & PgClassExpression2054 --> List2055
     PgSelect2062[["PgSelect[2062∈20]<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
-    Object18 & Access2423 --> PgSelect2062
+    Object18 -->|rejectNull| PgSelect2062
+    Access2423 --> PgSelect2062
     List2070{{"List[2070∈20]<br />ᐸ2068,2069ᐳ<br />ᐳPost"}}:::plan
     Constant2068{{"Constant[2068∈20]<br />ᐸ'posts'ᐳ<br />ᐳPost"}}:::plan
     PgClassExpression2069{{"PgClassExpression[2069∈20]<br />ᐸ__post__.”id”ᐳ"}}:::plan
     Constant2068 & PgClassExpression2069 --> List2070
     PgSelect2075[["PgSelect[2075∈20]<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
-    Object18 & Access2423 --> PgSelect2075
+    Object18 -->|rejectNull| PgSelect2075
+    Access2423 --> PgSelect2075
     List2083{{"List[2083∈20]<br />ᐸ2081,2082ᐳ<br />ᐳType"}}:::plan
     Constant2081{{"Constant[2081∈20]<br />ᐸ'types'ᐳ<br />ᐳType"}}:::plan
     PgClassExpression2082{{"PgClassExpression[2082∈20]<br />ᐸ__types__.”id”ᐳ"}}:::plan
     Constant2081 & PgClassExpression2082 --> List2083
     PgSelect2088[["PgSelect[2088∈20]<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
-    Object18 & Access2423 --> PgSelect2088
+    Object18 -->|rejectNull| PgSelect2088
+    Access2423 --> PgSelect2088
     List2096{{"List[2096∈20]<br />ᐸ2094,2095ᐳ<br />ᐳPersonSecret"}}:::plan
     Constant2094{{"Constant[2094∈20]<br />ᐸ'person_secrets'ᐳ<br />ᐳPersonSecret"}}:::plan
     PgClassExpression2095{{"PgClassExpression[2095∈20]<br />ᐸ__person_s...person_id”ᐳ"}}:::plan
     Constant2094 & PgClassExpression2095 --> List2096
     PgSelect2101[["PgSelect[2101∈20]<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
-    Object18 & Access2423 --> PgSelect2101
+    Object18 -->|rejectNull| PgSelect2101
+    Access2423 --> PgSelect2101
     List2109{{"List[2109∈20]<br />ᐸ2107,2108ᐳ<br />ᐳLeftArm"}}:::plan
     Constant2107{{"Constant[2107∈20]<br />ᐸ'left_arms'ᐳ<br />ᐳLeftArm"}}:::plan
     PgClassExpression2108{{"PgClassExpression[2108∈20]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
     Constant2107 & PgClassExpression2108 --> List2109
     PgSelect2114[["PgSelect[2114∈20]<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
-    Object18 & Access2423 --> PgSelect2114
+    Object18 -->|rejectNull| PgSelect2114
+    Access2423 --> PgSelect2114
     List2122{{"List[2122∈20]<br />ᐸ2120,2121ᐳ<br />ᐳMyTable"}}:::plan
     Constant2120{{"Constant[2120∈20]<br />ᐸ'my_tables'ᐳ<br />ᐳMyTable"}}:::plan
     PgClassExpression2121{{"PgClassExpression[2121∈20]<br />ᐸ__my_table__.”id”ᐳ"}}:::plan
     Constant2120 & PgClassExpression2121 --> List2122
     PgSelect2127[["PgSelect[2127∈20]<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
-    Object18 & Access2423 --> PgSelect2127
+    Object18 -->|rejectNull| PgSelect2127
+    Access2423 --> PgSelect2127
     List2135{{"List[2135∈20]<br />ᐸ2133,2134ᐳ<br />ᐳViewTable"}}:::plan
     Constant2133{{"Constant[2133∈20]<br />ᐸ'view_tables'ᐳ<br />ᐳViewTable"}}:::plan
     PgClassExpression2134{{"PgClassExpression[2134∈20]<br />ᐸ__view_table__.”id”ᐳ"}}:::plan
     Constant2133 & PgClassExpression2134 --> List2135
     PgSelect2140[["PgSelect[2140∈20]<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
-    Object18 & Access2423 --> PgSelect2140
+    Object18 -->|rejectNull| PgSelect2140
+    Access2423 --> PgSelect2140
     List2148{{"List[2148∈20]<br />ᐸ2146,2147ᐳ<br />ᐳSimilarTable1"}}:::plan
     Constant2146{{"Constant[2146∈20]<br />ᐸ'similar_table_1S'ᐳ<br />ᐳSimilarTable1"}}:::plan
     PgClassExpression2147{{"PgClassExpression[2147∈20]<br />ᐸ__similar_...e_1__.”id”ᐳ"}}:::plan
     Constant2146 & PgClassExpression2147 --> List2148
     PgSelect2157[["PgSelect[2157∈20]<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
-    Object18 & Access2423 --> PgSelect2157
+    Object18 -->|rejectNull| PgSelect2157
+    Access2423 --> PgSelect2157
     List2165{{"List[2165∈20]<br />ᐸ2163,2164ᐳ<br />ᐳSimilarTable2"}}:::plan
     Constant2163{{"Constant[2163∈20]<br />ᐸ'similar_table_2S'ᐳ<br />ᐳSimilarTable2"}}:::plan
     PgClassExpression2164{{"PgClassExpression[2164∈20]<br />ᐸ__similar_...e_2__.”id”ᐳ"}}:::plan
     Constant2163 & PgClassExpression2164 --> List2165
     PgSelect2174[["PgSelect[2174∈20]<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
-    Object18 & Access2423 --> PgSelect2174
+    Object18 -->|rejectNull| PgSelect2174
+    Access2423 --> PgSelect2174
     List2182{{"List[2182∈20]<br />ᐸ2180,2181ᐳ<br />ᐳNullTestRecord"}}:::plan
     Constant2180{{"Constant[2180∈20]<br />ᐸ'null_test_records'ᐳ<br />ᐳNullTestRecord"}}:::plan
     PgClassExpression2181{{"PgClassExpression[2181∈20]<br />ᐸ__null_tes...ord__.”id”ᐳ"}}:::plan
     Constant2180 & PgClassExpression2181 --> List2182
     PgSelect2187[["PgSelect[2187∈20]<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
-    Object18 & Access2423 --> PgSelect2187
+    Object18 -->|rejectNull| PgSelect2187
+    Access2423 --> PgSelect2187
     List2195{{"List[2195∈20]<br />ᐸ2193,2194ᐳ<br />ᐳIssue756"}}:::plan
     Constant2193{{"Constant[2193∈20]<br />ᐸ'issue756S'ᐳ<br />ᐳIssue756"}}:::plan
     PgClassExpression2194{{"PgClassExpression[2194∈20]<br />ᐸ__issue756__.”id”ᐳ"}}:::plan

--- a/postgraphile/postgraphile/__tests__/queries/v4/nodeId-earlyExit.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/nodeId-earlyExit.mermaid
@@ -15,10 +15,12 @@ graph TD
     Access34 & Access35 --> Object36
     PgSelect50[["PgSelect[50∈0]<br />ᐸpersonᐳ"]]:::plan
     Access48{{"Access[48∈0]<br />ᐸ47.1ᐳ"}}:::plan
-    Object36 & Access48 --> PgSelect50
+    Object36 -->|rejectNull| PgSelect50
+    Access48 --> PgSelect50
     PgSelect89[["PgSelect[89∈0]<br />ᐸpersonᐳ"]]:::plan
     Access87{{"Access[87∈0]<br />ᐸ86.1ᐳ"}}:::plan
-    Object36 & Access87 --> PgSelect89
+    Object36 -->|rejectNull| PgSelect89
+    Access87 --> PgSelect89
     __Value3["__Value[3∈0]<br />ᐸcontextᐳ"]:::plan
     __Value3 --> Access34
     __Value3 --> Access35

--- a/postgraphile/postgraphile/__tests__/queries/v4/query.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/query.mermaid
@@ -52,14 +52,17 @@ graph TD
     Object507{{"Object[507∈1]<br />ᐸ{pgSettings,withPgClient}ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access3159{{"Access[3159∈1]<br />ᐸ11.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access3160{{"Access[3160∈1]<br />ᐸ11.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
-    Object507 & Access3159 & Access3160 --> PgSelect584
+    Object507 -->|rejectNull| PgSelect584
+    Access3159 -->|rejectNull| PgSelect584
+    Access3160 --> PgSelect584
     List593{{"List[593∈1]<br />ᐸ590,591,592ᐳ<br />ᐳCompoundKey"}}:::plan
     Constant590{{"Constant[590∈1]<br />ᐸ'compound_keys'ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression591{{"PgClassExpression[591∈1]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression592{{"PgClassExpression[592∈1]<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     Constant590 & PgClassExpression591 & PgClassExpression592 --> List593
     PgSelect504[["PgSelect[504∈1]<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
-    Object507 & Access3159 --> PgSelect504
+    Object507 -->|rejectNull| PgSelect504
+    Access3159 --> PgSelect504
     Access505{{"Access[505∈1]<br />ᐸ3.pgSettingsᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access506{{"Access[506∈1]<br />ᐸ3.withPgClientᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access505 & Access506 --> Object507
@@ -68,97 +71,113 @@ graph TD
     PgClassExpression511{{"PgClassExpression[511∈1]<br />ᐸ__inputs__.”id”ᐳ"}}:::plan
     Constant510 & PgClassExpression511 --> List512
     PgSelect517[["PgSelect[517∈1]<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
-    Object507 & Access3159 --> PgSelect517
+    Object507 -->|rejectNull| PgSelect517
+    Access3159 --> PgSelect517
     List525{{"List[525∈1]<br />ᐸ523,524ᐳ<br />ᐳPatch"}}:::plan
     Constant523{{"Constant[523∈1]<br />ᐸ'patchs'ᐳ<br />ᐳPatch"}}:::plan
     PgClassExpression524{{"PgClassExpression[524∈1]<br />ᐸ__patchs__.”id”ᐳ"}}:::plan
     Constant523 & PgClassExpression524 --> List525
     PgSelect530[["PgSelect[530∈1]<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
-    Object507 & Access3159 --> PgSelect530
+    Object507 -->|rejectNull| PgSelect530
+    Access3159 --> PgSelect530
     List538{{"List[538∈1]<br />ᐸ536,537ᐳ<br />ᐳReserved"}}:::plan
     Constant536{{"Constant[536∈1]<br />ᐸ'reserveds'ᐳ<br />ᐳReserved"}}:::plan
     PgClassExpression537{{"PgClassExpression[537∈1]<br />ᐸ__reserved__.”id”ᐳ"}}:::plan
     Constant536 & PgClassExpression537 --> List538
     PgSelect543[["PgSelect[543∈1]<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
-    Object507 & Access3159 --> PgSelect543
+    Object507 -->|rejectNull| PgSelect543
+    Access3159 --> PgSelect543
     List551{{"List[551∈1]<br />ᐸ549,550ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     Constant549{{"Constant[549∈1]<br />ᐸ'reservedPatchs'ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     PgClassExpression550{{"PgClassExpression[550∈1]<br />ᐸ__reserved...chs__.”id”ᐳ"}}:::plan
     Constant549 & PgClassExpression550 --> List551
     PgSelect556[["PgSelect[556∈1]<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
-    Object507 & Access3159 --> PgSelect556
+    Object507 -->|rejectNull| PgSelect556
+    Access3159 --> PgSelect556
     List564{{"List[564∈1]<br />ᐸ562,563ᐳ<br />ᐳReservedInputRecord"}}:::plan
     Constant562{{"Constant[562∈1]<br />ᐸ'reserved_inputs'ᐳ<br />ᐳReservedInputRecord"}}:::plan
     PgClassExpression563{{"PgClassExpression[563∈1]<br />ᐸ__reserved_input__.”id”ᐳ"}}:::plan
     Constant562 & PgClassExpression563 --> List564
     PgSelect569[["PgSelect[569∈1]<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
-    Object507 & Access3159 --> PgSelect569
+    Object507 -->|rejectNull| PgSelect569
+    Access3159 --> PgSelect569
     List577{{"List[577∈1]<br />ᐸ575,576ᐳ<br />ᐳDefaultValue"}}:::plan
     Constant575{{"Constant[575∈1]<br />ᐸ'default_values'ᐳ<br />ᐳDefaultValue"}}:::plan
     PgClassExpression576{{"PgClassExpression[576∈1]<br />ᐸ__default_value__.”id”ᐳ"}}:::plan
     Constant575 & PgClassExpression576 --> List577
     PgSelect598[["PgSelect[598∈1]<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
-    Object507 & Access3159 --> PgSelect598
+    Object507 -->|rejectNull| PgSelect598
+    Access3159 --> PgSelect598
     List606{{"List[606∈1]<br />ᐸ604,605ᐳ<br />ᐳPerson"}}:::plan
     Constant604{{"Constant[604∈1]<br />ᐸ'people'ᐳ<br />ᐳPerson"}}:::plan
     PgClassExpression605{{"PgClassExpression[605∈1]<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant604 & PgClassExpression605 --> List606
     PgSelect611[["PgSelect[611∈1]<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
-    Object507 & Access3159 --> PgSelect611
+    Object507 -->|rejectNull| PgSelect611
+    Access3159 --> PgSelect611
     List619{{"List[619∈1]<br />ᐸ617,618ᐳ<br />ᐳPost"}}:::plan
     Constant617{{"Constant[617∈1]<br />ᐸ'posts'ᐳ<br />ᐳPost"}}:::plan
     PgClassExpression618{{"PgClassExpression[618∈1]<br />ᐸ__post__.”id”ᐳ"}}:::plan
     Constant617 & PgClassExpression618 --> List619
     PgSelect624[["PgSelect[624∈1]<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
-    Object507 & Access3159 --> PgSelect624
+    Object507 -->|rejectNull| PgSelect624
+    Access3159 --> PgSelect624
     List632{{"List[632∈1]<br />ᐸ630,631ᐳ<br />ᐳType"}}:::plan
     Constant630{{"Constant[630∈1]<br />ᐸ'types'ᐳ<br />ᐳType"}}:::plan
     PgClassExpression631{{"PgClassExpression[631∈1]<br />ᐸ__types__.”id”ᐳ"}}:::plan
     Constant630 & PgClassExpression631 --> List632
     PgSelect637[["PgSelect[637∈1]<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
-    Object507 & Access3159 --> PgSelect637
+    Object507 -->|rejectNull| PgSelect637
+    Access3159 --> PgSelect637
     List645{{"List[645∈1]<br />ᐸ643,644ᐳ<br />ᐳPersonSecret"}}:::plan
     Constant643{{"Constant[643∈1]<br />ᐸ'person_secrets'ᐳ<br />ᐳPersonSecret"}}:::plan
     PgClassExpression644{{"PgClassExpression[644∈1]<br />ᐸ__person_s...person_id”ᐳ"}}:::plan
     Constant643 & PgClassExpression644 --> List645
     PgSelect650[["PgSelect[650∈1]<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
-    Object507 & Access3159 --> PgSelect650
+    Object507 -->|rejectNull| PgSelect650
+    Access3159 --> PgSelect650
     List658{{"List[658∈1]<br />ᐸ656,657ᐳ<br />ᐳLeftArm"}}:::plan
     Constant656{{"Constant[656∈1]<br />ᐸ'left_arms'ᐳ<br />ᐳLeftArm"}}:::plan
     PgClassExpression657{{"PgClassExpression[657∈1]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
     Constant656 & PgClassExpression657 --> List658
     PgSelect663[["PgSelect[663∈1]<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
-    Object507 & Access3159 --> PgSelect663
+    Object507 -->|rejectNull| PgSelect663
+    Access3159 --> PgSelect663
     List671{{"List[671∈1]<br />ᐸ669,670ᐳ<br />ᐳMyTable"}}:::plan
     Constant669{{"Constant[669∈1]<br />ᐸ'my_tables'ᐳ<br />ᐳMyTable"}}:::plan
     PgClassExpression670{{"PgClassExpression[670∈1]<br />ᐸ__my_table__.”id”ᐳ"}}:::plan
     Constant669 & PgClassExpression670 --> List671
     PgSelect676[["PgSelect[676∈1]<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
-    Object507 & Access3159 --> PgSelect676
+    Object507 -->|rejectNull| PgSelect676
+    Access3159 --> PgSelect676
     List684{{"List[684∈1]<br />ᐸ682,683ᐳ<br />ᐳViewTable"}}:::plan
     Constant682{{"Constant[682∈1]<br />ᐸ'view_tables'ᐳ<br />ᐳViewTable"}}:::plan
     PgClassExpression683{{"PgClassExpression[683∈1]<br />ᐸ__view_table__.”id”ᐳ"}}:::plan
     Constant682 & PgClassExpression683 --> List684
     PgSelect689[["PgSelect[689∈1]<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
-    Object507 & Access3159 --> PgSelect689
+    Object507 -->|rejectNull| PgSelect689
+    Access3159 --> PgSelect689
     List697{{"List[697∈1]<br />ᐸ695,696ᐳ<br />ᐳSimilarTable1"}}:::plan
     Constant695{{"Constant[695∈1]<br />ᐸ'similar_table_1S'ᐳ<br />ᐳSimilarTable1"}}:::plan
     PgClassExpression696{{"PgClassExpression[696∈1]<br />ᐸ__similar_...e_1__.”id”ᐳ"}}:::plan
     Constant695 & PgClassExpression696 --> List697
     PgSelect702[["PgSelect[702∈1]<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
-    Object507 & Access3159 --> PgSelect702
+    Object507 -->|rejectNull| PgSelect702
+    Access3159 --> PgSelect702
     List710{{"List[710∈1]<br />ᐸ708,709ᐳ<br />ᐳSimilarTable2"}}:::plan
     Constant708{{"Constant[708∈1]<br />ᐸ'similar_table_2S'ᐳ<br />ᐳSimilarTable2"}}:::plan
     PgClassExpression709{{"PgClassExpression[709∈1]<br />ᐸ__similar_...e_2__.”id”ᐳ"}}:::plan
     Constant708 & PgClassExpression709 --> List710
     PgSelect715[["PgSelect[715∈1]<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
-    Object507 & Access3159 --> PgSelect715
+    Object507 -->|rejectNull| PgSelect715
+    Access3159 --> PgSelect715
     List723{{"List[723∈1]<br />ᐸ721,722ᐳ<br />ᐳNullTestRecord"}}:::plan
     Constant721{{"Constant[721∈1]<br />ᐸ'null_test_records'ᐳ<br />ᐳNullTestRecord"}}:::plan
     PgClassExpression722{{"PgClassExpression[722∈1]<br />ᐸ__null_tes...ord__.”id”ᐳ"}}:::plan
     Constant721 & PgClassExpression722 --> List723
     PgSelect728[["PgSelect[728∈1]<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
-    Object507 & Access3159 --> PgSelect728
+    Object507 -->|rejectNull| PgSelect728
+    Access3159 --> PgSelect728
     List736{{"List[736∈1]<br />ᐸ734,735ᐳ<br />ᐳIssue756"}}:::plan
     Constant734{{"Constant[734∈1]<br />ᐸ'issue756S'ᐳ<br />ᐳIssue756"}}:::plan
     PgClassExpression735{{"PgClassExpression[735∈1]<br />ᐸ__issue756__.”id”ᐳ"}}:::plan
@@ -308,110 +327,129 @@ graph TD
     PgSelect104[["PgSelect[104∈2]<br />ᐸcompound_keyᐳ<br />ᐳQueryᐳCompoundKey"]]:::plan
     Access3162{{"Access[3162∈2]<br />ᐸ17.base64JSON.1ᐳ<br />ᐳQueryᐳInput<br />ᐳQueryᐳPatch<br />ᐳQueryᐳReserved<br />ᐳQueryᐳReservedPatchRecord<br />ᐳQueryᐳReservedInputRecord<br />ᐳQueryᐳDefaultValue<br />ᐳQueryᐳCompoundKey<br />ᐳQueryᐳPerson<br />ᐳQueryᐳPost<br />ᐳQueryᐳType<br />ᐳQueryᐳPersonSecret<br />ᐳQueryᐳLeftArm<br />ᐳQueryᐳMyTable<br />ᐳQueryᐳViewTable<br />ᐳQueryᐳSimilarTable1<br />ᐳQueryᐳSimilarTable2<br />ᐳQueryᐳNullTestRecord<br />ᐳQueryᐳIssue756"}}:::plan
     Access3163{{"Access[3163∈2]<br />ᐸ17.base64JSON.2ᐳ<br />ᐳQueryᐳCompoundKey"}}:::plan
-    Object507 & Access3162 & Access3163 --> PgSelect104
+    Object507 -->|rejectNull| PgSelect104
+    Access3162 -->|rejectNull| PgSelect104
+    Access3163 --> PgSelect104
     List113{{"List[113∈2]<br />ᐸ110,111,112ᐳ<br />ᐳQueryᐳCompoundKey"}}:::plan
     Constant110{{"Constant[110∈2]<br />ᐸ'compound_keys'ᐳ<br />ᐳQueryᐳCompoundKey"}}:::plan
     PgClassExpression111{{"PgClassExpression[111∈2]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression112{{"PgClassExpression[112∈2]<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     Constant110 & PgClassExpression111 & PgClassExpression112 --> List113
     PgSelect24[["PgSelect[24∈2]<br />ᐸinputsᐳ<br />ᐳQueryᐳInput"]]:::plan
-    Object507 & Access3162 --> PgSelect24
+    Object507 -->|rejectNull| PgSelect24
+    Access3162 --> PgSelect24
     List32{{"List[32∈2]<br />ᐸ30,31ᐳ<br />ᐳQueryᐳInput"}}:::plan
     Constant30{{"Constant[30∈2]<br />ᐸ'inputs'ᐳ<br />ᐳQueryᐳInput"}}:::plan
     PgClassExpression31{{"PgClassExpression[31∈2]<br />ᐸ__inputs__.”id”ᐳ"}}:::plan
     Constant30 & PgClassExpression31 --> List32
     PgSelect37[["PgSelect[37∈2]<br />ᐸpatchsᐳ<br />ᐳQueryᐳPatch"]]:::plan
-    Object507 & Access3162 --> PgSelect37
+    Object507 -->|rejectNull| PgSelect37
+    Access3162 --> PgSelect37
     List45{{"List[45∈2]<br />ᐸ43,44ᐳ<br />ᐳQueryᐳPatch"}}:::plan
     Constant43{{"Constant[43∈2]<br />ᐸ'patchs'ᐳ<br />ᐳQueryᐳPatch"}}:::plan
     PgClassExpression44{{"PgClassExpression[44∈2]<br />ᐸ__patchs__.”id”ᐳ"}}:::plan
     Constant43 & PgClassExpression44 --> List45
     PgSelect50[["PgSelect[50∈2]<br />ᐸreservedᐳ<br />ᐳQueryᐳReserved"]]:::plan
-    Object507 & Access3162 --> PgSelect50
+    Object507 -->|rejectNull| PgSelect50
+    Access3162 --> PgSelect50
     List58{{"List[58∈2]<br />ᐸ56,57ᐳ<br />ᐳQueryᐳReserved"}}:::plan
     Constant56{{"Constant[56∈2]<br />ᐸ'reserveds'ᐳ<br />ᐳQueryᐳReserved"}}:::plan
     PgClassExpression57{{"PgClassExpression[57∈2]<br />ᐸ__reserved__.”id”ᐳ"}}:::plan
     Constant56 & PgClassExpression57 --> List58
     PgSelect63[["PgSelect[63∈2]<br />ᐸreservedPatchsᐳ<br />ᐳQueryᐳReservedPatchRecord"]]:::plan
-    Object507 & Access3162 --> PgSelect63
+    Object507 -->|rejectNull| PgSelect63
+    Access3162 --> PgSelect63
     List71{{"List[71∈2]<br />ᐸ69,70ᐳ<br />ᐳQueryᐳReservedPatchRecord"}}:::plan
     Constant69{{"Constant[69∈2]<br />ᐸ'reservedPatchs'ᐳ<br />ᐳQueryᐳReservedPatchRecord"}}:::plan
     PgClassExpression70{{"PgClassExpression[70∈2]<br />ᐸ__reserved...chs__.”id”ᐳ"}}:::plan
     Constant69 & PgClassExpression70 --> List71
     PgSelect76[["PgSelect[76∈2]<br />ᐸreserved_inputᐳ<br />ᐳQueryᐳReservedInputRecord"]]:::plan
-    Object507 & Access3162 --> PgSelect76
+    Object507 -->|rejectNull| PgSelect76
+    Access3162 --> PgSelect76
     List84{{"List[84∈2]<br />ᐸ82,83ᐳ<br />ᐳQueryᐳReservedInputRecord"}}:::plan
     Constant82{{"Constant[82∈2]<br />ᐸ'reserved_inputs'ᐳ<br />ᐳQueryᐳReservedInputRecord"}}:::plan
     PgClassExpression83{{"PgClassExpression[83∈2]<br />ᐸ__reserved_input__.”id”ᐳ"}}:::plan
     Constant82 & PgClassExpression83 --> List84
     PgSelect89[["PgSelect[89∈2]<br />ᐸdefault_valueᐳ<br />ᐳQueryᐳDefaultValue"]]:::plan
-    Object507 & Access3162 --> PgSelect89
+    Object507 -->|rejectNull| PgSelect89
+    Access3162 --> PgSelect89
     List97{{"List[97∈2]<br />ᐸ95,96ᐳ<br />ᐳQueryᐳDefaultValue"}}:::plan
     Constant95{{"Constant[95∈2]<br />ᐸ'default_values'ᐳ<br />ᐳQueryᐳDefaultValue"}}:::plan
     PgClassExpression96{{"PgClassExpression[96∈2]<br />ᐸ__default_value__.”id”ᐳ"}}:::plan
     Constant95 & PgClassExpression96 --> List97
     PgSelect118[["PgSelect[118∈2]<br />ᐸpersonᐳ<br />ᐳQueryᐳPerson"]]:::plan
-    Object507 & Access3162 --> PgSelect118
+    Object507 -->|rejectNull| PgSelect118
+    Access3162 --> PgSelect118
     List126{{"List[126∈2]<br />ᐸ124,125ᐳ<br />ᐳQueryᐳPerson"}}:::plan
     Constant124{{"Constant[124∈2]<br />ᐸ'people'ᐳ<br />ᐳQueryᐳPerson"}}:::plan
     PgClassExpression125{{"PgClassExpression[125∈2]<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant124 & PgClassExpression125 --> List126
     PgSelect131[["PgSelect[131∈2]<br />ᐸpostᐳ<br />ᐳQueryᐳPost"]]:::plan
-    Object507 & Access3162 --> PgSelect131
+    Object507 -->|rejectNull| PgSelect131
+    Access3162 --> PgSelect131
     List139{{"List[139∈2]<br />ᐸ137,138ᐳ<br />ᐳQueryᐳPost"}}:::plan
     Constant137{{"Constant[137∈2]<br />ᐸ'posts'ᐳ<br />ᐳQueryᐳPost"}}:::plan
     PgClassExpression138{{"PgClassExpression[138∈2]<br />ᐸ__post__.”id”ᐳ"}}:::plan
     Constant137 & PgClassExpression138 --> List139
     PgSelect144[["PgSelect[144∈2]<br />ᐸtypesᐳ<br />ᐳQueryᐳType"]]:::plan
-    Object507 & Access3162 --> PgSelect144
+    Object507 -->|rejectNull| PgSelect144
+    Access3162 --> PgSelect144
     List152{{"List[152∈2]<br />ᐸ150,151ᐳ<br />ᐳQueryᐳType"}}:::plan
     Constant150{{"Constant[150∈2]<br />ᐸ'types'ᐳ<br />ᐳQueryᐳType"}}:::plan
     PgClassExpression151{{"PgClassExpression[151∈2]<br />ᐸ__types__.”id”ᐳ"}}:::plan
     Constant150 & PgClassExpression151 --> List152
     PgSelect157[["PgSelect[157∈2]<br />ᐸperson_secretᐳ<br />ᐳQueryᐳPersonSecret"]]:::plan
-    Object507 & Access3162 --> PgSelect157
+    Object507 -->|rejectNull| PgSelect157
+    Access3162 --> PgSelect157
     List165{{"List[165∈2]<br />ᐸ163,164ᐳ<br />ᐳQueryᐳPersonSecret"}}:::plan
     Constant163{{"Constant[163∈2]<br />ᐸ'person_secrets'ᐳ<br />ᐳQueryᐳPersonSecret"}}:::plan
     PgClassExpression164{{"PgClassExpression[164∈2]<br />ᐸ__person_s...person_id”ᐳ"}}:::plan
     Constant163 & PgClassExpression164 --> List165
     PgSelect170[["PgSelect[170∈2]<br />ᐸleft_armᐳ<br />ᐳQueryᐳLeftArm"]]:::plan
-    Object507 & Access3162 --> PgSelect170
+    Object507 -->|rejectNull| PgSelect170
+    Access3162 --> PgSelect170
     List178{{"List[178∈2]<br />ᐸ176,177ᐳ<br />ᐳQueryᐳLeftArm"}}:::plan
     Constant176{{"Constant[176∈2]<br />ᐸ'left_arms'ᐳ<br />ᐳQueryᐳLeftArm"}}:::plan
     PgClassExpression177{{"PgClassExpression[177∈2]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
     Constant176 & PgClassExpression177 --> List178
     PgSelect183[["PgSelect[183∈2]<br />ᐸmy_tableᐳ<br />ᐳQueryᐳMyTable"]]:::plan
-    Object507 & Access3162 --> PgSelect183
+    Object507 -->|rejectNull| PgSelect183
+    Access3162 --> PgSelect183
     List191{{"List[191∈2]<br />ᐸ189,190ᐳ<br />ᐳQueryᐳMyTable"}}:::plan
     Constant189{{"Constant[189∈2]<br />ᐸ'my_tables'ᐳ<br />ᐳQueryᐳMyTable"}}:::plan
     PgClassExpression190{{"PgClassExpression[190∈2]<br />ᐸ__my_table__.”id”ᐳ"}}:::plan
     Constant189 & PgClassExpression190 --> List191
     PgSelect196[["PgSelect[196∈2]<br />ᐸview_tableᐳ<br />ᐳQueryᐳViewTable"]]:::plan
-    Object507 & Access3162 --> PgSelect196
+    Object507 -->|rejectNull| PgSelect196
+    Access3162 --> PgSelect196
     List204{{"List[204∈2]<br />ᐸ202,203ᐳ<br />ᐳQueryᐳViewTable"}}:::plan
     Constant202{{"Constant[202∈2]<br />ᐸ'view_tables'ᐳ<br />ᐳQueryᐳViewTable"}}:::plan
     PgClassExpression203{{"PgClassExpression[203∈2]<br />ᐸ__view_table__.”id”ᐳ"}}:::plan
     Constant202 & PgClassExpression203 --> List204
     PgSelect209[["PgSelect[209∈2]<br />ᐸsimilar_table_1ᐳ<br />ᐳQueryᐳSimilarTable1"]]:::plan
-    Object507 & Access3162 --> PgSelect209
+    Object507 -->|rejectNull| PgSelect209
+    Access3162 --> PgSelect209
     List217{{"List[217∈2]<br />ᐸ215,216ᐳ<br />ᐳQueryᐳSimilarTable1"}}:::plan
     Constant215{{"Constant[215∈2]<br />ᐸ'similar_table_1S'ᐳ<br />ᐳQueryᐳSimilarTable1"}}:::plan
     PgClassExpression216{{"PgClassExpression[216∈2]<br />ᐸ__similar_...e_1__.”id”ᐳ"}}:::plan
     Constant215 & PgClassExpression216 --> List217
     PgSelect222[["PgSelect[222∈2]<br />ᐸsimilar_table_2ᐳ<br />ᐳQueryᐳSimilarTable2"]]:::plan
-    Object507 & Access3162 --> PgSelect222
+    Object507 -->|rejectNull| PgSelect222
+    Access3162 --> PgSelect222
     List230{{"List[230∈2]<br />ᐸ228,229ᐳ<br />ᐳQueryᐳSimilarTable2"}}:::plan
     Constant228{{"Constant[228∈2]<br />ᐸ'similar_table_2S'ᐳ<br />ᐳQueryᐳSimilarTable2"}}:::plan
     PgClassExpression229{{"PgClassExpression[229∈2]<br />ᐸ__similar_...e_2__.”id”ᐳ"}}:::plan
     Constant228 & PgClassExpression229 --> List230
     PgSelect235[["PgSelect[235∈2]<br />ᐸnull_test_recordᐳ<br />ᐳQueryᐳNullTestRecord"]]:::plan
-    Object507 & Access3162 --> PgSelect235
+    Object507 -->|rejectNull| PgSelect235
+    Access3162 --> PgSelect235
     List243{{"List[243∈2]<br />ᐸ241,242ᐳ<br />ᐳQueryᐳNullTestRecord"}}:::plan
     Constant241{{"Constant[241∈2]<br />ᐸ'null_test_records'ᐳ<br />ᐳQueryᐳNullTestRecord"}}:::plan
     PgClassExpression242{{"PgClassExpression[242∈2]<br />ᐸ__null_tes...ord__.”id”ᐳ"}}:::plan
     Constant241 & PgClassExpression242 --> List243
     PgSelect248[["PgSelect[248∈2]<br />ᐸissue756ᐳ<br />ᐳQueryᐳIssue756"]]:::plan
-    Object507 & Access3162 --> PgSelect248
+    Object507 -->|rejectNull| PgSelect248
+    Access3162 --> PgSelect248
     List256{{"List[256∈2]<br />ᐸ254,255ᐳ<br />ᐳQueryᐳIssue756"}}:::plan
     Constant254{{"Constant[254∈2]<br />ᐸ'issue756S'ᐳ<br />ᐳQueryᐳIssue756"}}:::plan
     PgClassExpression255{{"PgClassExpression[255∈2]<br />ᐸ__issue756__.”id”ᐳ"}}:::plan
@@ -551,110 +589,129 @@ graph TD
     PgSelect347[["PgSelect[347∈3]<br />ᐸcompound_keyᐳ<br />ᐳQueryᐳCompoundKey"]]:::plan
     Access3165{{"Access[3165∈3]<br />ᐸ260.base64JSON.1ᐳ<br />ᐳQueryᐳInput<br />ᐳQueryᐳPatch<br />ᐳQueryᐳReserved<br />ᐳQueryᐳReservedPatchRecord<br />ᐳQueryᐳReservedInputRecord<br />ᐳQueryᐳDefaultValue<br />ᐳQueryᐳCompoundKey<br />ᐳQueryᐳPerson<br />ᐳQueryᐳPost<br />ᐳQueryᐳType<br />ᐳQueryᐳPersonSecret<br />ᐳQueryᐳLeftArm<br />ᐳQueryᐳMyTable<br />ᐳQueryᐳViewTable<br />ᐳQueryᐳSimilarTable1<br />ᐳQueryᐳSimilarTable2<br />ᐳQueryᐳNullTestRecord<br />ᐳQueryᐳIssue756"}}:::plan
     Access3166{{"Access[3166∈3]<br />ᐸ260.base64JSON.2ᐳ<br />ᐳQueryᐳCompoundKey"}}:::plan
-    Object507 & Access3165 & Access3166 --> PgSelect347
+    Object507 -->|rejectNull| PgSelect347
+    Access3165 -->|rejectNull| PgSelect347
+    Access3166 --> PgSelect347
     List356{{"List[356∈3]<br />ᐸ353,354,355ᐳ<br />ᐳQueryᐳCompoundKey"}}:::plan
     Constant353{{"Constant[353∈3]<br />ᐸ'compound_keys'ᐳ<br />ᐳQueryᐳCompoundKey"}}:::plan
     PgClassExpression354{{"PgClassExpression[354∈3]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression355{{"PgClassExpression[355∈3]<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     Constant353 & PgClassExpression354 & PgClassExpression355 --> List356
     PgSelect267[["PgSelect[267∈3]<br />ᐸinputsᐳ<br />ᐳQueryᐳInput"]]:::plan
-    Object507 & Access3165 --> PgSelect267
+    Object507 -->|rejectNull| PgSelect267
+    Access3165 --> PgSelect267
     List275{{"List[275∈3]<br />ᐸ273,274ᐳ<br />ᐳQueryᐳInput"}}:::plan
     Constant273{{"Constant[273∈3]<br />ᐸ'inputs'ᐳ<br />ᐳQueryᐳInput"}}:::plan
     PgClassExpression274{{"PgClassExpression[274∈3]<br />ᐸ__inputs__.”id”ᐳ"}}:::plan
     Constant273 & PgClassExpression274 --> List275
     PgSelect280[["PgSelect[280∈3]<br />ᐸpatchsᐳ<br />ᐳQueryᐳPatch"]]:::plan
-    Object507 & Access3165 --> PgSelect280
+    Object507 -->|rejectNull| PgSelect280
+    Access3165 --> PgSelect280
     List288{{"List[288∈3]<br />ᐸ286,287ᐳ<br />ᐳQueryᐳPatch"}}:::plan
     Constant286{{"Constant[286∈3]<br />ᐸ'patchs'ᐳ<br />ᐳQueryᐳPatch"}}:::plan
     PgClassExpression287{{"PgClassExpression[287∈3]<br />ᐸ__patchs__.”id”ᐳ"}}:::plan
     Constant286 & PgClassExpression287 --> List288
     PgSelect293[["PgSelect[293∈3]<br />ᐸreservedᐳ<br />ᐳQueryᐳReserved"]]:::plan
-    Object507 & Access3165 --> PgSelect293
+    Object507 -->|rejectNull| PgSelect293
+    Access3165 --> PgSelect293
     List301{{"List[301∈3]<br />ᐸ299,300ᐳ<br />ᐳQueryᐳReserved"}}:::plan
     Constant299{{"Constant[299∈3]<br />ᐸ'reserveds'ᐳ<br />ᐳQueryᐳReserved"}}:::plan
     PgClassExpression300{{"PgClassExpression[300∈3]<br />ᐸ__reserved__.”id”ᐳ"}}:::plan
     Constant299 & PgClassExpression300 --> List301
     PgSelect306[["PgSelect[306∈3]<br />ᐸreservedPatchsᐳ<br />ᐳQueryᐳReservedPatchRecord"]]:::plan
-    Object507 & Access3165 --> PgSelect306
+    Object507 -->|rejectNull| PgSelect306
+    Access3165 --> PgSelect306
     List314{{"List[314∈3]<br />ᐸ312,313ᐳ<br />ᐳQueryᐳReservedPatchRecord"}}:::plan
     Constant312{{"Constant[312∈3]<br />ᐸ'reservedPatchs'ᐳ<br />ᐳQueryᐳReservedPatchRecord"}}:::plan
     PgClassExpression313{{"PgClassExpression[313∈3]<br />ᐸ__reserved...chs__.”id”ᐳ"}}:::plan
     Constant312 & PgClassExpression313 --> List314
     PgSelect319[["PgSelect[319∈3]<br />ᐸreserved_inputᐳ<br />ᐳQueryᐳReservedInputRecord"]]:::plan
-    Object507 & Access3165 --> PgSelect319
+    Object507 -->|rejectNull| PgSelect319
+    Access3165 --> PgSelect319
     List327{{"List[327∈3]<br />ᐸ325,326ᐳ<br />ᐳQueryᐳReservedInputRecord"}}:::plan
     Constant325{{"Constant[325∈3]<br />ᐸ'reserved_inputs'ᐳ<br />ᐳQueryᐳReservedInputRecord"}}:::plan
     PgClassExpression326{{"PgClassExpression[326∈3]<br />ᐸ__reserved_input__.”id”ᐳ"}}:::plan
     Constant325 & PgClassExpression326 --> List327
     PgSelect332[["PgSelect[332∈3]<br />ᐸdefault_valueᐳ<br />ᐳQueryᐳDefaultValue"]]:::plan
-    Object507 & Access3165 --> PgSelect332
+    Object507 -->|rejectNull| PgSelect332
+    Access3165 --> PgSelect332
     List340{{"List[340∈3]<br />ᐸ338,339ᐳ<br />ᐳQueryᐳDefaultValue"}}:::plan
     Constant338{{"Constant[338∈3]<br />ᐸ'default_values'ᐳ<br />ᐳQueryᐳDefaultValue"}}:::plan
     PgClassExpression339{{"PgClassExpression[339∈3]<br />ᐸ__default_value__.”id”ᐳ"}}:::plan
     Constant338 & PgClassExpression339 --> List340
     PgSelect361[["PgSelect[361∈3]<br />ᐸpersonᐳ<br />ᐳQueryᐳPerson"]]:::plan
-    Object507 & Access3165 --> PgSelect361
+    Object507 -->|rejectNull| PgSelect361
+    Access3165 --> PgSelect361
     List369{{"List[369∈3]<br />ᐸ367,368ᐳ<br />ᐳQueryᐳPerson"}}:::plan
     Constant367{{"Constant[367∈3]<br />ᐸ'people'ᐳ<br />ᐳQueryᐳPerson"}}:::plan
     PgClassExpression368{{"PgClassExpression[368∈3]<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant367 & PgClassExpression368 --> List369
     PgSelect374[["PgSelect[374∈3]<br />ᐸpostᐳ<br />ᐳQueryᐳPost"]]:::plan
-    Object507 & Access3165 --> PgSelect374
+    Object507 -->|rejectNull| PgSelect374
+    Access3165 --> PgSelect374
     List382{{"List[382∈3]<br />ᐸ380,381ᐳ<br />ᐳQueryᐳPost"}}:::plan
     Constant380{{"Constant[380∈3]<br />ᐸ'posts'ᐳ<br />ᐳQueryᐳPost"}}:::plan
     PgClassExpression381{{"PgClassExpression[381∈3]<br />ᐸ__post__.”id”ᐳ"}}:::plan
     Constant380 & PgClassExpression381 --> List382
     PgSelect387[["PgSelect[387∈3]<br />ᐸtypesᐳ<br />ᐳQueryᐳType"]]:::plan
-    Object507 & Access3165 --> PgSelect387
+    Object507 -->|rejectNull| PgSelect387
+    Access3165 --> PgSelect387
     List395{{"List[395∈3]<br />ᐸ393,394ᐳ<br />ᐳQueryᐳType"}}:::plan
     Constant393{{"Constant[393∈3]<br />ᐸ'types'ᐳ<br />ᐳQueryᐳType"}}:::plan
     PgClassExpression394{{"PgClassExpression[394∈3]<br />ᐸ__types__.”id”ᐳ"}}:::plan
     Constant393 & PgClassExpression394 --> List395
     PgSelect400[["PgSelect[400∈3]<br />ᐸperson_secretᐳ<br />ᐳQueryᐳPersonSecret"]]:::plan
-    Object507 & Access3165 --> PgSelect400
+    Object507 -->|rejectNull| PgSelect400
+    Access3165 --> PgSelect400
     List408{{"List[408∈3]<br />ᐸ406,407ᐳ<br />ᐳQueryᐳPersonSecret"}}:::plan
     Constant406{{"Constant[406∈3]<br />ᐸ'person_secrets'ᐳ<br />ᐳQueryᐳPersonSecret"}}:::plan
     PgClassExpression407{{"PgClassExpression[407∈3]<br />ᐸ__person_s...person_id”ᐳ"}}:::plan
     Constant406 & PgClassExpression407 --> List408
     PgSelect413[["PgSelect[413∈3]<br />ᐸleft_armᐳ<br />ᐳQueryᐳLeftArm"]]:::plan
-    Object507 & Access3165 --> PgSelect413
+    Object507 -->|rejectNull| PgSelect413
+    Access3165 --> PgSelect413
     List421{{"List[421∈3]<br />ᐸ419,420ᐳ<br />ᐳQueryᐳLeftArm"}}:::plan
     Constant419{{"Constant[419∈3]<br />ᐸ'left_arms'ᐳ<br />ᐳQueryᐳLeftArm"}}:::plan
     PgClassExpression420{{"PgClassExpression[420∈3]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
     Constant419 & PgClassExpression420 --> List421
     PgSelect426[["PgSelect[426∈3]<br />ᐸmy_tableᐳ<br />ᐳQueryᐳMyTable"]]:::plan
-    Object507 & Access3165 --> PgSelect426
+    Object507 -->|rejectNull| PgSelect426
+    Access3165 --> PgSelect426
     List434{{"List[434∈3]<br />ᐸ432,433ᐳ<br />ᐳQueryᐳMyTable"}}:::plan
     Constant432{{"Constant[432∈3]<br />ᐸ'my_tables'ᐳ<br />ᐳQueryᐳMyTable"}}:::plan
     PgClassExpression433{{"PgClassExpression[433∈3]<br />ᐸ__my_table__.”id”ᐳ"}}:::plan
     Constant432 & PgClassExpression433 --> List434
     PgSelect439[["PgSelect[439∈3]<br />ᐸview_tableᐳ<br />ᐳQueryᐳViewTable"]]:::plan
-    Object507 & Access3165 --> PgSelect439
+    Object507 -->|rejectNull| PgSelect439
+    Access3165 --> PgSelect439
     List447{{"List[447∈3]<br />ᐸ445,446ᐳ<br />ᐳQueryᐳViewTable"}}:::plan
     Constant445{{"Constant[445∈3]<br />ᐸ'view_tables'ᐳ<br />ᐳQueryᐳViewTable"}}:::plan
     PgClassExpression446{{"PgClassExpression[446∈3]<br />ᐸ__view_table__.”id”ᐳ"}}:::plan
     Constant445 & PgClassExpression446 --> List447
     PgSelect452[["PgSelect[452∈3]<br />ᐸsimilar_table_1ᐳ<br />ᐳQueryᐳSimilarTable1"]]:::plan
-    Object507 & Access3165 --> PgSelect452
+    Object507 -->|rejectNull| PgSelect452
+    Access3165 --> PgSelect452
     List460{{"List[460∈3]<br />ᐸ458,459ᐳ<br />ᐳQueryᐳSimilarTable1"}}:::plan
     Constant458{{"Constant[458∈3]<br />ᐸ'similar_table_1S'ᐳ<br />ᐳQueryᐳSimilarTable1"}}:::plan
     PgClassExpression459{{"PgClassExpression[459∈3]<br />ᐸ__similar_...e_1__.”id”ᐳ"}}:::plan
     Constant458 & PgClassExpression459 --> List460
     PgSelect465[["PgSelect[465∈3]<br />ᐸsimilar_table_2ᐳ<br />ᐳQueryᐳSimilarTable2"]]:::plan
-    Object507 & Access3165 --> PgSelect465
+    Object507 -->|rejectNull| PgSelect465
+    Access3165 --> PgSelect465
     List473{{"List[473∈3]<br />ᐸ471,472ᐳ<br />ᐳQueryᐳSimilarTable2"}}:::plan
     Constant471{{"Constant[471∈3]<br />ᐸ'similar_table_2S'ᐳ<br />ᐳQueryᐳSimilarTable2"}}:::plan
     PgClassExpression472{{"PgClassExpression[472∈3]<br />ᐸ__similar_...e_2__.”id”ᐳ"}}:::plan
     Constant471 & PgClassExpression472 --> List473
     PgSelect478[["PgSelect[478∈3]<br />ᐸnull_test_recordᐳ<br />ᐳQueryᐳNullTestRecord"]]:::plan
-    Object507 & Access3165 --> PgSelect478
+    Object507 -->|rejectNull| PgSelect478
+    Access3165 --> PgSelect478
     List486{{"List[486∈3]<br />ᐸ484,485ᐳ<br />ᐳQueryᐳNullTestRecord"}}:::plan
     Constant484{{"Constant[484∈3]<br />ᐸ'null_test_records'ᐳ<br />ᐳQueryᐳNullTestRecord"}}:::plan
     PgClassExpression485{{"PgClassExpression[485∈3]<br />ᐸ__null_tes...ord__.”id”ᐳ"}}:::plan
     Constant484 & PgClassExpression485 --> List486
     PgSelect491[["PgSelect[491∈3]<br />ᐸissue756ᐳ<br />ᐳQueryᐳIssue756"]]:::plan
-    Object507 & Access3165 --> PgSelect491
+    Object507 -->|rejectNull| PgSelect491
+    Access3165 --> PgSelect491
     List499{{"List[499∈3]<br />ᐸ497,498ᐳ<br />ᐳQueryᐳIssue756"}}:::plan
     Constant497{{"Constant[497∈3]<br />ᐸ'issue756S'ᐳ<br />ᐳQueryᐳIssue756"}}:::plan
     PgClassExpression498{{"PgClassExpression[498∈3]<br />ᐸ__issue756__.”id”ᐳ"}}:::plan
@@ -795,14 +852,17 @@ graph TD
     Object1236{{"Object[1236∈4]<br />ᐸ{pgSettings,withPgClient}ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access3168{{"Access[3168∈4]<br />ᐸ740.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access3169{{"Access[3169∈4]<br />ᐸ740.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
-    Object1236 & Access3168 & Access3169 --> PgSelect1313
+    Object1236 -->|rejectNull| PgSelect1313
+    Access3168 -->|rejectNull| PgSelect1313
+    Access3169 --> PgSelect1313
     List1322{{"List[1322∈4]<br />ᐸ1319,1320,1321ᐳ<br />ᐳCompoundKey"}}:::plan
     Constant1319{{"Constant[1319∈4]<br />ᐸ'compound_keys'ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression1320{{"PgClassExpression[1320∈4]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression1321{{"PgClassExpression[1321∈4]<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     Constant1319 & PgClassExpression1320 & PgClassExpression1321 --> List1322
     PgSelect1233[["PgSelect[1233∈4]<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
-    Object1236 & Access3168 --> PgSelect1233
+    Object1236 -->|rejectNull| PgSelect1233
+    Access3168 --> PgSelect1233
     Access1234{{"Access[1234∈4]<br />ᐸ3.pgSettingsᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access1235{{"Access[1235∈4]<br />ᐸ3.withPgClientᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access1234 & Access1235 --> Object1236
@@ -811,97 +871,113 @@ graph TD
     PgClassExpression1240{{"PgClassExpression[1240∈4]<br />ᐸ__inputs__.”id”ᐳ"}}:::plan
     Constant1239 & PgClassExpression1240 --> List1241
     PgSelect1246[["PgSelect[1246∈4]<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
-    Object1236 & Access3168 --> PgSelect1246
+    Object1236 -->|rejectNull| PgSelect1246
+    Access3168 --> PgSelect1246
     List1254{{"List[1254∈4]<br />ᐸ1252,1253ᐳ<br />ᐳPatch"}}:::plan
     Constant1252{{"Constant[1252∈4]<br />ᐸ'patchs'ᐳ<br />ᐳPatch"}}:::plan
     PgClassExpression1253{{"PgClassExpression[1253∈4]<br />ᐸ__patchs__.”id”ᐳ"}}:::plan
     Constant1252 & PgClassExpression1253 --> List1254
     PgSelect1259[["PgSelect[1259∈4]<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
-    Object1236 & Access3168 --> PgSelect1259
+    Object1236 -->|rejectNull| PgSelect1259
+    Access3168 --> PgSelect1259
     List1267{{"List[1267∈4]<br />ᐸ1265,1266ᐳ<br />ᐳReserved"}}:::plan
     Constant1265{{"Constant[1265∈4]<br />ᐸ'reserveds'ᐳ<br />ᐳReserved"}}:::plan
     PgClassExpression1266{{"PgClassExpression[1266∈4]<br />ᐸ__reserved__.”id”ᐳ"}}:::plan
     Constant1265 & PgClassExpression1266 --> List1267
     PgSelect1272[["PgSelect[1272∈4]<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
-    Object1236 & Access3168 --> PgSelect1272
+    Object1236 -->|rejectNull| PgSelect1272
+    Access3168 --> PgSelect1272
     List1280{{"List[1280∈4]<br />ᐸ1278,1279ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     Constant1278{{"Constant[1278∈4]<br />ᐸ'reservedPatchs'ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     PgClassExpression1279{{"PgClassExpression[1279∈4]<br />ᐸ__reserved...chs__.”id”ᐳ"}}:::plan
     Constant1278 & PgClassExpression1279 --> List1280
     PgSelect1285[["PgSelect[1285∈4]<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
-    Object1236 & Access3168 --> PgSelect1285
+    Object1236 -->|rejectNull| PgSelect1285
+    Access3168 --> PgSelect1285
     List1293{{"List[1293∈4]<br />ᐸ1291,1292ᐳ<br />ᐳReservedInputRecord"}}:::plan
     Constant1291{{"Constant[1291∈4]<br />ᐸ'reserved_inputs'ᐳ<br />ᐳReservedInputRecord"}}:::plan
     PgClassExpression1292{{"PgClassExpression[1292∈4]<br />ᐸ__reserved_input__.”id”ᐳ"}}:::plan
     Constant1291 & PgClassExpression1292 --> List1293
     PgSelect1298[["PgSelect[1298∈4]<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
-    Object1236 & Access3168 --> PgSelect1298
+    Object1236 -->|rejectNull| PgSelect1298
+    Access3168 --> PgSelect1298
     List1306{{"List[1306∈4]<br />ᐸ1304,1305ᐳ<br />ᐳDefaultValue"}}:::plan
     Constant1304{{"Constant[1304∈4]<br />ᐸ'default_values'ᐳ<br />ᐳDefaultValue"}}:::plan
     PgClassExpression1305{{"PgClassExpression[1305∈4]<br />ᐸ__default_value__.”id”ᐳ"}}:::plan
     Constant1304 & PgClassExpression1305 --> List1306
     PgSelect1327[["PgSelect[1327∈4]<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
-    Object1236 & Access3168 --> PgSelect1327
+    Object1236 -->|rejectNull| PgSelect1327
+    Access3168 --> PgSelect1327
     List1335{{"List[1335∈4]<br />ᐸ1333,1334ᐳ<br />ᐳPerson"}}:::plan
     Constant1333{{"Constant[1333∈4]<br />ᐸ'people'ᐳ<br />ᐳPerson"}}:::plan
     PgClassExpression1334{{"PgClassExpression[1334∈4]<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant1333 & PgClassExpression1334 --> List1335
     PgSelect1340[["PgSelect[1340∈4]<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
-    Object1236 & Access3168 --> PgSelect1340
+    Object1236 -->|rejectNull| PgSelect1340
+    Access3168 --> PgSelect1340
     List1348{{"List[1348∈4]<br />ᐸ1346,1347ᐳ<br />ᐳPost"}}:::plan
     Constant1346{{"Constant[1346∈4]<br />ᐸ'posts'ᐳ<br />ᐳPost"}}:::plan
     PgClassExpression1347{{"PgClassExpression[1347∈4]<br />ᐸ__post__.”id”ᐳ"}}:::plan
     Constant1346 & PgClassExpression1347 --> List1348
     PgSelect1353[["PgSelect[1353∈4]<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
-    Object1236 & Access3168 --> PgSelect1353
+    Object1236 -->|rejectNull| PgSelect1353
+    Access3168 --> PgSelect1353
     List1361{{"List[1361∈4]<br />ᐸ1359,1360ᐳ<br />ᐳType"}}:::plan
     Constant1359{{"Constant[1359∈4]<br />ᐸ'types'ᐳ<br />ᐳType"}}:::plan
     PgClassExpression1360{{"PgClassExpression[1360∈4]<br />ᐸ__types__.”id”ᐳ"}}:::plan
     Constant1359 & PgClassExpression1360 --> List1361
     PgSelect1366[["PgSelect[1366∈4]<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
-    Object1236 & Access3168 --> PgSelect1366
+    Object1236 -->|rejectNull| PgSelect1366
+    Access3168 --> PgSelect1366
     List1374{{"List[1374∈4]<br />ᐸ1372,1373ᐳ<br />ᐳPersonSecret"}}:::plan
     Constant1372{{"Constant[1372∈4]<br />ᐸ'person_secrets'ᐳ<br />ᐳPersonSecret"}}:::plan
     PgClassExpression1373{{"PgClassExpression[1373∈4]<br />ᐸ__person_s...person_id”ᐳ"}}:::plan
     Constant1372 & PgClassExpression1373 --> List1374
     PgSelect1379[["PgSelect[1379∈4]<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
-    Object1236 & Access3168 --> PgSelect1379
+    Object1236 -->|rejectNull| PgSelect1379
+    Access3168 --> PgSelect1379
     List1387{{"List[1387∈4]<br />ᐸ1385,1386ᐳ<br />ᐳLeftArm"}}:::plan
     Constant1385{{"Constant[1385∈4]<br />ᐸ'left_arms'ᐳ<br />ᐳLeftArm"}}:::plan
     PgClassExpression1386{{"PgClassExpression[1386∈4]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
     Constant1385 & PgClassExpression1386 --> List1387
     PgSelect1392[["PgSelect[1392∈4]<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
-    Object1236 & Access3168 --> PgSelect1392
+    Object1236 -->|rejectNull| PgSelect1392
+    Access3168 --> PgSelect1392
     List1400{{"List[1400∈4]<br />ᐸ1398,1399ᐳ<br />ᐳMyTable"}}:::plan
     Constant1398{{"Constant[1398∈4]<br />ᐸ'my_tables'ᐳ<br />ᐳMyTable"}}:::plan
     PgClassExpression1399{{"PgClassExpression[1399∈4]<br />ᐸ__my_table__.”id”ᐳ"}}:::plan
     Constant1398 & PgClassExpression1399 --> List1400
     PgSelect1405[["PgSelect[1405∈4]<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
-    Object1236 & Access3168 --> PgSelect1405
+    Object1236 -->|rejectNull| PgSelect1405
+    Access3168 --> PgSelect1405
     List1413{{"List[1413∈4]<br />ᐸ1411,1412ᐳ<br />ᐳViewTable"}}:::plan
     Constant1411{{"Constant[1411∈4]<br />ᐸ'view_tables'ᐳ<br />ᐳViewTable"}}:::plan
     PgClassExpression1412{{"PgClassExpression[1412∈4]<br />ᐸ__view_table__.”id”ᐳ"}}:::plan
     Constant1411 & PgClassExpression1412 --> List1413
     PgSelect1418[["PgSelect[1418∈4]<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
-    Object1236 & Access3168 --> PgSelect1418
+    Object1236 -->|rejectNull| PgSelect1418
+    Access3168 --> PgSelect1418
     List1426{{"List[1426∈4]<br />ᐸ1424,1425ᐳ<br />ᐳSimilarTable1"}}:::plan
     Constant1424{{"Constant[1424∈4]<br />ᐸ'similar_table_1S'ᐳ<br />ᐳSimilarTable1"}}:::plan
     PgClassExpression1425{{"PgClassExpression[1425∈4]<br />ᐸ__similar_...e_1__.”id”ᐳ"}}:::plan
     Constant1424 & PgClassExpression1425 --> List1426
     PgSelect1431[["PgSelect[1431∈4]<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
-    Object1236 & Access3168 --> PgSelect1431
+    Object1236 -->|rejectNull| PgSelect1431
+    Access3168 --> PgSelect1431
     List1439{{"List[1439∈4]<br />ᐸ1437,1438ᐳ<br />ᐳSimilarTable2"}}:::plan
     Constant1437{{"Constant[1437∈4]<br />ᐸ'similar_table_2S'ᐳ<br />ᐳSimilarTable2"}}:::plan
     PgClassExpression1438{{"PgClassExpression[1438∈4]<br />ᐸ__similar_...e_2__.”id”ᐳ"}}:::plan
     Constant1437 & PgClassExpression1438 --> List1439
     PgSelect1444[["PgSelect[1444∈4]<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
-    Object1236 & Access3168 --> PgSelect1444
+    Object1236 -->|rejectNull| PgSelect1444
+    Access3168 --> PgSelect1444
     List1452{{"List[1452∈4]<br />ᐸ1450,1451ᐳ<br />ᐳNullTestRecord"}}:::plan
     Constant1450{{"Constant[1450∈4]<br />ᐸ'null_test_records'ᐳ<br />ᐳNullTestRecord"}}:::plan
     PgClassExpression1451{{"PgClassExpression[1451∈4]<br />ᐸ__null_tes...ord__.”id”ᐳ"}}:::plan
     Constant1450 & PgClassExpression1451 --> List1452
     PgSelect1457[["PgSelect[1457∈4]<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
-    Object1236 & Access3168 --> PgSelect1457
+    Object1236 -->|rejectNull| PgSelect1457
+    Access3168 --> PgSelect1457
     List1465{{"List[1465∈4]<br />ᐸ1463,1464ᐳ<br />ᐳIssue756"}}:::plan
     Constant1463{{"Constant[1463∈4]<br />ᐸ'issue756S'ᐳ<br />ᐳIssue756"}}:::plan
     PgClassExpression1464{{"PgClassExpression[1464∈4]<br />ᐸ__issue756__.”id”ᐳ"}}:::plan
@@ -1051,110 +1127,129 @@ graph TD
     PgSelect833[["PgSelect[833∈5]<br />ᐸcompound_keyᐳ<br />ᐳQueryᐳCompoundKey"]]:::plan
     Access3171{{"Access[3171∈5]<br />ᐸ746.base64JSON.1ᐳ<br />ᐳQueryᐳInput<br />ᐳQueryᐳPatch<br />ᐳQueryᐳReserved<br />ᐳQueryᐳReservedPatchRecord<br />ᐳQueryᐳReservedInputRecord<br />ᐳQueryᐳDefaultValue<br />ᐳQueryᐳCompoundKey<br />ᐳQueryᐳPerson<br />ᐳQueryᐳPost<br />ᐳQueryᐳType<br />ᐳQueryᐳPersonSecret<br />ᐳQueryᐳLeftArm<br />ᐳQueryᐳMyTable<br />ᐳQueryᐳViewTable<br />ᐳQueryᐳSimilarTable1<br />ᐳQueryᐳSimilarTable2<br />ᐳQueryᐳNullTestRecord<br />ᐳQueryᐳIssue756"}}:::plan
     Access3172{{"Access[3172∈5]<br />ᐸ746.base64JSON.2ᐳ<br />ᐳQueryᐳCompoundKey"}}:::plan
-    Object1236 & Access3171 & Access3172 --> PgSelect833
+    Object1236 -->|rejectNull| PgSelect833
+    Access3171 -->|rejectNull| PgSelect833
+    Access3172 --> PgSelect833
     List842{{"List[842∈5]<br />ᐸ839,840,841ᐳ<br />ᐳQueryᐳCompoundKey"}}:::plan
     Constant839{{"Constant[839∈5]<br />ᐸ'compound_keys'ᐳ<br />ᐳQueryᐳCompoundKey"}}:::plan
     PgClassExpression840{{"PgClassExpression[840∈5]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression841{{"PgClassExpression[841∈5]<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     Constant839 & PgClassExpression840 & PgClassExpression841 --> List842
     PgSelect753[["PgSelect[753∈5]<br />ᐸinputsᐳ<br />ᐳQueryᐳInput"]]:::plan
-    Object1236 & Access3171 --> PgSelect753
+    Object1236 -->|rejectNull| PgSelect753
+    Access3171 --> PgSelect753
     List761{{"List[761∈5]<br />ᐸ759,760ᐳ<br />ᐳQueryᐳInput"}}:::plan
     Constant759{{"Constant[759∈5]<br />ᐸ'inputs'ᐳ<br />ᐳQueryᐳInput"}}:::plan
     PgClassExpression760{{"PgClassExpression[760∈5]<br />ᐸ__inputs__.”id”ᐳ"}}:::plan
     Constant759 & PgClassExpression760 --> List761
     PgSelect766[["PgSelect[766∈5]<br />ᐸpatchsᐳ<br />ᐳQueryᐳPatch"]]:::plan
-    Object1236 & Access3171 --> PgSelect766
+    Object1236 -->|rejectNull| PgSelect766
+    Access3171 --> PgSelect766
     List774{{"List[774∈5]<br />ᐸ772,773ᐳ<br />ᐳQueryᐳPatch"}}:::plan
     Constant772{{"Constant[772∈5]<br />ᐸ'patchs'ᐳ<br />ᐳQueryᐳPatch"}}:::plan
     PgClassExpression773{{"PgClassExpression[773∈5]<br />ᐸ__patchs__.”id”ᐳ"}}:::plan
     Constant772 & PgClassExpression773 --> List774
     PgSelect779[["PgSelect[779∈5]<br />ᐸreservedᐳ<br />ᐳQueryᐳReserved"]]:::plan
-    Object1236 & Access3171 --> PgSelect779
+    Object1236 -->|rejectNull| PgSelect779
+    Access3171 --> PgSelect779
     List787{{"List[787∈5]<br />ᐸ785,786ᐳ<br />ᐳQueryᐳReserved"}}:::plan
     Constant785{{"Constant[785∈5]<br />ᐸ'reserveds'ᐳ<br />ᐳQueryᐳReserved"}}:::plan
     PgClassExpression786{{"PgClassExpression[786∈5]<br />ᐸ__reserved__.”id”ᐳ"}}:::plan
     Constant785 & PgClassExpression786 --> List787
     PgSelect792[["PgSelect[792∈5]<br />ᐸreservedPatchsᐳ<br />ᐳQueryᐳReservedPatchRecord"]]:::plan
-    Object1236 & Access3171 --> PgSelect792
+    Object1236 -->|rejectNull| PgSelect792
+    Access3171 --> PgSelect792
     List800{{"List[800∈5]<br />ᐸ798,799ᐳ<br />ᐳQueryᐳReservedPatchRecord"}}:::plan
     Constant798{{"Constant[798∈5]<br />ᐸ'reservedPatchs'ᐳ<br />ᐳQueryᐳReservedPatchRecord"}}:::plan
     PgClassExpression799{{"PgClassExpression[799∈5]<br />ᐸ__reserved...chs__.”id”ᐳ"}}:::plan
     Constant798 & PgClassExpression799 --> List800
     PgSelect805[["PgSelect[805∈5]<br />ᐸreserved_inputᐳ<br />ᐳQueryᐳReservedInputRecord"]]:::plan
-    Object1236 & Access3171 --> PgSelect805
+    Object1236 -->|rejectNull| PgSelect805
+    Access3171 --> PgSelect805
     List813{{"List[813∈5]<br />ᐸ811,812ᐳ<br />ᐳQueryᐳReservedInputRecord"}}:::plan
     Constant811{{"Constant[811∈5]<br />ᐸ'reserved_inputs'ᐳ<br />ᐳQueryᐳReservedInputRecord"}}:::plan
     PgClassExpression812{{"PgClassExpression[812∈5]<br />ᐸ__reserved_input__.”id”ᐳ"}}:::plan
     Constant811 & PgClassExpression812 --> List813
     PgSelect818[["PgSelect[818∈5]<br />ᐸdefault_valueᐳ<br />ᐳQueryᐳDefaultValue"]]:::plan
-    Object1236 & Access3171 --> PgSelect818
+    Object1236 -->|rejectNull| PgSelect818
+    Access3171 --> PgSelect818
     List826{{"List[826∈5]<br />ᐸ824,825ᐳ<br />ᐳQueryᐳDefaultValue"}}:::plan
     Constant824{{"Constant[824∈5]<br />ᐸ'default_values'ᐳ<br />ᐳQueryᐳDefaultValue"}}:::plan
     PgClassExpression825{{"PgClassExpression[825∈5]<br />ᐸ__default_value__.”id”ᐳ"}}:::plan
     Constant824 & PgClassExpression825 --> List826
     PgSelect847[["PgSelect[847∈5]<br />ᐸpersonᐳ<br />ᐳQueryᐳPerson"]]:::plan
-    Object1236 & Access3171 --> PgSelect847
+    Object1236 -->|rejectNull| PgSelect847
+    Access3171 --> PgSelect847
     List855{{"List[855∈5]<br />ᐸ853,854ᐳ<br />ᐳQueryᐳPerson"}}:::plan
     Constant853{{"Constant[853∈5]<br />ᐸ'people'ᐳ<br />ᐳQueryᐳPerson"}}:::plan
     PgClassExpression854{{"PgClassExpression[854∈5]<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant853 & PgClassExpression854 --> List855
     PgSelect860[["PgSelect[860∈5]<br />ᐸpostᐳ<br />ᐳQueryᐳPost"]]:::plan
-    Object1236 & Access3171 --> PgSelect860
+    Object1236 -->|rejectNull| PgSelect860
+    Access3171 --> PgSelect860
     List868{{"List[868∈5]<br />ᐸ866,867ᐳ<br />ᐳQueryᐳPost"}}:::plan
     Constant866{{"Constant[866∈5]<br />ᐸ'posts'ᐳ<br />ᐳQueryᐳPost"}}:::plan
     PgClassExpression867{{"PgClassExpression[867∈5]<br />ᐸ__post__.”id”ᐳ"}}:::plan
     Constant866 & PgClassExpression867 --> List868
     PgSelect873[["PgSelect[873∈5]<br />ᐸtypesᐳ<br />ᐳQueryᐳType"]]:::plan
-    Object1236 & Access3171 --> PgSelect873
+    Object1236 -->|rejectNull| PgSelect873
+    Access3171 --> PgSelect873
     List881{{"List[881∈5]<br />ᐸ879,880ᐳ<br />ᐳQueryᐳType"}}:::plan
     Constant879{{"Constant[879∈5]<br />ᐸ'types'ᐳ<br />ᐳQueryᐳType"}}:::plan
     PgClassExpression880{{"PgClassExpression[880∈5]<br />ᐸ__types__.”id”ᐳ"}}:::plan
     Constant879 & PgClassExpression880 --> List881
     PgSelect886[["PgSelect[886∈5]<br />ᐸperson_secretᐳ<br />ᐳQueryᐳPersonSecret"]]:::plan
-    Object1236 & Access3171 --> PgSelect886
+    Object1236 -->|rejectNull| PgSelect886
+    Access3171 --> PgSelect886
     List894{{"List[894∈5]<br />ᐸ892,893ᐳ<br />ᐳQueryᐳPersonSecret"}}:::plan
     Constant892{{"Constant[892∈5]<br />ᐸ'person_secrets'ᐳ<br />ᐳQueryᐳPersonSecret"}}:::plan
     PgClassExpression893{{"PgClassExpression[893∈5]<br />ᐸ__person_s...person_id”ᐳ"}}:::plan
     Constant892 & PgClassExpression893 --> List894
     PgSelect899[["PgSelect[899∈5]<br />ᐸleft_armᐳ<br />ᐳQueryᐳLeftArm"]]:::plan
-    Object1236 & Access3171 --> PgSelect899
+    Object1236 -->|rejectNull| PgSelect899
+    Access3171 --> PgSelect899
     List907{{"List[907∈5]<br />ᐸ905,906ᐳ<br />ᐳQueryᐳLeftArm"}}:::plan
     Constant905{{"Constant[905∈5]<br />ᐸ'left_arms'ᐳ<br />ᐳQueryᐳLeftArm"}}:::plan
     PgClassExpression906{{"PgClassExpression[906∈5]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
     Constant905 & PgClassExpression906 --> List907
     PgSelect912[["PgSelect[912∈5]<br />ᐸmy_tableᐳ<br />ᐳQueryᐳMyTable"]]:::plan
-    Object1236 & Access3171 --> PgSelect912
+    Object1236 -->|rejectNull| PgSelect912
+    Access3171 --> PgSelect912
     List920{{"List[920∈5]<br />ᐸ918,919ᐳ<br />ᐳQueryᐳMyTable"}}:::plan
     Constant918{{"Constant[918∈5]<br />ᐸ'my_tables'ᐳ<br />ᐳQueryᐳMyTable"}}:::plan
     PgClassExpression919{{"PgClassExpression[919∈5]<br />ᐸ__my_table__.”id”ᐳ"}}:::plan
     Constant918 & PgClassExpression919 --> List920
     PgSelect925[["PgSelect[925∈5]<br />ᐸview_tableᐳ<br />ᐳQueryᐳViewTable"]]:::plan
-    Object1236 & Access3171 --> PgSelect925
+    Object1236 -->|rejectNull| PgSelect925
+    Access3171 --> PgSelect925
     List933{{"List[933∈5]<br />ᐸ931,932ᐳ<br />ᐳQueryᐳViewTable"}}:::plan
     Constant931{{"Constant[931∈5]<br />ᐸ'view_tables'ᐳ<br />ᐳQueryᐳViewTable"}}:::plan
     PgClassExpression932{{"PgClassExpression[932∈5]<br />ᐸ__view_table__.”id”ᐳ"}}:::plan
     Constant931 & PgClassExpression932 --> List933
     PgSelect938[["PgSelect[938∈5]<br />ᐸsimilar_table_1ᐳ<br />ᐳQueryᐳSimilarTable1"]]:::plan
-    Object1236 & Access3171 --> PgSelect938
+    Object1236 -->|rejectNull| PgSelect938
+    Access3171 --> PgSelect938
     List946{{"List[946∈5]<br />ᐸ944,945ᐳ<br />ᐳQueryᐳSimilarTable1"}}:::plan
     Constant944{{"Constant[944∈5]<br />ᐸ'similar_table_1S'ᐳ<br />ᐳQueryᐳSimilarTable1"}}:::plan
     PgClassExpression945{{"PgClassExpression[945∈5]<br />ᐸ__similar_...e_1__.”id”ᐳ"}}:::plan
     Constant944 & PgClassExpression945 --> List946
     PgSelect951[["PgSelect[951∈5]<br />ᐸsimilar_table_2ᐳ<br />ᐳQueryᐳSimilarTable2"]]:::plan
-    Object1236 & Access3171 --> PgSelect951
+    Object1236 -->|rejectNull| PgSelect951
+    Access3171 --> PgSelect951
     List959{{"List[959∈5]<br />ᐸ957,958ᐳ<br />ᐳQueryᐳSimilarTable2"}}:::plan
     Constant957{{"Constant[957∈5]<br />ᐸ'similar_table_2S'ᐳ<br />ᐳQueryᐳSimilarTable2"}}:::plan
     PgClassExpression958{{"PgClassExpression[958∈5]<br />ᐸ__similar_...e_2__.”id”ᐳ"}}:::plan
     Constant957 & PgClassExpression958 --> List959
     PgSelect964[["PgSelect[964∈5]<br />ᐸnull_test_recordᐳ<br />ᐳQueryᐳNullTestRecord"]]:::plan
-    Object1236 & Access3171 --> PgSelect964
+    Object1236 -->|rejectNull| PgSelect964
+    Access3171 --> PgSelect964
     List972{{"List[972∈5]<br />ᐸ970,971ᐳ<br />ᐳQueryᐳNullTestRecord"}}:::plan
     Constant970{{"Constant[970∈5]<br />ᐸ'null_test_records'ᐳ<br />ᐳQueryᐳNullTestRecord"}}:::plan
     PgClassExpression971{{"PgClassExpression[971∈5]<br />ᐸ__null_tes...ord__.”id”ᐳ"}}:::plan
     Constant970 & PgClassExpression971 --> List972
     PgSelect977[["PgSelect[977∈5]<br />ᐸissue756ᐳ<br />ᐳQueryᐳIssue756"]]:::plan
-    Object1236 & Access3171 --> PgSelect977
+    Object1236 -->|rejectNull| PgSelect977
+    Access3171 --> PgSelect977
     List985{{"List[985∈5]<br />ᐸ983,984ᐳ<br />ᐳQueryᐳIssue756"}}:::plan
     Constant983{{"Constant[983∈5]<br />ᐸ'issue756S'ᐳ<br />ᐳQueryᐳIssue756"}}:::plan
     PgClassExpression984{{"PgClassExpression[984∈5]<br />ᐸ__issue756__.”id”ᐳ"}}:::plan
@@ -1294,110 +1389,129 @@ graph TD
     PgSelect1076[["PgSelect[1076∈6]<br />ᐸcompound_keyᐳ<br />ᐳQueryᐳCompoundKey"]]:::plan
     Access3174{{"Access[3174∈6]<br />ᐸ989.base64JSON.1ᐳ<br />ᐳQueryᐳInput<br />ᐳQueryᐳPatch<br />ᐳQueryᐳReserved<br />ᐳQueryᐳReservedPatchRecord<br />ᐳQueryᐳReservedInputRecord<br />ᐳQueryᐳDefaultValue<br />ᐳQueryᐳCompoundKey<br />ᐳQueryᐳPerson<br />ᐳQueryᐳPost<br />ᐳQueryᐳType<br />ᐳQueryᐳPersonSecret<br />ᐳQueryᐳLeftArm<br />ᐳQueryᐳMyTable<br />ᐳQueryᐳViewTable<br />ᐳQueryᐳSimilarTable1<br />ᐳQueryᐳSimilarTable2<br />ᐳQueryᐳNullTestRecord<br />ᐳQueryᐳIssue756"}}:::plan
     Access3175{{"Access[3175∈6]<br />ᐸ989.base64JSON.2ᐳ<br />ᐳQueryᐳCompoundKey"}}:::plan
-    Object1236 & Access3174 & Access3175 --> PgSelect1076
+    Object1236 -->|rejectNull| PgSelect1076
+    Access3174 -->|rejectNull| PgSelect1076
+    Access3175 --> PgSelect1076
     List1085{{"List[1085∈6]<br />ᐸ1082,1083,1084ᐳ<br />ᐳQueryᐳCompoundKey"}}:::plan
     Constant1082{{"Constant[1082∈6]<br />ᐸ'compound_keys'ᐳ<br />ᐳQueryᐳCompoundKey"}}:::plan
     PgClassExpression1083{{"PgClassExpression[1083∈6]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression1084{{"PgClassExpression[1084∈6]<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     Constant1082 & PgClassExpression1083 & PgClassExpression1084 --> List1085
     PgSelect996[["PgSelect[996∈6]<br />ᐸinputsᐳ<br />ᐳQueryᐳInput"]]:::plan
-    Object1236 & Access3174 --> PgSelect996
+    Object1236 -->|rejectNull| PgSelect996
+    Access3174 --> PgSelect996
     List1004{{"List[1004∈6]<br />ᐸ1002,1003ᐳ<br />ᐳQueryᐳInput"}}:::plan
     Constant1002{{"Constant[1002∈6]<br />ᐸ'inputs'ᐳ<br />ᐳQueryᐳInput"}}:::plan
     PgClassExpression1003{{"PgClassExpression[1003∈6]<br />ᐸ__inputs__.”id”ᐳ"}}:::plan
     Constant1002 & PgClassExpression1003 --> List1004
     PgSelect1009[["PgSelect[1009∈6]<br />ᐸpatchsᐳ<br />ᐳQueryᐳPatch"]]:::plan
-    Object1236 & Access3174 --> PgSelect1009
+    Object1236 -->|rejectNull| PgSelect1009
+    Access3174 --> PgSelect1009
     List1017{{"List[1017∈6]<br />ᐸ1015,1016ᐳ<br />ᐳQueryᐳPatch"}}:::plan
     Constant1015{{"Constant[1015∈6]<br />ᐸ'patchs'ᐳ<br />ᐳQueryᐳPatch"}}:::plan
     PgClassExpression1016{{"PgClassExpression[1016∈6]<br />ᐸ__patchs__.”id”ᐳ"}}:::plan
     Constant1015 & PgClassExpression1016 --> List1017
     PgSelect1022[["PgSelect[1022∈6]<br />ᐸreservedᐳ<br />ᐳQueryᐳReserved"]]:::plan
-    Object1236 & Access3174 --> PgSelect1022
+    Object1236 -->|rejectNull| PgSelect1022
+    Access3174 --> PgSelect1022
     List1030{{"List[1030∈6]<br />ᐸ1028,1029ᐳ<br />ᐳQueryᐳReserved"}}:::plan
     Constant1028{{"Constant[1028∈6]<br />ᐸ'reserveds'ᐳ<br />ᐳQueryᐳReserved"}}:::plan
     PgClassExpression1029{{"PgClassExpression[1029∈6]<br />ᐸ__reserved__.”id”ᐳ"}}:::plan
     Constant1028 & PgClassExpression1029 --> List1030
     PgSelect1035[["PgSelect[1035∈6]<br />ᐸreservedPatchsᐳ<br />ᐳQueryᐳReservedPatchRecord"]]:::plan
-    Object1236 & Access3174 --> PgSelect1035
+    Object1236 -->|rejectNull| PgSelect1035
+    Access3174 --> PgSelect1035
     List1043{{"List[1043∈6]<br />ᐸ1041,1042ᐳ<br />ᐳQueryᐳReservedPatchRecord"}}:::plan
     Constant1041{{"Constant[1041∈6]<br />ᐸ'reservedPatchs'ᐳ<br />ᐳQueryᐳReservedPatchRecord"}}:::plan
     PgClassExpression1042{{"PgClassExpression[1042∈6]<br />ᐸ__reserved...chs__.”id”ᐳ"}}:::plan
     Constant1041 & PgClassExpression1042 --> List1043
     PgSelect1048[["PgSelect[1048∈6]<br />ᐸreserved_inputᐳ<br />ᐳQueryᐳReservedInputRecord"]]:::plan
-    Object1236 & Access3174 --> PgSelect1048
+    Object1236 -->|rejectNull| PgSelect1048
+    Access3174 --> PgSelect1048
     List1056{{"List[1056∈6]<br />ᐸ1054,1055ᐳ<br />ᐳQueryᐳReservedInputRecord"}}:::plan
     Constant1054{{"Constant[1054∈6]<br />ᐸ'reserved_inputs'ᐳ<br />ᐳQueryᐳReservedInputRecord"}}:::plan
     PgClassExpression1055{{"PgClassExpression[1055∈6]<br />ᐸ__reserved_input__.”id”ᐳ"}}:::plan
     Constant1054 & PgClassExpression1055 --> List1056
     PgSelect1061[["PgSelect[1061∈6]<br />ᐸdefault_valueᐳ<br />ᐳQueryᐳDefaultValue"]]:::plan
-    Object1236 & Access3174 --> PgSelect1061
+    Object1236 -->|rejectNull| PgSelect1061
+    Access3174 --> PgSelect1061
     List1069{{"List[1069∈6]<br />ᐸ1067,1068ᐳ<br />ᐳQueryᐳDefaultValue"}}:::plan
     Constant1067{{"Constant[1067∈6]<br />ᐸ'default_values'ᐳ<br />ᐳQueryᐳDefaultValue"}}:::plan
     PgClassExpression1068{{"PgClassExpression[1068∈6]<br />ᐸ__default_value__.”id”ᐳ"}}:::plan
     Constant1067 & PgClassExpression1068 --> List1069
     PgSelect1090[["PgSelect[1090∈6]<br />ᐸpersonᐳ<br />ᐳQueryᐳPerson"]]:::plan
-    Object1236 & Access3174 --> PgSelect1090
+    Object1236 -->|rejectNull| PgSelect1090
+    Access3174 --> PgSelect1090
     List1098{{"List[1098∈6]<br />ᐸ1096,1097ᐳ<br />ᐳQueryᐳPerson"}}:::plan
     Constant1096{{"Constant[1096∈6]<br />ᐸ'people'ᐳ<br />ᐳQueryᐳPerson"}}:::plan
     PgClassExpression1097{{"PgClassExpression[1097∈6]<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant1096 & PgClassExpression1097 --> List1098
     PgSelect1103[["PgSelect[1103∈6]<br />ᐸpostᐳ<br />ᐳQueryᐳPost"]]:::plan
-    Object1236 & Access3174 --> PgSelect1103
+    Object1236 -->|rejectNull| PgSelect1103
+    Access3174 --> PgSelect1103
     List1111{{"List[1111∈6]<br />ᐸ1109,1110ᐳ<br />ᐳQueryᐳPost"}}:::plan
     Constant1109{{"Constant[1109∈6]<br />ᐸ'posts'ᐳ<br />ᐳQueryᐳPost"}}:::plan
     PgClassExpression1110{{"PgClassExpression[1110∈6]<br />ᐸ__post__.”id”ᐳ"}}:::plan
     Constant1109 & PgClassExpression1110 --> List1111
     PgSelect1116[["PgSelect[1116∈6]<br />ᐸtypesᐳ<br />ᐳQueryᐳType"]]:::plan
-    Object1236 & Access3174 --> PgSelect1116
+    Object1236 -->|rejectNull| PgSelect1116
+    Access3174 --> PgSelect1116
     List1124{{"List[1124∈6]<br />ᐸ1122,1123ᐳ<br />ᐳQueryᐳType"}}:::plan
     Constant1122{{"Constant[1122∈6]<br />ᐸ'types'ᐳ<br />ᐳQueryᐳType"}}:::plan
     PgClassExpression1123{{"PgClassExpression[1123∈6]<br />ᐸ__types__.”id”ᐳ"}}:::plan
     Constant1122 & PgClassExpression1123 --> List1124
     PgSelect1129[["PgSelect[1129∈6]<br />ᐸperson_secretᐳ<br />ᐳQueryᐳPersonSecret"]]:::plan
-    Object1236 & Access3174 --> PgSelect1129
+    Object1236 -->|rejectNull| PgSelect1129
+    Access3174 --> PgSelect1129
     List1137{{"List[1137∈6]<br />ᐸ1135,1136ᐳ<br />ᐳQueryᐳPersonSecret"}}:::plan
     Constant1135{{"Constant[1135∈6]<br />ᐸ'person_secrets'ᐳ<br />ᐳQueryᐳPersonSecret"}}:::plan
     PgClassExpression1136{{"PgClassExpression[1136∈6]<br />ᐸ__person_s...person_id”ᐳ"}}:::plan
     Constant1135 & PgClassExpression1136 --> List1137
     PgSelect1142[["PgSelect[1142∈6]<br />ᐸleft_armᐳ<br />ᐳQueryᐳLeftArm"]]:::plan
-    Object1236 & Access3174 --> PgSelect1142
+    Object1236 -->|rejectNull| PgSelect1142
+    Access3174 --> PgSelect1142
     List1150{{"List[1150∈6]<br />ᐸ1148,1149ᐳ<br />ᐳQueryᐳLeftArm"}}:::plan
     Constant1148{{"Constant[1148∈6]<br />ᐸ'left_arms'ᐳ<br />ᐳQueryᐳLeftArm"}}:::plan
     PgClassExpression1149{{"PgClassExpression[1149∈6]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
     Constant1148 & PgClassExpression1149 --> List1150
     PgSelect1155[["PgSelect[1155∈6]<br />ᐸmy_tableᐳ<br />ᐳQueryᐳMyTable"]]:::plan
-    Object1236 & Access3174 --> PgSelect1155
+    Object1236 -->|rejectNull| PgSelect1155
+    Access3174 --> PgSelect1155
     List1163{{"List[1163∈6]<br />ᐸ1161,1162ᐳ<br />ᐳQueryᐳMyTable"}}:::plan
     Constant1161{{"Constant[1161∈6]<br />ᐸ'my_tables'ᐳ<br />ᐳQueryᐳMyTable"}}:::plan
     PgClassExpression1162{{"PgClassExpression[1162∈6]<br />ᐸ__my_table__.”id”ᐳ"}}:::plan
     Constant1161 & PgClassExpression1162 --> List1163
     PgSelect1168[["PgSelect[1168∈6]<br />ᐸview_tableᐳ<br />ᐳQueryᐳViewTable"]]:::plan
-    Object1236 & Access3174 --> PgSelect1168
+    Object1236 -->|rejectNull| PgSelect1168
+    Access3174 --> PgSelect1168
     List1176{{"List[1176∈6]<br />ᐸ1174,1175ᐳ<br />ᐳQueryᐳViewTable"}}:::plan
     Constant1174{{"Constant[1174∈6]<br />ᐸ'view_tables'ᐳ<br />ᐳQueryᐳViewTable"}}:::plan
     PgClassExpression1175{{"PgClassExpression[1175∈6]<br />ᐸ__view_table__.”id”ᐳ"}}:::plan
     Constant1174 & PgClassExpression1175 --> List1176
     PgSelect1181[["PgSelect[1181∈6]<br />ᐸsimilar_table_1ᐳ<br />ᐳQueryᐳSimilarTable1"]]:::plan
-    Object1236 & Access3174 --> PgSelect1181
+    Object1236 -->|rejectNull| PgSelect1181
+    Access3174 --> PgSelect1181
     List1189{{"List[1189∈6]<br />ᐸ1187,1188ᐳ<br />ᐳQueryᐳSimilarTable1"}}:::plan
     Constant1187{{"Constant[1187∈6]<br />ᐸ'similar_table_1S'ᐳ<br />ᐳQueryᐳSimilarTable1"}}:::plan
     PgClassExpression1188{{"PgClassExpression[1188∈6]<br />ᐸ__similar_...e_1__.”id”ᐳ"}}:::plan
     Constant1187 & PgClassExpression1188 --> List1189
     PgSelect1194[["PgSelect[1194∈6]<br />ᐸsimilar_table_2ᐳ<br />ᐳQueryᐳSimilarTable2"]]:::plan
-    Object1236 & Access3174 --> PgSelect1194
+    Object1236 -->|rejectNull| PgSelect1194
+    Access3174 --> PgSelect1194
     List1202{{"List[1202∈6]<br />ᐸ1200,1201ᐳ<br />ᐳQueryᐳSimilarTable2"}}:::plan
     Constant1200{{"Constant[1200∈6]<br />ᐸ'similar_table_2S'ᐳ<br />ᐳQueryᐳSimilarTable2"}}:::plan
     PgClassExpression1201{{"PgClassExpression[1201∈6]<br />ᐸ__similar_...e_2__.”id”ᐳ"}}:::plan
     Constant1200 & PgClassExpression1201 --> List1202
     PgSelect1207[["PgSelect[1207∈6]<br />ᐸnull_test_recordᐳ<br />ᐳQueryᐳNullTestRecord"]]:::plan
-    Object1236 & Access3174 --> PgSelect1207
+    Object1236 -->|rejectNull| PgSelect1207
+    Access3174 --> PgSelect1207
     List1215{{"List[1215∈6]<br />ᐸ1213,1214ᐳ<br />ᐳQueryᐳNullTestRecord"}}:::plan
     Constant1213{{"Constant[1213∈6]<br />ᐸ'null_test_records'ᐳ<br />ᐳQueryᐳNullTestRecord"}}:::plan
     PgClassExpression1214{{"PgClassExpression[1214∈6]<br />ᐸ__null_tes...ord__.”id”ᐳ"}}:::plan
     Constant1213 & PgClassExpression1214 --> List1215
     PgSelect1220[["PgSelect[1220∈6]<br />ᐸissue756ᐳ<br />ᐳQueryᐳIssue756"]]:::plan
-    Object1236 & Access3174 --> PgSelect1220
+    Object1236 -->|rejectNull| PgSelect1220
+    Access3174 --> PgSelect1220
     List1228{{"List[1228∈6]<br />ᐸ1226,1227ᐳ<br />ᐳQueryᐳIssue756"}}:::plan
     Constant1226{{"Constant[1226∈6]<br />ᐸ'issue756S'ᐳ<br />ᐳQueryᐳIssue756"}}:::plan
     PgClassExpression1227{{"PgClassExpression[1227∈6]<br />ᐸ__issue756__.”id”ᐳ"}}:::plan
@@ -1538,14 +1652,17 @@ graph TD
     Object1481{{"Object[1481∈7]<br />ᐸ{pgSettings,withPgClient}ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access3177{{"Access[3177∈7]<br />ᐸ1471.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access3178{{"Access[3178∈7]<br />ᐸ1471.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
-    Object1481 & Access3177 & Access3178 --> PgSelect1558
+    Object1481 -->|rejectNull| PgSelect1558
+    Access3177 -->|rejectNull| PgSelect1558
+    Access3178 --> PgSelect1558
     List1567{{"List[1567∈7]<br />ᐸ1564,1565,1566ᐳ<br />ᐳCompoundKey"}}:::plan
     Constant1564{{"Constant[1564∈7]<br />ᐸ'compound_keys'ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression1565{{"PgClassExpression[1565∈7]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression1566{{"PgClassExpression[1566∈7]<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     Constant1564 & PgClassExpression1565 & PgClassExpression1566 --> List1567
     PgSelect1478[["PgSelect[1478∈7]<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
-    Object1481 & Access3177 --> PgSelect1478
+    Object1481 -->|rejectNull| PgSelect1478
+    Access3177 --> PgSelect1478
     Access1479{{"Access[1479∈7]<br />ᐸ3.pgSettingsᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access1480{{"Access[1480∈7]<br />ᐸ3.withPgClientᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access1479 & Access1480 --> Object1481
@@ -1554,97 +1671,113 @@ graph TD
     PgClassExpression1485{{"PgClassExpression[1485∈7]<br />ᐸ__inputs__.”id”ᐳ"}}:::plan
     Constant1484 & PgClassExpression1485 --> List1486
     PgSelect1491[["PgSelect[1491∈7]<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
-    Object1481 & Access3177 --> PgSelect1491
+    Object1481 -->|rejectNull| PgSelect1491
+    Access3177 --> PgSelect1491
     List1499{{"List[1499∈7]<br />ᐸ1497,1498ᐳ<br />ᐳPatch"}}:::plan
     Constant1497{{"Constant[1497∈7]<br />ᐸ'patchs'ᐳ<br />ᐳPatch"}}:::plan
     PgClassExpression1498{{"PgClassExpression[1498∈7]<br />ᐸ__patchs__.”id”ᐳ"}}:::plan
     Constant1497 & PgClassExpression1498 --> List1499
     PgSelect1504[["PgSelect[1504∈7]<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
-    Object1481 & Access3177 --> PgSelect1504
+    Object1481 -->|rejectNull| PgSelect1504
+    Access3177 --> PgSelect1504
     List1512{{"List[1512∈7]<br />ᐸ1510,1511ᐳ<br />ᐳReserved"}}:::plan
     Constant1510{{"Constant[1510∈7]<br />ᐸ'reserveds'ᐳ<br />ᐳReserved"}}:::plan
     PgClassExpression1511{{"PgClassExpression[1511∈7]<br />ᐸ__reserved__.”id”ᐳ"}}:::plan
     Constant1510 & PgClassExpression1511 --> List1512
     PgSelect1517[["PgSelect[1517∈7]<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
-    Object1481 & Access3177 --> PgSelect1517
+    Object1481 -->|rejectNull| PgSelect1517
+    Access3177 --> PgSelect1517
     List1525{{"List[1525∈7]<br />ᐸ1523,1524ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     Constant1523{{"Constant[1523∈7]<br />ᐸ'reservedPatchs'ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     PgClassExpression1524{{"PgClassExpression[1524∈7]<br />ᐸ__reserved...chs__.”id”ᐳ"}}:::plan
     Constant1523 & PgClassExpression1524 --> List1525
     PgSelect1530[["PgSelect[1530∈7]<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
-    Object1481 & Access3177 --> PgSelect1530
+    Object1481 -->|rejectNull| PgSelect1530
+    Access3177 --> PgSelect1530
     List1538{{"List[1538∈7]<br />ᐸ1536,1537ᐳ<br />ᐳReservedInputRecord"}}:::plan
     Constant1536{{"Constant[1536∈7]<br />ᐸ'reserved_inputs'ᐳ<br />ᐳReservedInputRecord"}}:::plan
     PgClassExpression1537{{"PgClassExpression[1537∈7]<br />ᐸ__reserved_input__.”id”ᐳ"}}:::plan
     Constant1536 & PgClassExpression1537 --> List1538
     PgSelect1543[["PgSelect[1543∈7]<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
-    Object1481 & Access3177 --> PgSelect1543
+    Object1481 -->|rejectNull| PgSelect1543
+    Access3177 --> PgSelect1543
     List1551{{"List[1551∈7]<br />ᐸ1549,1550ᐳ<br />ᐳDefaultValue"}}:::plan
     Constant1549{{"Constant[1549∈7]<br />ᐸ'default_values'ᐳ<br />ᐳDefaultValue"}}:::plan
     PgClassExpression1550{{"PgClassExpression[1550∈7]<br />ᐸ__default_value__.”id”ᐳ"}}:::plan
     Constant1549 & PgClassExpression1550 --> List1551
     PgSelect1572[["PgSelect[1572∈7]<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
-    Object1481 & Access3177 --> PgSelect1572
+    Object1481 -->|rejectNull| PgSelect1572
+    Access3177 --> PgSelect1572
     List1580{{"List[1580∈7]<br />ᐸ1578,1579ᐳ<br />ᐳPerson"}}:::plan
     Constant1578{{"Constant[1578∈7]<br />ᐸ'people'ᐳ<br />ᐳPerson"}}:::plan
     PgClassExpression1579{{"PgClassExpression[1579∈7]<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant1578 & PgClassExpression1579 --> List1580
     PgSelect1585[["PgSelect[1585∈7]<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
-    Object1481 & Access3177 --> PgSelect1585
+    Object1481 -->|rejectNull| PgSelect1585
+    Access3177 --> PgSelect1585
     List1593{{"List[1593∈7]<br />ᐸ1591,1592ᐳ<br />ᐳPost"}}:::plan
     Constant1591{{"Constant[1591∈7]<br />ᐸ'posts'ᐳ<br />ᐳPost"}}:::plan
     PgClassExpression1592{{"PgClassExpression[1592∈7]<br />ᐸ__post__.”id”ᐳ"}}:::plan
     Constant1591 & PgClassExpression1592 --> List1593
     PgSelect1598[["PgSelect[1598∈7]<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
-    Object1481 & Access3177 --> PgSelect1598
+    Object1481 -->|rejectNull| PgSelect1598
+    Access3177 --> PgSelect1598
     List1606{{"List[1606∈7]<br />ᐸ1604,1605ᐳ<br />ᐳType"}}:::plan
     Constant1604{{"Constant[1604∈7]<br />ᐸ'types'ᐳ<br />ᐳType"}}:::plan
     PgClassExpression1605{{"PgClassExpression[1605∈7]<br />ᐸ__types__.”id”ᐳ"}}:::plan
     Constant1604 & PgClassExpression1605 --> List1606
     PgSelect1611[["PgSelect[1611∈7]<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
-    Object1481 & Access3177 --> PgSelect1611
+    Object1481 -->|rejectNull| PgSelect1611
+    Access3177 --> PgSelect1611
     List1619{{"List[1619∈7]<br />ᐸ1617,1618ᐳ<br />ᐳPersonSecret"}}:::plan
     Constant1617{{"Constant[1617∈7]<br />ᐸ'person_secrets'ᐳ<br />ᐳPersonSecret"}}:::plan
     PgClassExpression1618{{"PgClassExpression[1618∈7]<br />ᐸ__person_s...person_id”ᐳ"}}:::plan
     Constant1617 & PgClassExpression1618 --> List1619
     PgSelect1624[["PgSelect[1624∈7]<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
-    Object1481 & Access3177 --> PgSelect1624
+    Object1481 -->|rejectNull| PgSelect1624
+    Access3177 --> PgSelect1624
     List1632{{"List[1632∈7]<br />ᐸ1630,1631ᐳ<br />ᐳLeftArm"}}:::plan
     Constant1630{{"Constant[1630∈7]<br />ᐸ'left_arms'ᐳ<br />ᐳLeftArm"}}:::plan
     PgClassExpression1631{{"PgClassExpression[1631∈7]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
     Constant1630 & PgClassExpression1631 --> List1632
     PgSelect1637[["PgSelect[1637∈7]<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
-    Object1481 & Access3177 --> PgSelect1637
+    Object1481 -->|rejectNull| PgSelect1637
+    Access3177 --> PgSelect1637
     List1645{{"List[1645∈7]<br />ᐸ1643,1644ᐳ<br />ᐳMyTable"}}:::plan
     Constant1643{{"Constant[1643∈7]<br />ᐸ'my_tables'ᐳ<br />ᐳMyTable"}}:::plan
     PgClassExpression1644{{"PgClassExpression[1644∈7]<br />ᐸ__my_table__.”id”ᐳ"}}:::plan
     Constant1643 & PgClassExpression1644 --> List1645
     PgSelect1650[["PgSelect[1650∈7]<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
-    Object1481 & Access3177 --> PgSelect1650
+    Object1481 -->|rejectNull| PgSelect1650
+    Access3177 --> PgSelect1650
     List1658{{"List[1658∈7]<br />ᐸ1656,1657ᐳ<br />ᐳViewTable"}}:::plan
     Constant1656{{"Constant[1656∈7]<br />ᐸ'view_tables'ᐳ<br />ᐳViewTable"}}:::plan
     PgClassExpression1657{{"PgClassExpression[1657∈7]<br />ᐸ__view_table__.”id”ᐳ"}}:::plan
     Constant1656 & PgClassExpression1657 --> List1658
     PgSelect1663[["PgSelect[1663∈7]<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
-    Object1481 & Access3177 --> PgSelect1663
+    Object1481 -->|rejectNull| PgSelect1663
+    Access3177 --> PgSelect1663
     List1671{{"List[1671∈7]<br />ᐸ1669,1670ᐳ<br />ᐳSimilarTable1"}}:::plan
     Constant1669{{"Constant[1669∈7]<br />ᐸ'similar_table_1S'ᐳ<br />ᐳSimilarTable1"}}:::plan
     PgClassExpression1670{{"PgClassExpression[1670∈7]<br />ᐸ__similar_...e_1__.”id”ᐳ"}}:::plan
     Constant1669 & PgClassExpression1670 --> List1671
     PgSelect1676[["PgSelect[1676∈7]<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
-    Object1481 & Access3177 --> PgSelect1676
+    Object1481 -->|rejectNull| PgSelect1676
+    Access3177 --> PgSelect1676
     List1684{{"List[1684∈7]<br />ᐸ1682,1683ᐳ<br />ᐳSimilarTable2"}}:::plan
     Constant1682{{"Constant[1682∈7]<br />ᐸ'similar_table_2S'ᐳ<br />ᐳSimilarTable2"}}:::plan
     PgClassExpression1683{{"PgClassExpression[1683∈7]<br />ᐸ__similar_...e_2__.”id”ᐳ"}}:::plan
     Constant1682 & PgClassExpression1683 --> List1684
     PgSelect1689[["PgSelect[1689∈7]<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
-    Object1481 & Access3177 --> PgSelect1689
+    Object1481 -->|rejectNull| PgSelect1689
+    Access3177 --> PgSelect1689
     List1697{{"List[1697∈7]<br />ᐸ1695,1696ᐳ<br />ᐳNullTestRecord"}}:::plan
     Constant1695{{"Constant[1695∈7]<br />ᐸ'null_test_records'ᐳ<br />ᐳNullTestRecord"}}:::plan
     PgClassExpression1696{{"PgClassExpression[1696∈7]<br />ᐸ__null_tes...ord__.”id”ᐳ"}}:::plan
     Constant1695 & PgClassExpression1696 --> List1697
     PgSelect1702[["PgSelect[1702∈7]<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
-    Object1481 & Access3177 --> PgSelect1702
+    Object1481 -->|rejectNull| PgSelect1702
+    Access3177 --> PgSelect1702
     List1710{{"List[1710∈7]<br />ᐸ1708,1709ᐳ<br />ᐳIssue756"}}:::plan
     Constant1708{{"Constant[1708∈7]<br />ᐸ'issue756S'ᐳ<br />ᐳIssue756"}}:::plan
     PgClassExpression1709{{"PgClassExpression[1709∈7]<br />ᐸ__issue756__.”id”ᐳ"}}:::plan
@@ -1787,14 +1920,17 @@ graph TD
     Object1724{{"Object[1724∈8]<br />ᐸ{pgSettings,withPgClient}ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access3180{{"Access[3180∈8]<br />ᐸ1714.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access3181{{"Access[3181∈8]<br />ᐸ1714.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
-    Object1724 & Access3180 & Access3181 --> PgSelect1801
+    Object1724 -->|rejectNull| PgSelect1801
+    Access3180 -->|rejectNull| PgSelect1801
+    Access3181 --> PgSelect1801
     List1810{{"List[1810∈8]<br />ᐸ1807,1808,1809ᐳ<br />ᐳCompoundKey"}}:::plan
     Constant1807{{"Constant[1807∈8]<br />ᐸ'compound_keys'ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression1808{{"PgClassExpression[1808∈8]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression1809{{"PgClassExpression[1809∈8]<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     Constant1807 & PgClassExpression1808 & PgClassExpression1809 --> List1810
     PgSelect1721[["PgSelect[1721∈8]<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
-    Object1724 & Access3180 --> PgSelect1721
+    Object1724 -->|rejectNull| PgSelect1721
+    Access3180 --> PgSelect1721
     Access1722{{"Access[1722∈8]<br />ᐸ3.pgSettingsᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access1723{{"Access[1723∈8]<br />ᐸ3.withPgClientᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access1722 & Access1723 --> Object1724
@@ -1803,97 +1939,113 @@ graph TD
     PgClassExpression1728{{"PgClassExpression[1728∈8]<br />ᐸ__inputs__.”id”ᐳ"}}:::plan
     Constant1727 & PgClassExpression1728 --> List1729
     PgSelect1734[["PgSelect[1734∈8]<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
-    Object1724 & Access3180 --> PgSelect1734
+    Object1724 -->|rejectNull| PgSelect1734
+    Access3180 --> PgSelect1734
     List1742{{"List[1742∈8]<br />ᐸ1740,1741ᐳ<br />ᐳPatch"}}:::plan
     Constant1740{{"Constant[1740∈8]<br />ᐸ'patchs'ᐳ<br />ᐳPatch"}}:::plan
     PgClassExpression1741{{"PgClassExpression[1741∈8]<br />ᐸ__patchs__.”id”ᐳ"}}:::plan
     Constant1740 & PgClassExpression1741 --> List1742
     PgSelect1747[["PgSelect[1747∈8]<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
-    Object1724 & Access3180 --> PgSelect1747
+    Object1724 -->|rejectNull| PgSelect1747
+    Access3180 --> PgSelect1747
     List1755{{"List[1755∈8]<br />ᐸ1753,1754ᐳ<br />ᐳReserved"}}:::plan
     Constant1753{{"Constant[1753∈8]<br />ᐸ'reserveds'ᐳ<br />ᐳReserved"}}:::plan
     PgClassExpression1754{{"PgClassExpression[1754∈8]<br />ᐸ__reserved__.”id”ᐳ"}}:::plan
     Constant1753 & PgClassExpression1754 --> List1755
     PgSelect1760[["PgSelect[1760∈8]<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
-    Object1724 & Access3180 --> PgSelect1760
+    Object1724 -->|rejectNull| PgSelect1760
+    Access3180 --> PgSelect1760
     List1768{{"List[1768∈8]<br />ᐸ1766,1767ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     Constant1766{{"Constant[1766∈8]<br />ᐸ'reservedPatchs'ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     PgClassExpression1767{{"PgClassExpression[1767∈8]<br />ᐸ__reserved...chs__.”id”ᐳ"}}:::plan
     Constant1766 & PgClassExpression1767 --> List1768
     PgSelect1773[["PgSelect[1773∈8]<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
-    Object1724 & Access3180 --> PgSelect1773
+    Object1724 -->|rejectNull| PgSelect1773
+    Access3180 --> PgSelect1773
     List1781{{"List[1781∈8]<br />ᐸ1779,1780ᐳ<br />ᐳReservedInputRecord"}}:::plan
     Constant1779{{"Constant[1779∈8]<br />ᐸ'reserved_inputs'ᐳ<br />ᐳReservedInputRecord"}}:::plan
     PgClassExpression1780{{"PgClassExpression[1780∈8]<br />ᐸ__reserved_input__.”id”ᐳ"}}:::plan
     Constant1779 & PgClassExpression1780 --> List1781
     PgSelect1786[["PgSelect[1786∈8]<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
-    Object1724 & Access3180 --> PgSelect1786
+    Object1724 -->|rejectNull| PgSelect1786
+    Access3180 --> PgSelect1786
     List1794{{"List[1794∈8]<br />ᐸ1792,1793ᐳ<br />ᐳDefaultValue"}}:::plan
     Constant1792{{"Constant[1792∈8]<br />ᐸ'default_values'ᐳ<br />ᐳDefaultValue"}}:::plan
     PgClassExpression1793{{"PgClassExpression[1793∈8]<br />ᐸ__default_value__.”id”ᐳ"}}:::plan
     Constant1792 & PgClassExpression1793 --> List1794
     PgSelect1815[["PgSelect[1815∈8]<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
-    Object1724 & Access3180 --> PgSelect1815
+    Object1724 -->|rejectNull| PgSelect1815
+    Access3180 --> PgSelect1815
     List1823{{"List[1823∈8]<br />ᐸ1821,1822ᐳ<br />ᐳPerson"}}:::plan
     Constant1821{{"Constant[1821∈8]<br />ᐸ'people'ᐳ<br />ᐳPerson"}}:::plan
     PgClassExpression1822{{"PgClassExpression[1822∈8]<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant1821 & PgClassExpression1822 --> List1823
     PgSelect1828[["PgSelect[1828∈8]<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
-    Object1724 & Access3180 --> PgSelect1828
+    Object1724 -->|rejectNull| PgSelect1828
+    Access3180 --> PgSelect1828
     List1836{{"List[1836∈8]<br />ᐸ1834,1835ᐳ<br />ᐳPost"}}:::plan
     Constant1834{{"Constant[1834∈8]<br />ᐸ'posts'ᐳ<br />ᐳPost"}}:::plan
     PgClassExpression1835{{"PgClassExpression[1835∈8]<br />ᐸ__post__.”id”ᐳ"}}:::plan
     Constant1834 & PgClassExpression1835 --> List1836
     PgSelect1841[["PgSelect[1841∈8]<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
-    Object1724 & Access3180 --> PgSelect1841
+    Object1724 -->|rejectNull| PgSelect1841
+    Access3180 --> PgSelect1841
     List1849{{"List[1849∈8]<br />ᐸ1847,1848ᐳ<br />ᐳType"}}:::plan
     Constant1847{{"Constant[1847∈8]<br />ᐸ'types'ᐳ<br />ᐳType"}}:::plan
     PgClassExpression1848{{"PgClassExpression[1848∈8]<br />ᐸ__types__.”id”ᐳ"}}:::plan
     Constant1847 & PgClassExpression1848 --> List1849
     PgSelect1854[["PgSelect[1854∈8]<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
-    Object1724 & Access3180 --> PgSelect1854
+    Object1724 -->|rejectNull| PgSelect1854
+    Access3180 --> PgSelect1854
     List1862{{"List[1862∈8]<br />ᐸ1860,1861ᐳ<br />ᐳPersonSecret"}}:::plan
     Constant1860{{"Constant[1860∈8]<br />ᐸ'person_secrets'ᐳ<br />ᐳPersonSecret"}}:::plan
     PgClassExpression1861{{"PgClassExpression[1861∈8]<br />ᐸ__person_s...person_id”ᐳ"}}:::plan
     Constant1860 & PgClassExpression1861 --> List1862
     PgSelect1867[["PgSelect[1867∈8]<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
-    Object1724 & Access3180 --> PgSelect1867
+    Object1724 -->|rejectNull| PgSelect1867
+    Access3180 --> PgSelect1867
     List1875{{"List[1875∈8]<br />ᐸ1873,1874ᐳ<br />ᐳLeftArm"}}:::plan
     Constant1873{{"Constant[1873∈8]<br />ᐸ'left_arms'ᐳ<br />ᐳLeftArm"}}:::plan
     PgClassExpression1874{{"PgClassExpression[1874∈8]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
     Constant1873 & PgClassExpression1874 --> List1875
     PgSelect1880[["PgSelect[1880∈8]<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
-    Object1724 & Access3180 --> PgSelect1880
+    Object1724 -->|rejectNull| PgSelect1880
+    Access3180 --> PgSelect1880
     List1888{{"List[1888∈8]<br />ᐸ1886,1887ᐳ<br />ᐳMyTable"}}:::plan
     Constant1886{{"Constant[1886∈8]<br />ᐸ'my_tables'ᐳ<br />ᐳMyTable"}}:::plan
     PgClassExpression1887{{"PgClassExpression[1887∈8]<br />ᐸ__my_table__.”id”ᐳ"}}:::plan
     Constant1886 & PgClassExpression1887 --> List1888
     PgSelect1893[["PgSelect[1893∈8]<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
-    Object1724 & Access3180 --> PgSelect1893
+    Object1724 -->|rejectNull| PgSelect1893
+    Access3180 --> PgSelect1893
     List1901{{"List[1901∈8]<br />ᐸ1899,1900ᐳ<br />ᐳViewTable"}}:::plan
     Constant1899{{"Constant[1899∈8]<br />ᐸ'view_tables'ᐳ<br />ᐳViewTable"}}:::plan
     PgClassExpression1900{{"PgClassExpression[1900∈8]<br />ᐸ__view_table__.”id”ᐳ"}}:::plan
     Constant1899 & PgClassExpression1900 --> List1901
     PgSelect1906[["PgSelect[1906∈8]<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
-    Object1724 & Access3180 --> PgSelect1906
+    Object1724 -->|rejectNull| PgSelect1906
+    Access3180 --> PgSelect1906
     List1914{{"List[1914∈8]<br />ᐸ1912,1913ᐳ<br />ᐳSimilarTable1"}}:::plan
     Constant1912{{"Constant[1912∈8]<br />ᐸ'similar_table_1S'ᐳ<br />ᐳSimilarTable1"}}:::plan
     PgClassExpression1913{{"PgClassExpression[1913∈8]<br />ᐸ__similar_...e_1__.”id”ᐳ"}}:::plan
     Constant1912 & PgClassExpression1913 --> List1914
     PgSelect1919[["PgSelect[1919∈8]<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
-    Object1724 & Access3180 --> PgSelect1919
+    Object1724 -->|rejectNull| PgSelect1919
+    Access3180 --> PgSelect1919
     List1927{{"List[1927∈8]<br />ᐸ1925,1926ᐳ<br />ᐳSimilarTable2"}}:::plan
     Constant1925{{"Constant[1925∈8]<br />ᐸ'similar_table_2S'ᐳ<br />ᐳSimilarTable2"}}:::plan
     PgClassExpression1926{{"PgClassExpression[1926∈8]<br />ᐸ__similar_...e_2__.”id”ᐳ"}}:::plan
     Constant1925 & PgClassExpression1926 --> List1927
     PgSelect1932[["PgSelect[1932∈8]<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
-    Object1724 & Access3180 --> PgSelect1932
+    Object1724 -->|rejectNull| PgSelect1932
+    Access3180 --> PgSelect1932
     List1940{{"List[1940∈8]<br />ᐸ1938,1939ᐳ<br />ᐳNullTestRecord"}}:::plan
     Constant1938{{"Constant[1938∈8]<br />ᐸ'null_test_records'ᐳ<br />ᐳNullTestRecord"}}:::plan
     PgClassExpression1939{{"PgClassExpression[1939∈8]<br />ᐸ__null_tes...ord__.”id”ᐳ"}}:::plan
     Constant1938 & PgClassExpression1939 --> List1940
     PgSelect1945[["PgSelect[1945∈8]<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
-    Object1724 & Access3180 --> PgSelect1945
+    Object1724 -->|rejectNull| PgSelect1945
+    Access3180 --> PgSelect1945
     List1953{{"List[1953∈8]<br />ᐸ1951,1952ᐳ<br />ᐳIssue756"}}:::plan
     Constant1951{{"Constant[1951∈8]<br />ᐸ'issue756S'ᐳ<br />ᐳIssue756"}}:::plan
     PgClassExpression1952{{"PgClassExpression[1952∈8]<br />ᐸ__issue756__.”id”ᐳ"}}:::plan
@@ -2036,14 +2188,17 @@ graph TD
     Object1969{{"Object[1969∈9]<br />ᐸ{pgSettings,withPgClient}ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access3183{{"Access[3183∈9]<br />ᐸ1959.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access3184{{"Access[3184∈9]<br />ᐸ1959.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
-    Object1969 & Access3183 & Access3184 --> PgSelect2046
+    Object1969 -->|rejectNull| PgSelect2046
+    Access3183 -->|rejectNull| PgSelect2046
+    Access3184 --> PgSelect2046
     List2055{{"List[2055∈9]<br />ᐸ2052,2053,2054ᐳ<br />ᐳCompoundKey"}}:::plan
     Constant2052{{"Constant[2052∈9]<br />ᐸ'compound_keys'ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression2053{{"PgClassExpression[2053∈9]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression2054{{"PgClassExpression[2054∈9]<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     Constant2052 & PgClassExpression2053 & PgClassExpression2054 --> List2055
     PgSelect1966[["PgSelect[1966∈9]<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
-    Object1969 & Access3183 --> PgSelect1966
+    Object1969 -->|rejectNull| PgSelect1966
+    Access3183 --> PgSelect1966
     Access1967{{"Access[1967∈9]<br />ᐸ3.pgSettingsᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access1968{{"Access[1968∈9]<br />ᐸ3.withPgClientᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access1967 & Access1968 --> Object1969
@@ -2052,97 +2207,113 @@ graph TD
     PgClassExpression1973{{"PgClassExpression[1973∈9]<br />ᐸ__inputs__.”id”ᐳ"}}:::plan
     Constant1972 & PgClassExpression1973 --> List1974
     PgSelect1979[["PgSelect[1979∈9]<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
-    Object1969 & Access3183 --> PgSelect1979
+    Object1969 -->|rejectNull| PgSelect1979
+    Access3183 --> PgSelect1979
     List1987{{"List[1987∈9]<br />ᐸ1985,1986ᐳ<br />ᐳPatch"}}:::plan
     Constant1985{{"Constant[1985∈9]<br />ᐸ'patchs'ᐳ<br />ᐳPatch"}}:::plan
     PgClassExpression1986{{"PgClassExpression[1986∈9]<br />ᐸ__patchs__.”id”ᐳ"}}:::plan
     Constant1985 & PgClassExpression1986 --> List1987
     PgSelect1992[["PgSelect[1992∈9]<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
-    Object1969 & Access3183 --> PgSelect1992
+    Object1969 -->|rejectNull| PgSelect1992
+    Access3183 --> PgSelect1992
     List2000{{"List[2000∈9]<br />ᐸ1998,1999ᐳ<br />ᐳReserved"}}:::plan
     Constant1998{{"Constant[1998∈9]<br />ᐸ'reserveds'ᐳ<br />ᐳReserved"}}:::plan
     PgClassExpression1999{{"PgClassExpression[1999∈9]<br />ᐸ__reserved__.”id”ᐳ"}}:::plan
     Constant1998 & PgClassExpression1999 --> List2000
     PgSelect2005[["PgSelect[2005∈9]<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
-    Object1969 & Access3183 --> PgSelect2005
+    Object1969 -->|rejectNull| PgSelect2005
+    Access3183 --> PgSelect2005
     List2013{{"List[2013∈9]<br />ᐸ2011,2012ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     Constant2011{{"Constant[2011∈9]<br />ᐸ'reservedPatchs'ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     PgClassExpression2012{{"PgClassExpression[2012∈9]<br />ᐸ__reserved...chs__.”id”ᐳ"}}:::plan
     Constant2011 & PgClassExpression2012 --> List2013
     PgSelect2018[["PgSelect[2018∈9]<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
-    Object1969 & Access3183 --> PgSelect2018
+    Object1969 -->|rejectNull| PgSelect2018
+    Access3183 --> PgSelect2018
     List2026{{"List[2026∈9]<br />ᐸ2024,2025ᐳ<br />ᐳReservedInputRecord"}}:::plan
     Constant2024{{"Constant[2024∈9]<br />ᐸ'reserved_inputs'ᐳ<br />ᐳReservedInputRecord"}}:::plan
     PgClassExpression2025{{"PgClassExpression[2025∈9]<br />ᐸ__reserved_input__.”id”ᐳ"}}:::plan
     Constant2024 & PgClassExpression2025 --> List2026
     PgSelect2031[["PgSelect[2031∈9]<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
-    Object1969 & Access3183 --> PgSelect2031
+    Object1969 -->|rejectNull| PgSelect2031
+    Access3183 --> PgSelect2031
     List2039{{"List[2039∈9]<br />ᐸ2037,2038ᐳ<br />ᐳDefaultValue"}}:::plan
     Constant2037{{"Constant[2037∈9]<br />ᐸ'default_values'ᐳ<br />ᐳDefaultValue"}}:::plan
     PgClassExpression2038{{"PgClassExpression[2038∈9]<br />ᐸ__default_value__.”id”ᐳ"}}:::plan
     Constant2037 & PgClassExpression2038 --> List2039
     PgSelect2060[["PgSelect[2060∈9]<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
-    Object1969 & Access3183 --> PgSelect2060
+    Object1969 -->|rejectNull| PgSelect2060
+    Access3183 --> PgSelect2060
     List2068{{"List[2068∈9]<br />ᐸ2066,2067ᐳ<br />ᐳPerson"}}:::plan
     Constant2066{{"Constant[2066∈9]<br />ᐸ'people'ᐳ<br />ᐳPerson"}}:::plan
     PgClassExpression2067{{"PgClassExpression[2067∈9]<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant2066 & PgClassExpression2067 --> List2068
     PgSelect2073[["PgSelect[2073∈9]<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
-    Object1969 & Access3183 --> PgSelect2073
+    Object1969 -->|rejectNull| PgSelect2073
+    Access3183 --> PgSelect2073
     List2081{{"List[2081∈9]<br />ᐸ2079,2080ᐳ<br />ᐳPost"}}:::plan
     Constant2079{{"Constant[2079∈9]<br />ᐸ'posts'ᐳ<br />ᐳPost"}}:::plan
     PgClassExpression2080{{"PgClassExpression[2080∈9]<br />ᐸ__post__.”id”ᐳ"}}:::plan
     Constant2079 & PgClassExpression2080 --> List2081
     PgSelect2086[["PgSelect[2086∈9]<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
-    Object1969 & Access3183 --> PgSelect2086
+    Object1969 -->|rejectNull| PgSelect2086
+    Access3183 --> PgSelect2086
     List2094{{"List[2094∈9]<br />ᐸ2092,2093ᐳ<br />ᐳType"}}:::plan
     Constant2092{{"Constant[2092∈9]<br />ᐸ'types'ᐳ<br />ᐳType"}}:::plan
     PgClassExpression2093{{"PgClassExpression[2093∈9]<br />ᐸ__types__.”id”ᐳ"}}:::plan
     Constant2092 & PgClassExpression2093 --> List2094
     PgSelect2099[["PgSelect[2099∈9]<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
-    Object1969 & Access3183 --> PgSelect2099
+    Object1969 -->|rejectNull| PgSelect2099
+    Access3183 --> PgSelect2099
     List2107{{"List[2107∈9]<br />ᐸ2105,2106ᐳ<br />ᐳPersonSecret"}}:::plan
     Constant2105{{"Constant[2105∈9]<br />ᐸ'person_secrets'ᐳ<br />ᐳPersonSecret"}}:::plan
     PgClassExpression2106{{"PgClassExpression[2106∈9]<br />ᐸ__person_s...person_id”ᐳ"}}:::plan
     Constant2105 & PgClassExpression2106 --> List2107
     PgSelect2112[["PgSelect[2112∈9]<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
-    Object1969 & Access3183 --> PgSelect2112
+    Object1969 -->|rejectNull| PgSelect2112
+    Access3183 --> PgSelect2112
     List2120{{"List[2120∈9]<br />ᐸ2118,2119ᐳ<br />ᐳLeftArm"}}:::plan
     Constant2118{{"Constant[2118∈9]<br />ᐸ'left_arms'ᐳ<br />ᐳLeftArm"}}:::plan
     PgClassExpression2119{{"PgClassExpression[2119∈9]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
     Constant2118 & PgClassExpression2119 --> List2120
     PgSelect2125[["PgSelect[2125∈9]<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
-    Object1969 & Access3183 --> PgSelect2125
+    Object1969 -->|rejectNull| PgSelect2125
+    Access3183 --> PgSelect2125
     List2133{{"List[2133∈9]<br />ᐸ2131,2132ᐳ<br />ᐳMyTable"}}:::plan
     Constant2131{{"Constant[2131∈9]<br />ᐸ'my_tables'ᐳ<br />ᐳMyTable"}}:::plan
     PgClassExpression2132{{"PgClassExpression[2132∈9]<br />ᐸ__my_table__.”id”ᐳ"}}:::plan
     Constant2131 & PgClassExpression2132 --> List2133
     PgSelect2138[["PgSelect[2138∈9]<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
-    Object1969 & Access3183 --> PgSelect2138
+    Object1969 -->|rejectNull| PgSelect2138
+    Access3183 --> PgSelect2138
     List2146{{"List[2146∈9]<br />ᐸ2144,2145ᐳ<br />ᐳViewTable"}}:::plan
     Constant2144{{"Constant[2144∈9]<br />ᐸ'view_tables'ᐳ<br />ᐳViewTable"}}:::plan
     PgClassExpression2145{{"PgClassExpression[2145∈9]<br />ᐸ__view_table__.”id”ᐳ"}}:::plan
     Constant2144 & PgClassExpression2145 --> List2146
     PgSelect2151[["PgSelect[2151∈9]<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
-    Object1969 & Access3183 --> PgSelect2151
+    Object1969 -->|rejectNull| PgSelect2151
+    Access3183 --> PgSelect2151
     List2159{{"List[2159∈9]<br />ᐸ2157,2158ᐳ<br />ᐳSimilarTable1"}}:::plan
     Constant2157{{"Constant[2157∈9]<br />ᐸ'similar_table_1S'ᐳ<br />ᐳSimilarTable1"}}:::plan
     PgClassExpression2158{{"PgClassExpression[2158∈9]<br />ᐸ__similar_...e_1__.”id”ᐳ"}}:::plan
     Constant2157 & PgClassExpression2158 --> List2159
     PgSelect2164[["PgSelect[2164∈9]<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
-    Object1969 & Access3183 --> PgSelect2164
+    Object1969 -->|rejectNull| PgSelect2164
+    Access3183 --> PgSelect2164
     List2172{{"List[2172∈9]<br />ᐸ2170,2171ᐳ<br />ᐳSimilarTable2"}}:::plan
     Constant2170{{"Constant[2170∈9]<br />ᐸ'similar_table_2S'ᐳ<br />ᐳSimilarTable2"}}:::plan
     PgClassExpression2171{{"PgClassExpression[2171∈9]<br />ᐸ__similar_...e_2__.”id”ᐳ"}}:::plan
     Constant2170 & PgClassExpression2171 --> List2172
     PgSelect2177[["PgSelect[2177∈9]<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
-    Object1969 & Access3183 --> PgSelect2177
+    Object1969 -->|rejectNull| PgSelect2177
+    Access3183 --> PgSelect2177
     List2185{{"List[2185∈9]<br />ᐸ2183,2184ᐳ<br />ᐳNullTestRecord"}}:::plan
     Constant2183{{"Constant[2183∈9]<br />ᐸ'null_test_records'ᐳ<br />ᐳNullTestRecord"}}:::plan
     PgClassExpression2184{{"PgClassExpression[2184∈9]<br />ᐸ__null_tes...ord__.”id”ᐳ"}}:::plan
     Constant2183 & PgClassExpression2184 --> List2185
     PgSelect2190[["PgSelect[2190∈9]<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
-    Object1969 & Access3183 --> PgSelect2190
+    Object1969 -->|rejectNull| PgSelect2190
+    Access3183 --> PgSelect2190
     List2198{{"List[2198∈9]<br />ᐸ2196,2197ᐳ<br />ᐳIssue756"}}:::plan
     Constant2196{{"Constant[2196∈9]<br />ᐸ'issue756S'ᐳ<br />ᐳIssue756"}}:::plan
     PgClassExpression2197{{"PgClassExpression[2197∈9]<br />ᐸ__issue756__.”id”ᐳ"}}:::plan
@@ -2285,14 +2456,17 @@ graph TD
     Object2212{{"Object[2212∈10]<br />ᐸ{pgSettings,withPgClient}ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access3186{{"Access[3186∈10]<br />ᐸ2202.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access3187{{"Access[3187∈10]<br />ᐸ2202.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
-    Object2212 & Access3186 & Access3187 --> PgSelect2289
+    Object2212 -->|rejectNull| PgSelect2289
+    Access3186 -->|rejectNull| PgSelect2289
+    Access3187 --> PgSelect2289
     List2298{{"List[2298∈10]<br />ᐸ2295,2296,2297ᐳ<br />ᐳCompoundKey"}}:::plan
     Constant2295{{"Constant[2295∈10]<br />ᐸ'compound_keys'ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression2296{{"PgClassExpression[2296∈10]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression2297{{"PgClassExpression[2297∈10]<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     Constant2295 & PgClassExpression2296 & PgClassExpression2297 --> List2298
     PgSelect2209[["PgSelect[2209∈10]<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
-    Object2212 & Access3186 --> PgSelect2209
+    Object2212 -->|rejectNull| PgSelect2209
+    Access3186 --> PgSelect2209
     Access2210{{"Access[2210∈10]<br />ᐸ3.pgSettingsᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access2211{{"Access[2211∈10]<br />ᐸ3.withPgClientᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access2210 & Access2211 --> Object2212
@@ -2301,97 +2475,113 @@ graph TD
     PgClassExpression2216{{"PgClassExpression[2216∈10]<br />ᐸ__inputs__.”id”ᐳ"}}:::plan
     Constant2215 & PgClassExpression2216 --> List2217
     PgSelect2222[["PgSelect[2222∈10]<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
-    Object2212 & Access3186 --> PgSelect2222
+    Object2212 -->|rejectNull| PgSelect2222
+    Access3186 --> PgSelect2222
     List2230{{"List[2230∈10]<br />ᐸ2228,2229ᐳ<br />ᐳPatch"}}:::plan
     Constant2228{{"Constant[2228∈10]<br />ᐸ'patchs'ᐳ<br />ᐳPatch"}}:::plan
     PgClassExpression2229{{"PgClassExpression[2229∈10]<br />ᐸ__patchs__.”id”ᐳ"}}:::plan
     Constant2228 & PgClassExpression2229 --> List2230
     PgSelect2235[["PgSelect[2235∈10]<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
-    Object2212 & Access3186 --> PgSelect2235
+    Object2212 -->|rejectNull| PgSelect2235
+    Access3186 --> PgSelect2235
     List2243{{"List[2243∈10]<br />ᐸ2241,2242ᐳ<br />ᐳReserved"}}:::plan
     Constant2241{{"Constant[2241∈10]<br />ᐸ'reserveds'ᐳ<br />ᐳReserved"}}:::plan
     PgClassExpression2242{{"PgClassExpression[2242∈10]<br />ᐸ__reserved__.”id”ᐳ"}}:::plan
     Constant2241 & PgClassExpression2242 --> List2243
     PgSelect2248[["PgSelect[2248∈10]<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
-    Object2212 & Access3186 --> PgSelect2248
+    Object2212 -->|rejectNull| PgSelect2248
+    Access3186 --> PgSelect2248
     List2256{{"List[2256∈10]<br />ᐸ2254,2255ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     Constant2254{{"Constant[2254∈10]<br />ᐸ'reservedPatchs'ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     PgClassExpression2255{{"PgClassExpression[2255∈10]<br />ᐸ__reserved...chs__.”id”ᐳ"}}:::plan
     Constant2254 & PgClassExpression2255 --> List2256
     PgSelect2261[["PgSelect[2261∈10]<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
-    Object2212 & Access3186 --> PgSelect2261
+    Object2212 -->|rejectNull| PgSelect2261
+    Access3186 --> PgSelect2261
     List2269{{"List[2269∈10]<br />ᐸ2267,2268ᐳ<br />ᐳReservedInputRecord"}}:::plan
     Constant2267{{"Constant[2267∈10]<br />ᐸ'reserved_inputs'ᐳ<br />ᐳReservedInputRecord"}}:::plan
     PgClassExpression2268{{"PgClassExpression[2268∈10]<br />ᐸ__reserved_input__.”id”ᐳ"}}:::plan
     Constant2267 & PgClassExpression2268 --> List2269
     PgSelect2274[["PgSelect[2274∈10]<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
-    Object2212 & Access3186 --> PgSelect2274
+    Object2212 -->|rejectNull| PgSelect2274
+    Access3186 --> PgSelect2274
     List2282{{"List[2282∈10]<br />ᐸ2280,2281ᐳ<br />ᐳDefaultValue"}}:::plan
     Constant2280{{"Constant[2280∈10]<br />ᐸ'default_values'ᐳ<br />ᐳDefaultValue"}}:::plan
     PgClassExpression2281{{"PgClassExpression[2281∈10]<br />ᐸ__default_value__.”id”ᐳ"}}:::plan
     Constant2280 & PgClassExpression2281 --> List2282
     PgSelect2303[["PgSelect[2303∈10]<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
-    Object2212 & Access3186 --> PgSelect2303
+    Object2212 -->|rejectNull| PgSelect2303
+    Access3186 --> PgSelect2303
     List2311{{"List[2311∈10]<br />ᐸ2309,2310ᐳ<br />ᐳPerson"}}:::plan
     Constant2309{{"Constant[2309∈10]<br />ᐸ'people'ᐳ<br />ᐳPerson"}}:::plan
     PgClassExpression2310{{"PgClassExpression[2310∈10]<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant2309 & PgClassExpression2310 --> List2311
     PgSelect2316[["PgSelect[2316∈10]<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
-    Object2212 & Access3186 --> PgSelect2316
+    Object2212 -->|rejectNull| PgSelect2316
+    Access3186 --> PgSelect2316
     List2324{{"List[2324∈10]<br />ᐸ2322,2323ᐳ<br />ᐳPost"}}:::plan
     Constant2322{{"Constant[2322∈10]<br />ᐸ'posts'ᐳ<br />ᐳPost"}}:::plan
     PgClassExpression2323{{"PgClassExpression[2323∈10]<br />ᐸ__post__.”id”ᐳ"}}:::plan
     Constant2322 & PgClassExpression2323 --> List2324
     PgSelect2329[["PgSelect[2329∈10]<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
-    Object2212 & Access3186 --> PgSelect2329
+    Object2212 -->|rejectNull| PgSelect2329
+    Access3186 --> PgSelect2329
     List2337{{"List[2337∈10]<br />ᐸ2335,2336ᐳ<br />ᐳType"}}:::plan
     Constant2335{{"Constant[2335∈10]<br />ᐸ'types'ᐳ<br />ᐳType"}}:::plan
     PgClassExpression2336{{"PgClassExpression[2336∈10]<br />ᐸ__types__.”id”ᐳ"}}:::plan
     Constant2335 & PgClassExpression2336 --> List2337
     PgSelect2342[["PgSelect[2342∈10]<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
-    Object2212 & Access3186 --> PgSelect2342
+    Object2212 -->|rejectNull| PgSelect2342
+    Access3186 --> PgSelect2342
     List2350{{"List[2350∈10]<br />ᐸ2348,2349ᐳ<br />ᐳPersonSecret"}}:::plan
     Constant2348{{"Constant[2348∈10]<br />ᐸ'person_secrets'ᐳ<br />ᐳPersonSecret"}}:::plan
     PgClassExpression2349{{"PgClassExpression[2349∈10]<br />ᐸ__person_s...person_id”ᐳ"}}:::plan
     Constant2348 & PgClassExpression2349 --> List2350
     PgSelect2355[["PgSelect[2355∈10]<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
-    Object2212 & Access3186 --> PgSelect2355
+    Object2212 -->|rejectNull| PgSelect2355
+    Access3186 --> PgSelect2355
     List2363{{"List[2363∈10]<br />ᐸ2361,2362ᐳ<br />ᐳLeftArm"}}:::plan
     Constant2361{{"Constant[2361∈10]<br />ᐸ'left_arms'ᐳ<br />ᐳLeftArm"}}:::plan
     PgClassExpression2362{{"PgClassExpression[2362∈10]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
     Constant2361 & PgClassExpression2362 --> List2363
     PgSelect2368[["PgSelect[2368∈10]<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
-    Object2212 & Access3186 --> PgSelect2368
+    Object2212 -->|rejectNull| PgSelect2368
+    Access3186 --> PgSelect2368
     List2376{{"List[2376∈10]<br />ᐸ2374,2375ᐳ<br />ᐳMyTable"}}:::plan
     Constant2374{{"Constant[2374∈10]<br />ᐸ'my_tables'ᐳ<br />ᐳMyTable"}}:::plan
     PgClassExpression2375{{"PgClassExpression[2375∈10]<br />ᐸ__my_table__.”id”ᐳ"}}:::plan
     Constant2374 & PgClassExpression2375 --> List2376
     PgSelect2381[["PgSelect[2381∈10]<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
-    Object2212 & Access3186 --> PgSelect2381
+    Object2212 -->|rejectNull| PgSelect2381
+    Access3186 --> PgSelect2381
     List2389{{"List[2389∈10]<br />ᐸ2387,2388ᐳ<br />ᐳViewTable"}}:::plan
     Constant2387{{"Constant[2387∈10]<br />ᐸ'view_tables'ᐳ<br />ᐳViewTable"}}:::plan
     PgClassExpression2388{{"PgClassExpression[2388∈10]<br />ᐸ__view_table__.”id”ᐳ"}}:::plan
     Constant2387 & PgClassExpression2388 --> List2389
     PgSelect2394[["PgSelect[2394∈10]<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
-    Object2212 & Access3186 --> PgSelect2394
+    Object2212 -->|rejectNull| PgSelect2394
+    Access3186 --> PgSelect2394
     List2402{{"List[2402∈10]<br />ᐸ2400,2401ᐳ<br />ᐳSimilarTable1"}}:::plan
     Constant2400{{"Constant[2400∈10]<br />ᐸ'similar_table_1S'ᐳ<br />ᐳSimilarTable1"}}:::plan
     PgClassExpression2401{{"PgClassExpression[2401∈10]<br />ᐸ__similar_...e_1__.”id”ᐳ"}}:::plan
     Constant2400 & PgClassExpression2401 --> List2402
     PgSelect2407[["PgSelect[2407∈10]<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
-    Object2212 & Access3186 --> PgSelect2407
+    Object2212 -->|rejectNull| PgSelect2407
+    Access3186 --> PgSelect2407
     List2415{{"List[2415∈10]<br />ᐸ2413,2414ᐳ<br />ᐳSimilarTable2"}}:::plan
     Constant2413{{"Constant[2413∈10]<br />ᐸ'similar_table_2S'ᐳ<br />ᐳSimilarTable2"}}:::plan
     PgClassExpression2414{{"PgClassExpression[2414∈10]<br />ᐸ__similar_...e_2__.”id”ᐳ"}}:::plan
     Constant2413 & PgClassExpression2414 --> List2415
     PgSelect2420[["PgSelect[2420∈10]<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
-    Object2212 & Access3186 --> PgSelect2420
+    Object2212 -->|rejectNull| PgSelect2420
+    Access3186 --> PgSelect2420
     List2428{{"List[2428∈10]<br />ᐸ2426,2427ᐳ<br />ᐳNullTestRecord"}}:::plan
     Constant2426{{"Constant[2426∈10]<br />ᐸ'null_test_records'ᐳ<br />ᐳNullTestRecord"}}:::plan
     PgClassExpression2427{{"PgClassExpression[2427∈10]<br />ᐸ__null_tes...ord__.”id”ᐳ"}}:::plan
     Constant2426 & PgClassExpression2427 --> List2428
     PgSelect2433[["PgSelect[2433∈10]<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
-    Object2212 & Access3186 --> PgSelect2433
+    Object2212 -->|rejectNull| PgSelect2433
+    Access3186 --> PgSelect2433
     List2441{{"List[2441∈10]<br />ᐸ2439,2440ᐳ<br />ᐳIssue756"}}:::plan
     Constant2439{{"Constant[2439∈10]<br />ᐸ'issue756S'ᐳ<br />ᐳIssue756"}}:::plan
     PgClassExpression2440{{"PgClassExpression[2440∈10]<br />ᐸ__issue756__.”id”ᐳ"}}:::plan
@@ -2534,14 +2724,17 @@ graph TD
     Object2457{{"Object[2457∈11]<br />ᐸ{pgSettings,withPgClient}ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access3189{{"Access[3189∈11]<br />ᐸ2447.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access3190{{"Access[3190∈11]<br />ᐸ2447.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
-    Object2457 & Access3189 & Access3190 --> PgSelect2534
+    Object2457 -->|rejectNull| PgSelect2534
+    Access3189 -->|rejectNull| PgSelect2534
+    Access3190 --> PgSelect2534
     List2543{{"List[2543∈11]<br />ᐸ2540,2541,2542ᐳ<br />ᐳCompoundKey"}}:::plan
     Constant2540{{"Constant[2540∈11]<br />ᐸ'compound_keys'ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression2541{{"PgClassExpression[2541∈11]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression2542{{"PgClassExpression[2542∈11]<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     Constant2540 & PgClassExpression2541 & PgClassExpression2542 --> List2543
     PgSelect2454[["PgSelect[2454∈11]<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
-    Object2457 & Access3189 --> PgSelect2454
+    Object2457 -->|rejectNull| PgSelect2454
+    Access3189 --> PgSelect2454
     Access2455{{"Access[2455∈11]<br />ᐸ3.pgSettingsᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access2456{{"Access[2456∈11]<br />ᐸ3.withPgClientᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access2455 & Access2456 --> Object2457
@@ -2550,97 +2743,113 @@ graph TD
     PgClassExpression2461{{"PgClassExpression[2461∈11]<br />ᐸ__inputs__.”id”ᐳ"}}:::plan
     Constant2460 & PgClassExpression2461 --> List2462
     PgSelect2467[["PgSelect[2467∈11]<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
-    Object2457 & Access3189 --> PgSelect2467
+    Object2457 -->|rejectNull| PgSelect2467
+    Access3189 --> PgSelect2467
     List2475{{"List[2475∈11]<br />ᐸ2473,2474ᐳ<br />ᐳPatch"}}:::plan
     Constant2473{{"Constant[2473∈11]<br />ᐸ'patchs'ᐳ<br />ᐳPatch"}}:::plan
     PgClassExpression2474{{"PgClassExpression[2474∈11]<br />ᐸ__patchs__.”id”ᐳ"}}:::plan
     Constant2473 & PgClassExpression2474 --> List2475
     PgSelect2480[["PgSelect[2480∈11]<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
-    Object2457 & Access3189 --> PgSelect2480
+    Object2457 -->|rejectNull| PgSelect2480
+    Access3189 --> PgSelect2480
     List2488{{"List[2488∈11]<br />ᐸ2486,2487ᐳ<br />ᐳReserved"}}:::plan
     Constant2486{{"Constant[2486∈11]<br />ᐸ'reserveds'ᐳ<br />ᐳReserved"}}:::plan
     PgClassExpression2487{{"PgClassExpression[2487∈11]<br />ᐸ__reserved__.”id”ᐳ"}}:::plan
     Constant2486 & PgClassExpression2487 --> List2488
     PgSelect2493[["PgSelect[2493∈11]<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
-    Object2457 & Access3189 --> PgSelect2493
+    Object2457 -->|rejectNull| PgSelect2493
+    Access3189 --> PgSelect2493
     List2501{{"List[2501∈11]<br />ᐸ2499,2500ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     Constant2499{{"Constant[2499∈11]<br />ᐸ'reservedPatchs'ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     PgClassExpression2500{{"PgClassExpression[2500∈11]<br />ᐸ__reserved...chs__.”id”ᐳ"}}:::plan
     Constant2499 & PgClassExpression2500 --> List2501
     PgSelect2506[["PgSelect[2506∈11]<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
-    Object2457 & Access3189 --> PgSelect2506
+    Object2457 -->|rejectNull| PgSelect2506
+    Access3189 --> PgSelect2506
     List2514{{"List[2514∈11]<br />ᐸ2512,2513ᐳ<br />ᐳReservedInputRecord"}}:::plan
     Constant2512{{"Constant[2512∈11]<br />ᐸ'reserved_inputs'ᐳ<br />ᐳReservedInputRecord"}}:::plan
     PgClassExpression2513{{"PgClassExpression[2513∈11]<br />ᐸ__reserved_input__.”id”ᐳ"}}:::plan
     Constant2512 & PgClassExpression2513 --> List2514
     PgSelect2519[["PgSelect[2519∈11]<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
-    Object2457 & Access3189 --> PgSelect2519
+    Object2457 -->|rejectNull| PgSelect2519
+    Access3189 --> PgSelect2519
     List2527{{"List[2527∈11]<br />ᐸ2525,2526ᐳ<br />ᐳDefaultValue"}}:::plan
     Constant2525{{"Constant[2525∈11]<br />ᐸ'default_values'ᐳ<br />ᐳDefaultValue"}}:::plan
     PgClassExpression2526{{"PgClassExpression[2526∈11]<br />ᐸ__default_value__.”id”ᐳ"}}:::plan
     Constant2525 & PgClassExpression2526 --> List2527
     PgSelect2548[["PgSelect[2548∈11]<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
-    Object2457 & Access3189 --> PgSelect2548
+    Object2457 -->|rejectNull| PgSelect2548
+    Access3189 --> PgSelect2548
     List2556{{"List[2556∈11]<br />ᐸ2554,2555ᐳ<br />ᐳPerson"}}:::plan
     Constant2554{{"Constant[2554∈11]<br />ᐸ'people'ᐳ<br />ᐳPerson"}}:::plan
     PgClassExpression2555{{"PgClassExpression[2555∈11]<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant2554 & PgClassExpression2555 --> List2556
     PgSelect2561[["PgSelect[2561∈11]<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
-    Object2457 & Access3189 --> PgSelect2561
+    Object2457 -->|rejectNull| PgSelect2561
+    Access3189 --> PgSelect2561
     List2569{{"List[2569∈11]<br />ᐸ2567,2568ᐳ<br />ᐳPost"}}:::plan
     Constant2567{{"Constant[2567∈11]<br />ᐸ'posts'ᐳ<br />ᐳPost"}}:::plan
     PgClassExpression2568{{"PgClassExpression[2568∈11]<br />ᐸ__post__.”id”ᐳ"}}:::plan
     Constant2567 & PgClassExpression2568 --> List2569
     PgSelect2574[["PgSelect[2574∈11]<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
-    Object2457 & Access3189 --> PgSelect2574
+    Object2457 -->|rejectNull| PgSelect2574
+    Access3189 --> PgSelect2574
     List2582{{"List[2582∈11]<br />ᐸ2580,2581ᐳ<br />ᐳType"}}:::plan
     Constant2580{{"Constant[2580∈11]<br />ᐸ'types'ᐳ<br />ᐳType"}}:::plan
     PgClassExpression2581{{"PgClassExpression[2581∈11]<br />ᐸ__types__.”id”ᐳ"}}:::plan
     Constant2580 & PgClassExpression2581 --> List2582
     PgSelect2587[["PgSelect[2587∈11]<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
-    Object2457 & Access3189 --> PgSelect2587
+    Object2457 -->|rejectNull| PgSelect2587
+    Access3189 --> PgSelect2587
     List2595{{"List[2595∈11]<br />ᐸ2593,2594ᐳ<br />ᐳPersonSecret"}}:::plan
     Constant2593{{"Constant[2593∈11]<br />ᐸ'person_secrets'ᐳ<br />ᐳPersonSecret"}}:::plan
     PgClassExpression2594{{"PgClassExpression[2594∈11]<br />ᐸ__person_s...person_id”ᐳ"}}:::plan
     Constant2593 & PgClassExpression2594 --> List2595
     PgSelect2600[["PgSelect[2600∈11]<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
-    Object2457 & Access3189 --> PgSelect2600
+    Object2457 -->|rejectNull| PgSelect2600
+    Access3189 --> PgSelect2600
     List2608{{"List[2608∈11]<br />ᐸ2606,2607ᐳ<br />ᐳLeftArm"}}:::plan
     Constant2606{{"Constant[2606∈11]<br />ᐸ'left_arms'ᐳ<br />ᐳLeftArm"}}:::plan
     PgClassExpression2607{{"PgClassExpression[2607∈11]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
     Constant2606 & PgClassExpression2607 --> List2608
     PgSelect2613[["PgSelect[2613∈11]<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
-    Object2457 & Access3189 --> PgSelect2613
+    Object2457 -->|rejectNull| PgSelect2613
+    Access3189 --> PgSelect2613
     List2621{{"List[2621∈11]<br />ᐸ2619,2620ᐳ<br />ᐳMyTable"}}:::plan
     Constant2619{{"Constant[2619∈11]<br />ᐸ'my_tables'ᐳ<br />ᐳMyTable"}}:::plan
     PgClassExpression2620{{"PgClassExpression[2620∈11]<br />ᐸ__my_table__.”id”ᐳ"}}:::plan
     Constant2619 & PgClassExpression2620 --> List2621
     PgSelect2626[["PgSelect[2626∈11]<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
-    Object2457 & Access3189 --> PgSelect2626
+    Object2457 -->|rejectNull| PgSelect2626
+    Access3189 --> PgSelect2626
     List2634{{"List[2634∈11]<br />ᐸ2632,2633ᐳ<br />ᐳViewTable"}}:::plan
     Constant2632{{"Constant[2632∈11]<br />ᐸ'view_tables'ᐳ<br />ᐳViewTable"}}:::plan
     PgClassExpression2633{{"PgClassExpression[2633∈11]<br />ᐸ__view_table__.”id”ᐳ"}}:::plan
     Constant2632 & PgClassExpression2633 --> List2634
     PgSelect2639[["PgSelect[2639∈11]<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
-    Object2457 & Access3189 --> PgSelect2639
+    Object2457 -->|rejectNull| PgSelect2639
+    Access3189 --> PgSelect2639
     List2647{{"List[2647∈11]<br />ᐸ2645,2646ᐳ<br />ᐳSimilarTable1"}}:::plan
     Constant2645{{"Constant[2645∈11]<br />ᐸ'similar_table_1S'ᐳ<br />ᐳSimilarTable1"}}:::plan
     PgClassExpression2646{{"PgClassExpression[2646∈11]<br />ᐸ__similar_...e_1__.”id”ᐳ"}}:::plan
     Constant2645 & PgClassExpression2646 --> List2647
     PgSelect2652[["PgSelect[2652∈11]<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
-    Object2457 & Access3189 --> PgSelect2652
+    Object2457 -->|rejectNull| PgSelect2652
+    Access3189 --> PgSelect2652
     List2660{{"List[2660∈11]<br />ᐸ2658,2659ᐳ<br />ᐳSimilarTable2"}}:::plan
     Constant2658{{"Constant[2658∈11]<br />ᐸ'similar_table_2S'ᐳ<br />ᐳSimilarTable2"}}:::plan
     PgClassExpression2659{{"PgClassExpression[2659∈11]<br />ᐸ__similar_...e_2__.”id”ᐳ"}}:::plan
     Constant2658 & PgClassExpression2659 --> List2660
     PgSelect2665[["PgSelect[2665∈11]<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
-    Object2457 & Access3189 --> PgSelect2665
+    Object2457 -->|rejectNull| PgSelect2665
+    Access3189 --> PgSelect2665
     List2673{{"List[2673∈11]<br />ᐸ2671,2672ᐳ<br />ᐳNullTestRecord"}}:::plan
     Constant2671{{"Constant[2671∈11]<br />ᐸ'null_test_records'ᐳ<br />ᐳNullTestRecord"}}:::plan
     PgClassExpression2672{{"PgClassExpression[2672∈11]<br />ᐸ__null_tes...ord__.”id”ᐳ"}}:::plan
     Constant2671 & PgClassExpression2672 --> List2673
     PgSelect2678[["PgSelect[2678∈11]<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
-    Object2457 & Access3189 --> PgSelect2678
+    Object2457 -->|rejectNull| PgSelect2678
+    Access3189 --> PgSelect2678
     List2686{{"List[2686∈11]<br />ᐸ2684,2685ᐳ<br />ᐳIssue756"}}:::plan
     Constant2684{{"Constant[2684∈11]<br />ᐸ'issue756S'ᐳ<br />ᐳIssue756"}}:::plan
     PgClassExpression2685{{"PgClassExpression[2685∈11]<br />ᐸ__issue756__.”id”ᐳ"}}:::plan
@@ -2783,14 +2992,17 @@ graph TD
     Object2700{{"Object[2700∈12]<br />ᐸ{pgSettings,withPgClient}ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access3192{{"Access[3192∈12]<br />ᐸ2690.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access3193{{"Access[3193∈12]<br />ᐸ2690.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
-    Object2700 & Access3192 & Access3193 --> PgSelect2777
+    Object2700 -->|rejectNull| PgSelect2777
+    Access3192 -->|rejectNull| PgSelect2777
+    Access3193 --> PgSelect2777
     List2786{{"List[2786∈12]<br />ᐸ2783,2784,2785ᐳ<br />ᐳCompoundKey"}}:::plan
     Constant2783{{"Constant[2783∈12]<br />ᐸ'compound_keys'ᐳ<br />ᐳCompoundKey"}}:::plan
     PgClassExpression2784{{"PgClassExpression[2784∈12]<br />ᐸ__compound...rson_id_1”ᐳ"}}:::plan
     PgClassExpression2785{{"PgClassExpression[2785∈12]<br />ᐸ__compound...rson_id_2”ᐳ"}}:::plan
     Constant2783 & PgClassExpression2784 & PgClassExpression2785 --> List2786
     PgSelect2697[["PgSelect[2697∈12]<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
-    Object2700 & Access3192 --> PgSelect2697
+    Object2700 -->|rejectNull| PgSelect2697
+    Access3192 --> PgSelect2697
     Access2698{{"Access[2698∈12]<br />ᐸ3.pgSettingsᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access2699{{"Access[2699∈12]<br />ᐸ3.withPgClientᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access2698 & Access2699 --> Object2700
@@ -2799,97 +3011,113 @@ graph TD
     PgClassExpression2704{{"PgClassExpression[2704∈12]<br />ᐸ__inputs__.”id”ᐳ"}}:::plan
     Constant2703 & PgClassExpression2704 --> List2705
     PgSelect2710[["PgSelect[2710∈12]<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
-    Object2700 & Access3192 --> PgSelect2710
+    Object2700 -->|rejectNull| PgSelect2710
+    Access3192 --> PgSelect2710
     List2718{{"List[2718∈12]<br />ᐸ2716,2717ᐳ<br />ᐳPatch"}}:::plan
     Constant2716{{"Constant[2716∈12]<br />ᐸ'patchs'ᐳ<br />ᐳPatch"}}:::plan
     PgClassExpression2717{{"PgClassExpression[2717∈12]<br />ᐸ__patchs__.”id”ᐳ"}}:::plan
     Constant2716 & PgClassExpression2717 --> List2718
     PgSelect2723[["PgSelect[2723∈12]<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
-    Object2700 & Access3192 --> PgSelect2723
+    Object2700 -->|rejectNull| PgSelect2723
+    Access3192 --> PgSelect2723
     List2731{{"List[2731∈12]<br />ᐸ2729,2730ᐳ<br />ᐳReserved"}}:::plan
     Constant2729{{"Constant[2729∈12]<br />ᐸ'reserveds'ᐳ<br />ᐳReserved"}}:::plan
     PgClassExpression2730{{"PgClassExpression[2730∈12]<br />ᐸ__reserved__.”id”ᐳ"}}:::plan
     Constant2729 & PgClassExpression2730 --> List2731
     PgSelect2736[["PgSelect[2736∈12]<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
-    Object2700 & Access3192 --> PgSelect2736
+    Object2700 -->|rejectNull| PgSelect2736
+    Access3192 --> PgSelect2736
     List2744{{"List[2744∈12]<br />ᐸ2742,2743ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     Constant2742{{"Constant[2742∈12]<br />ᐸ'reservedPatchs'ᐳ<br />ᐳReservedPatchRecord"}}:::plan
     PgClassExpression2743{{"PgClassExpression[2743∈12]<br />ᐸ__reserved...chs__.”id”ᐳ"}}:::plan
     Constant2742 & PgClassExpression2743 --> List2744
     PgSelect2749[["PgSelect[2749∈12]<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
-    Object2700 & Access3192 --> PgSelect2749
+    Object2700 -->|rejectNull| PgSelect2749
+    Access3192 --> PgSelect2749
     List2757{{"List[2757∈12]<br />ᐸ2755,2756ᐳ<br />ᐳReservedInputRecord"}}:::plan
     Constant2755{{"Constant[2755∈12]<br />ᐸ'reserved_inputs'ᐳ<br />ᐳReservedInputRecord"}}:::plan
     PgClassExpression2756{{"PgClassExpression[2756∈12]<br />ᐸ__reserved_input__.”id”ᐳ"}}:::plan
     Constant2755 & PgClassExpression2756 --> List2757
     PgSelect2762[["PgSelect[2762∈12]<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
-    Object2700 & Access3192 --> PgSelect2762
+    Object2700 -->|rejectNull| PgSelect2762
+    Access3192 --> PgSelect2762
     List2770{{"List[2770∈12]<br />ᐸ2768,2769ᐳ<br />ᐳDefaultValue"}}:::plan
     Constant2768{{"Constant[2768∈12]<br />ᐸ'default_values'ᐳ<br />ᐳDefaultValue"}}:::plan
     PgClassExpression2769{{"PgClassExpression[2769∈12]<br />ᐸ__default_value__.”id”ᐳ"}}:::plan
     Constant2768 & PgClassExpression2769 --> List2770
     PgSelect2791[["PgSelect[2791∈12]<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
-    Object2700 & Access3192 --> PgSelect2791
+    Object2700 -->|rejectNull| PgSelect2791
+    Access3192 --> PgSelect2791
     List2799{{"List[2799∈12]<br />ᐸ2797,2798ᐳ<br />ᐳPerson"}}:::plan
     Constant2797{{"Constant[2797∈12]<br />ᐸ'people'ᐳ<br />ᐳPerson"}}:::plan
     PgClassExpression2798{{"PgClassExpression[2798∈12]<br />ᐸ__person__.”id”ᐳ"}}:::plan
     Constant2797 & PgClassExpression2798 --> List2799
     PgSelect2804[["PgSelect[2804∈12]<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
-    Object2700 & Access3192 --> PgSelect2804
+    Object2700 -->|rejectNull| PgSelect2804
+    Access3192 --> PgSelect2804
     List2812{{"List[2812∈12]<br />ᐸ2810,2811ᐳ<br />ᐳPost"}}:::plan
     Constant2810{{"Constant[2810∈12]<br />ᐸ'posts'ᐳ<br />ᐳPost"}}:::plan
     PgClassExpression2811{{"PgClassExpression[2811∈12]<br />ᐸ__post__.”id”ᐳ"}}:::plan
     Constant2810 & PgClassExpression2811 --> List2812
     PgSelect2817[["PgSelect[2817∈12]<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
-    Object2700 & Access3192 --> PgSelect2817
+    Object2700 -->|rejectNull| PgSelect2817
+    Access3192 --> PgSelect2817
     List2825{{"List[2825∈12]<br />ᐸ2823,2824ᐳ<br />ᐳType"}}:::plan
     Constant2823{{"Constant[2823∈12]<br />ᐸ'types'ᐳ<br />ᐳType"}}:::plan
     PgClassExpression2824{{"PgClassExpression[2824∈12]<br />ᐸ__types__.”id”ᐳ"}}:::plan
     Constant2823 & PgClassExpression2824 --> List2825
     PgSelect2830[["PgSelect[2830∈12]<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
-    Object2700 & Access3192 --> PgSelect2830
+    Object2700 -->|rejectNull| PgSelect2830
+    Access3192 --> PgSelect2830
     List2838{{"List[2838∈12]<br />ᐸ2836,2837ᐳ<br />ᐳPersonSecret"}}:::plan
     Constant2836{{"Constant[2836∈12]<br />ᐸ'person_secrets'ᐳ<br />ᐳPersonSecret"}}:::plan
     PgClassExpression2837{{"PgClassExpression[2837∈12]<br />ᐸ__person_s...person_id”ᐳ"}}:::plan
     Constant2836 & PgClassExpression2837 --> List2838
     PgSelect2843[["PgSelect[2843∈12]<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
-    Object2700 & Access3192 --> PgSelect2843
+    Object2700 -->|rejectNull| PgSelect2843
+    Access3192 --> PgSelect2843
     List2851{{"List[2851∈12]<br />ᐸ2849,2850ᐳ<br />ᐳLeftArm"}}:::plan
     Constant2849{{"Constant[2849∈12]<br />ᐸ'left_arms'ᐳ<br />ᐳLeftArm"}}:::plan
     PgClassExpression2850{{"PgClassExpression[2850∈12]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
     Constant2849 & PgClassExpression2850 --> List2851
     PgSelect2856[["PgSelect[2856∈12]<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
-    Object2700 & Access3192 --> PgSelect2856
+    Object2700 -->|rejectNull| PgSelect2856
+    Access3192 --> PgSelect2856
     List2864{{"List[2864∈12]<br />ᐸ2862,2863ᐳ<br />ᐳMyTable"}}:::plan
     Constant2862{{"Constant[2862∈12]<br />ᐸ'my_tables'ᐳ<br />ᐳMyTable"}}:::plan
     PgClassExpression2863{{"PgClassExpression[2863∈12]<br />ᐸ__my_table__.”id”ᐳ"}}:::plan
     Constant2862 & PgClassExpression2863 --> List2864
     PgSelect2869[["PgSelect[2869∈12]<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
-    Object2700 & Access3192 --> PgSelect2869
+    Object2700 -->|rejectNull| PgSelect2869
+    Access3192 --> PgSelect2869
     List2877{{"List[2877∈12]<br />ᐸ2875,2876ᐳ<br />ᐳViewTable"}}:::plan
     Constant2875{{"Constant[2875∈12]<br />ᐸ'view_tables'ᐳ<br />ᐳViewTable"}}:::plan
     PgClassExpression2876{{"PgClassExpression[2876∈12]<br />ᐸ__view_table__.”id”ᐳ"}}:::plan
     Constant2875 & PgClassExpression2876 --> List2877
     PgSelect2882[["PgSelect[2882∈12]<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
-    Object2700 & Access3192 --> PgSelect2882
+    Object2700 -->|rejectNull| PgSelect2882
+    Access3192 --> PgSelect2882
     List2890{{"List[2890∈12]<br />ᐸ2888,2889ᐳ<br />ᐳSimilarTable1"}}:::plan
     Constant2888{{"Constant[2888∈12]<br />ᐸ'similar_table_1S'ᐳ<br />ᐳSimilarTable1"}}:::plan
     PgClassExpression2889{{"PgClassExpression[2889∈12]<br />ᐸ__similar_...e_1__.”id”ᐳ"}}:::plan
     Constant2888 & PgClassExpression2889 --> List2890
     PgSelect2895[["PgSelect[2895∈12]<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
-    Object2700 & Access3192 --> PgSelect2895
+    Object2700 -->|rejectNull| PgSelect2895
+    Access3192 --> PgSelect2895
     List2903{{"List[2903∈12]<br />ᐸ2901,2902ᐳ<br />ᐳSimilarTable2"}}:::plan
     Constant2901{{"Constant[2901∈12]<br />ᐸ'similar_table_2S'ᐳ<br />ᐳSimilarTable2"}}:::plan
     PgClassExpression2902{{"PgClassExpression[2902∈12]<br />ᐸ__similar_...e_2__.”id”ᐳ"}}:::plan
     Constant2901 & PgClassExpression2902 --> List2903
     PgSelect2908[["PgSelect[2908∈12]<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
-    Object2700 & Access3192 --> PgSelect2908
+    Object2700 -->|rejectNull| PgSelect2908
+    Access3192 --> PgSelect2908
     List2916{{"List[2916∈12]<br />ᐸ2914,2915ᐳ<br />ᐳNullTestRecord"}}:::plan
     Constant2914{{"Constant[2914∈12]<br />ᐸ'null_test_records'ᐳ<br />ᐳNullTestRecord"}}:::plan
     PgClassExpression2915{{"PgClassExpression[2915∈12]<br />ᐸ__null_tes...ord__.”id”ᐳ"}}:::plan
     Constant2914 & PgClassExpression2915 --> List2916
     PgSelect2921[["PgSelect[2921∈12]<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
-    Object2700 & Access3192 --> PgSelect2921
+    Object2700 -->|rejectNull| PgSelect2921
+    Access3192 --> PgSelect2921
     List2929{{"List[2929∈12]<br />ᐸ2927,2928ᐳ<br />ᐳIssue756"}}:::plan
     Constant2927{{"Constant[2927∈12]<br />ᐸ'issue756S'ᐳ<br />ᐳIssue756"}}:::plan
     PgClassExpression2928{{"PgClassExpression[2928∈12]<br />ᐸ__issue756__.”id”ᐳ"}}:::plan

--- a/postgraphile/postgraphile/__tests__/queries/v4/rbac.basic.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/rbac.basic.mermaid
@@ -21,10 +21,12 @@ graph TD
     Object11 & Constant280 --> PgSelect43
     PgSelect70[["PgSelect[70∈0]<br />ᐸpersonᐳ"]]:::plan
     Access68{{"Access[68∈0]<br />ᐸ67.1ᐳ"}}:::plan
-    Object11 & Access68 --> PgSelect70
+    Object11 -->|rejectNull| PgSelect70
+    Access68 --> PgSelect70
     PgSelect97[["PgSelect[97∈0]<br />ᐸpersonᐳ"]]:::plan
     Access95{{"Access[95∈0]<br />ᐸ94.1ᐳ"}}:::plan
-    Object11 & Access95 --> PgSelect97
+    Object11 -->|rejectNull| PgSelect97
+    Access95 --> PgSelect97
     PgSelect121[["PgSelect[121∈0]<br />ᐸleft_armᐳ"]]:::plan
     Constant283{{"Constant[283∈0]<br />ᐸ42ᐳ"}}:::plan
     Object11 & Constant283 --> PgSelect121

--- a/postgraphile/postgraphile/__tests__/queries/v4/smart_comment_relations.houses.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/smart_comment_relations.houses.mermaid
@@ -17,7 +17,9 @@ graph TD
     PgSelect340[["PgSelect[340∈0]<br />ᐸhousesᐳ"]]:::plan
     Access336{{"Access[336∈0]<br />ᐸ335.1ᐳ"}}:::plan
     Access338{{"Access[338∈0]<br />ᐸ335.2ᐳ"}}:::plan
-    Object18 & Access336 & Access338 --> PgSelect340
+    Object18 -->|rejectNull| PgSelect340
+    Access336 -->|rejectNull| PgSelect340
+    Access338 --> PgSelect340
     Access16{{"Access[16∈0]<br />ᐸ3.pgSettingsᐳ"}}:::plan
     Access17{{"Access[17∈0]<br />ᐸ3.withPgClientᐳ"}}:::plan
     Access16 & Access17 --> Object18

--- a/postgraphile/postgraphile/__tests__/queries/v4/types-single-node.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/types-single-node.mermaid
@@ -21,44 +21,63 @@ graph TD
     Object17{{"Object[17∈1]<br />ᐸ{pgSettings,withPgClient}ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access195{{"Access[195∈1]<br />ᐸ9.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access196{{"Access[196∈1]<br />ᐸ9.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
-    Object17 & Access195 & Access196 --> PgSelect70
+    Object17 -->|rejectNull| PgSelect70
+    Access195 -->|rejectNull| PgSelect70
+    Access196 --> PgSelect70
     PgSelect14[["PgSelect[14∈1]<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
-    Object17 & Access195 --> PgSelect14
+    Object17 -->|rejectNull| PgSelect14
+    Access195 --> PgSelect14
     Access15{{"Access[15∈1]<br />ᐸ3.pgSettingsᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access16{{"Access[16∈1]<br />ᐸ3.withPgClientᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access15 & Access16 --> Object17
     PgSelect23[["PgSelect[23∈1]<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
-    Object17 & Access195 --> PgSelect23
+    Object17 -->|rejectNull| PgSelect23
+    Access195 --> PgSelect23
     PgSelect32[["PgSelect[32∈1]<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
-    Object17 & Access195 --> PgSelect32
+    Object17 -->|rejectNull| PgSelect32
+    Access195 --> PgSelect32
     PgSelect41[["PgSelect[41∈1]<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
-    Object17 & Access195 --> PgSelect41
+    Object17 -->|rejectNull| PgSelect41
+    Access195 --> PgSelect41
     PgSelect50[["PgSelect[50∈1]<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
-    Object17 & Access195 --> PgSelect50
+    Object17 -->|rejectNull| PgSelect50
+    Access195 --> PgSelect50
     PgSelect59[["PgSelect[59∈1]<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
-    Object17 & Access195 --> PgSelect59
+    Object17 -->|rejectNull| PgSelect59
+    Access195 --> PgSelect59
     PgSelect79[["PgSelect[79∈1]<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
-    Object17 & Access195 --> PgSelect79
+    Object17 -->|rejectNull| PgSelect79
+    Access195 --> PgSelect79
     PgSelect88[["PgSelect[88∈1]<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
-    Object17 & Access195 --> PgSelect88
+    Object17 -->|rejectNull| PgSelect88
+    Access195 --> PgSelect88
     PgSelect97[["PgSelect[97∈1]<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
-    Object17 & Access195 --> PgSelect97
+    Object17 -->|rejectNull| PgSelect97
+    Access195 --> PgSelect97
     PgSelect107[["PgSelect[107∈1]<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
-    Object17 & Access195 --> PgSelect107
+    Object17 -->|rejectNull| PgSelect107
+    Access195 --> PgSelect107
     PgSelect116[["PgSelect[116∈1]<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
-    Object17 & Access195 --> PgSelect116
+    Object17 -->|rejectNull| PgSelect116
+    Access195 --> PgSelect116
     PgSelect125[["PgSelect[125∈1]<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
-    Object17 & Access195 --> PgSelect125
+    Object17 -->|rejectNull| PgSelect125
+    Access195 --> PgSelect125
     PgSelect134[["PgSelect[134∈1]<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
-    Object17 & Access195 --> PgSelect134
+    Object17 -->|rejectNull| PgSelect134
+    Access195 --> PgSelect134
     PgSelect143[["PgSelect[143∈1]<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
-    Object17 & Access195 --> PgSelect143
+    Object17 -->|rejectNull| PgSelect143
+    Access195 --> PgSelect143
     PgSelect152[["PgSelect[152∈1]<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
-    Object17 & Access195 --> PgSelect152
+    Object17 -->|rejectNull| PgSelect152
+    Access195 --> PgSelect152
     PgSelect161[["PgSelect[161∈1]<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
-    Object17 & Access195 --> PgSelect161
+    Object17 -->|rejectNull| PgSelect161
+    Access195 --> PgSelect161
     PgSelect170[["PgSelect[170∈1]<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
-    Object17 & Access195 --> PgSelect170
+    Object17 -->|rejectNull| PgSelect170
+    Access195 --> PgSelect170
     __Value3 --> Access15
     __Value3 --> Access16
     First18{{"First[18∈1]"}}:::plan

--- a/postgraphile/postgraphile/__tests__/queries/v4/types.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/types.mermaid
@@ -21,7 +21,8 @@ graph TD
     Object18 & Constant4354 --> PgSelect685
     PgSelect905[["PgSelect[905∈0]<br />ᐸtypesᐳ"]]:::plan
     Access903{{"Access[903∈0]<br />ᐸ902.1ᐳ"}}:::plan
-    Object18 & Access903 --> PgSelect905
+    Object18 -->|rejectNull| PgSelect905
+    Access903 --> PgSelect905
     PgSelect1500[["PgSelect[1500∈0]<br />ᐸtype_functionᐳ"]]:::plan
     Object18 & Constant4354 --> PgSelect1500
     PgSelect3300[["PgSelect[3300∈0]<br />ᐸpostᐳ"]]:::plan
@@ -1362,41 +1363,60 @@ graph TD
     PgSelect1184[["PgSelect[1184∈138]<br />ᐸcompound_keyᐳ<br />ᐳCompoundKey"]]:::plan
     Access4356{{"Access[4356∈138]<br />ᐸ1123.base64JSON.1ᐳ<br />ᐳInput<br />ᐳPatch<br />ᐳReserved<br />ᐳReservedPatchRecord<br />ᐳReservedInputRecord<br />ᐳDefaultValue<br />ᐳCompoundKey<br />ᐳPerson<br />ᐳPost<br />ᐳType<br />ᐳPersonSecret<br />ᐳLeftArm<br />ᐳMyTable<br />ᐳViewTable<br />ᐳSimilarTable1<br />ᐳSimilarTable2<br />ᐳNullTestRecord<br />ᐳIssue756"}}:::plan
     Access4357{{"Access[4357∈138]<br />ᐸ1123.base64JSON.2ᐳ<br />ᐳCompoundKey"}}:::plan
-    Object18 & Access4356 & Access4357 --> PgSelect1184
+    Object18 -->|rejectNull| PgSelect1184
+    Access4356 -->|rejectNull| PgSelect1184
+    Access4357 --> PgSelect1184
     PgSelect1128[["PgSelect[1128∈138]<br />ᐸinputsᐳ<br />ᐳInput"]]:::plan
-    Object18 & Access4356 --> PgSelect1128
+    Object18 -->|rejectNull| PgSelect1128
+    Access4356 --> PgSelect1128
     PgSelect1137[["PgSelect[1137∈138]<br />ᐸpatchsᐳ<br />ᐳPatch"]]:::plan
-    Object18 & Access4356 --> PgSelect1137
+    Object18 -->|rejectNull| PgSelect1137
+    Access4356 --> PgSelect1137
     PgSelect1146[["PgSelect[1146∈138]<br />ᐸreservedᐳ<br />ᐳReserved"]]:::plan
-    Object18 & Access4356 --> PgSelect1146
+    Object18 -->|rejectNull| PgSelect1146
+    Access4356 --> PgSelect1146
     PgSelect1155[["PgSelect[1155∈138]<br />ᐸreservedPatchsᐳ<br />ᐳReservedPatchRecord"]]:::plan
-    Object18 & Access4356 --> PgSelect1155
+    Object18 -->|rejectNull| PgSelect1155
+    Access4356 --> PgSelect1155
     PgSelect1164[["PgSelect[1164∈138]<br />ᐸreserved_inputᐳ<br />ᐳReservedInputRecord"]]:::plan
-    Object18 & Access4356 --> PgSelect1164
+    Object18 -->|rejectNull| PgSelect1164
+    Access4356 --> PgSelect1164
     PgSelect1173[["PgSelect[1173∈138]<br />ᐸdefault_valueᐳ<br />ᐳDefaultValue"]]:::plan
-    Object18 & Access4356 --> PgSelect1173
+    Object18 -->|rejectNull| PgSelect1173
+    Access4356 --> PgSelect1173
     PgSelect1193[["PgSelect[1193∈138]<br />ᐸpersonᐳ<br />ᐳPerson"]]:::plan
-    Object18 & Access4356 --> PgSelect1193
+    Object18 -->|rejectNull| PgSelect1193
+    Access4356 --> PgSelect1193
     PgSelect1202[["PgSelect[1202∈138]<br />ᐸpostᐳ<br />ᐳPost"]]:::plan
-    Object18 & Access4356 --> PgSelect1202
+    Object18 -->|rejectNull| PgSelect1202
+    Access4356 --> PgSelect1202
     PgSelect1211[["PgSelect[1211∈138]<br />ᐸtypesᐳ<br />ᐳType"]]:::plan
-    Object18 & Access4356 --> PgSelect1211
+    Object18 -->|rejectNull| PgSelect1211
+    Access4356 --> PgSelect1211
     PgSelect1430[["PgSelect[1430∈138]<br />ᐸperson_secretᐳ<br />ᐳPersonSecret"]]:::plan
-    Object18 & Access4356 --> PgSelect1430
+    Object18 -->|rejectNull| PgSelect1430
+    Access4356 --> PgSelect1430
     PgSelect1439[["PgSelect[1439∈138]<br />ᐸleft_armᐳ<br />ᐳLeftArm"]]:::plan
-    Object18 & Access4356 --> PgSelect1439
+    Object18 -->|rejectNull| PgSelect1439
+    Access4356 --> PgSelect1439
     PgSelect1448[["PgSelect[1448∈138]<br />ᐸmy_tableᐳ<br />ᐳMyTable"]]:::plan
-    Object18 & Access4356 --> PgSelect1448
+    Object18 -->|rejectNull| PgSelect1448
+    Access4356 --> PgSelect1448
     PgSelect1457[["PgSelect[1457∈138]<br />ᐸview_tableᐳ<br />ᐳViewTable"]]:::plan
-    Object18 & Access4356 --> PgSelect1457
+    Object18 -->|rejectNull| PgSelect1457
+    Access4356 --> PgSelect1457
     PgSelect1466[["PgSelect[1466∈138]<br />ᐸsimilar_table_1ᐳ<br />ᐳSimilarTable1"]]:::plan
-    Object18 & Access4356 --> PgSelect1466
+    Object18 -->|rejectNull| PgSelect1466
+    Access4356 --> PgSelect1466
     PgSelect1475[["PgSelect[1475∈138]<br />ᐸsimilar_table_2ᐳ<br />ᐳSimilarTable2"]]:::plan
-    Object18 & Access4356 --> PgSelect1475
+    Object18 -->|rejectNull| PgSelect1475
+    Access4356 --> PgSelect1475
     PgSelect1484[["PgSelect[1484∈138]<br />ᐸnull_test_recordᐳ<br />ᐳNullTestRecord"]]:::plan
-    Object18 & Access4356 --> PgSelect1484
+    Object18 -->|rejectNull| PgSelect1484
+    Access4356 --> PgSelect1484
     PgSelect1493[["PgSelect[1493∈138]<br />ᐸissue756ᐳ<br />ᐳIssue756"]]:::plan
-    Object18 & Access4356 --> PgSelect1493
+    Object18 -->|rejectNull| PgSelect1493
+    Access4356 --> PgSelect1493
     First1132{{"First[1132∈138]"}}:::plan
     PgSelect1128 --> First1132
     PgSelectSingle1133{{"PgSelectSingle[1133∈138]<br />ᐸinputsᐳ"}}:::plan


### PR DESCRIPTION
## Description

This adds visibility to where dependencies are made with non-standard flags.

Also I made all the inhibit/assert/trap methods generic.

## Performance impact

Mermaid only.

## Security impact

None known.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
