### PR TITLE
orderByAscDesc now accepts `nullable?: boolean` and defaults true if `nulls` is set

### DIFF
--- a/.changeset/moody-balloons-design.md
+++ b/.changeset/moody-balloons-design.md
@@ -1,0 +1,6 @@
+---
+"graphile-utils": patch
+---
+
+Expose `nullable?: boolean` as an orderByAscDesc option, and default it true if
+'nulls' is set. Vital if you're ordering by nullable things!

--- a/graphile-build/graphile-utils/src/makeAddPgTableOrderByPlugin.ts
+++ b/graphile-build/graphile-utils/src/makeAddPgTableOrderByPlugin.ts
@@ -82,7 +82,11 @@ export type NullsSortMethod =
 export interface OrderByAscDescOptions {
   unique?: boolean;
   nulls?: NullsSortMethod;
-  /** If this expression/column is nullable, you must set this true otherwise cursor pagination over null values will break */
+  /**
+   * If this expression/column is nullable, you must set this true otherwise
+   * cursor pagination over null values will break. If `nulls` is specified,
+   * we'll default this to true.
+   */
   nullable?: boolean;
 }
 
@@ -95,7 +99,7 @@ export function orderByAscDesc(
     typeof uniqueOrOptions === "boolean"
       ? { unique: uniqueOrOptions }
       : uniqueOrOptions ?? {};
-  const { unique = false, nulls, nullable } = options;
+  const { unique = false, nulls, nullable = nulls != null } = options;
 
   if (typeof unique !== "boolean") {
     throw new Error(

--- a/graphile-build/graphile-utils/src/makeAddPgTableOrderByPlugin.ts
+++ b/graphile-build/graphile-utils/src/makeAddPgTableOrderByPlugin.ts
@@ -82,6 +82,8 @@ export type NullsSortMethod =
 export interface OrderByAscDescOptions {
   unique?: boolean;
   nulls?: NullsSortMethod;
+  /** If this expression/column is nullable, you must set this true otherwise cursor pagination over null values will break */
+  nullable?: boolean;
 }
 
 export function orderByAscDesc(
@@ -93,7 +95,7 @@ export function orderByAscDesc(
     typeof uniqueOrOptions === "boolean"
       ? { unique: uniqueOrOptions }
       : uniqueOrOptions ?? {};
-  const { unique = false, nulls } = options;
+  const { unique = false, nulls, nullable } = options;
 
   if (typeof unique !== "boolean") {
     throw new Error(
@@ -133,38 +135,41 @@ export function orderByAscDesc(
   const ascendingPlan: Plan =
     typeof attributeOrSqlFragment === "string"
       ? EXPORTABLE(
-          (ascendingNulls, attributeOrSqlFragment, unique) =>
+          (ascendingNulls, attributeOrSqlFragment, nullable, unique) =>
             function applyPlan($select) {
               $select.orderBy({
                 nulls: ascendingNulls,
                 attribute: attributeOrSqlFragment,
                 direction: "ASC",
+                nullable,
               });
               if (unique) {
                 $select.setOrderIsUnique();
               }
             },
-          [ascendingNulls, attributeOrSqlFragment, unique],
+          [ascendingNulls, attributeOrSqlFragment, nullable, unique],
         )
       : typeof attributeOrSqlFragment === "function"
       ? EXPORTABLE(
-          (ascendingNulls, attributeOrSqlFragment, unique) =>
+          (ascendingNulls, attributeOrSqlFragment, nullable, unique) =>
             function applyPlan($select) {
               $select.orderBy({
                 nulls: ascendingNulls,
                 ...attributeOrSqlFragment($select),
                 direction: "ASC",
+                nullable,
               } as PgOrderSpec);
               if (unique) {
                 $select.setOrderIsUnique();
               }
             },
-          [ascendingNulls, attributeOrSqlFragment, unique],
+          [ascendingNulls, attributeOrSqlFragment, nullable, unique],
         )
       : ((spec = {
           nulls: ascendingNulls,
           ...attributeOrSqlFragment,
           direction: "ASC",
+          nullable,
         } as PgOrderSpec),
         EXPORTABLE(
           (spec, unique) =>
@@ -179,38 +184,41 @@ export function orderByAscDesc(
   const descendingPlan: Plan =
     typeof attributeOrSqlFragment === "string"
       ? EXPORTABLE(
-          (attributeOrSqlFragment, descendingNulls, unique) =>
+          (attributeOrSqlFragment, descendingNulls, nullable, unique) =>
             function applyPlan($select) {
               $select.orderBy({
                 nulls: descendingNulls,
                 attribute: attributeOrSqlFragment,
                 direction: "DESC",
+                nullable,
               });
               if (unique) {
                 $select.setOrderIsUnique();
               }
             },
-          [attributeOrSqlFragment, descendingNulls, unique],
+          [attributeOrSqlFragment, descendingNulls, nullable, unique],
         )
       : typeof attributeOrSqlFragment === "function"
       ? EXPORTABLE(
-          (attributeOrSqlFragment, descendingNulls, unique) =>
+          (attributeOrSqlFragment, descendingNulls, nullable, unique) =>
             function applyPlan($select) {
               $select.orderBy({
                 nulls: descendingNulls,
                 ...attributeOrSqlFragment($select),
                 direction: "DESC",
+                nullable,
               } as PgOrderSpec);
               if (unique) {
                 $select.setOrderIsUnique();
               }
             },
-          [attributeOrSqlFragment, descendingNulls, unique],
+          [attributeOrSqlFragment, descendingNulls, nullable, unique],
         )
       : ((spec = {
           nulls: descendingNulls,
           ...attributeOrSqlFragment,
           direction: "DESC",
+          nullable,
         } as PgOrderSpec),
         EXPORTABLE(
           (spec, unique) =>

--- a/postgraphile/website/postgraphile/make-add-pg-table-order-by-plugin.md
+++ b/postgraphile/website/postgraphile/make-add-pg-table-order-by-plugin.md
@@ -177,6 +177,7 @@ export type NullsSortMethod =
 export interface OrderByAscDescOptions {
   unique?: boolean;
   nulls?: NullsSortMethod;
+  nullable?: boolean;
 }
 ```
 
@@ -218,3 +219,12 @@ movie with no ratings is not exactly what one thinks of when one hears
 "top-rated"! By specifying `{ nulls: 'last' }`, however, PostGraphile knows that
 this orderBy plugin should still show the movies without any reviews, but just
 put them at the end of the list.
+
+:::warning
+
+If your column or expression is nullable, you must either specify `nullable:
+true` or pass a value for `nulls`; if you don't do this then PostGraphile will
+use a simpler expression for comparisons which is not null-capable, and this
+will break cursor pagination when nulls occur.
+
+:::


### PR DESCRIPTION
Critical that you set this if you're ordering by something nullable, otherwise cursor pagination won't work across null values because the simpler and cheaper equality check is used without any null fiddling.

(Advice: don't order by nullable things!)