### PR TITLE
Expose PgSelectPlan.clone

### DIFF
--- a/.changeset/angry-pugs-design.md
+++ b/.changeset/angry-pugs-design.md
@@ -1,0 +1,5 @@
+---
+"@dataplan/pg": patch
+---
+
+Exposes PgSelectPlan.clone, no longer internal.

--- a/grafast/dataplan-pg/src/steps/pgSelect.ts
+++ b/grafast/dataplan-pg/src/steps/pgSelect.ts
@@ -913,8 +913,6 @@ export class PgSelectStep<
    * Finalizes this instance and returns a mutable clone; useful for
    * connections/etc (e.g. copying `where` conditions but adding more, or
    * pagination, or grouping, aggregates, etc)
-   *
-   * @internal
    */
   clone(mode?: PgSelectMode): PgSelectStep<TResource> {
     return new PgSelectStep(this, mode);


### PR DESCRIPTION
The easiest way to get an aggregate would be something like `pgResource.find().clone("aggregate")`; this saves us from having to add APIs like `pgResources.find({}, {mode: "aggregate"})` or `pgResources.findAggregate()`. To make this possible, we now expose the `.clone()` method on `PgSelectStep`.