### PR TITLE
Remove GrafastError, introduce `flagError()`

### DIFF
--- a/grafast/dataplan-pg/src/examples/exampleSchema.ts
+++ b/grafast/dataplan-pg/src/examples/exampleSchema.ts
@@ -5076,7 +5076,10 @@ export function makeExampleSchema(
             withPgClientTransaction,
           ) =>
             function plan(_$root, { $input: { $a } }) {
-              const $transactionResult = withPgClientTransaction(
+              const $transactionResult = withPgClientTransaction<
+                { a: number | null | undefined },
+                number[]
+              >(
                 relationalPostsResource.executor,
                 object({
                   a: $a as ExecutableStep<number | null | undefined>,

--- a/grafast/grafast/src/engine/LayerPlan.ts
+++ b/grafast/grafast/src/engine/LayerPlan.ts
@@ -4,11 +4,12 @@ import te from "tamedevil";
 
 import * as assert from "../assert.js";
 import type { Bucket } from "../bucket.js";
-import type { GrafastError } from "../error.js";
-import { isGrafastError } from "../error.js";
 import { inspect } from "../inspect.js";
 import type { UnaryExecutionValue } from "../interfaces.js";
 import {
+  FLAG_ERROR,
+  FLAG_INHIBITED,
+  FLAG_NULL,
   FORBIDDEN_BY_NULLABLE_BOUNDARY_FLAGS,
   NO_FLAGS,
 } from "../interfaces.js";
@@ -478,7 +479,7 @@ export class LayerPlan<TReason extends LayerPlanReason = LayerPlanReason> {
             originalIndex < parentBucket.size;
             originalIndex++
           ) {
-            const fieldValue: any[] | null | undefined | GrafastError =
+            const fieldValue: any[] | null | undefined | Error =
               nullableStepStore.at(originalIndex);
             if (fieldValue != null) {
               const newIndex = size++;
@@ -548,7 +549,7 @@ export class LayerPlan<TReason extends LayerPlanReason = LayerPlanReason> {
           originalIndex < parentBucket.size;
           originalIndex++
         ) {
-          const list: any[] | null | undefined | GrafastError =
+          const list: any[] | null | undefined | Error =
             listStepStore.at(originalIndex);
           if (Array.isArray(list)) {
             const newIndexes: number[] = [];
@@ -626,13 +627,14 @@ export class LayerPlan<TReason extends LayerPlanReason = LayerPlanReason> {
           originalIndex < parentBucket.size;
           originalIndex++
         ) {
+          const flags = polymorphicPlanStore._flagsAt(originalIndex);
+          if (
+            (flags & (FLAG_ERROR | FLAG_INHIBITED | FLAG_NULL)) !==
+            NO_FLAGS
+          ) {
+            continue;
+          }
           const value = polymorphicPlanStore.at(originalIndex);
-          if (value == null) {
-            continue;
-          }
-          if (isGrafastError(value)) {
-            continue;
-          }
           const typeName = resolveType(value);
           if (!targetTypeNames.includes(typeName)) {
             continue;

--- a/grafast/grafast/src/engine/OutputPlan.ts
+++ b/grafast/grafast/src/engine/OutputPlan.ts
@@ -13,11 +13,10 @@ import te, { stringifyJSON, stringifyString } from "tamedevil";
 import * as assert from "../assert.js";
 import type { Bucket } from "../bucket.js";
 import { isDev } from "../dev.js";
-import { $$error } from "../error.js";
 import { AccessStep } from "../index.js";
 import { inspect } from "../inspect.js";
 import type { JSONValue, LocationDetails } from "../interfaces.js";
-import { $$concreteType, $$streamMore } from "../interfaces.js";
+import { $$concreteType, $$streamMore, FLAG_ERROR } from "../interfaces.js";
 import { isPolymorphicData } from "../polymorphic.js";
 import type { ExecutableStep } from "../step.js";
 import { expressionSymbol } from "../steps/access.js";
@@ -147,7 +146,7 @@ export type OutputPlanKeyValueOutputPlanWithCachedBits =
     layerPlanId: number;
   };
 
-const ref_$$error = te.ref($$error, "$$error");
+const ref_FLAG_ERROR = te.ref(FLAG_ERROR, "FLAG_ERROR");
 const ref_coerceError = te.ref(coerceError, "coerceError");
 const ref_nonNullError = te.ref(nonNullError, "nonNullError");
 const ref_stringifyString = te.ref(stringifyString, "stringifyString");
@@ -829,9 +828,10 @@ function makeExecutorExpression<TAsString extends boolean>(
   mutablePath,
   bucket,
   bucketIndex,
-  rawBucketRootValue = bucket.store.get(this.rootStep.id).at(bucketIndex)
+  rawBucketRootValue = bucket.store.get(this.rootStep.id).at(bucketIndex),
+  bucketRootFlags = bucket.store.get(this.rootStep.id)._flagsAt(bucketIndex)
 ) {
-  const bucketRootValue = this.processRoot !== null ? this.processRoot(rawBucketRootValue) : rawBucketRootValue;
+  const bucketRootValue = this.processRoot !== null ? this.processRoot(rawBucketRootValue, bucketRootFlags) : rawBucketRootValue;
 ${preamble}\
   ${
     skipNullHandling
@@ -842,10 +842,8 @@ ${preamble}\
           asString ? te_nullString : te_null
         };`
   }
-  if (bucketRootValue${
-    skipNullHandling ? te_questionDot : te.blank
-  }[${ref_$$error}]) {
-    throw ${ref_coerceError}(bucketRootValue.originalError, this.locationDetails, mutablePath.slice(1));
+  if (bucketRootFlags & ${ref_FLAG_ERROR}) {
+    throw ${ref_coerceError}(bucketRootValue, this.locationDetails, mutablePath.slice(1));
   }
 ${inner}
 })`;
@@ -883,7 +881,14 @@ function makeExecuteChildPlanCode(
 ) {
   const te_childOutputPlanExecute = te`${childOutputPlan}.${
     asString ? te_executeString : te_execute
-  }(root, mutablePath, ${childBucket}, ${childBucketIndex}, ${childBucket}.rootStep === this.rootStep ? rawBucketRootValue : undefined)`;
+  }(
+  root,
+  mutablePath,
+  ${childBucket},
+  ${childBucketIndex},
+  ${childBucket}.rootStep === this.rootStep ? rawBucketRootValue : undefined,
+  ${childBucket}.rootStep === this.rootStep ? bucketRootFlags : undefined
+)`;
   // This is the code that changes based on if the field is nullable or not
   if (isNonNull) {
     // No need to catch error

--- a/grafast/grafast/src/engine/executeBucket.ts
+++ b/grafast/grafast/src/engine/executeBucket.ts
@@ -656,7 +656,11 @@ export function executeBucket(
               stepFlags = indexFlags;
             } else {
               const rawStepResult = step.unbatchedExecute(extra, ...deps);
-              if (isFlaggedValue(rawStepResult)) {
+              if (
+                typeof rawStepResult === "object" &&
+                rawStepResult !== null &&
+                isFlaggedValue(rawStepResult)
+              ) {
                 stepResult = rawStepResult.value;
                 stepFlags = rawStepResult.flags;
               } else {

--- a/grafast/grafast/src/error.ts
+++ b/grafast/grafast/src/error.ts
@@ -1,65 +1,62 @@
-import type { $$extensions } from "./interfaces.js";
-import { $$safeError } from "./interfaces.js";
+import type { ExecutionEntryFlags } from "./interfaces.js";
+import {
+  $$safeError,
+  FLAG_ERROR,
+  FLAG_INHIBITED,
+  FLAG_NULL,
+} from "./interfaces.js";
+
+export const $$flagged = Symbol("grafastFlaggedValue");
 
 /**
- * Internally we wrap errors that occur in a GrafastError; this allows us to do
- * simple `instanceof` checks to see if a value is an actual value or an error.
- * Users should never use this class; it's for internal usage only.
+ * Wrapper for errors to return (rather than throw or reject) from user code.
  *
  * @internal
  */
-export interface GrafastError extends Error {
-  originalError: Error;
-  [$$extensions]?: Record<string, any>;
+export interface FlaggedValue<TValue = any> {
+  [$$flagged]: true;
+  flags: ExecutionEntryFlags;
+  value: TValue;
+  planId: number | null;
 }
 
-export const $$error = Symbol("isGrafastError");
+function flaggedValue<T>(
+  flags: ExecutionEntryFlags,
+  value: any,
+  planId: null | number,
+): FlaggedValue<T> {
+  return {
+    [$$flagged]: true,
+    flags,
+    value,
+    planId,
+  };
+}
 
-// IMPORTANT: this WILL NOT WORK when compiled down to ES5. It requires ES6+
-// native class support.
-/**
- * When an error occurs during plan execution we wrap it in a GrafastError so
- * that we can pass it around as a value.  It gets unwrapped and thrown in the
- * grafast resolver.
- *
- * @internal
- */
-export const _GrafastError = class GrafastError
-  extends Error
-  implements GrafastError
-{
-  public readonly originalError: Error;
-  extensions: Record<string, any>;
-  [$$error] = true;
-  constructor(originalError: Error, planId: number | null) {
-    if (originalError instanceof _GrafastError) {
-      throw new Error(
-        "GrafastInternalError<62505509-8b21-4ef7-80f5-d0f99873174b>: attempted to wrap a GrafastError with a GrafastError.",
-      );
-    }
-    const message = originalError?.message;
-    super(message);
-    Object.setPrototypeOf(this, GrafastError.prototype);
-    this.originalError = originalError;
-    this.extensions = { grafast: { planId } };
-  }
-};
+export const $$inhibit = flaggedValue<null>(
+  FLAG_NULL & FLAG_INHIBITED,
+  null,
+  null,
+);
 
 /**
- * DO NOT ALLOW CONSTRUCTION OF ERRORS OUTSIDE OF THIS MODULE!
- *
- * @internal
+ * Used to wrap error values to have Grafast treat them as if they were
+ * thrown/rejected (rather than just regular values).
  */
-export function newGrafastError(error: Error, planId: number | null) {
-  return new _GrafastError(error, planId);
+export function flagError<TError extends Error = Error>(
+  value: TError,
+  planId: number | null = null,
+): FlaggedValue<TError> {
+  return flaggedValue(FLAG_ERROR, value, planId);
 }
 
 /**
- * Is the given value a GrafastError? This is the only public API that people
- * should use for looking at GrafastErrors.
+ * Is this a flagged value?
+ *
+ * @internal
  */
-export function isGrafastError(value: any): value is GrafastError {
-  return typeof value === "object" && value !== null && $$error in value;
+export function isFlaggedValue(value: object): value is FlaggedValue {
+  return typeof value !== null && Object.hasOwn(value, $$flagged);
 }
 
 export class SafeError<
@@ -84,47 +81,4 @@ export class SafeError<
 
 export function isSafeError(error: Error): error is SafeError {
   return (error as any)[$$safeError];
-}
-
-export const $$trappedError = Symbol("isTrappedError");
-
-/**
- * When an error is trapped via `trap()`, we need to make it not an
- * `Error`-derivative otherwise it will become an error again, so we wrap
- * it in `TrappedError` instead.
- */
-export class TrappedError
-  // Does NOT extend Error
-  implements TrappedError
-{
-  public readonly originalError: Error;
-  [$$trappedError] = true;
-  public message: string;
-  private constructor(originalError: Error) {
-    if (originalError instanceof TrappedError) {
-      throw new Error(
-        "GrafastInternalError<29e0a06f-fb3e-40f5-82ec-b47d9d041048>: attempted to wrap a TrappedError with a TrappedError.",
-      );
-    }
-    this.message = originalError?.message;
-    this.originalError = originalError;
-    // TODO: copy other attributes across?
-  }
-}
-
-/**
- * DO NOT ALLOW CONSTRUCTION OF ERRORS OUTSIDE OF THIS MODULE!
- *
- * @internal
- */
-export function newTrappedError(error: Error): TrappedError {
-  return new (TrappedError as any)(error);
-}
-
-/**
- * Is the given value a TrappedError? This is the only public API that people
- * should use for looking at GrafastErrors.
- */
-export function isTrappedError(value: any): value is TrappedError {
-  return typeof value === "object" && value !== null && $$trappedError in value;
 }

--- a/grafast/grafast/src/error.ts
+++ b/grafast/grafast/src/error.ts
@@ -6,7 +6,7 @@ import {
   FLAG_NULL,
 } from "./interfaces.js";
 
-export const $$flagged = Symbol("grafastFlaggedValue");
+const $$flagged = Symbol("grafastFlaggedValue");
 
 /**
  * Wrapper for errors to return (rather than throw or reject) from user code.
@@ -34,7 +34,7 @@ function flaggedValue<T>(
 }
 
 export const $$inhibit = flaggedValue<null>(
-  FLAG_NULL & FLAG_INHIBITED,
+  FLAG_NULL | FLAG_INHIBITED,
   null,
   null,
 );

--- a/grafast/grafast/src/index.ts
+++ b/grafast/grafast/src/index.ts
@@ -35,7 +35,7 @@ import { defer, Deferred } from "./deferred.js";
 import { isDev, noop } from "./dev.js";
 import { isUnaryStep } from "./engine/lib/withGlobalLayerPlan.js";
 import { OperationPlan } from "./engine/OperationPlan.js";
-import { isSafeError, SafeError } from "./error.js";
+import { $$inhibit, flagError,isSafeError, SafeError } from "./error.js";
 import { execute } from "./execute.js";
 import { grafast, grafastSync } from "./grafastGraphql.js";
 import type {
@@ -257,6 +257,7 @@ export {
   $$eventEmitter,
   $$extensions,
   $$idempotent,
+  $$inhibit,
   $$verbatim,
   access,
   AccessStep,
@@ -314,6 +315,7 @@ export {
   FilterPlanMemo,
   first,
   FirstStep,
+  flagError,
   getEnumValueConfig,
   grafast,
   GrafastArgumentConfig,
@@ -573,6 +575,8 @@ exportAsMany("grafast", {
   LoadedRecordStep,
   LoadStep,
   isSafeError,
+  $$inhibit,
+  flagError,
   SafeError,
   isUnaryStep,
 });

--- a/grafast/grafast/src/index.ts
+++ b/grafast/grafast/src/index.ts
@@ -35,12 +35,7 @@ import { defer, Deferred } from "./deferred.js";
 import { isDev, noop } from "./dev.js";
 import { isUnaryStep } from "./engine/lib/withGlobalLayerPlan.js";
 import { OperationPlan } from "./engine/OperationPlan.js";
-import {
-  GrafastError,
-  isGrafastError,
-  isSafeError,
-  SafeError,
-} from "./error.js";
+import { isSafeError, SafeError } from "./error.js";
 import { execute } from "./execute.js";
 import { grafast, grafastSync } from "./grafastGraphql.js";
 import type {
@@ -322,7 +317,6 @@ export {
   getEnumValueConfig,
   grafast,
   GrafastArgumentConfig,
-  GrafastError,
   GrafastFieldConfig,
   GrafastFieldConfigArgumentMap,
   grafast as grafastGraphql,
@@ -356,7 +350,6 @@ export {
   InterfaceOrUnionPlans,
   isDev,
   isExecutableStep,
-  isGrafastError,
   isListCapableStep,
   isListLikeStep,
   isModifierStep,
@@ -513,7 +506,6 @@ exportAsMany("grafast", {
   TRAP_ERROR,
   TRAP_ERROR_OR_INHIBITED,
   TRAP_INHIBITED,
-  isGrafastError,
   debugPlans,
   each,
   error,

--- a/grafast/grafast/src/index.ts
+++ b/grafast/grafast/src/index.ts
@@ -11,6 +11,7 @@ import type {
 } from "graphql";
 
 import type { __InputDynamicScalarStep } from "./steps/__inputDynamicScalar.js";
+import type { DataFromObjectSteps } from "./steps/object.js";
 
 type PromiseOrValue<T> = T | Promise<T>;
 
@@ -35,7 +36,7 @@ import { defer, Deferred } from "./deferred.js";
 import { isDev, noop } from "./dev.js";
 import { isUnaryStep } from "./engine/lib/withGlobalLayerPlan.js";
 import { OperationPlan } from "./engine/OperationPlan.js";
-import { $$inhibit, flagError,isSafeError, SafeError } from "./error.js";
+import { $$inhibit, flagError, isSafeError, SafeError } from "./error.js";
 import { execute } from "./execute.js";
 import { grafast, grafastSync } from "./grafastGraphql.js";
 import type {
@@ -43,6 +44,7 @@ import type {
   $$hooked,
   $$queryCache,
   CacheByOperationEntry,
+  DataFromStep,
   GrafastTimeouts,
   ScalarInputPlanResolver,
 } from "./interfaces.js";
@@ -287,6 +289,8 @@ export {
   constant,
   ConstantStep,
   context,
+  DataFromObjectSteps,
+  DataFromStep,
   debugPlans,
   defer,
   Deferred,

--- a/grafast/grafast/src/interfaces.ts
+++ b/grafast/grafast/src/interfaces.ts
@@ -23,7 +23,7 @@ import type {
 
 import type { Bucket, RequestTools } from "./bucket.js";
 import type { OperationPlan } from "./engine/OperationPlan.js";
-import type { SafeError } from "./error.js";
+import type { FlaggedValue, SafeError } from "./error.js";
 import type { ExecutableStep, ListCapableStep, ModifierStep } from "./step.js";
 import type { __InputDynamicScalarStep } from "./steps/__inputDynamicScalar.js";
 import type {
@@ -182,9 +182,14 @@ export interface IndexByListItemStepId {
 // These values are just to make reading the code a little clearer
 export type GrafastValuesList<T> = ReadonlyArray<T>;
 export type PromiseOrDirect<T> = PromiseLike<T> | T;
-export type GrafastResultsList<T> = ReadonlyArray<PromiseOrDirect<T>>;
+export type GrafastResultsList<T> = ReadonlyArray<
+  PromiseOrDirect<T | FlaggedValue<Error> | FlaggedValue<null>>
+>;
 export type GrafastResultStreamList<T> = ReadonlyArray<
-  PromiseOrDirect<AsyncIterable<PromiseOrDirect<T>> | null> | PromiseLike<never>
+  | PromiseOrDirect<AsyncIterable<
+      PromiseOrDirect<T | FlaggedValue<Error> | FlaggedValue<null>>
+    > | null>
+  | PromiseLike<never>
 >;
 
 /** @internal */
@@ -934,3 +939,6 @@ export interface AddDependencyOptions {
  * @internal
  */
 export const $$deepDepSkip = Symbol("deepDepSkip_experimental");
+
+export type DataFromStep<TStep extends ExecutableStep> =
+  TStep extends ExecutableStep<infer TData> ? TData : never;

--- a/grafast/grafast/src/interfaces.ts
+++ b/grafast/grafast/src/interfaces.ts
@@ -23,7 +23,7 @@ import type {
 
 import type { Bucket, RequestTools } from "./bucket.js";
 import type { OperationPlan } from "./engine/OperationPlan.js";
-import type { GrafastError, SafeError } from "./error.js";
+import type { SafeError } from "./error.js";
 import type { ExecutableStep, ListCapableStep, ModifierStep } from "./step.js";
 import type { __InputDynamicScalarStep } from "./steps/__inputDynamicScalar.js";
 import type {
@@ -166,9 +166,6 @@ export const $$timeout = Symbol("timeout");
 /** For tracking _when_ the timeout happened (because once the JIT has warmed it might not need so long) */
 export const $$ts = Symbol("timestamp");
 
-/** Used as a return value from __FlagStep to force inhibition */
-export const $$inhibit = Symbol("inhibit");
-
 /**
  * When dealing with a polymorphic thing we need to be able to determine what
  * the concrete type of it is, we use the $$concreteType property for that.
@@ -196,7 +193,7 @@ export type ForcedValues = {
     [index: number]: ExecutionEntryFlags | undefined;
   };
   results: {
-    [index: number]: GrafastError | null | undefined;
+    [index: number]: Error | null | undefined;
   };
 };
 
@@ -931,7 +928,7 @@ export interface AddDependencyOptions {
   skipDeduplication?: boolean;
   /** @defaultValue `FLAG_NULL` */
   acceptFlags?: ExecutionEntryFlags;
-  onReject?: null | GrafastError | undefined;
+  onReject?: null | Error | undefined;
 }
 /**
  * @internal

--- a/grafast/grafast/src/step.ts
+++ b/grafast/grafast/src/step.ts
@@ -15,7 +15,6 @@ import {
 } from "./engine/lib/withGlobalLayerPlan.js";
 import { $$unlock } from "./engine/lock.js";
 import type { OperationPlan } from "./engine/OperationPlan.js";
-import type { GrafastError } from "./error.js";
 import { getDebug } from "./global.js";
 import { inspect } from "./inspect.js";
 import type {
@@ -207,7 +206,7 @@ export /* abstract */ class ExecutableStep<TData = any> extends BaseStep {
    * - The `execute` method must be a regular (not async) function
    * - The `execute` method must NEVER return a promise
    * - The values within the list returned from `execute` must NEVER include
-   *   promises or GrafastError objects
+   *   promises or FlaggedValue objects
    * - The result of calling `execute` should not differ after a
    *   `step.hasSideEffects` has executed (i.e. it should be pure, only
    *   dependent on its deps and use no external state)
@@ -235,7 +234,7 @@ export /* abstract */ class ExecutableStep<TData = any> extends BaseStep {
    */
   protected readonly dependencyForbiddenFlags: ReadonlyArray<ExecutionEntryFlags>;
   protected readonly dependencyOnReject: ReadonlyArray<
-    GrafastError | null | undefined
+    Error | null | undefined
   >;
 
   /**

--- a/grafast/grafast/src/step.ts
+++ b/grafast/grafast/src/step.ts
@@ -15,6 +15,7 @@ import {
 } from "./engine/lib/withGlobalLayerPlan.js";
 import { $$unlock } from "./engine/lock.js";
 import type { OperationPlan } from "./engine/OperationPlan.js";
+import { flagError } from "./error.js";
 import { getDebug } from "./global.js";
 import { inspect } from "./inspect.js";
 import type {
@@ -46,6 +47,8 @@ import { stepAMayDependOnStepB } from "./utils.js";
  * @internal
  */
 export const $$noExec = Symbol("noExec");
+
+const ref_flagError = te.ref(flagError, "flagError");
 
 function throwDestroyed(this: ExecutableStep): any {
   let message: string;
@@ -514,7 +517,7 @@ function _buildOptimizedExecuteV2Expression(
     try {
   ${te.indent(inFrag)}
     } catch (e) {
-      results[i] = e instanceof Error ? e : Promise.reject(e);
+      results[i] = ${ref_flagError}(e);
     }\
 `;
     }
@@ -615,7 +618,7 @@ export abstract class UnbatchedExecutableStep<
         const tuple = values.map((list) => list.at(i));
         return this.unbatchedExecute(extra, ...tuple);
       } catch (e) {
-        return e instanceof Error ? (e as never) : Promise.reject(e);
+        return flagError(e);
       }
     });
   }

--- a/grafast/grafast/src/steps/__flag.ts
+++ b/grafast/grafast/src/steps/__flag.ts
@@ -1,5 +1,5 @@
 import type { FlaggedValue } from "../error.js";
-import { $$inhibit, flagError, SafeError } from "../error.js";
+import { $$inhibit, flagError, isFlaggedValue, SafeError } from "../error.js";
 import { inspect } from "../inspect.js";
 import type {
   AddDependencyOptions,
@@ -138,12 +138,9 @@ export class __FlagStep<TData> extends ExecutableStep<TData> {
   }
   public toStringMeta(): string | null {
     const acceptFlags = ALL_FLAGS & ~this.forbiddenFlags;
-    const rej =
-      this.onRejectReturnValue === $$inhibit
-        ? `INHIBIT`
-        : this.onRejectReturnValue
-        ? trim(String(this.onRejectReturnValue))
-        : inspect(this.onRejectReturnValue);
+    const rej = this.onRejectReturnValue
+      ? trim(String(this.onRejectReturnValue))
+      : inspect(this.onRejectReturnValue);
     const $if =
       this.ifDep !== null ? this.getDepOptions(this.ifDep).step : null;
     return `${this.dependencies[0].id}, ${

--- a/grafast/grafast/src/steps/__flag.ts
+++ b/grafast/grafast/src/steps/__flag.ts
@@ -1,10 +1,5 @@
-import type { GrafastError } from "../error.js";
-import {
-  isGrafastError,
-  newGrafastError,
-  newTrappedError,
-  SafeError,
-} from "../error.js";
+import type { FlaggedValue } from "../error.js";
+import { $$inhibit, flagError, SafeError } from "../error.js";
 import { inspect } from "../inspect.js";
 import type {
   AddDependencyOptions,
@@ -14,7 +9,6 @@ import type {
 } from "../interfaces.js";
 import {
   $$deepDepSkip,
-  $$inhibit,
   ALL_FLAGS,
   DEFAULT_ACCEPT_FLAGS,
   DEFAULT_FORBIDDEN_FLAGS,
@@ -59,7 +53,7 @@ export type TrapValue = (typeof TRAP_VALUES)[number];
 export type ResolvedTrapValue = false | null | undefined | readonly never[];
 export interface FlagStepOptions {
   acceptFlags?: ExecutionEntryFlags;
-  onReject?: GrafastError | null;
+  onReject?: Error | null;
   if?: ExecutableStep<boolean>;
   // Trapping an error might want to result in a null or an empty list.
   valueForInhibited?: TrapValue;
@@ -104,7 +98,7 @@ export class __FlagStep<TData> extends ExecutableStep<TData> {
   isSyncAndSafe = false;
   private ifDep: number | null = null;
   private forbiddenFlags: ExecutionEntryFlags;
-  private onRejectReturnValue: GrafastError | typeof $$inhibit;
+  private onRejectReturnValue: FlaggedValue<Error> | FlaggedValue<null>;
   private valueForInhibited: ResolvedTrapValue;
   private valueForError: ResolvedTrapValue;
   private canBeInlined: boolean;
@@ -119,11 +113,7 @@ export class __FlagStep<TData> extends ExecutableStep<TData> {
     } = options;
     this.forbiddenFlags = ALL_FLAGS & ~acceptFlags;
     this.onRejectReturnValue =
-      onReject == null
-        ? $$inhibit
-        : isGrafastError(onReject)
-        ? onReject
-        : newGrafastError(onReject, step.id);
+      onReject == null ? $$inhibit : flagError(onReject, step.id);
     this.valueForInhibited = resolveTrapValue(valueForInhibited);
     this.valueForError = resolveTrapValue(valueForError);
     this.canBeInlined =
@@ -255,37 +245,25 @@ export class __FlagStep<TData> extends ExecutableStep<TData> {
       // Search for "f2b3b1b3" for similar block
       const flags = dataEv._flagsAt(i);
       const disallowedFlags = flags & forbiddenFlags;
-      if (disallowedFlags !== NO_FLAGS) {
+      if (disallowedFlags) {
         if (disallowedFlags & FLAG_INHIBITED) {
           // We were already rejected, maintain this
           return $$inhibit;
         } else if (disallowedFlags & FLAG_ERROR) {
           // We were already rejected, maintain this
-          return dataEv.at(i);
+          return flagError(dataEv.at(i) as Error);
         } else {
           // We weren't already inhibited
           return onRejectReturnValue;
         }
       } else {
-        if ((flags & FLAG_ERROR) !== 0) {
-          // Trapped an error
-          if (this.valueForError !== false) {
-            return valueForError;
-          }
-          const value = dataEv.at(i);
-          if (isGrafastError(value)) {
-            return newTrappedError(value.originalError);
-          }
-          return value;
+        if (flags & FLAG_ERROR && this.valueForError !== false) {
+          return valueForError;
         }
-        if (
-          (flags & FLAG_INHIBITED) !== 0 &&
-          this.valueForInhibited !== false
-        ) {
-          // Trapped an inhibit
+        if (flags & FLAG_INHIBITED && this.valueForInhibited !== false) {
           return valueForInhibited;
         }
-        // Else, assume pass-through
+        // Assume pass-through
         return dataEv.at(i);
       }
     });
@@ -328,7 +306,7 @@ export function assertNotNull<T>(
   return new __FlagStep<T>($step, {
     ...options,
     acceptFlags: DEFAULT_ACCEPT_FLAGS & ~FLAG_NULL,
-    onReject: newGrafastError(new SafeError(message), $step.id),
+    onReject: new SafeError(message),
   });
 }
 

--- a/grafast/grafast/src/steps/applyTransforms.ts
+++ b/grafast/grafast/src/steps/applyTransforms.ts
@@ -10,7 +10,6 @@ import {
 import type { LayerPlanReasonSubroutine } from "../engine/LayerPlan.js";
 import { LayerPlan } from "../engine/LayerPlan.js";
 import { withGlobalLayerPlan } from "../engine/lib/withGlobalLayerPlan.js";
-import type { GrafastError } from "../error.js";
 import type { ExecutionDetails, GrafastResultsList } from "../interfaces.js";
 import type { ListCapableStep } from "../step.js";
 import { ExecutableStep, isListCapableStep } from "../step.js";
@@ -78,7 +77,7 @@ export class ApplyTransformsStep extends ExecutableStep {
     indexMap,
     values: [values0],
     extra,
-  }: ExecutionDetails<[any[] | null | undefined | GrafastError]>): Promise<
+  }: ExecutionDetails<[any[] | null | undefined | Error]>): Promise<
     GrafastResultsList<any[] | null | undefined>
   > {
     const bucket = extra._bucket;

--- a/grafast/grafast/src/steps/applyTransforms.ts
+++ b/grafast/grafast/src/steps/applyTransforms.ts
@@ -10,7 +10,12 @@ import {
 import type { LayerPlanReasonSubroutine } from "../engine/LayerPlan.js";
 import { LayerPlan } from "../engine/LayerPlan.js";
 import { withGlobalLayerPlan } from "../engine/lib/withGlobalLayerPlan.js";
-import type { ExecutionDetails, GrafastResultsList } from "../interfaces.js";
+import { flagError } from "../error.js";
+import {
+  type ExecutionDetails,
+  FLAG_ERROR,
+  type GrafastResultsList,
+} from "../interfaces.js";
 import type { ListCapableStep } from "../step.js";
 import { ExecutableStep, isListCapableStep } from "../step.js";
 import { __ItemStep } from "./__item.js";
@@ -186,8 +191,9 @@ export class ApplyTransformsStep extends ExecutableStep {
       }
       const values = indexes.map((idx) => {
         const val = depResults.at(idx);
-        if (val instanceof Error) {
-          throw val;
+        if (depResults._flagsAt(idx) & FLAG_ERROR) {
+          // throw val;
+          return flagError(val);
         }
         return val;
       });

--- a/grafast/grafast/src/steps/error.ts
+++ b/grafast/grafast/src/steps/error.ts
@@ -1,3 +1,4 @@
+import { flagError } from "../error.js";
 import { inspect } from "../inspect.js";
 import type { ExecutionDetails, GrafastResultsList } from "../interfaces.js";
 import { UnbatchedExecutableStep } from "../step.js";
@@ -21,10 +22,10 @@ export class ErrorStep<
   }
 
   execute({ count }: ExecutionDetails): GrafastResultsList<any> {
-    return arrayOfLength(count, this.error);
+    return arrayOfLength(count, flagError(this.error));
   }
   unbatchedExecute(): any {
-    return this.error;
+    return flagError(this.error);
   }
 }
 

--- a/grafast/grafast/src/steps/graphqlResolver.ts
+++ b/grafast/grafast/src/steps/graphqlResolver.ts
@@ -56,6 +56,19 @@ function dcr(
     return flagError(data);
   } else if (isPromiseLike(data)) {
     return data.then((data) => dcr(data, context, resolveInfo));
+  } else if (
+    // TODO: this should actually be "if is iterable"
+    Array.isArray(data) &&
+    data.some(isPromiseLike)
+  ) {
+    const resolved = Promise.all(
+      data.map((entry) =>
+        isPromiseLike(entry) ? entry.then(null, flagError) : entry,
+      ),
+    );
+    // TODO: this does recursion which is inefficient and also incorrect. We
+    // should only traverse as deep as the GraphQL type has lists.
+    return dcr(resolved, context, resolveInfo);
   }
   return { data, context, resolveInfo };
 }

--- a/grafast/grafast/src/steps/listTransform.ts
+++ b/grafast/grafast/src/steps/listTransform.ts
@@ -10,7 +10,6 @@ import {
 import type { LayerPlanReasonSubroutine } from "../engine/LayerPlan.js";
 import { LayerPlan } from "../engine/LayerPlan.js";
 import { withGlobalLayerPlan } from "../engine/lib/withGlobalLayerPlan.js";
-import type { GrafastError } from "../error.js";
 import type { ConnectionCapableStep, ExecutionDetails } from "../index.js";
 import type { GrafastResultsList } from "../interfaces.js";
 import { $$deepDepSkip } from "../interfaces.js";
@@ -203,7 +202,7 @@ export class __ListTransformStep<
     indexMap,
     values,
     extra,
-  }: ExecutionDetails<[any[] | null | undefined | GrafastError]>): Promise<
+  }: ExecutionDetails<[any[] | null | undefined | Error]>): Promise<
     GrafastResultsList<TMemo>
   > {
     const bucket = extra._bucket;

--- a/grafast/grafast/src/utils.ts
+++ b/grafast/grafast/src/utils.ts
@@ -25,7 +25,6 @@ import type { Deferred } from "./deferred.js";
 import { isDev } from "./dev.js";
 import type { LayerPlan } from "./engine/LayerPlan.js";
 import type { OperationPlan } from "./engine/OperationPlan.js";
-import type { GrafastError } from "./error.js";
 import { SafeError } from "./error.js";
 import { inspect } from "./inspect.js";
 import type {
@@ -930,7 +929,7 @@ export type Sudo<T> = T extends ExecutableStep<any>
   ? T & {
       dependencies: ReadonlyArray<ExecutableStep>;
       dependencyForbiddenFlags: ReadonlyArray<ExecutionEntryFlags>;
-      dependencyOnReject: ReadonlyArray<GrafastError | null | undefined>;
+      dependencyOnReject: ReadonlyArray<Error | null | undefined>;
       defaultForbiddenFlags: ExecutionEntryFlags;
       getDepOptions: ExecutableStep["getDepOptions"];
     }

--- a/graphile-build/graphile-build-pg/src/plugins/PgPolymorphismPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgPolymorphismPlugin.ts
@@ -953,20 +953,17 @@ export const PgPolymorphismPlugin: GraphileConfig.Plugin = {
                       const $pkValues = lambda(
                         $handlerMatches,
                         (handlerMatches) => {
-                          const match =
-                            // TS knows this in my editor, but not in `tsc` for
-                            // some reason.
-                            (
-                              handlerMatches as DataFromObjectSteps<{
-                                match: LambdaStep<
-                                  {
-                                    [codecName: string]: any;
-                                  } | null,
-                                  boolean
-                                >;
-                                pks: ListStep<any[]>;
-                              }>[]
-                            ).find((pk) => pk.match);
+                          const match = (
+                            handlerMatches as DataFromObjectSteps<{
+                              match: LambdaStep<
+                                {
+                                  [codecName: string]: any;
+                                } | null,
+                                boolean
+                              >;
+                              pks: ListStep<any[]>;
+                            }>[]
+                          ).find((pk) => pk.match);
                           return match?.pks;
                         },
                         true,

--- a/graphile-build/graphile-build-pg/src/plugins/PgPolymorphismPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgPolymorphismPlugin.ts
@@ -24,7 +24,13 @@ import type {
   PgSelectSingleStep,
 } from "@dataplan/pg";
 import { assertPgClassSingleStep } from "@dataplan/pg";
-import type { ExecutableStep, ListStep, NodeIdHandler } from "grafast";
+import type {
+  DataFromObjectSteps,
+  ExecutableStep,
+  LambdaStep,
+  ListStep,
+  NodeIdHandler,
+} from "grafast";
 import {
   access,
   arraysMatch,
@@ -947,7 +953,20 @@ export const PgPolymorphismPlugin: GraphileConfig.Plugin = {
                       const $pkValues = lambda(
                         $handlerMatches,
                         (handlerMatches) => {
-                          const match = handlerMatches.find((pk) => pk.match);
+                          const match =
+                            // TS knows this in my editor, but not in `tsc` for
+                            // some reason.
+                            (
+                              handlerMatches as DataFromObjectSteps<{
+                                match: LambdaStep<
+                                  {
+                                    [codecName: string]: any;
+                                  } | null,
+                                  boolean
+                                >;
+                                pks: ListStep<any[]>;
+                              }>[]
+                            ).find((pk) => pk.match);
                           return match?.pks;
                         },
                         true,
@@ -1018,7 +1037,19 @@ export const PgPolymorphismPlugin: GraphileConfig.Plugin = {
                       const $pkValues = lambda(
                         $handlerMatches,
                         (handlerMatches) => {
-                          const match = handlerMatches.find((pk) => pk.match);
+                          // Explicit typing because TypeScript has lost the
+                          // plot.
+                          const match = (
+                            handlerMatches as DataFromObjectSteps<{
+                              match: LambdaStep<
+                                {
+                                  [codecName: string]: any;
+                                } | null,
+                                boolean
+                              >;
+                              pks: ListStep<any[]>;
+                            }>[]
+                          ).find((pk) => pk.match);
                           return match?.pks;
                         },
                         true,

--- a/graphile-build/graphile-utils/__tests__/makeAddPgTableOrderByPlugin.test.ts
+++ b/graphile-build/graphile-utils/__tests__/makeAddPgTableOrderByPlugin.test.ts
@@ -147,6 +147,9 @@ it('allows creating a "order by" plugin with DEFAULT asc/desc ordering', async (
     userNodesDesc,
   } = await getAscDescData(schemaResult);
 
+  expect(errorsAsc).toBeFalsy();
+  expect(errorsDesc).toBeFalsy();
+
   // by default, the natural order by puts nulls last when using ascending order
   const correctOrderAsc = ["Bob", "Caroline", "Alice"];
   const resultingOrderAsc = getResultingOrderFromUserNodes(userNodesAsc);
@@ -156,7 +159,6 @@ it('allows creating a "order by" plugin with DEFAULT asc/desc ordering', async (
     resultingOrderAsc,
   );
 
-  expect(errorsAsc).toBeFalsy();
   expect(dataAsc).toBeTruthy();
   expect(ascOrdersAreEqual).toBeTruthy();
 
@@ -169,7 +171,6 @@ it('allows creating a "order by" plugin with DEFAULT asc/desc ordering', async (
     resultingOrderDesc,
   );
 
-  expect(errorsDesc).toBeFalsy();
   expect(dataDesc).toBeTruthy();
   expect(descOrdersAreEqual).toBeTruthy();
 });


### PR DESCRIPTION
In the old system, errors would be wrapped in GrafastError to make detection easier. In the new system we use bit flags to indicate an error, so we don't need this any more. This PR strips out all the GrafastError instances and replaces them with their newer equivalents (flag checks). This also means that errors can now be treated as values, and that things that are not `instanceof Error` can be used as errors. It also gives a new way to return explicit errors in the form of the `flagError()` function (alternative methods are to throw the error, or to return a rejected promise, but `flagError()` works in synchronous cases in the middle of a list without breaking the rest of the list).

The special value `$$inhibited` is no longer a symbol, it is now a `FlaggedValue` same as the values returned by `flagError()`. This is more flexible.

When trapping an error you now just get the value directly, no need for TrappedError any more (which was never published anyway)

GraphQL resolver emulation is a little more expensive now, and may not work with iterables which yield promises (only with arrays).

:rotating_light:  Breaking change: We no longer check for `instanceof Error` - you must use `flagError()` directly if you want to return an error in the middle of a list/batch synchronously. This allows errors to be treated as values (pretty important!) and also means that we don't do expensive `instanceof` checks which should help performance, perhaps.