### PR TITLE
Help detect more invalid presets and plugins

### DIFF
--- a/.changeset/nervous-cats-develop.md
+++ b/.changeset/nervous-cats-develop.md
@@ -3,5 +3,5 @@
 "postgraphile": patch
 ---
 
-Help detect more invalid presets (bad imports) by forbidding keys starting with
-a capital.
+Help detect more invalid presets and plugins (bad imports) by forbidding keys
+starting with a capital or the key `default`.

--- a/.changeset/nervous-cats-develop.md
+++ b/.changeset/nervous-cats-develop.md
@@ -1,0 +1,7 @@
+---
+"graphile-config": patch
+"postgraphile": patch
+---
+
+Help detect more invalid presets (bad imports) by forbidding keys starting with
+a capital.

--- a/utils/graphile-config/src/resolvePresets.ts
+++ b/utils/graphile-config/src/resolvePresets.ts
@@ -123,6 +123,20 @@ function assertPlugin(plugin: any): asserts plugin is GraphileConfig.Plugin {
       }' to have a string 'version'; found ${inspect(plugin.version)}`,
     );
   }
+  const keys = Object.keys(plugin);
+  const forbiddenKeys = keys.filter(isForbiddenPluginKey);
+  if (forbiddenKeys.length) {
+    throw new Error(
+      `Expected a GraphileConfig plugin, but found an object with forbidden keys ` +
+        `(e.g. keys starting with a capital letter, or a 'default' key). This typically indicates an ` +
+        `issue with ESM compatibility or import method, for example ` +
+        `doing \`import MyPlugin from 'my-plugin'\` instead of ` +
+        `\`import { MyPlugin } from 'my-plugin'\` or vice versa. ` +
+        `Forbidden keys: '${forbiddenKeys.join(
+          "', '",
+        )}', full value: '${inspect(plugin)}'`,
+    );
+  }
   for (const forbiddenKey of PLUGIN_FORBIDDEN_KEYS) {
     if (plugin[forbiddenKey]) {
       throw new Error(
@@ -133,7 +147,11 @@ function assertPlugin(plugin: any): asserts plugin is GraphileConfig.Plugin {
 }
 
 function isForbiddenPresetKey(key: string): boolean {
-  return /^[A-Z_]/.test(key);
+  return /^[A-Z_]/.test(key) || key === "default";
+}
+
+function isForbiddenPluginKey(key: string): boolean {
+  return /^[A-Z_]/.test(key) || key === "default";
 }
 
 /**
@@ -157,7 +175,7 @@ function resolvePreset(
   if (forbiddenKeys.length) {
     throw new Error(
       `Expected a GraphileConfig preset, but found an object with forbidden keys ` +
-        `(e.g. keys starting with a capital letter). This typically indicates an ` +
+        `(e.g. keys starting with a capital letter, or a 'default' key). This typically indicates an ` +
         `issue with ESM compatibility or import method, for example ` +
         `doing \`import MyPreset from 'my-preset'\` instead of ` +
         `\`import { MyPreset } from 'my-preset'\` or vice versa. ` +


### PR DESCRIPTION
## Description

I'm still receiving support requests where people are importing presets incorrectly (e.g. `import FooPreset from 'foo-preset'` rather than `import { FooPreset from 'foo-preset' }`.

## Performance impact

Startup impact only. Marginal.

## Security impact

Improvement: rejects more invalid configurations.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
