### PR TITLE
Various major fixes to schema exporting

### DIFF
--- a/.changeset/chatty-pianos-move.md
+++ b/.changeset/chatty-pianos-move.md
@@ -1,0 +1,6 @@
+---
+"grafast": patch
+---
+
+Fix detection of enableDeferStream by seeing if `@defer`/`@stream` directives
+are present.

--- a/.changeset/clean-rings-rule.md
+++ b/.changeset/clean-rings-rule.md
@@ -1,0 +1,7 @@
+---
+"graphile-export": patch
+---
+
+Graphile Export now auto-detects that a function has additional properties set,
+and makes sure these properties are exported too. (Typically this is
+`fn.isSyncAndSafe=true` for Grafast optimization.)

--- a/.changeset/clever-eagles-destroy.md
+++ b/.changeset/clever-eagles-destroy.md
@@ -1,0 +1,5 @@
+---
+"graphile-export": patch
+---
+
+Fix exporting input object inputPlan in typeDefs mode.

--- a/.changeset/flat-frogs-rush.md
+++ b/.changeset/flat-frogs-rush.md
@@ -1,0 +1,6 @@
+---
+"grafast": patch
+---
+
+makeGrafastSchema completely reworked. Fixes issues with enums, custom scalars,
+and more.

--- a/.changeset/light-ties-join.md
+++ b/.changeset/light-ties-join.md
@@ -1,0 +1,7 @@
+---
+"graphile-build-pg": patch
+"graphile-build": patch
+"postgraphile": patch
+---
+
+Add missing EXPORTABLE (and remove excessive EXPORTABLE) to fix schema exports.

--- a/.changeset/many-feet-cheat.md
+++ b/.changeset/many-feet-cheat.md
@@ -1,0 +1,5 @@
+---
+"grafast": patch
+---
+
+makeGrafastSchema can now have an inputPlan specified for input objects.

--- a/.changeset/pretty-mayflies-hope.md
+++ b/.changeset/pretty-mayflies-hope.md
@@ -1,0 +1,5 @@
+---
+"grafast": patch
+---
+
+`ConstantStep` now supports `.get(key)` and `.at(index)` methods.

--- a/.changeset/selfish-candles-decide.md
+++ b/.changeset/selfish-candles-decide.md
@@ -1,0 +1,5 @@
+---
+"graphile-export": patch
+---
+
+Don't pass filePath to lintText to avoid ESLint ignoring the file.

--- a/.github/workflows/test-base.yml
+++ b/.github/workflows/test-base.yml
@@ -22,6 +22,11 @@ on:
         type: string
         default: ""
         required: false
+      exportSchema:
+        description: Optional mode for graphile-export
+        type: string
+        default: ""
+        required: false
 
 jobs:
   build:
@@ -99,6 +104,8 @@ jobs:
           run prepack
 
       - name: "Test Project"
+        env:
+          EXPORT_SCHEMA: ${{ inputs.exportSchema }}
         run:
           yarn run pretest && yarn workspaces foreach -vp --jobs 2 --from '${{
           inputs.package }}' run ${{ inputs.testcommand }} ${{ inputs.args }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
     with:
       prepackPackages: "{pg-sql2,tamedevil,postgraphile}"
       package: "postgraphile"
-      testcommand: "test:operations:polymorphic"
+      testcommand: "test:operations:polymorphic_etc"
       args: "--ci"
 
   postgraphile_queries_polymorphic_export_typeDefs:
@@ -56,7 +56,7 @@ jobs:
     with:
       prepackPackages: "{pg-sql2,tamedevil,postgraphile}"
       package: "postgraphile"
-      testcommand: "test:operations:polymorphic"
+      testcommand: "test:operations:polymorphic_etc"
       args: "--ci"
       exportSchema: "typeDefs"
 
@@ -66,7 +66,7 @@ jobs:
     with:
       prepackPackages: "{pg-sql2,tamedevil,postgraphile}"
       package: "postgraphile"
-      testcommand: "test:operations:polymorphic"
+      testcommand: "test:operations:polymorphic_etc"
       args: "--ci"
       exportSchema: "graphql-js"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     with:
       prepackPackages: "{pg-sql2,tamedevil,postgraphile}"
       package: "postgraphile"
-      testcommand: "test:v4"
+      testcommand: "test:operations:v4"
       args: "--ci"
 
   postgraphile_queries_v4_export_typeDefs:
@@ -27,7 +27,7 @@ jobs:
     with:
       prepackPackages: "{pg-sql2,tamedevil,postgraphile}"
       package: "postgraphile"
-      testcommand: "test:v4"
+      testcommand: "test:operations:v4"
       args: "--ci"
       exportSchema: "typeDefs"
 
@@ -37,7 +37,7 @@ jobs:
     with:
       prepackPackages: "{pg-sql2,tamedevil,postgraphile}"
       package: "postgraphile"
-      testcommand: "test:v4"
+      testcommand: "test:operations:v4"
       args: "--ci"
       exportSchema: "graphql-js"
 
@@ -47,7 +47,7 @@ jobs:
     with:
       prepackPackages: "{pg-sql2,tamedevil,postgraphile}"
       package: "postgraphile"
-      testcommand: "test:polymorphic"
+      testcommand: "test:operations:polymorphic"
       args: "--ci"
 
   postgraphile_queries_polymorphic_export_typeDefs:
@@ -56,7 +56,7 @@ jobs:
     with:
       prepackPackages: "{pg-sql2,tamedevil,postgraphile}"
       package: "postgraphile"
-      testcommand: "test:polymorphic"
+      testcommand: "test:operations:polymorphic"
       args: "--ci"
       exportSchema: "typeDefs"
 
@@ -66,7 +66,7 @@ jobs:
     with:
       prepackPackages: "{pg-sql2,tamedevil,postgraphile}"
       package: "postgraphile"
-      testcommand: "test:polymorphic"
+      testcommand: "test:operations:polymorphic"
       args: "--ci"
       exportSchema: "graphql-js"
 
@@ -76,7 +76,7 @@ jobs:
     with:
       prepackPackages: "{pg-sql2,tamedevil,postgraphile}"
       package: "postgraphile"
-      testcommand: "test:mutations"
+      testcommand: "test:operations:mutations"
       args: "--ci"
 
   postgraphile_mutations_export_typeDefs:
@@ -85,7 +85,7 @@ jobs:
     with:
       prepackPackages: "{pg-sql2,tamedevil,postgraphile}"
       package: "postgraphile"
-      testcommand: "test:mutations"
+      testcommand: "test:operations:mutations"
       args: "--ci"
       exportSchema: "typeDefs"
 
@@ -95,7 +95,7 @@ jobs:
     with:
       prepackPackages: "{pg-sql2,tamedevil,postgraphile}"
       package: "postgraphile"
-      testcommand: "test:mutations"
+      testcommand: "test:operations:mutations"
       args: "--ci"
       exportSchema: "graphql-js"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,26 @@ jobs:
       testcommand: "test:v4"
       args: "--ci"
 
+  postgraphile_queries_v4_export_typeDefs:
+    name: PostGraphile v4 queries tests (exported as typeDefs)
+    uses: ./.github/workflows/test-base.yml
+    with:
+      prepackPackages: "{pg-sql2,tamedevil,postgraphile}"
+      package: "postgraphile"
+      testcommand: "test:v4"
+      args: "--ci"
+      exportSchema: "typeDefs"
+
+  postgraphile_queries_v4_export_graphqljs:
+    name: PostGraphile v4 queries tests (exported as graphql-js)
+    uses: ./.github/workflows/test-base.yml
+    with:
+      prepackPackages: "{pg-sql2,tamedevil,postgraphile}"
+      package: "postgraphile"
+      testcommand: "test:v4"
+      args: "--ci"
+      exportSchema: "graphql-js"
+
   postgraphile_queries_polymorphic:
     name: PostGraphile polymorphic query tests
     uses: ./.github/workflows/test-base.yml
@@ -30,6 +50,26 @@ jobs:
       testcommand: "test:polymorphic"
       args: "--ci"
 
+  postgraphile_queries_polymorphic_export_typeDefs:
+    name: PostGraphile polymorphic query tests (exported as typeDefs)
+    uses: ./.github/workflows/test-base.yml
+    with:
+      prepackPackages: "{pg-sql2,tamedevil,postgraphile}"
+      package: "postgraphile"
+      testcommand: "test:polymorphic"
+      args: "--ci"
+      exportSchema: "typeDefs"
+
+  postgraphile_queries_polymorphic_export_graphqljs:
+    name: PostGraphile polymorphic query tests (exported as graphql-js)
+    uses: ./.github/workflows/test-base.yml
+    with:
+      prepackPackages: "{pg-sql2,tamedevil,postgraphile}"
+      package: "postgraphile"
+      testcommand: "test:polymorphic"
+      args: "--ci"
+      exportSchema: "graphql-js"
+
   postgraphile_mutations:
     name: PostGraphile mutation tests
     uses: ./.github/workflows/test-base.yml
@@ -38,6 +78,26 @@ jobs:
       package: "postgraphile"
       testcommand: "test:mutations"
       args: "--ci"
+
+  postgraphile_mutations_export_typeDefs:
+    name: PostGraphile mutation tests (exported as typeDefs)
+    uses: ./.github/workflows/test-base.yml
+    with:
+      prepackPackages: "{pg-sql2,tamedevil,postgraphile}"
+      package: "postgraphile"
+      testcommand: "test:mutations"
+      args: "--ci"
+      exportSchema: "typeDefs"
+
+  postgraphile_mutations_export_graphqljs:
+    name: PostGraphile mutation tests (exported as graphql-js)
+    uses: ./.github/workflows/test-base.yml
+    with:
+      prepackPackages: "{pg-sql2,tamedevil,postgraphile}"
+      package: "postgraphile"
+      testcommand: "test:mutations"
+      args: "--ci"
+      exportSchema: "graphql-js"
 
   postgraphile_schemas:
     name: PostGraphile schema tests

--- a/grafast/dataplan-pg/__tests__/helpers.ts
+++ b/grafast/dataplan-pg/__tests__/helpers.ts
@@ -6,7 +6,7 @@ Error.stackTraceLimit = Infinity;
 jest.setTimeout(15000);
 if (process.env.DEBUG) {
   // When debug is set, outputting the console logs makes the tests slow.
-  jest.setTimeout(30000);
+  jest.setTimeout(60000);
 }
 
 import { promises as fsp } from "fs";

--- a/grafast/dataplan-pg/__tests__/transform-graphql.js
+++ b/grafast/dataplan-pg/__tests__/transform-graphql.js
@@ -119,7 +119,7 @@ beforeAll(() => {
   };
   // Wait for these promises to resolve, even if it's with errors.
   return Promise.all([result1.catch(e => {}), result2.catch(e => {}), result3.catch(e => {})]);
-}, 30000);
+}, 60000);
 
 afterAll(() => {
   result1 = result2 = result3 = null;

--- a/grafast/dataplan-pg/package.json
+++ b/grafast/dataplan-pg/package.json
@@ -22,8 +22,8 @@
     "test:install-schema": "psql -X1v ON_ERROR_STOP=1 -f __tests__/schema.sql -f __tests__/sequence_reset.sql \"${TEST_DATABASE_URL:-graphile_crystal}\"",
     "test": "GRAPHILE_ENV=test yarn test:install-schema && jest -i",
     "posttest": "yarn test:exportSchema:graphql-js && yarn test:exportSchema:typeDefs",
-    "test:exportSchema:graphql-js": "ENABLE_DEFER_STREAM=1 ts-node ./scripts/exportExampleSchema.ts graphql-js && node ./scripts/runExampleSchema.mjs",
-    "test:exportSchema:typeDefs": "ENABLE_DEFER_STREAM=1 ts-node ./scripts/exportExampleSchema.ts typeDefs && node ./scripts/runExampleSchema.mjs",
+    "test:exportSchema:graphql-js": "ts-node ./scripts/exportExampleSchema.ts graphql-js && node ./scripts/runExampleSchema.mjs",
+    "test:exportSchema:typeDefs": "ts-node ./scripts/exportExampleSchema.ts typeDefs && node ./scripts/runExampleSchema.mjs",
     "prepack": "tsc -b && cp src/.npmignore dist/.npmignore",
     "serve:example": "GRAPHILE_ENV=development NODE_ENV=development yarn nodemon --watch serve-example-schema.js --watch dist --watch ../grafast/dist/ -x 'node --inspect --enable-source-maps serve-example-schema.js'"
   },

--- a/grafast/grafast/src/makeGrafastSchema.ts
+++ b/grafast/grafast/src/makeGrafastSchema.ts
@@ -60,6 +60,8 @@ export type ObjectPlans = {
  * The plans for each field of a GraphQL input object type.
  */
 export type InputObjectPlans = {
+  __inputPlan?: () => ExecutableStep;
+} & {
   [fieldName: string]: Grafast.InputFieldExtensions;
 };
 
@@ -331,6 +333,12 @@ export function makeGrafastSchema(details: {
         const rawConfig = astType.toConfig();
         const config: graphql.GraphQLInputObjectTypeConfig = {
           ...rawConfig,
+          extensions: {
+            ...rawConfig.extensions,
+            grafast: {
+              ...rawConfig.extensions?.grafast,
+            },
+          },
         };
         const inputObjectPlans = plans[astType.name] as
           | InputObjectPlans
@@ -340,6 +348,11 @@ export function makeGrafastSchema(details: {
           for (const [fieldName, fieldSpec] of Object.entries(
             inputObjectPlans,
           )) {
+            if (fieldName === "__inputPlan") {
+              config.extensions!.grafast!.inputPlan =
+                fieldSpec as () => ExecutableStep;
+              continue;
+            }
             const field = rawConfig.fields[fieldName];
             if (!field) {
               console.warn(

--- a/grafast/grafast/src/makeGrafastSchema.ts
+++ b/grafast/grafast/src/makeGrafastSchema.ts
@@ -401,6 +401,11 @@ export function makeGrafastSchema(details: {
               type: mapType(rawFieldSpec.type),
             };
             fields[fieldName] = fieldConfig;
+            if (fieldConfig.args) {
+              for (const [argName, arg] of Object.entries(fieldConfig.args)) {
+                arg.type = mapType(arg.type);
+              }
+            }
           }
           return fields;
         };

--- a/grafast/grafast/src/makeGrafastSchema.ts
+++ b/grafast/grafast/src/makeGrafastSchema.ts
@@ -222,7 +222,9 @@ export function makeGrafastSchema(details: {
               typeof fieldSpec.args === "object" &&
               fieldSpec.args != null
             ) {
-              for (const [argName, argSpec] of Object.entries(fieldSpec.args)) {
+              for (const [argName, _argSpec] of Object.entries(
+                fieldSpec.args,
+              )) {
                 const arg = field.args?.[argName];
                 if (!arg) {
                   console.warn(
@@ -415,7 +417,7 @@ export function makeGrafastSchema(details: {
             };
             fields[fieldName] = fieldConfig;
             if (fieldConfig.args) {
-              for (const [argName, arg] of Object.entries(fieldConfig.args)) {
+              for (const [_argName, arg] of Object.entries(fieldConfig.args)) {
                 arg.type = mapType(arg.type);
               }
             }

--- a/grafast/grafast/src/operationPlan-input.ts
+++ b/grafast/grafast/src/operationPlan-input.ts
@@ -236,7 +236,7 @@ export function withFieldArgsForArguments<
               $val = $val.get(pathSegment);
             } else {
               throw new Error(
-                `GrafastInternalError<b9e9a57a-bbdd-486c-bdcf-25cf99bf0243>: Processing input object type, but '${$val}' has no .get() method.`,
+                `GrafastInternalError<91e1e80d-cf24-4828-a749-3f24156c7b9c>: Processing input object type, but '${$val}' has no .get() method.`,
               );
             }
           } else if (

--- a/grafast/grafast/src/steps/constant.ts
+++ b/grafast/grafast/src/steps/constant.ts
@@ -62,6 +62,21 @@ export class ConstantStep<TData> extends UnbatchedExecutableStep<TData> {
   isUndefined() {
     return this.data === undefined;
   }
+
+  get(key: string) {
+    const value =
+      typeof this.data === "object" &&
+      this.data !== null &&
+      Object.hasOwn(this.data, key)
+        ? (this.data as Record<string, any>)[key]
+        : undefined;
+    return constant(value);
+  }
+
+  at(index: number) {
+    const value = Array.isArray(this.data) ? this.data[index] : undefined;
+    return constant(value);
+  }
 }
 
 function isTemplateStringsArray(data: any): data is TemplateStringsArray {

--- a/graphile-build/graphile-build-pg/src/plugins/PgCodecsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgCodecsPlugin.ts
@@ -403,6 +403,8 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
             typeTagsAndDescription.description ??
             classTagsAndDescription.description;
 
+          // Do NOT mark `extensions` as `EXPORTABLE` otherwise changes
+          // implemented through hooks will not be represented in the export.
           const extensions: PgCodecExtensions = {
             oid: pgClass.reltype,
             isTableLike: ["r", "v", "m", "f", "p"].includes(pgClass.relkind),
@@ -418,32 +420,16 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
           const sqlIdent = info.helpers.pgBasics.identifier(nspName, className);
           exportNameHint(sqlIdent, `${codecName}Identifier`);
           exportNameHint(attributes, `${codecName}Attributes`);
-          const spec: PgRecordTypeCodecSpec<any, any> = EXPORTABLE(
-            (
-              attributes,
-              codecName,
-              description,
-              executor,
-              extensions,
-              sqlIdent,
-            ) => ({
-              name: codecName,
-              identifier: sqlIdent,
-              attributes,
-              description,
-              extensions,
-              executor,
-            }),
-            [
-              attributes,
-              codecName,
-              description,
-              executor,
-              extensions,
-              sqlIdent,
-            ],
-            `${codecName}CodecSpec`,
-          );
+          // Do NOT mark `spec` as `EXPORTABLE` otherwise the changes from
+          // `pgCodecs_recordType_spec` won't be represented in the export.
+          const spec: PgRecordTypeCodecSpec<any, any> = {
+            name: codecName,
+            identifier: sqlIdent,
+            attributes,
+            description,
+            extensions,
+            executor,
+          };
           await info.process("pgCodecs_recordType_spec", {
             serviceName,
             pgClass,

--- a/graphile-build/graphile-build-pg/src/plugins/PgTypesPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgTypesPlugin.ts
@@ -713,35 +713,39 @@ export const PgTypesPlugin: GraphileConfig.Plugin = {
               }
             };
 
-            const parseValueLiteral = (
-              ast: ValueNode,
-              variables: { [key: string]: any } | null | undefined,
-            ) => {
-              switch (ast.kind) {
-                case Kind.INT:
-                case Kind.FLOAT:
-                  // Number isn't really okay, but we'll coerce it to a string anyway.
-                  return String(parseFloat(ast.value));
-                case Kind.STRING:
-                  // String is okay.
-                  return String(ast.value);
-                case Kind.NULL:
-                  // Null is okay.
-                  return null;
-                case Kind.VARIABLE: {
-                  // Variable is okay if that variable is either a string or null.
-                  const name = ast.name.value;
-                  const value = variables ? variables[name] : undefined;
-                  if (value === null || typeof value === "string") {
-                    return value;
+            const parseValueLiteral = EXPORTABLE(
+              (Kind) =>
+                (
+                  ast: ValueNode,
+                  variables: { [key: string]: any } | null | undefined,
+                ) => {
+                  switch (ast.kind) {
+                    case Kind.INT:
+                    case Kind.FLOAT:
+                      // Number isn't really okay, but we'll coerce it to a string anyway.
+                      return String(parseFloat(ast.value));
+                    case Kind.STRING:
+                      // String is okay.
+                      return String(ast.value);
+                    case Kind.NULL:
+                      // Null is okay.
+                      return null;
+                    case Kind.VARIABLE: {
+                      // Variable is okay if that variable is either a string or null.
+                      const name = ast.name.value;
+                      const value = variables ? variables[name] : undefined;
+                      if (value === null || typeof value === "string") {
+                        return value;
+                      }
+                      return undefined;
+                    }
+                    default:
+                      // Everything else is invalid.
+                      return undefined;
                   }
-                  return undefined;
-                }
-                default:
-                  // Everything else is invalid.
-                  return undefined;
-              }
-            };
+                },
+              [Kind],
+            );
 
             build.registerScalarType(
               hstoreTypeName,

--- a/graphile-build/graphile-build/src/plugins/NodeIdCodecBase64JSONPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/NodeIdCodecBase64JSONPlugin.ts
@@ -1,12 +1,4 @@
 import "graphile-config";
-function base64JSONEncode(value: any): string | null {
-  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-}
-base64JSONEncode.isSyncAndSafe = true; // Optimization
-function base64JSONDecode(value: string): any {
-  return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-}
-base64JSONDecode.isSyncAndSafe = true; // Optimization
 
 export const NodeIdCodecBase64JSONPlugin: GraphileConfig.Plugin = {
   name: "NodeIdCodecBase64JSONPlugin",
@@ -20,6 +12,23 @@ export const NodeIdCodecBase64JSONPlugin: GraphileConfig.Plugin = {
           return _;
         }
         const { EXPORTABLE } = build;
+        const base64JSONEncode = EXPORTABLE(() => {
+          function base64JSONEncode(value: any): string | null {
+            return Buffer.from(JSON.stringify(value), "utf8").toString(
+              "base64",
+            );
+          }
+          base64JSONEncode.isSyncAndSafe = true; // Optimization
+          return base64JSONEncode;
+        }, []);
+        const base64JSONDecode = EXPORTABLE(() => {
+          function base64JSONDecode(value: string): any {
+            return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+          }
+          base64JSONDecode.isSyncAndSafe = true; // Optimization
+          return base64JSONDecode;
+        }, []);
+
         build.registerNodeIdCodec(
           EXPORTABLE(
             (base64JSONDecode, base64JSONEncode) => ({

--- a/package.json
+++ b/package.json
@@ -85,6 +85,9 @@
     "yarn": ">=1.3.2"
   },
   "packageManager": "yarn@4.0.0-rc.33",
+  "resolutions": {
+    "graphql": "16.1.0-experimental-stream-defer.6"
+  },
   "dependencies": {
     "@changesets/changelog-github": "^0.4.8",
     "@changesets/cli": "^2.26.2"

--- a/postgraphile/postgraphile/__tests__/helpers.ts
+++ b/postgraphile/postgraphile/__tests__/helpers.ts
@@ -3,7 +3,7 @@ Error.stackTraceLimit = Infinity;
 
 if (process.env.DEBUG) {
   // When debug is set, outputting the console logs makes the tests slow.
-  jest.setTimeout(30000);
+  jest.setTimeout(60000);
 }
 
 import "graphile-config";

--- a/postgraphile/postgraphile/__tests__/helpers.ts
+++ b/postgraphile/postgraphile/__tests__/helpers.ts
@@ -40,6 +40,7 @@ import { exportSchema } from "graphile-export";
 import { isAsyncIterable } from "iterall";
 import JSON5 from "json5";
 import type { JwtPayload } from "jsonwebtoken";
+import * as jsonwebtoken from "jsonwebtoken";
 import { decode } from "jsonwebtoken";
 import { relative } from "path";
 import type { PoolClient } from "pg";
@@ -183,7 +184,12 @@ async function importExportedSchema(schema: GraphQLSchema) {
   await mktmp();
   const tempDir = await mkdtemp(`${TMPDIR}/postgraphiletests-`);
   const targetFile = tempDir + "/schema.js";
-  await exportSchema(schema, targetFile, { mode: "typeDefs" });
+  await exportSchema(schema, targetFile, {
+    mode: "typeDefs",
+    modules: {
+      jsonwebtoken,
+    },
+  });
   try {
     const module = await import(targetFile);
     await unlink(targetFile);

--- a/postgraphile/postgraphile/__tests__/helpers.ts
+++ b/postgraphile/postgraphile/__tests__/helpers.ts
@@ -704,14 +704,6 @@ export const assertSnapshotsMatch = async (
     ext?: string;
   },
 ): Promise<void> => {
-  if (EXPORT_SCHEMA_MODE && only === "mermaid") {
-    // TODO: Remove this, we should aim for identical planning snapshots in
-    // source and exported schema.
-    console.warn(
-      "SKIPPING MERMAID SNAPSHOT COMPARISON due to EXPORT_SCHEMA=1.",
-    );
-    return;
-  }
   const { path, result, ext, config } = props;
   const basePath = path.replace(/\.test\.graphql$/, "");
   if (basePath === path) {

--- a/postgraphile/postgraphile/__tests__/helpers.ts
+++ b/postgraphile/postgraphile/__tests__/helpers.ts
@@ -58,7 +58,20 @@ import { makeV4Preset } from "../src/presets/v4.js";
  */
 export const UPDATE_SNAPSHOTS = process.env.UPDATE_SNAPSHOTS === "1";
 
-const EXPORT_SCHEMA_MODE = process.env.EXPORT_SCHEMA === "1";
+const EXPORT_SCHEMA_MODE = process.env.EXPORT_SCHEMA as
+  | undefined
+  | "graphql-js"
+  | "typeDefs";
+
+if (
+  EXPORT_SCHEMA_MODE &&
+  EXPORT_SCHEMA_MODE !== "graphql-js" &&
+  EXPORT_SCHEMA_MODE !== "typeDefs"
+) {
+  throw new Error(
+    `EXPORT_SCHEMA must be unset, or set to 'graphql-js' or 'typeDefs'`,
+  );
+}
 
 async function getServerVersionNum(pgClient: Pool | PoolClient) {
   const versionResult = await pgClient.query("show server_version_num;");
@@ -185,7 +198,7 @@ async function importExportedSchema(schema: GraphQLSchema) {
   const tempDir = await mkdtemp(`${TMPDIR}/postgraphiletests-`);
   const targetFile = tempDir + "/schema.js";
   await exportSchema(schema, targetFile, {
-    mode: "typeDefs",
+    mode: EXPORT_SCHEMA_MODE,
     modules: {
       jsonwebtoken,
     },

--- a/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields-cut-down-for-export.json5
+++ b/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields-cut-down-for-export.json5
@@ -1,0 +1,10 @@
+{
+  postById: {
+    id: 1,
+    computedCompoundTypeArray: [
+      null,
+      null,
+      null,
+    ],
+  },
+}

--- a/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields-cut-down-for-export.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields-cut-down-for-export.mermaid
@@ -1,0 +1,60 @@
+%%{init: {'themeVariables': { 'fontSize': '12px'}}}%%
+graph TD
+    classDef path fill:#eee,stroke:#000,color:#000
+    classDef plan fill:#fff,stroke-width:1px,color:#000
+    classDef itemplan fill:#fff,stroke-width:2px,color:#000
+    classDef unbatchedplan fill:#dff,stroke-width:1px,color:#000
+    classDef sideeffectplan fill:#fcc,stroke-width:2px,color:#000
+    classDef bucket fill:#f6f6f6,color:#000,stroke-width:2px,text-align:left
+
+
+    %% plan dependencies
+    PgSelect8[["PgSelect[8∈0]<br />ᐸpostᐳ"]]:::plan
+    Object11{{"Object[11∈0]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Constant42{{"Constant[42∈0]<br />ᐸ1ᐳ"}}:::plan
+    Constant43{{"Constant[43∈0]<br />ᐸ[Object: null prototype] {}ᐳ"}}:::plan
+    Object11 & Constant42 & Constant43 --> PgSelect8
+    Access9{{"Access[9∈0]<br />ᐸ3.pgSettingsᐳ"}}:::plan
+    Access10{{"Access[10∈0]<br />ᐸ3.withPgClientᐳ"}}:::plan
+    Access9 & Access10 --> Object11
+    __Value3["__Value[3∈0]<br />ᐸcontextᐳ"]:::plan
+    __Value3 --> Access9
+    __Value3 --> Access10
+    First12{{"First[12∈0]"}}:::plan
+    PgSelect8 --> First12
+    PgSelectSingle13{{"PgSelectSingle[13∈0]<br />ᐸpostᐳ"}}:::plan
+    First12 --> PgSelectSingle13
+    __Value0["__Value[0∈0]"]:::plan
+    __Value5["__Value[5∈0]<br />ᐸrootValueᐳ"]:::plan
+    PgClassExpression14{{"PgClassExpression[14∈1]<br />ᐸ__post__.”id”ᐳ"}}:::plan
+    PgSelectSingle13 --> PgClassExpression14
+    Access39{{"Access[39∈1]<br />ᐸ40.0ᐳ"}}:::plan
+    RemapKeys40{{"RemapKeys[40∈1]<br />ᐸ13:{”0”:1}ᐳ"}}:::plan
+    RemapKeys40 --> Access39
+    PgSelectSingle13 --> RemapKeys40
+    __Item37[/"__Item[37∈2]<br />ᐸ39ᐳ"\]:::itemplan
+    Access39 ==> __Item37
+    PgSelectSingle38{{"PgSelectSingle[38∈2]<br />ᐸpost_computed_compound_type_arrayᐳ"}}:::plan
+    __Item37 --> PgSelectSingle38
+
+    %% define steps
+
+    subgraph "Buckets for queries/v4/procedure-computed-fields-cut-down-for-export"
+    Bucket0("Bucket 0 (root)<br />1: <br />ᐳ: 9, 10, 42, 43, 11<br />2: PgSelect[8]<br />ᐳ: First[12], PgSelectSingle[13]"):::bucket
+    classDef bucket0 stroke:#696969
+    class Bucket0,__Value0,__Value3,__Value5,PgSelect8,Access9,Access10,Object11,First12,PgSelectSingle13,Constant42,Constant43 bucket0
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 13<br /><br />ROOT PgSelectSingleᐸpostᐳ[13]"):::bucket
+    classDef bucket1 stroke:#00bfff
+    class Bucket1,PgClassExpression14,Access39,RemapKeys40 bucket1
+    Bucket2("Bucket 2 (listItem)<br />ROOT __Item{2}ᐸ39ᐳ[37]"):::bucket
+    classDef bucket2 stroke:#7f007f
+    class Bucket2,__Item37,PgSelectSingle38 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 38<br /><br />ROOT PgSelectSingle{2}ᐸpost_computed_compound_type_arrayᐳ[38]"):::bucket
+    classDef bucket3 stroke:#ffa500
+    class Bucket3 bucket3
+    Bucket0 --> Bucket1
+    Bucket1 --> Bucket2
+    Bucket2 --> Bucket3
+    classDef unary fill:#fafffa,borderWidth:8px
+    class PgSelect8,Object11,Access9,Access10,First12,PgSelectSingle13,__Value0,__Value3,__Value5,Constant42,Constant43,PgClassExpression14,Access39,RemapKeys40 unary
+    end

--- a/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields-cut-down-for-export.sql
+++ b/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields-cut-down-for-export.sql
@@ -1,0 +1,21 @@
+select __post_result__.*
+from (select 0 as idx, $1::"int4" as "id0", $2::"c"."compound_type" as "id1") as __post_identifiers__,
+lateral (
+  select
+    __post__."id"::text as "0",
+    (select json_agg(s) from (
+      select
+        (not (__post_computed_compound_type_array__ is null))::text as "0"
+      from unnest("a"."post_computed_compound_type_array"(
+        __post_2,
+        __post_identifiers__."id1"
+      )) as __post_computed_compound_type_array__
+    ) s) as "1",
+    __post_identifiers__.idx as "2"
+  from "a"."post" as __post__
+  left outer join lateral (select (__post__).*) as __post_2
+  on TRUE
+  where (
+    __post__."id" = __post_identifiers__."id0"
+  )
+) as __post_result__;

--- a/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields-cut-down-for-export.test.graphql
+++ b/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields-cut-down-for-export.test.graphql
@@ -1,0 +1,11 @@
+## expect(errors).toBeFalsy();
+#> schema: ["a"]
+#> subscriptions: true
+query {
+  postById(id: 1) {
+    id
+    computedCompoundTypeArray(object: {}) {
+      __typename
+    }
+  }
+}

--- a/postgraphile/postgraphile/__tests__/schema/v4/core.ts
+++ b/postgraphile/postgraphile/__tests__/schema/v4/core.ts
@@ -15,7 +15,7 @@ import {
   withPoolClientTransaction,
 } from "../../helpers.js";
 
-jest.setTimeout(30000);
+jest.setTimeout(60000);
 
 let countByPath = Object.create(null);
 

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, domainOfCodec, enumCodec, listOfCodec, makeRegistry, pgClassExpression, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectFromRecords, pgSelectSingleFromRecord, pgUpdateSingle, rangeOfCodec, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
+import { GraphQLError, GraphQLInt, GraphQLString, Kind, valueFromASTUntyped } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -442,21 +459,20 @@ const textArrayCodec = listOfCodec(TYPES.text, {
   description: undefined,
   name: "textArray"
 });
-const nonUpdatableViewAttributes = Object.assign(Object.create(null), {
-  "?column?": {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const nonUpdatableViewCodec = recordCodec({
+const spec_nonUpdatableView = {
   name: "nonUpdatableView",
   identifier: sql.identifier("a", "non_updatable_view"),
-  attributes: nonUpdatableViewAttributes,
+  attributes: Object.assign(Object.create(null), {
+    "?column?": {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -467,23 +483,23 @@ const nonUpdatableViewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const inputsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const inputsCodec = recordCodec({
+  executor: executor
+};
+const nonUpdatableViewCodec = recordCodec(spec_nonUpdatableView);
+const spec_inputs = {
   name: "inputs",
   identifier: sql.identifier("a", "inputs"),
-  attributes: inputsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Should output as Input",
   extensions: {
     isTableLike: true,
@@ -494,23 +510,23 @@ const inputsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const patchsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const patchsCodec = recordCodec({
+  executor: executor
+};
+const inputsCodec = recordCodec(spec_inputs);
+const spec_patchs = {
   name: "patchs",
   identifier: sql.identifier("a", "patchs"),
-  attributes: patchsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Should output as Patch",
   extensions: {
     isTableLike: true,
@@ -521,23 +537,23 @@ const patchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const reservedAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const reservedCodec = recordCodec({
+  executor: executor
+};
+const patchsCodec = recordCodec(spec_patchs);
+const spec_reserved = {
   name: "reserved",
   identifier: sql.identifier("a", "reserved"),
-  attributes: reservedAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -548,23 +564,23 @@ const reservedCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const reservedPatchsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const reservedPatchsCodec = recordCodec({
+  executor: executor
+};
+const reservedCodec = recordCodec(spec_reserved);
+const spec_reservedPatchs = {
   name: "reservedPatchs",
   identifier: sql.identifier("a", "reservedPatchs"),
-  attributes: reservedPatchsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   extensions: {
     isTableLike: true,
@@ -575,23 +591,23 @@ const reservedPatchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const reservedInputAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const reservedInputCodec = recordCodec({
+  executor: executor
+};
+const reservedPatchsCodec = recordCodec(spec_reservedPatchs);
+const spec_reservedInput = {
   name: "reservedInput",
   identifier: sql.identifier("a", "reserved_input"),
-  attributes: reservedInputAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
   extensions: {
     isTableLike: true,
@@ -602,32 +618,32 @@ const reservedInputCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const defaultValueAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  null_value: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const defaultValueCodec = recordCodec({
+  executor: executor
+};
+const reservedInputCodec = recordCodec(spec_reservedInput);
+const spec_defaultValue = {
   name: "defaultValue",
   identifier: sql.identifier("a", "default_value"),
-  attributes: defaultValueAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    null_value: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -638,41 +654,41 @@ const defaultValueCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const foreignKeyAttributes = Object.assign(Object.create(null), {
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_key_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_key_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const foreignKeyCodec = recordCodec({
+  executor: executor
+};
+const defaultValueCodec = recordCodec(spec_defaultValue);
+const spec_foreignKey = {
   name: "foreignKey",
   identifier: sql.identifier("a", "foreign_key"),
-  attributes: foreignKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_key_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_key_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -683,32 +699,32 @@ const foreignKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  str: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const noPrimaryKeyCodec = recordCodec({
+  executor: executor
+};
+const foreignKeyCodec = recordCodec(spec_foreignKey);
+const spec_noPrimaryKey = {
   name: "noPrimaryKey",
   identifier: sql.identifier("a", "no_primary_key"),
-  attributes: noPrimaryKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    str: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -719,41 +735,41 @@ const noPrimaryKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const testviewAttributes = Object.assign(Object.create(null), {
-  testviewid: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const testviewCodec = recordCodec({
+  executor: executor
+};
+const noPrimaryKeyCodec = recordCodec(spec_noPrimaryKey);
+const spec_testview = {
   name: "testview",
   identifier: sql.identifier("a", "testview"),
-  attributes: testviewAttributes,
+  attributes: Object.assign(Object.create(null), {
+    testviewid: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -764,21 +780,10 @@ const testviewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const extensions12 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "unique_foreign_key"
-  },
-  tags: Object.assign(Object.create(null), {
-    omit: "create,update,delete,all,order,filter",
-    behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy"]
-  })
+  executor: executor
 };
-const uniqueForeignKeyCodec = recordCodec({
+const testviewCodec = recordCodec(spec_testview);
+const spec_uniqueForeignKey = {
   name: "uniqueForeignKey",
   identifier: sql.identifier("a", "unique_foreign_key"),
   attributes: Object.assign(Object.create(null), {
@@ -802,33 +807,44 @@ const uniqueForeignKeyCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions: extensions12,
-  executor
-});
-const myTableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "unique_foreign_key"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: "create,update,delete,all,order,filter",
+      behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy"]
+    })
   },
-  json_data: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const myTableCodec = recordCodec({
+  executor: executor
+};
+const uniqueForeignKeyCodec = recordCodec(spec_uniqueForeignKey);
+const spec_myTable = {
   name: "myTable",
   identifier: sql.identifier("c", "my_table"),
-  attributes: myTableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    json_data: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -839,34 +855,34 @@ const myTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const personSecretAttributes = Object.assign(Object.create(null), {
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  sekrit: {
-    description: "A secret held by the associated Person",
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "secret"
-      }
-    }
-  }
-});
-const personSecretCodec = recordCodec({
+  executor: executor
+};
+const myTableCodec = recordCodec(spec_myTable);
+const spec_personSecret = {
   name: "personSecret",
   identifier: sql.identifier("c", "person_secret"),
-  attributes: personSecretAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    sekrit: {
+      description: "A secret held by the associated Person",
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "secret"
+        }
+      }
+    }
+  }),
   description: "Tracks the person's secret",
   extensions: {
     isTableLike: true,
@@ -879,41 +895,41 @@ const personSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor
-});
-const viewTableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const viewTableCodec = recordCodec({
+  executor: executor
+};
+const personSecretCodec = recordCodec(spec_personSecret);
+const spec_viewTable = {
   name: "viewTable",
   identifier: sql.identifier("a", "view_table"),
-  attributes: viewTableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -924,41 +940,41 @@ const viewTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const compoundKeyAttributes = Object.assign(Object.create(null), {
-  person_id_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  extra: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const compoundKeyCodec = recordCodec({
+  executor: executor
+};
+const viewTableCodec = recordCodec(spec_viewTable);
+const spec_compoundKey = {
   name: "compoundKey",
   identifier: sql.identifier("c", "compound_key"),
-  attributes: compoundKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    extra: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -969,50 +985,50 @@ const compoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const similarTable1Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col3: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const similarTable1Codec = recordCodec({
+  executor: executor
+};
+const compoundKeyCodec = recordCodec(spec_compoundKey);
+const spec_similarTable1 = {
   name: "similarTable1",
   identifier: sql.identifier("a", "similar_table_1"),
-  attributes: similarTable1Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col3: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1023,50 +1039,50 @@ const similarTable1Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const similarTable2Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  col3: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col4: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col5: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const similarTable2Codec = recordCodec({
+  executor: executor
+};
+const similarTable1Codec = recordCodec(spec_similarTable1);
+const spec_similarTable2 = {
   name: "similarTable2",
   identifier: sql.identifier("a", "similar_table_2"),
-  attributes: similarTable2Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    col3: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col4: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col5: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1077,50 +1093,50 @@ const similarTable2Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const updatableViewAttributes = Object.assign(Object.create(null), {
-  x: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  description: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  constant: {
-    description: "This is constantly 2",
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const updatableViewCodec = recordCodec({
+  executor: executor
+};
+const similarTable2Codec = recordCodec(spec_similarTable2);
+const spec_updatableView = {
   name: "updatableView",
   identifier: sql.identifier("b", "updatable_view"),
-  attributes: updatableViewAttributes,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    description: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    constant: {
+      description: "This is constantly 2",
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "YOYOYO!!",
   extensions: {
     isTableLike: true,
@@ -1134,50 +1150,50 @@ const updatableViewCodec = recordCodec({
       unique: "x|@behavior -single -update -delete"
     })
   },
-  executor
-});
-const nullTestRecordAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_int: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  non_null_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const nullTestRecordCodec = recordCodec({
+  executor: executor
+};
+const updatableViewCodec = recordCodec(spec_updatableView);
+const spec_nullTestRecord = {
   name: "nullTestRecord",
   identifier: sql.identifier("c", "null_test_record"),
-  attributes: nullTestRecordAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_int: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    non_null_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1188,8 +1204,9 @@ const nullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const nullTestRecordCodec = recordCodec(spec_nullTestRecord);
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   extensions: {
     pg: {
@@ -1203,39 +1220,38 @@ const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   description: undefined,
   name: "uuidArray"
 });
-const edgeCaseAttributes = Object.assign(Object.create(null), {
-  not_null_has_default: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  wont_cast_easy: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  row_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const edgeCaseCodec = recordCodec({
+const spec_edgeCase = {
   name: "edgeCase",
   identifier: sql.identifier("c", "edge_case"),
-  attributes: edgeCaseAttributes,
+  attributes: Object.assign(Object.create(null), {
+    not_null_has_default: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    wont_cast_easy: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    row_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1246,50 +1262,50 @@ const edgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const leftArmAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  length_in_metres: {
-    description: undefined,
-    codec: TYPES.float,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  mood: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const leftArmCodec = recordCodec({
+  executor: executor
+};
+const edgeCaseCodec = recordCodec(spec_edgeCase);
+const spec_leftArm = {
   name: "leftArm",
   identifier: sql.identifier("c", "left_arm"),
-  attributes: leftArmAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    length_in_metres: {
+      description: undefined,
+      codec: TYPES.float,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    mood: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Tracks metadata about the left arms of various people",
   extensions: {
     isTableLike: true,
@@ -1300,8 +1316,9 @@ const leftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const leftArmCodec = recordCodec(spec_leftArm);
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
   identifier: sql.identifier("b", "jwt_token"),
@@ -1362,7 +1379,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
@@ -1376,30 +1393,29 @@ const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp
   },
   notNull: true
 });
-const issue756Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  ts: {
-    description: undefined,
-    codec: notNullTimestampCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const issue756Codec = recordCodec({
+const spec_issue756 = {
   name: "issue756",
   identifier: sql.identifier("c", "issue756"),
-  attributes: issue756Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    ts: {
+      description: undefined,
+      codec: notNullTimestampCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1410,8 +1426,9 @@ const issue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const issue756Codec = recordCodec(spec_issue756);
 const authPayloadCodec = recordCodec({
   name: "authPayload",
   identifier: sql.identifier("b", "auth_payload"),
@@ -1456,7 +1473,7 @@ const authPayloadCodec = recordCodec({
       foreignKey: "(id) references c.person"
     })
   },
-  executor
+  executor: executor
 });
 const colorCodec = enumCodec({
   name: "color",
@@ -1587,7 +1604,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
@@ -1709,7 +1726,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1724,66 +1741,65 @@ const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   description: undefined,
   name: "comptypeArray"
 });
-const postAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  headline: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  body: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  enums: {
-    description: undefined,
-    codec: anEnumArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  comptypes: {
-    description: undefined,
-    codec: comptypeArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const postCodec = recordCodec({
+const spec_post = {
   name: "post",
   identifier: sql.identifier("a", "post"),
-  attributes: postAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    headline: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    body: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    enums: {
+      description: undefined,
+      codec: anEnumArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    comptypes: {
+      description: undefined,
+      codec: comptypeArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1794,8 +1810,9 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const postCodec = recordCodec(spec_post);
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
@@ -1942,117 +1959,116 @@ const wrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const personAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: "The primary unique identifier for the person",
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_full_name: {
-    description: "The person\u2019s name",
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "name"
-      }
-    }
-  },
-  aliases: {
-    description: undefined,
-    codec: textArrayCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  about: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  email: {
-    description: undefined,
-    codec: emailCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  site: {
-    description: undefined,
-    codec: wrappedUrlCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        deprecated: "Don\u2019t use me"
-      }
-    }
-  },
-  config: {
-    description: undefined,
-    codec: TYPES.hstore,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_login_from_ip: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_login_from_subnet: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  user_mac: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  created_at: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const personCodec = recordCodec({
+const spec_person = {
   name: "person",
   identifier: sql.identifier("c", "person"),
-  attributes: personAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: "The primary unique identifier for the person",
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_full_name: {
+      description: "The person\u2019s name",
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "name"
+        }
+      }
+    },
+    aliases: {
+      description: undefined,
+      codec: textArrayCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    about: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    email: {
+      description: undefined,
+      codec: emailCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    site: {
+      description: undefined,
+      codec: wrappedUrlCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          deprecated: "Don\u2019t use me"
+        }
+      }
+    },
+    config: {
+      description: undefined,
+      codec: TYPES.hstore,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_login_from_ip: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_login_from_subnet: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    user_mac: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    created_at: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Person test comment",
   extensions: {
     isTableLike: true,
@@ -2063,8 +2079,9 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const personCodec = recordCodec(spec_person);
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
@@ -2397,7 +2414,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -2449,7 +2466,7 @@ const byteaArrayCodec = listOfCodec(TYPES.bytea, {
   description: undefined,
   name: "byteaArray"
 });
-const typesAttributes_ltree_codec_ltree = {
+const spec_types_attributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -2461,469 +2478,468 @@ const typesAttributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
-const typesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  smallint: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bigint: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numeric: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  decimal: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  boolean: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  varchar: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum_array: {
-    description: undefined,
-    codec: colorArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain: {
-    description: undefined,
-    codec: anIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain2: {
-    description: undefined,
-    codec: anotherIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array: {
-    description: undefined,
-    codec: textArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  json: {
-    description: undefined,
-    codec: TYPES.json,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  jsonb: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_range: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numrange: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  daterange: {
-    description: undefined,
-    codec: daterangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  an_int_range: {
-    description: undefined,
-    codec: anIntRangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamp: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamptz: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  date: {
-    description: undefined,
-    codec: TYPES.date,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  time: {
-    description: undefined,
-    codec: TYPES.time,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timetz: {
-    description: undefined,
-    codec: TYPES.timetz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval_array: {
-    description: undefined,
-    codec: intervalArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  money: {
-    description: undefined,
-    codec: TYPES.money,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  point: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullablePoint: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  inet: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  cidr: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  macaddr: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regproc: {
-    description: undefined,
-    codec: TYPES.regproc,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regprocedure: {
-    description: undefined,
-    codec: TYPES.regprocedure,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoper: {
-    description: undefined,
-    codec: TYPES.regoper,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoperator: {
-    description: undefined,
-    codec: TYPES.regoperator,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regclass: {
-    description: undefined,
-    codec: TYPES.regclass,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regtype: {
-    description: undefined,
-    codec: TYPES.regtype,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regconfig: {
-    description: undefined,
-    codec: TYPES.regconfig,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regdictionary: {
-    description: undefined,
-    codec: TYPES.regdictionary,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array_domain: {
-    description: undefined,
-    codec: textArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  int8_array_domain: {
-    description: undefined,
-    codec: int8ArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea: {
-    description: undefined,
-    codec: TYPES.bytea,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea_array: {
-    description: undefined,
-    codec: byteaArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree: {
-    description: undefined,
-    codec: typesAttributes_ltree_codec_ltree,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree_array: {
-    description: undefined,
-    codec: typesAttributes_ltree_array_codec_ltree_,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions46 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "types"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: ["(smallint) references a.post", "(id) references a.post"]
-  })
-};
-const typesCodec = recordCodec({
+const spec_types_attributes_ltree_array_codec_ltree_ = listOfCodec(spec_types_attributes_ltree_codec_ltree);
+const spec_types = {
   name: "types",
   identifier: sql.identifier("b", "types"),
-  attributes: typesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    smallint: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bigint: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numeric: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    decimal: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    boolean: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    varchar: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum_array: {
+      description: undefined,
+      codec: colorArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain: {
+      description: undefined,
+      codec: anIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain2: {
+      description: undefined,
+      codec: anotherIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array: {
+      description: undefined,
+      codec: textArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    json: {
+      description: undefined,
+      codec: TYPES.json,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    jsonb: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_range: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numrange: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    daterange: {
+      description: undefined,
+      codec: daterangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    an_int_range: {
+      description: undefined,
+      codec: anIntRangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamp: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamptz: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    date: {
+      description: undefined,
+      codec: TYPES.date,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    time: {
+      description: undefined,
+      codec: TYPES.time,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timetz: {
+      description: undefined,
+      codec: TYPES.timetz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval_array: {
+      description: undefined,
+      codec: intervalArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    money: {
+      description: undefined,
+      codec: TYPES.money,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    point: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullablePoint: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    inet: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    cidr: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    macaddr: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regproc: {
+      description: undefined,
+      codec: TYPES.regproc,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regprocedure: {
+      description: undefined,
+      codec: TYPES.regprocedure,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoper: {
+      description: undefined,
+      codec: TYPES.regoper,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoperator: {
+      description: undefined,
+      codec: TYPES.regoperator,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regclass: {
+      description: undefined,
+      codec: TYPES.regclass,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regtype: {
+      description: undefined,
+      codec: TYPES.regtype,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regconfig: {
+      description: undefined,
+      codec: TYPES.regconfig,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regdictionary: {
+      description: undefined,
+      codec: TYPES.regdictionary,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array_domain: {
+      description: undefined,
+      codec: textArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    int8_array_domain: {
+      description: undefined,
+      codec: int8ArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea: {
+      description: undefined,
+      codec: TYPES.bytea,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea_array: {
+      description: undefined,
+      codec: byteaArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree: {
+      description: undefined,
+      codec: spec_types_attributes_ltree_codec_ltree,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree_array: {
+      description: undefined,
+      codec: spec_types_attributes_ltree_array_codec_ltree_,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions46,
-  executor
-});
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "types"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: ["(smallint) references a.post", "(id) references a.post"]
+    })
+  },
+  executor: executor
+};
+const typesCodec = recordCodec(spec_types);
 const int4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
     pg: {
@@ -3116,7 +3132,7 @@ const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
     },
     tags: {
       omit: "create,update,delete,all,order,filter",
-      behavior: extensions12.tags.behavior
+      behavior: spec_uniqueForeignKey.extensions.tags.behavior
     }
   }
 };
@@ -3465,7 +3481,7 @@ const registryConfig_pgResources_types_types = {
       name: "types"
     },
     tags: {
-      foreignKey: extensions46.tags.foreignKey
+      foreignKey: spec_types.extensions.tags.foreignKey
     }
   }
 };
@@ -3588,8 +3604,8 @@ const registry = makeRegistry({
     int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
     byteaArray: byteaArrayCodec,
-    ltree: typesAttributes_ltree_codec_ltree,
-    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
+    ltree: spec_types_attributes_ltree_codec_ltree,
+    "ltree[]": spec_types_attributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     compoundTypeArray: listOfCodec(compoundTypeCodec, {
       extensions: {
@@ -3676,7 +3692,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor
+      executor: executor
     }),
     tablefuncCrosstab3: recordCodec({
       name: "tablefuncCrosstab3",
@@ -3729,7 +3745,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor
+      executor: executor
     }),
     tablefuncCrosstab4: recordCodec({
       name: "tablefuncCrosstab4",
@@ -3791,7 +3807,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor
+      executor: executor
     })
   }),
   pgResources: Object.assign(Object.create(null), {
@@ -12373,6 +12389,15 @@ const makeArgs64 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
+function UUIDSerialize(value) {
+  return "" + value;
+}
+const coerce = string => {
+  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
+    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
+  }
+  return string;
+};
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -12877,6 +12902,60 @@ const makeArgs73 = (args, path = []) => {
 const resource_post_computed_compound_type_arrayPgResource = registry.pgResources["post_computed_compound_type_array"];
 const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
+function LTreeParseValue(value) {
+  return value;
+}
+const isValidHstoreObject = obj => {
+  if (obj === null) {
+    // Null is okay
+    return true;
+  } else if (typeof obj === "object") {
+    // A hash with string/null values is also okay
+    const keys = Object.keys(obj);
+    for (const key of keys) {
+      const val = obj[key];
+      if (val === null) {
+        // Null is okay
+      } else if (typeof val === "string") {
+        // String is okay
+      } else {
+        // Everything else is invalid.
+        return false;
+      }
+    }
+    return true;
+  } else {
+    // Everything else is invalid.
+    return false;
+  }
+};
+const parseValueLiteral = (ast, variables) => {
+  switch (ast.kind) {
+    case Kind.INT:
+    case Kind.FLOAT:
+      // Number isn't really okay, but we'll coerce it to a string anyway.
+      return String(parseFloat(ast.value));
+    case Kind.STRING:
+      // String is okay.
+      return String(ast.value);
+    case Kind.NULL:
+      // Null is okay.
+      return null;
+    case Kind.VARIABLE:
+      {
+        // Variable is okay if that variable is either a string or null.
+        const name = ast.name.value;
+        const value = variables ? variables[name] : undefined;
+        if (value === null || typeof value === "string") {
+          return value;
+        }
+        return undefined;
+      }
+    default:
+      // Everything else is invalid.
+      return undefined;
+  }
+};
 const argDetailsSimple74 = [];
 const makeArgs74 = (args, path = []) => {
   const selectArgs = [];
@@ -29725,6 +29804,11 @@ export const plans = {
       return $record.get("o");
     }
   },
+  Email: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
   PersonComputedFirstArgInoutOutRecord: {
     __assertStep: assertPgClassSingleStep,
     person($record) {
@@ -29834,6 +29918,19 @@ export const plans = {
     },
     BLUE: {
       value: "blue"
+    }
+  },
+  UUID: {
+    serialize: UUIDSerialize,
+    parseValue(value) {
+      return coerce("" + value);
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // ERRORS: add name to this error
+        throw new GraphQLError(`${"UUID" ?? "This scalar"} can only parse string values (kind = '${ast.kind}')`);
+      }
+      return coerce(ast.value);
     }
   },
   EnumCaps: {
@@ -30340,6 +30437,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -30356,6 +30463,9 @@ export const plans = {
     }
   },
   CompoundTypeInput: {
+    "__inputPlan": function CompoundTypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     a: {
       applyPlan($insert, val) {
         $insert.set("a", val.get());
@@ -30484,6 +30594,16 @@ export const plans = {
     },
     isOptimised($record) {
       return $record.get("is_optimised");
+    }
+  },
+  Datetime: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   TypesConnection: {
@@ -30690,12 +30810,77 @@ export const plans = {
       });
     }
   },
+  BigInt: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigInt" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  BigFloat: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigFloat" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  AnInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
+  AnotherInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
+  JSON: {
+    serialize(value) {
+      return JSON.stringify(value);
+    },
+    parseValue(value) {
+      return JSON.parse(value);
+    },
+    parseLiteral(ast, _variables) {
+      if (ast.kind === Kind.STRING) {
+        return JSON.parse(ast.value);
+      } else {
+        return undefined;
+      }
+    }
+  },
   BigFloatRange: {},
   BigFloatRangeBound: {},
   DateRange: {},
   DateRangeBound: {},
+  Date: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Date" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   AnIntRange: {},
   AnIntRangeBound: {},
+  Time: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Time" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   NestedCompoundType: {
     __assertStep: assertPgClassSingleStep,
     a($record) {
@@ -30721,6 +30906,128 @@ export const plans = {
     }
   },
   Point: {},
+  InternetAddress: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"InternetAddress" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProc: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProc" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProcedure: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProcedure" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOper: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOper" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOperator: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOperator" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegClass: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegClass" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegType: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegType" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegConfig: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegConfig" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegDictionary: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegDictionary" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  Base64EncodedBinary: {
+    serialize(data) {
+      if (Buffer.isBuffer(data)) {
+        return data.toString("base64");
+      } else {
+        throw new Error(`Base64EncodeBinary can only be used with Node.js buffers.`);
+      }
+    },
+    parseValue(data) {
+      if (typeof data === "string") {
+        return Buffer.from(data, "base64");
+      } else {
+        throw new GraphQLError("Base64EncodedBinary can only parse string values.");
+      }
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // TODO: add name to this error
+        throw new GraphQLError("Base64EncodedBinary can only parse string values");
+      }
+      return Buffer.from(ast.value, "base64");
+    }
+  },
+  LTree: {
+    serialize(x) {
+      return x;
+    },
+    parseValue: LTreeParseValue,
+    parseLiteral(node, variables) {
+      return LTreeParseValue(valueFromASTUntyped(node, variables));
+    }
+  },
   TypesEdge: {
     __assertStep: assertEdgeCapableStep,
     cursor($edge) {
@@ -32041,7 +32348,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.id.codec)}`;
             }
           });
         }
@@ -32064,7 +32371,7 @@ export const plans = {
             type: "attribute",
             attribute: "smallint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.smallint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.smallint.codec)}`;
             }
           });
         }
@@ -32087,7 +32394,7 @@ export const plans = {
             type: "attribute",
             attribute: "bigint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.bigint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.bigint.codec)}`;
             }
           });
         }
@@ -32110,7 +32417,7 @@ export const plans = {
             type: "attribute",
             attribute: "numeric",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numeric.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.numeric.codec)}`;
             }
           });
         }
@@ -32133,7 +32440,7 @@ export const plans = {
             type: "attribute",
             attribute: "decimal",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.decimal.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.decimal.codec)}`;
             }
           });
         }
@@ -32156,7 +32463,7 @@ export const plans = {
             type: "attribute",
             attribute: "boolean",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.boolean.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.boolean.codec)}`;
             }
           });
         }
@@ -32179,7 +32486,7 @@ export const plans = {
             type: "attribute",
             attribute: "varchar",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.varchar.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.varchar.codec)}`;
             }
           });
         }
@@ -32202,7 +32509,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.enum.codec)}`;
             }
           });
         }
@@ -32225,7 +32532,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.enum_array.codec)}`;
             }
           });
         }
@@ -32248,7 +32555,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.domain.codec)}`;
             }
           });
         }
@@ -32271,7 +32578,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.domain2.codec)}`;
             }
           });
         }
@@ -32294,7 +32601,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.text_array.codec)}`;
             }
           });
         }
@@ -32317,7 +32624,7 @@ export const plans = {
             type: "attribute",
             attribute: "json",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.json.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.json.codec)}`;
             }
           });
         }
@@ -32340,7 +32647,7 @@ export const plans = {
             type: "attribute",
             attribute: "jsonb",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.jsonb.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.jsonb.codec)}`;
             }
           });
         }
@@ -32363,7 +32670,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullable_range.codec)}`;
             }
           });
         }
@@ -32386,7 +32693,7 @@ export const plans = {
             type: "attribute",
             attribute: "numrange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numrange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.numrange.codec)}`;
             }
           });
         }
@@ -32409,7 +32716,7 @@ export const plans = {
             type: "attribute",
             attribute: "daterange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.daterange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.daterange.codec)}`;
             }
           });
         }
@@ -32432,7 +32739,7 @@ export const plans = {
             type: "attribute",
             attribute: "an_int_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.an_int_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.an_int_range.codec)}`;
             }
           });
         }
@@ -32455,7 +32762,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamp",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamp.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.timestamp.codec)}`;
             }
           });
         }
@@ -32478,7 +32785,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamptz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamptz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.timestamptz.codec)}`;
             }
           });
         }
@@ -32501,7 +32808,7 @@ export const plans = {
             type: "attribute",
             attribute: "date",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.date.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.date.codec)}`;
             }
           });
         }
@@ -32524,7 +32831,7 @@ export const plans = {
             type: "attribute",
             attribute: "time",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.time.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.time.codec)}`;
             }
           });
         }
@@ -32547,7 +32854,7 @@ export const plans = {
             type: "attribute",
             attribute: "timetz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timetz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.timetz.codec)}`;
             }
           });
         }
@@ -32570,7 +32877,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.interval.codec)}`;
             }
           });
         }
@@ -32593,7 +32900,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.interval_array.codec)}`;
             }
           });
         }
@@ -32616,7 +32923,7 @@ export const plans = {
             type: "attribute",
             attribute: "money",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.money.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.money.codec)}`;
             }
           });
         }
@@ -32639,7 +32946,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.compound_type.codec)}`;
             }
           });
         }
@@ -32662,7 +32969,7 @@ export const plans = {
             type: "attribute",
             attribute: "nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nested_compound_type.codec)}`;
             }
           });
         }
@@ -32685,7 +32992,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullable_compound_type.codec)}`;
             }
           });
         }
@@ -32708,7 +33015,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullable_nested_compound_type.codec)}`;
             }
           });
         }
@@ -32731,7 +33038,7 @@ export const plans = {
             type: "attribute",
             attribute: "point",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.point.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.point.codec)}`;
             }
           });
         }
@@ -32754,7 +33061,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullablePoint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullablePoint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullablePoint.codec)}`;
             }
           });
         }
@@ -32777,7 +33084,7 @@ export const plans = {
             type: "attribute",
             attribute: "inet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.inet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.inet.codec)}`;
             }
           });
         }
@@ -32800,7 +33107,7 @@ export const plans = {
             type: "attribute",
             attribute: "cidr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.cidr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.cidr.codec)}`;
             }
           });
         }
@@ -32823,7 +33130,7 @@ export const plans = {
             type: "attribute",
             attribute: "macaddr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.macaddr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.macaddr.codec)}`;
             }
           });
         }
@@ -32846,7 +33153,7 @@ export const plans = {
             type: "attribute",
             attribute: "regproc",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regproc.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regproc.codec)}`;
             }
           });
         }
@@ -32869,7 +33176,7 @@ export const plans = {
             type: "attribute",
             attribute: "regprocedure",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regprocedure.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regprocedure.codec)}`;
             }
           });
         }
@@ -32892,7 +33199,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoper",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoper.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regoper.codec)}`;
             }
           });
         }
@@ -32915,7 +33222,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoperator",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoperator.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regoperator.codec)}`;
             }
           });
         }
@@ -32938,7 +33245,7 @@ export const plans = {
             type: "attribute",
             attribute: "regclass",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regclass.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regclass.codec)}`;
             }
           });
         }
@@ -32961,7 +33268,7 @@ export const plans = {
             type: "attribute",
             attribute: "regtype",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regtype.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regtype.codec)}`;
             }
           });
         }
@@ -32984,7 +33291,7 @@ export const plans = {
             type: "attribute",
             attribute: "regconfig",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regconfig.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regconfig.codec)}`;
             }
           });
         }
@@ -33007,7 +33314,7 @@ export const plans = {
             type: "attribute",
             attribute: "regdictionary",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regdictionary.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regdictionary.codec)}`;
             }
           });
         }
@@ -33030,7 +33337,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.text_array_domain.codec)}`;
             }
           });
         }
@@ -33053,7 +33360,7 @@ export const plans = {
             type: "attribute",
             attribute: "int8_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.int8_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.int8_array_domain.codec)}`;
             }
           });
         }
@@ -33076,7 +33383,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.ltree.codec)}`;
             }
           });
         }
@@ -33099,7 +33406,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.ltree_array.codec)}`;
             }
           });
         }
@@ -33133,6 +33440,9 @@ export const plans = {
     inclusive: undefined
   },
   NestedCompoundTypeInput: {
+    "__inputPlan": function NestedCompoundTypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     a: {
       applyPlan($insert, val) {
         $insert.set("a", val.get());
@@ -33627,6 +33937,50 @@ export const plans = {
       return $record.get("url");
     }
   },
+  NotNullUrl: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
+  KeyValueHash: {
+    serialize(value) {
+      return value;
+    },
+    parseValue(obj) {
+      if (isValidHstoreObject(obj)) {
+        return obj;
+      }
+      throw new GraphQLError(`This is not a valid ${"KeyValueHash"} object, it must be a key/value hash where keys and values are both strings (or null).`);
+    },
+    parseLiteral(ast, variables) {
+      switch (ast.kind) {
+        case Kind.OBJECT:
+          {
+            const value = ast.fields.reduce((memo, field) => {
+              memo[field.name.value] = parseValueLiteral(field.value, variables);
+              return memo;
+            }, Object.create(null));
+            if (!isValidHstoreObject(value)) {
+              return undefined;
+            }
+            return value;
+          }
+        case Kind.NULL:
+          return null;
+        case Kind.VARIABLE:
+          {
+            const name = ast.name.value;
+            const value = variables ? variables[name] : undefined;
+            if (!isValidHstoreObject(value)) {
+              return undefined;
+            }
+            return value;
+          }
+        default:
+          return undefined;
+      }
+    }
+  },
   PostsConnection: {
     __assertStep: ConnectionStep,
     nodes($connection) {
@@ -33871,7 +34225,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.id.codec)}`;
             }
           });
         }
@@ -33894,7 +34248,7 @@ export const plans = {
             type: "attribute",
             attribute: "headline",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.headline.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.headline.codec)}`;
             }
           });
         }
@@ -33917,7 +34271,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.body.codec)}`;
             }
           });
         }
@@ -33940,7 +34294,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.author_id.codec)}`;
             }
           });
         }
@@ -33963,7 +34317,7 @@ export const plans = {
             type: "attribute",
             attribute: "enums",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.enums.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.enums.codec)}`;
             }
           });
         }
@@ -33986,7 +34340,7 @@ export const plans = {
             type: "attribute",
             attribute: "comptypes",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.comptypes.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.comptypes.codec)}`;
             }
           });
         }
@@ -34011,6 +34365,9 @@ export const plans = {
     }
   },
   ComptypeInput: {
+    "__inputPlan": function ComptypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     schedule: {
       applyPlan($insert, val) {
         $insert.set("schedule", val.get());
@@ -34197,7 +34554,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_foreignKey.attributes.person_id.codec)}`;
             }
           });
         }
@@ -34220,7 +34577,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_foreignKey.attributes.compound_key_1.codec)}`;
             }
           });
         }
@@ -34243,7 +34600,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_foreignKey.attributes.compound_key_2.codec)}`;
             }
           });
         }
@@ -34474,7 +34831,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.person_id_2.codec)}`;
             }
           });
         }
@@ -34497,7 +34854,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.person_id_1.codec)}`;
             }
           });
         }
@@ -34520,7 +34877,7 @@ export const plans = {
             type: "attribute",
             attribute: "extra",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.extra.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.extra.codec)}`;
             }
           });
         }
@@ -34626,6 +34983,16 @@ export const plans = {
     },
     ts($record) {
       return $record.get("ts");
+    }
+  },
+  NotNullTimestamp: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   FuncOutSetofConnection: {
@@ -35021,7 +35388,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.id.codec)}`;
             }
           });
         }
@@ -35044,7 +35411,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_full_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.person_full_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.person_full_name.codec)}`;
             }
           });
         }
@@ -35067,7 +35434,7 @@ export const plans = {
             type: "attribute",
             attribute: "aliases",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.aliases.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.aliases.codec)}`;
             }
           });
         }
@@ -35090,7 +35457,7 @@ export const plans = {
             type: "attribute",
             attribute: "about",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.about.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.about.codec)}`;
             }
           });
         }
@@ -35113,7 +35480,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.email.codec)}`;
             }
           });
         }
@@ -35136,7 +35503,7 @@ export const plans = {
             type: "attribute",
             attribute: "site",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.site.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.site.codec)}`;
             }
           });
         }
@@ -35159,7 +35526,7 @@ export const plans = {
             type: "attribute",
             attribute: "config",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.config.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.config.codec)}`;
             }
           });
         }
@@ -35182,7 +35549,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_ip",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_ip.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_login_from_ip.codec)}`;
             }
           });
         }
@@ -35205,7 +35572,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_subnet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_subnet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_login_from_subnet.codec)}`;
             }
           });
         }
@@ -35228,7 +35595,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_mac",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.user_mac.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.user_mac.codec)}`;
             }
           });
         }
@@ -35251,7 +35618,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.created_at.codec)}`;
             }
           });
         }
@@ -35276,6 +35643,9 @@ export const plans = {
     }
   },
   WrappedUrlInput: {
+    "__inputPlan": function WrappedUrlInput_inputPlan() {
+      return object(Object.create(null));
+    },
     url: {
       applyPlan($insert, val) {
         $insert.set("url", val.get());
@@ -35370,7 +35740,7 @@ export const plans = {
             type: "attribute",
             attribute: "?column?",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nonUpdatableViewAttributes["?column?"].codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nonUpdatableView.attributes["?column?"].codec)}`;
             }
           });
         }
@@ -35491,7 +35861,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), inputsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_inputs.attributes.id.codec)}`;
             }
           });
         }
@@ -35612,7 +35982,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), patchsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_patchs.attributes.id.codec)}`;
             }
           });
         }
@@ -35733,7 +36103,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reserved.attributes.id.codec)}`;
             }
           });
         }
@@ -35854,7 +36224,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedPatchsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reservedPatchs.attributes.id.codec)}`;
             }
           });
         }
@@ -35975,7 +36345,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedInputAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reservedInput.attributes.id.codec)}`;
             }
           });
         }
@@ -36130,7 +36500,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_defaultValue.attributes.id.codec)}`;
             }
           });
         }
@@ -36153,7 +36523,7 @@ export const plans = {
             type: "attribute",
             attribute: "null_value",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.null_value.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_defaultValue.attributes.null_value.codec)}`;
             }
           });
         }
@@ -36276,7 +36646,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_noPrimaryKey.attributes.id.codec)}`;
             }
           });
         }
@@ -36299,7 +36669,7 @@ export const plans = {
             type: "attribute",
             attribute: "str",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.str.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_noPrimaryKey.attributes.str.codec)}`;
             }
           });
         }
@@ -36468,7 +36838,7 @@ export const plans = {
             type: "attribute",
             attribute: "testviewid",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.testviewid.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_testview.attributes.testviewid.codec)}`;
             }
           });
         }
@@ -36491,7 +36861,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_testview.attributes.col1.codec)}`;
             }
           });
         }
@@ -36514,7 +36884,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_testview.attributes.col2.codec)}`;
             }
           });
         }
@@ -36669,7 +37039,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_myTable.attributes.id.codec)}`;
             }
           });
         }
@@ -36692,7 +37062,7 @@ export const plans = {
             type: "attribute",
             attribute: "json_data",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.json_data.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_myTable.attributes.json_data.codec)}`;
             }
           });
         }
@@ -36847,7 +37217,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_personSecret.attributes.person_id.codec)}`;
             }
           });
         }
@@ -36870,7 +37240,7 @@ export const plans = {
             type: "attribute",
             attribute: "sekrit",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.sekrit.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_personSecret.attributes.sekrit.codec)}`;
             }
           });
         }
@@ -37059,7 +37429,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_viewTable.attributes.id.codec)}`;
             }
           });
         }
@@ -37082,7 +37452,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_viewTable.attributes.col1.codec)}`;
             }
           });
         }
@@ -37105,7 +37475,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_viewTable.attributes.col2.codec)}`;
             }
           });
         }
@@ -37328,7 +37698,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.id.codec)}`;
             }
           });
         }
@@ -37351,7 +37721,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.col1.codec)}`;
             }
           });
         }
@@ -37374,7 +37744,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.col2.codec)}`;
             }
           });
         }
@@ -37397,7 +37767,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.col3.codec)}`;
             }
           });
         }
@@ -37620,7 +37990,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.id.codec)}`;
             }
           });
         }
@@ -37643,7 +38013,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.col3.codec)}`;
             }
           });
         }
@@ -37666,7 +38036,7 @@ export const plans = {
             type: "attribute",
             attribute: "col4",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col4.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.col4.codec)}`;
             }
           });
         }
@@ -37689,7 +38059,7 @@ export const plans = {
             type: "attribute",
             attribute: "col5",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col5.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.col5.codec)}`;
             }
           });
         }
@@ -37895,7 +38265,7 @@ export const plans = {
             type: "attribute",
             attribute: "x",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.x.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.x.codec)}`;
             }
           });
         }
@@ -37918,7 +38288,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.name.codec)}`;
             }
           });
         }
@@ -37941,7 +38311,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.description.codec)}`;
             }
           });
         }
@@ -37964,7 +38334,7 @@ export const plans = {
             type: "attribute",
             attribute: "constant",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.constant.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.constant.codec)}`;
             }
           });
         }
@@ -38187,7 +38557,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.id.codec)}`;
             }
           });
         }
@@ -38210,7 +38580,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.nullable_text.codec)}`;
             }
           });
         }
@@ -38233,7 +38603,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_int",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_int.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.nullable_int.codec)}`;
             }
           });
         }
@@ -38256,7 +38626,7 @@ export const plans = {
             type: "attribute",
             attribute: "non_null_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.non_null_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.non_null_text.codec)}`;
             }
           });
         }
@@ -38459,7 +38829,7 @@ export const plans = {
             type: "attribute",
             attribute: "not_null_has_default",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.not_null_has_default.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.not_null_has_default.codec)}`;
             }
           });
         }
@@ -38482,7 +38852,7 @@ export const plans = {
             type: "attribute",
             attribute: "wont_cast_easy",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.wont_cast_easy.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.wont_cast_easy.codec)}`;
             }
           });
         }
@@ -38505,7 +38875,7 @@ export const plans = {
             type: "attribute",
             attribute: "row_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.row_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.row_id.codec)}`;
             }
           });
         }
@@ -38728,7 +39098,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.id.codec)}`;
             }
           });
         }
@@ -38751,7 +39121,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.person_id.codec)}`;
             }
           });
         }
@@ -38774,7 +39144,7 @@ export const plans = {
             type: "attribute",
             attribute: "length_in_metres",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.length_in_metres.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.length_in_metres.codec)}`;
             }
           });
         }
@@ -38797,7 +39167,7 @@ export const plans = {
             type: "attribute",
             attribute: "mood",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.mood.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.mood.codec)}`;
             }
           });
         }
@@ -38952,7 +39322,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_issue756.attributes.id.codec)}`;
             }
           });
         }
@@ -38975,7 +39345,7 @@ export const plans = {
             type: "attribute",
             attribute: "ts",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.ts.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_issue756.attributes.ts.codec)}`;
             }
           });
         }
@@ -42311,6 +42681,11 @@ export const plans = {
       return rootValue();
     }
   },
+  Guid: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
   GuidFnInput: {
     clientMutationId: {
       applyPlan($input, val) {
@@ -42502,6 +42877,9 @@ export const plans = {
     leftArm: undefined
   },
   LeftArmBaseInput: {
+    "__inputPlan": function LeftArmBaseInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -42896,6 +43274,9 @@ export const plans = {
     suffix: undefined
   },
   PostInput: {
+    "__inputPlan": function PostInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43346,6 +43727,9 @@ export const plans = {
     }
   },
   InputInput: {
+    "__inputPlan": function InputInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43413,6 +43797,9 @@ export const plans = {
     }
   },
   PatchInput: {
+    "__inputPlan": function PatchInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43480,6 +43867,9 @@ export const plans = {
     }
   },
   ReservedInput: {
+    "__inputPlan": function ReservedInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43547,6 +43937,9 @@ export const plans = {
     }
   },
   ReservedPatchRecordInput: {
+    "__inputPlan": function ReservedPatchRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43614,6 +44007,9 @@ export const plans = {
     }
   },
   ReservedInputRecordInput: {
+    "__inputPlan": function ReservedInputRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43681,6 +44077,9 @@ export const plans = {
     }
   },
   DefaultValueInput: {
+    "__inputPlan": function DefaultValueInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43735,6 +44134,9 @@ export const plans = {
     }
   },
   ForeignKeyInput: {
+    "__inputPlan": function ForeignKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -43785,6 +44187,9 @@ export const plans = {
     }
   },
   NoPrimaryKeyInput: {
+    "__inputPlan": function NoPrimaryKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43828,6 +44233,9 @@ export const plans = {
     }
   },
   TestviewInput: {
+    "__inputPlan": function TestviewInput_inputPlan() {
+      return object(Object.create(null));
+    },
     testviewid: {
       applyPlan($insert, val) {
         $insert.set("testviewid", val.get());
@@ -43909,6 +44317,9 @@ export const plans = {
     }
   },
   MyTableInput: {
+    "__inputPlan": function MyTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43988,6 +44399,9 @@ export const plans = {
     }
   },
   PersonSecretInput: {
+    "__inputPlan": function PersonSecretInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -44062,6 +44476,9 @@ export const plans = {
     }
   },
   ViewTableInput: {
+    "__inputPlan": function ViewTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44153,6 +44570,9 @@ export const plans = {
     }
   },
   CompoundKeyInput: {
+    "__inputPlan": function CompoundKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId2: {
       applyPlan($insert, val) {
         $insert.set("person_id_2", val.get());
@@ -44234,6 +44654,9 @@ export const plans = {
     }
   },
   SimilarTable1Input: {
+    "__inputPlan": function SimilarTable1Input_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44322,6 +44745,9 @@ export const plans = {
     }
   },
   SimilarTable2Input: {
+    "__inputPlan": function SimilarTable2Input_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44379,6 +44805,9 @@ export const plans = {
     }
   },
   UpdatableViewInput: {
+    "__inputPlan": function UpdatableViewInput_inputPlan() {
+      return object(Object.create(null));
+    },
     x: {
       applyPlan($insert, val) {
         $insert.set("x", val.get());
@@ -44467,6 +44896,9 @@ export const plans = {
     }
   },
   NullTestRecordInput: {
+    "__inputPlan": function NullTestRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44524,6 +44956,9 @@ export const plans = {
     }
   },
   EdgeCaseInput: {
+    "__inputPlan": function EdgeCaseInput_inputPlan() {
+      return object(Object.create(null));
+    },
     notNullHasDefault: {
       applyPlan($insert, val) {
         $insert.set("not_null_has_default", val.get());
@@ -44610,6 +45045,9 @@ export const plans = {
     }
   },
   LeftArmInput: {
+    "__inputPlan": function LeftArmInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44698,6 +45136,9 @@ export const plans = {
     }
   },
   Issue756Input: {
+    "__inputPlan": function Issue756Input_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44835,6 +45276,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44982,6 +45426,9 @@ export const plans = {
     }
   },
   TypeInput: {
+    "__inputPlan": function TypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45384,6 +45831,9 @@ export const plans = {
     }
   },
   InputPatch: {
+    "__inputPlan": function InputPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45464,6 +45914,9 @@ export const plans = {
     }
   },
   PatchPatch: {
+    "__inputPlan": function PatchPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45544,6 +45997,9 @@ export const plans = {
     }
   },
   ReservedPatch: {
+    "__inputPlan": function ReservedPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45624,6 +46080,9 @@ export const plans = {
     }
   },
   ReservedPatchRecordPatch: {
+    "__inputPlan": function ReservedPatchRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45704,6 +46163,9 @@ export const plans = {
     }
   },
   ReservedInputRecordPatch: {
+    "__inputPlan": function ReservedInputRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45784,6 +46246,9 @@ export const plans = {
     }
   },
   DefaultValuePatch: {
+    "__inputPlan": function DefaultValuePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45840,6 +46305,9 @@ export const plans = {
     }
   },
   NoPrimaryKeyPatch: {
+    "__inputPlan": function NoPrimaryKeyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45913,6 +46381,9 @@ export const plans = {
     }
   },
   MyTablePatch: {
+    "__inputPlan": function MyTablePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46005,6 +46476,9 @@ export const plans = {
     }
   },
   PersonSecretPatch: {
+    "__inputPlan": function PersonSecretPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -46092,6 +46566,9 @@ export const plans = {
     }
   },
   ViewTablePatch: {
+    "__inputPlan": function ViewTablePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46196,6 +46673,9 @@ export const plans = {
     }
   },
   CompoundKeyPatch: {
+    "__inputPlan": function CompoundKeyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     personId2: {
       applyPlan($insert, val) {
         $insert.set("person_id_2", val.get());
@@ -46291,6 +46771,9 @@ export const plans = {
     }
   },
   SimilarTable1Patch: {
+    "__inputPlan": function SimilarTable1Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46392,6 +46875,9 @@ export const plans = {
     }
   },
   SimilarTable2Patch: {
+    "__inputPlan": function SimilarTable2Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46493,6 +46979,9 @@ export const plans = {
     }
   },
   NullTestRecordPatch: {
+    "__inputPlan": function NullTestRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46599,6 +47088,9 @@ export const plans = {
     }
   },
   LeftArmPatch: {
+    "__inputPlan": function LeftArmPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46714,6 +47206,9 @@ export const plans = {
     }
   },
   Issue756Patch: {
+    "__inputPlan": function Issue756Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46806,6 +47301,9 @@ export const plans = {
     }
   },
   PostPatch: {
+    "__inputPlan": function PostPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46921,6 +47419,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -47095,6 +47596,9 @@ export const plans = {
     }
   },
   TypePatch: {
+    "__inputPlan": function TypePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.nested_arrays.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.nested_arrays.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, domainOfCodec, listOfCodec, makeRegistry, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectFromRecords, pgUpdateSingle, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, each, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId } from "grafast";
+import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -109,7 +126,7 @@ const workHourPartsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const workHourCodec = domainOfCodec(workHourPartsCodec, "workHour", sql.identifier("nested_arrays", "work_hour"), {
   description: undefined,
@@ -173,30 +190,29 @@ const workingHoursCodec = domainOfCodec(workhoursArrayCodec, "workingHours", sql
   },
   notNull: false
 });
-const tAttributes = Object.assign(Object.create(null), {
-  k: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  v: {
-    description: undefined,
-    codec: workingHoursCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const tCodec = recordCodec({
+const spec_t = {
   name: "t",
   identifier: sql.identifier("nested_arrays", "t"),
-  attributes: tAttributes,
+  attributes: Object.assign(Object.create(null), {
+    k: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    v: {
+      description: undefined,
+      codec: workingHoursCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -207,8 +223,9 @@ const tCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const tCodec = recordCodec(spec_t);
 const check_work_hoursFunctionIdentifer = sql.identifier("nested_arrays", "check_work_hours");
 const tUniques = [{
   isPrimary: true,
@@ -406,6 +423,9 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
   });
 };
 const resource_frmcdc_workHourPgResource = registry.pgResources["frmcdc_workHour"];
+function CursorSerialize(value) {
+  return "" + value;
+}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.T, $nodeId);
@@ -897,6 +917,9 @@ export const plans = {
     }
   },
   WorkHourInput: {
+    "__inputPlan": function WorkHourInput_inputPlan() {
+      return object(Object.create(null));
+    },
     fromHours: {
       applyPlan($insert, val) {
         $insert.set("from_hours", val.get());
@@ -949,6 +972,16 @@ export const plans = {
     },
     node($edge) {
       return $edge.node();
+    }
+  },
+  Cursor: {
+    serialize: CursorSerialize,
+    parseValue: CursorSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   PageInfo: {
@@ -1053,7 +1086,7 @@ export const plans = {
             type: "attribute",
             attribute: "k",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tAttributes.k.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_t.attributes.k.codec)}`;
             }
           });
         }
@@ -1076,7 +1109,7 @@ export const plans = {
             type: "attribute",
             attribute: "v",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tAttributes.v.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_t.attributes.v.codec)}`;
             }
           });
         }
@@ -1232,6 +1265,9 @@ export const plans = {
     }
   },
   TInput: {
+    "__inputPlan": function TInput_inputPlan() {
+      return object(Object.create(null));
+    },
     k: {
       applyPlan($insert, val) {
         $insert.set("k", val.get());
@@ -1305,6 +1341,9 @@ export const plans = {
     }
   },
   TPatch: {
+    "__inputPlan": function TPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     k: {
       applyPlan($insert, val) {
         $insert.set("k", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, domainOfCodec, enumCodec, listOfCodec, makeRegistry, pgClassExpression, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectFromRecords, pgSelectSingleFromRecord, pgUpdateSingle, rangeOfCodec, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
+import { GraphQLError, GraphQLInt, GraphQLString, Kind, valueFromASTUntyped } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -442,21 +459,20 @@ const textArrayCodec = listOfCodec(TYPES.text, {
   description: undefined,
   name: "textArray"
 });
-const nonUpdatableViewAttributes = Object.assign(Object.create(null), {
-  "?column?": {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const nonUpdatableViewCodec = recordCodec({
+const spec_nonUpdatableView = {
   name: "nonUpdatableView",
   identifier: sql.identifier("a", "non_updatable_view"),
-  attributes: nonUpdatableViewAttributes,
+  attributes: Object.assign(Object.create(null), {
+    "?column?": {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -467,23 +483,23 @@ const nonUpdatableViewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const inputsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const inputsCodec = recordCodec({
+  executor: executor
+};
+const nonUpdatableViewCodec = recordCodec(spec_nonUpdatableView);
+const spec_inputs = {
   name: "inputs",
   identifier: sql.identifier("a", "inputs"),
-  attributes: inputsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Should output as Input",
   extensions: {
     isTableLike: true,
@@ -494,23 +510,23 @@ const inputsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const patchsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const patchsCodec = recordCodec({
+  executor: executor
+};
+const inputsCodec = recordCodec(spec_inputs);
+const spec_patchs = {
   name: "patchs",
   identifier: sql.identifier("a", "patchs"),
-  attributes: patchsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Should output as Patch",
   extensions: {
     isTableLike: true,
@@ -521,23 +537,23 @@ const patchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const reservedAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const reservedCodec = recordCodec({
+  executor: executor
+};
+const patchsCodec = recordCodec(spec_patchs);
+const spec_reserved = {
   name: "reserved",
   identifier: sql.identifier("a", "reserved"),
-  attributes: reservedAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -548,23 +564,23 @@ const reservedCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const reservedPatchsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const reservedPatchsCodec = recordCodec({
+  executor: executor
+};
+const reservedCodec = recordCodec(spec_reserved);
+const spec_reservedPatchs = {
   name: "reservedPatchs",
   identifier: sql.identifier("a", "reservedPatchs"),
-  attributes: reservedPatchsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   extensions: {
     isTableLike: true,
@@ -575,23 +591,23 @@ const reservedPatchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const reservedInputAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const reservedInputCodec = recordCodec({
+  executor: executor
+};
+const reservedPatchsCodec = recordCodec(spec_reservedPatchs);
+const spec_reservedInput = {
   name: "reservedInput",
   identifier: sql.identifier("a", "reserved_input"),
-  attributes: reservedInputAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
   extensions: {
     isTableLike: true,
@@ -602,32 +618,32 @@ const reservedInputCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const defaultValueAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  null_value: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const defaultValueCodec = recordCodec({
+  executor: executor
+};
+const reservedInputCodec = recordCodec(spec_reservedInput);
+const spec_defaultValue = {
   name: "defaultValue",
   identifier: sql.identifier("a", "default_value"),
-  attributes: defaultValueAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    null_value: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -638,41 +654,41 @@ const defaultValueCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const foreignKeyAttributes = Object.assign(Object.create(null), {
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_key_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_key_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const foreignKeyCodec = recordCodec({
+  executor: executor
+};
+const defaultValueCodec = recordCodec(spec_defaultValue);
+const spec_foreignKey = {
   name: "foreignKey",
   identifier: sql.identifier("a", "foreign_key"),
-  attributes: foreignKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_key_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_key_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -683,32 +699,32 @@ const foreignKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  str: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const noPrimaryKeyCodec = recordCodec({
+  executor: executor
+};
+const foreignKeyCodec = recordCodec(spec_foreignKey);
+const spec_noPrimaryKey = {
   name: "noPrimaryKey",
   identifier: sql.identifier("a", "no_primary_key"),
-  attributes: noPrimaryKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    str: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -719,41 +735,41 @@ const noPrimaryKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const testviewAttributes = Object.assign(Object.create(null), {
-  testviewid: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const testviewCodec = recordCodec({
+  executor: executor
+};
+const noPrimaryKeyCodec = recordCodec(spec_noPrimaryKey);
+const spec_testview = {
   name: "testview",
   identifier: sql.identifier("a", "testview"),
-  attributes: testviewAttributes,
+  attributes: Object.assign(Object.create(null), {
+    testviewid: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -764,21 +780,10 @@ const testviewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const extensions12 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "unique_foreign_key"
-  },
-  tags: Object.assign(Object.create(null), {
-    omit: "create,update,delete,all,order,filter",
-    behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy"]
-  })
+  executor: executor
 };
-const uniqueForeignKeyCodec = recordCodec({
+const testviewCodec = recordCodec(spec_testview);
+const spec_uniqueForeignKey = {
   name: "uniqueForeignKey",
   identifier: sql.identifier("a", "unique_foreign_key"),
   attributes: Object.assign(Object.create(null), {
@@ -802,33 +807,44 @@ const uniqueForeignKeyCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions: extensions12,
-  executor
-});
-const myTableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "unique_foreign_key"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: "create,update,delete,all,order,filter",
+      behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy"]
+    })
   },
-  json_data: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const myTableCodec = recordCodec({
+  executor: executor
+};
+const uniqueForeignKeyCodec = recordCodec(spec_uniqueForeignKey);
+const spec_myTable = {
   name: "myTable",
   identifier: sql.identifier("c", "my_table"),
-  attributes: myTableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    json_data: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -839,34 +855,34 @@ const myTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const personSecretAttributes = Object.assign(Object.create(null), {
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  sekrit: {
-    description: "A secret held by the associated Person",
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "secret"
-      }
-    }
-  }
-});
-const personSecretCodec = recordCodec({
+  executor: executor
+};
+const myTableCodec = recordCodec(spec_myTable);
+const spec_personSecret = {
   name: "personSecret",
   identifier: sql.identifier("c", "person_secret"),
-  attributes: personSecretAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    sekrit: {
+      description: "A secret held by the associated Person",
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "secret"
+        }
+      }
+    }
+  }),
   description: "Tracks the person's secret",
   extensions: {
     isTableLike: true,
@@ -879,41 +895,41 @@ const personSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor
-});
-const viewTableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const viewTableCodec = recordCodec({
+  executor: executor
+};
+const personSecretCodec = recordCodec(spec_personSecret);
+const spec_viewTable = {
   name: "viewTable",
   identifier: sql.identifier("a", "view_table"),
-  attributes: viewTableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -924,41 +940,41 @@ const viewTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const compoundKeyAttributes = Object.assign(Object.create(null), {
-  person_id_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  extra: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const compoundKeyCodec = recordCodec({
+  executor: executor
+};
+const viewTableCodec = recordCodec(spec_viewTable);
+const spec_compoundKey = {
   name: "compoundKey",
   identifier: sql.identifier("c", "compound_key"),
-  attributes: compoundKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    extra: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -969,50 +985,50 @@ const compoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const similarTable1Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col3: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const similarTable1Codec = recordCodec({
+  executor: executor
+};
+const compoundKeyCodec = recordCodec(spec_compoundKey);
+const spec_similarTable1 = {
   name: "similarTable1",
   identifier: sql.identifier("a", "similar_table_1"),
-  attributes: similarTable1Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col3: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1023,50 +1039,50 @@ const similarTable1Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const similarTable2Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  col3: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col4: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col5: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const similarTable2Codec = recordCodec({
+  executor: executor
+};
+const similarTable1Codec = recordCodec(spec_similarTable1);
+const spec_similarTable2 = {
   name: "similarTable2",
   identifier: sql.identifier("a", "similar_table_2"),
-  attributes: similarTable2Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    col3: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col4: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col5: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1077,50 +1093,50 @@ const similarTable2Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const updatableViewAttributes = Object.assign(Object.create(null), {
-  x: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  description: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  constant: {
-    description: "This is constantly 2",
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const updatableViewCodec = recordCodec({
+  executor: executor
+};
+const similarTable2Codec = recordCodec(spec_similarTable2);
+const spec_updatableView = {
   name: "updatableView",
   identifier: sql.identifier("b", "updatable_view"),
-  attributes: updatableViewAttributes,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    description: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    constant: {
+      description: "This is constantly 2",
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "YOYOYO!!",
   extensions: {
     isTableLike: true,
@@ -1134,50 +1150,50 @@ const updatableViewCodec = recordCodec({
       unique: "x|@behavior -single -update -delete"
     })
   },
-  executor
-});
-const nullTestRecordAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_int: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  non_null_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const nullTestRecordCodec = recordCodec({
+  executor: executor
+};
+const updatableViewCodec = recordCodec(spec_updatableView);
+const spec_nullTestRecord = {
   name: "nullTestRecord",
   identifier: sql.identifier("c", "null_test_record"),
-  attributes: nullTestRecordAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_int: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    non_null_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1188,8 +1204,9 @@ const nullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const nullTestRecordCodec = recordCodec(spec_nullTestRecord);
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   extensions: {
     pg: {
@@ -1203,39 +1220,38 @@ const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   description: undefined,
   name: "uuidArray"
 });
-const edgeCaseAttributes = Object.assign(Object.create(null), {
-  not_null_has_default: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  wont_cast_easy: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  row_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const edgeCaseCodec = recordCodec({
+const spec_edgeCase = {
   name: "edgeCase",
   identifier: sql.identifier("c", "edge_case"),
-  attributes: edgeCaseAttributes,
+  attributes: Object.assign(Object.create(null), {
+    not_null_has_default: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    wont_cast_easy: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    row_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1246,50 +1262,50 @@ const edgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const leftArmAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  length_in_metres: {
-    description: undefined,
-    codec: TYPES.float,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  mood: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const leftArmCodec = recordCodec({
+  executor: executor
+};
+const edgeCaseCodec = recordCodec(spec_edgeCase);
+const spec_leftArm = {
   name: "leftArm",
   identifier: sql.identifier("c", "left_arm"),
-  attributes: leftArmAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    length_in_metres: {
+      description: undefined,
+      codec: TYPES.float,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    mood: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Tracks metadata about the left arms of various people",
   extensions: {
     isTableLike: true,
@@ -1300,8 +1316,9 @@ const leftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const leftArmCodec = recordCodec(spec_leftArm);
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
   identifier: sql.identifier("b", "jwt_token"),
@@ -1362,7 +1379,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
@@ -1376,30 +1393,29 @@ const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp
   },
   notNull: true
 });
-const issue756Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  ts: {
-    description: undefined,
-    codec: notNullTimestampCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const issue756Codec = recordCodec({
+const spec_issue756 = {
   name: "issue756",
   identifier: sql.identifier("c", "issue756"),
-  attributes: issue756Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    ts: {
+      description: undefined,
+      codec: notNullTimestampCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1410,8 +1426,9 @@ const issue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const issue756Codec = recordCodec(spec_issue756);
 const authPayloadCodec = recordCodec({
   name: "authPayload",
   identifier: sql.identifier("b", "auth_payload"),
@@ -1456,7 +1473,7 @@ const authPayloadCodec = recordCodec({
       foreignKey: "(id) references c.person"
     })
   },
-  executor
+  executor: executor
 });
 const colorCodec = enumCodec({
   name: "color",
@@ -1587,7 +1604,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
@@ -1709,7 +1726,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1724,66 +1741,65 @@ const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   description: undefined,
   name: "comptypeArray"
 });
-const postAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  headline: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  body: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  enums: {
-    description: undefined,
-    codec: anEnumArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  comptypes: {
-    description: undefined,
-    codec: comptypeArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const postCodec = recordCodec({
+const spec_post = {
   name: "post",
   identifier: sql.identifier("a", "post"),
-  attributes: postAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    headline: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    body: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    enums: {
+      description: undefined,
+      codec: anEnumArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    comptypes: {
+      description: undefined,
+      codec: comptypeArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1794,8 +1810,9 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const postCodec = recordCodec(spec_post);
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
@@ -1942,117 +1959,116 @@ const wrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const personAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: "The primary unique identifier for the person",
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_full_name: {
-    description: "The person\u2019s name",
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "name"
-      }
-    }
-  },
-  aliases: {
-    description: undefined,
-    codec: textArrayCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  about: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  email: {
-    description: undefined,
-    codec: emailCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  site: {
-    description: undefined,
-    codec: wrappedUrlCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        deprecated: "Don\u2019t use me"
-      }
-    }
-  },
-  config: {
-    description: undefined,
-    codec: TYPES.hstore,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_login_from_ip: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_login_from_subnet: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  user_mac: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  created_at: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const personCodec = recordCodec({
+const spec_person = {
   name: "person",
   identifier: sql.identifier("c", "person"),
-  attributes: personAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: "The primary unique identifier for the person",
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_full_name: {
+      description: "The person\u2019s name",
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "name"
+        }
+      }
+    },
+    aliases: {
+      description: undefined,
+      codec: textArrayCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    about: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    email: {
+      description: undefined,
+      codec: emailCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    site: {
+      description: undefined,
+      codec: wrappedUrlCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          deprecated: "Don\u2019t use me"
+        }
+      }
+    },
+    config: {
+      description: undefined,
+      codec: TYPES.hstore,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_login_from_ip: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_login_from_subnet: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    user_mac: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    created_at: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Person test comment",
   extensions: {
     isTableLike: true,
@@ -2063,8 +2079,9 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const personCodec = recordCodec(spec_person);
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
@@ -2397,7 +2414,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -2449,7 +2466,7 @@ const byteaArrayCodec = listOfCodec(TYPES.bytea, {
   description: undefined,
   name: "byteaArray"
 });
-const typesAttributes_ltree_codec_ltree = {
+const spec_types_attributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -2461,469 +2478,468 @@ const typesAttributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
-const typesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  smallint: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bigint: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numeric: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  decimal: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  boolean: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  varchar: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum_array: {
-    description: undefined,
-    codec: colorArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain: {
-    description: undefined,
-    codec: anIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain2: {
-    description: undefined,
-    codec: anotherIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array: {
-    description: undefined,
-    codec: textArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  json: {
-    description: undefined,
-    codec: TYPES.json,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  jsonb: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_range: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numrange: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  daterange: {
-    description: undefined,
-    codec: daterangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  an_int_range: {
-    description: undefined,
-    codec: anIntRangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamp: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamptz: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  date: {
-    description: undefined,
-    codec: TYPES.date,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  time: {
-    description: undefined,
-    codec: TYPES.time,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timetz: {
-    description: undefined,
-    codec: TYPES.timetz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval_array: {
-    description: undefined,
-    codec: intervalArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  money: {
-    description: undefined,
-    codec: TYPES.money,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  point: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullablePoint: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  inet: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  cidr: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  macaddr: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regproc: {
-    description: undefined,
-    codec: TYPES.regproc,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regprocedure: {
-    description: undefined,
-    codec: TYPES.regprocedure,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoper: {
-    description: undefined,
-    codec: TYPES.regoper,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoperator: {
-    description: undefined,
-    codec: TYPES.regoperator,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regclass: {
-    description: undefined,
-    codec: TYPES.regclass,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regtype: {
-    description: undefined,
-    codec: TYPES.regtype,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regconfig: {
-    description: undefined,
-    codec: TYPES.regconfig,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regdictionary: {
-    description: undefined,
-    codec: TYPES.regdictionary,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array_domain: {
-    description: undefined,
-    codec: textArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  int8_array_domain: {
-    description: undefined,
-    codec: int8ArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea: {
-    description: undefined,
-    codec: TYPES.bytea,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea_array: {
-    description: undefined,
-    codec: byteaArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree: {
-    description: undefined,
-    codec: typesAttributes_ltree_codec_ltree,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree_array: {
-    description: undefined,
-    codec: typesAttributes_ltree_array_codec_ltree_,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions46 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "types"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: ["(smallint) references a.post", "(id) references a.post"]
-  })
-};
-const typesCodec = recordCodec({
+const spec_types_attributes_ltree_array_codec_ltree_ = listOfCodec(spec_types_attributes_ltree_codec_ltree);
+const spec_types = {
   name: "types",
   identifier: sql.identifier("b", "types"),
-  attributes: typesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    smallint: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bigint: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numeric: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    decimal: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    boolean: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    varchar: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum_array: {
+      description: undefined,
+      codec: colorArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain: {
+      description: undefined,
+      codec: anIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain2: {
+      description: undefined,
+      codec: anotherIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array: {
+      description: undefined,
+      codec: textArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    json: {
+      description: undefined,
+      codec: TYPES.json,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    jsonb: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_range: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numrange: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    daterange: {
+      description: undefined,
+      codec: daterangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    an_int_range: {
+      description: undefined,
+      codec: anIntRangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamp: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamptz: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    date: {
+      description: undefined,
+      codec: TYPES.date,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    time: {
+      description: undefined,
+      codec: TYPES.time,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timetz: {
+      description: undefined,
+      codec: TYPES.timetz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval_array: {
+      description: undefined,
+      codec: intervalArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    money: {
+      description: undefined,
+      codec: TYPES.money,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    point: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullablePoint: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    inet: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    cidr: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    macaddr: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regproc: {
+      description: undefined,
+      codec: TYPES.regproc,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regprocedure: {
+      description: undefined,
+      codec: TYPES.regprocedure,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoper: {
+      description: undefined,
+      codec: TYPES.regoper,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoperator: {
+      description: undefined,
+      codec: TYPES.regoperator,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regclass: {
+      description: undefined,
+      codec: TYPES.regclass,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regtype: {
+      description: undefined,
+      codec: TYPES.regtype,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regconfig: {
+      description: undefined,
+      codec: TYPES.regconfig,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regdictionary: {
+      description: undefined,
+      codec: TYPES.regdictionary,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array_domain: {
+      description: undefined,
+      codec: textArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    int8_array_domain: {
+      description: undefined,
+      codec: int8ArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea: {
+      description: undefined,
+      codec: TYPES.bytea,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea_array: {
+      description: undefined,
+      codec: byteaArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree: {
+      description: undefined,
+      codec: spec_types_attributes_ltree_codec_ltree,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree_array: {
+      description: undefined,
+      codec: spec_types_attributes_ltree_array_codec_ltree_,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions46,
-  executor
-});
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "types"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: ["(smallint) references a.post", "(id) references a.post"]
+    })
+  },
+  executor: executor
+};
+const typesCodec = recordCodec(spec_types);
 const int4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
     pg: {
@@ -3116,7 +3132,7 @@ const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
     },
     tags: {
       omit: "create,update,delete,all,order,filter",
-      behavior: extensions12.tags.behavior
+      behavior: spec_uniqueForeignKey.extensions.tags.behavior
     }
   }
 };
@@ -3465,7 +3481,7 @@ const registryConfig_pgResources_types_types = {
       name: "types"
     },
     tags: {
-      foreignKey: extensions46.tags.foreignKey
+      foreignKey: spec_types.extensions.tags.foreignKey
     }
   }
 };
@@ -3588,8 +3604,8 @@ const registry = makeRegistry({
     int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
     byteaArray: byteaArrayCodec,
-    ltree: typesAttributes_ltree_codec_ltree,
-    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
+    ltree: spec_types_attributes_ltree_codec_ltree,
+    "ltree[]": spec_types_attributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     compoundTypeArray: listOfCodec(compoundTypeCodec, {
       extensions: {
@@ -3676,7 +3692,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor
+      executor: executor
     }),
     tablefuncCrosstab3: recordCodec({
       name: "tablefuncCrosstab3",
@@ -3729,7 +3745,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor
+      executor: executor
     }),
     tablefuncCrosstab4: recordCodec({
       name: "tablefuncCrosstab4",
@@ -3791,7 +3807,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor
+      executor: executor
     })
   }),
   pgResources: Object.assign(Object.create(null), {
@@ -12373,6 +12389,15 @@ const makeArgs64 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
+function UUIDSerialize(value) {
+  return "" + value;
+}
+const coerce = string => {
+  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
+    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
+  }
+  return string;
+};
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -12877,6 +12902,60 @@ const makeArgs73 = (args, path = []) => {
 const resource_post_computed_compound_type_arrayPgResource = registry.pgResources["post_computed_compound_type_array"];
 const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
+function LTreeParseValue(value) {
+  return value;
+}
+const isValidHstoreObject = obj => {
+  if (obj === null) {
+    // Null is okay
+    return true;
+  } else if (typeof obj === "object") {
+    // A hash with string/null values is also okay
+    const keys = Object.keys(obj);
+    for (const key of keys) {
+      const val = obj[key];
+      if (val === null) {
+        // Null is okay
+      } else if (typeof val === "string") {
+        // String is okay
+      } else {
+        // Everything else is invalid.
+        return false;
+      }
+    }
+    return true;
+  } else {
+    // Everything else is invalid.
+    return false;
+  }
+};
+const parseValueLiteral = (ast, variables) => {
+  switch (ast.kind) {
+    case Kind.INT:
+    case Kind.FLOAT:
+      // Number isn't really okay, but we'll coerce it to a string anyway.
+      return String(parseFloat(ast.value));
+    case Kind.STRING:
+      // String is okay.
+      return String(ast.value);
+    case Kind.NULL:
+      // Null is okay.
+      return null;
+    case Kind.VARIABLE:
+      {
+        // Variable is okay if that variable is either a string or null.
+        const name = ast.name.value;
+        const value = variables ? variables[name] : undefined;
+        if (value === null || typeof value === "string") {
+          return value;
+        }
+        return undefined;
+      }
+    default:
+      // Everything else is invalid.
+      return undefined;
+  }
+};
 const argDetailsSimple74 = [];
 const makeArgs74 = (args, path = []) => {
   const selectArgs = [];
@@ -29725,6 +29804,11 @@ export const plans = {
       return $record.get("o");
     }
   },
+  Email: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
   PersonComputedFirstArgInoutOutRecord: {
     __assertStep: assertPgClassSingleStep,
     person($record) {
@@ -29834,6 +29918,19 @@ export const plans = {
     },
     BLUE: {
       value: "blue"
+    }
+  },
+  UUID: {
+    serialize: UUIDSerialize,
+    parseValue(value) {
+      return coerce("" + value);
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // ERRORS: add name to this error
+        throw new GraphQLError(`${"UUID" ?? "This scalar"} can only parse string values (kind = '${ast.kind}')`);
+      }
+      return coerce(ast.value);
     }
   },
   EnumCaps: {
@@ -30340,6 +30437,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -30356,6 +30463,9 @@ export const plans = {
     }
   },
   CompoundTypeInput: {
+    "__inputPlan": function CompoundTypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     a: {
       applyPlan($insert, val) {
         $insert.set("a", val.get());
@@ -30484,6 +30594,16 @@ export const plans = {
     },
     isOptimised($record) {
       return $record.get("is_optimised");
+    }
+  },
+  Datetime: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   TypesConnection: {
@@ -30690,12 +30810,77 @@ export const plans = {
       });
     }
   },
+  BigInt: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigInt" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  BigFloat: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigFloat" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  AnInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
+  AnotherInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
+  JSON: {
+    serialize(value) {
+      return JSON.stringify(value);
+    },
+    parseValue(value) {
+      return JSON.parse(value);
+    },
+    parseLiteral(ast, _variables) {
+      if (ast.kind === Kind.STRING) {
+        return JSON.parse(ast.value);
+      } else {
+        return undefined;
+      }
+    }
+  },
   BigFloatRange: {},
   BigFloatRangeBound: {},
   DateRange: {},
   DateRangeBound: {},
+  Date: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Date" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   AnIntRange: {},
   AnIntRangeBound: {},
+  Time: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Time" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   NestedCompoundType: {
     __assertStep: assertPgClassSingleStep,
     a($record) {
@@ -30721,6 +30906,128 @@ export const plans = {
     }
   },
   Point: {},
+  InternetAddress: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"InternetAddress" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProc: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProc" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProcedure: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProcedure" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOper: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOper" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOperator: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOperator" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegClass: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegClass" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegType: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegType" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegConfig: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegConfig" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegDictionary: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegDictionary" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  Base64EncodedBinary: {
+    serialize(data) {
+      if (Buffer.isBuffer(data)) {
+        return data.toString("base64");
+      } else {
+        throw new Error(`Base64EncodeBinary can only be used with Node.js buffers.`);
+      }
+    },
+    parseValue(data) {
+      if (typeof data === "string") {
+        return Buffer.from(data, "base64");
+      } else {
+        throw new GraphQLError("Base64EncodedBinary can only parse string values.");
+      }
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // TODO: add name to this error
+        throw new GraphQLError("Base64EncodedBinary can only parse string values");
+      }
+      return Buffer.from(ast.value, "base64");
+    }
+  },
+  LTree: {
+    serialize(x) {
+      return x;
+    },
+    parseValue: LTreeParseValue,
+    parseLiteral(node, variables) {
+      return LTreeParseValue(valueFromASTUntyped(node, variables));
+    }
+  },
   TypesEdge: {
     __assertStep: assertEdgeCapableStep,
     cursor($edge) {
@@ -32041,7 +32348,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.id.codec)}`;
             }
           });
         }
@@ -32064,7 +32371,7 @@ export const plans = {
             type: "attribute",
             attribute: "smallint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.smallint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.smallint.codec)}`;
             }
           });
         }
@@ -32087,7 +32394,7 @@ export const plans = {
             type: "attribute",
             attribute: "bigint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.bigint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.bigint.codec)}`;
             }
           });
         }
@@ -32110,7 +32417,7 @@ export const plans = {
             type: "attribute",
             attribute: "numeric",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numeric.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.numeric.codec)}`;
             }
           });
         }
@@ -32133,7 +32440,7 @@ export const plans = {
             type: "attribute",
             attribute: "decimal",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.decimal.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.decimal.codec)}`;
             }
           });
         }
@@ -32156,7 +32463,7 @@ export const plans = {
             type: "attribute",
             attribute: "boolean",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.boolean.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.boolean.codec)}`;
             }
           });
         }
@@ -32179,7 +32486,7 @@ export const plans = {
             type: "attribute",
             attribute: "varchar",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.varchar.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.varchar.codec)}`;
             }
           });
         }
@@ -32202,7 +32509,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.enum.codec)}`;
             }
           });
         }
@@ -32225,7 +32532,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.enum_array.codec)}`;
             }
           });
         }
@@ -32248,7 +32555,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.domain.codec)}`;
             }
           });
         }
@@ -32271,7 +32578,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.domain2.codec)}`;
             }
           });
         }
@@ -32294,7 +32601,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.text_array.codec)}`;
             }
           });
         }
@@ -32317,7 +32624,7 @@ export const plans = {
             type: "attribute",
             attribute: "json",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.json.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.json.codec)}`;
             }
           });
         }
@@ -32340,7 +32647,7 @@ export const plans = {
             type: "attribute",
             attribute: "jsonb",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.jsonb.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.jsonb.codec)}`;
             }
           });
         }
@@ -32363,7 +32670,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullable_range.codec)}`;
             }
           });
         }
@@ -32386,7 +32693,7 @@ export const plans = {
             type: "attribute",
             attribute: "numrange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numrange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.numrange.codec)}`;
             }
           });
         }
@@ -32409,7 +32716,7 @@ export const plans = {
             type: "attribute",
             attribute: "daterange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.daterange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.daterange.codec)}`;
             }
           });
         }
@@ -32432,7 +32739,7 @@ export const plans = {
             type: "attribute",
             attribute: "an_int_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.an_int_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.an_int_range.codec)}`;
             }
           });
         }
@@ -32455,7 +32762,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamp",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamp.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.timestamp.codec)}`;
             }
           });
         }
@@ -32478,7 +32785,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamptz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamptz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.timestamptz.codec)}`;
             }
           });
         }
@@ -32501,7 +32808,7 @@ export const plans = {
             type: "attribute",
             attribute: "date",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.date.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.date.codec)}`;
             }
           });
         }
@@ -32524,7 +32831,7 @@ export const plans = {
             type: "attribute",
             attribute: "time",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.time.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.time.codec)}`;
             }
           });
         }
@@ -32547,7 +32854,7 @@ export const plans = {
             type: "attribute",
             attribute: "timetz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timetz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.timetz.codec)}`;
             }
           });
         }
@@ -32570,7 +32877,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.interval.codec)}`;
             }
           });
         }
@@ -32593,7 +32900,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.interval_array.codec)}`;
             }
           });
         }
@@ -32616,7 +32923,7 @@ export const plans = {
             type: "attribute",
             attribute: "money",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.money.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.money.codec)}`;
             }
           });
         }
@@ -32639,7 +32946,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.compound_type.codec)}`;
             }
           });
         }
@@ -32662,7 +32969,7 @@ export const plans = {
             type: "attribute",
             attribute: "nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nested_compound_type.codec)}`;
             }
           });
         }
@@ -32685,7 +32992,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullable_compound_type.codec)}`;
             }
           });
         }
@@ -32708,7 +33015,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullable_nested_compound_type.codec)}`;
             }
           });
         }
@@ -32731,7 +33038,7 @@ export const plans = {
             type: "attribute",
             attribute: "point",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.point.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.point.codec)}`;
             }
           });
         }
@@ -32754,7 +33061,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullablePoint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullablePoint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullablePoint.codec)}`;
             }
           });
         }
@@ -32777,7 +33084,7 @@ export const plans = {
             type: "attribute",
             attribute: "inet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.inet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.inet.codec)}`;
             }
           });
         }
@@ -32800,7 +33107,7 @@ export const plans = {
             type: "attribute",
             attribute: "cidr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.cidr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.cidr.codec)}`;
             }
           });
         }
@@ -32823,7 +33130,7 @@ export const plans = {
             type: "attribute",
             attribute: "macaddr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.macaddr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.macaddr.codec)}`;
             }
           });
         }
@@ -32846,7 +33153,7 @@ export const plans = {
             type: "attribute",
             attribute: "regproc",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regproc.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regproc.codec)}`;
             }
           });
         }
@@ -32869,7 +33176,7 @@ export const plans = {
             type: "attribute",
             attribute: "regprocedure",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regprocedure.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regprocedure.codec)}`;
             }
           });
         }
@@ -32892,7 +33199,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoper",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoper.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regoper.codec)}`;
             }
           });
         }
@@ -32915,7 +33222,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoperator",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoperator.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regoperator.codec)}`;
             }
           });
         }
@@ -32938,7 +33245,7 @@ export const plans = {
             type: "attribute",
             attribute: "regclass",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regclass.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regclass.codec)}`;
             }
           });
         }
@@ -32961,7 +33268,7 @@ export const plans = {
             type: "attribute",
             attribute: "regtype",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regtype.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regtype.codec)}`;
             }
           });
         }
@@ -32984,7 +33291,7 @@ export const plans = {
             type: "attribute",
             attribute: "regconfig",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regconfig.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regconfig.codec)}`;
             }
           });
         }
@@ -33007,7 +33314,7 @@ export const plans = {
             type: "attribute",
             attribute: "regdictionary",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regdictionary.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regdictionary.codec)}`;
             }
           });
         }
@@ -33030,7 +33337,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.text_array_domain.codec)}`;
             }
           });
         }
@@ -33053,7 +33360,7 @@ export const plans = {
             type: "attribute",
             attribute: "int8_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.int8_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.int8_array_domain.codec)}`;
             }
           });
         }
@@ -33076,7 +33383,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.ltree.codec)}`;
             }
           });
         }
@@ -33099,7 +33406,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.ltree_array.codec)}`;
             }
           });
         }
@@ -33133,6 +33440,9 @@ export const plans = {
     inclusive: undefined
   },
   NestedCompoundTypeInput: {
+    "__inputPlan": function NestedCompoundTypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     a: {
       applyPlan($insert, val) {
         $insert.set("a", val.get());
@@ -33627,6 +33937,50 @@ export const plans = {
       return $record.get("url");
     }
   },
+  NotNullUrl: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
+  KeyValueHash: {
+    serialize(value) {
+      return value;
+    },
+    parseValue(obj) {
+      if (isValidHstoreObject(obj)) {
+        return obj;
+      }
+      throw new GraphQLError(`This is not a valid ${"KeyValueHash"} object, it must be a key/value hash where keys and values are both strings (or null).`);
+    },
+    parseLiteral(ast, variables) {
+      switch (ast.kind) {
+        case Kind.OBJECT:
+          {
+            const value = ast.fields.reduce((memo, field) => {
+              memo[field.name.value] = parseValueLiteral(field.value, variables);
+              return memo;
+            }, Object.create(null));
+            if (!isValidHstoreObject(value)) {
+              return undefined;
+            }
+            return value;
+          }
+        case Kind.NULL:
+          return null;
+        case Kind.VARIABLE:
+          {
+            const name = ast.name.value;
+            const value = variables ? variables[name] : undefined;
+            if (!isValidHstoreObject(value)) {
+              return undefined;
+            }
+            return value;
+          }
+        default:
+          return undefined;
+      }
+    }
+  },
   PostsConnection: {
     __assertStep: ConnectionStep,
     nodes($connection) {
@@ -33871,7 +34225,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.id.codec)}`;
             }
           });
         }
@@ -33894,7 +34248,7 @@ export const plans = {
             type: "attribute",
             attribute: "headline",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.headline.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.headline.codec)}`;
             }
           });
         }
@@ -33917,7 +34271,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.body.codec)}`;
             }
           });
         }
@@ -33940,7 +34294,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.author_id.codec)}`;
             }
           });
         }
@@ -33963,7 +34317,7 @@ export const plans = {
             type: "attribute",
             attribute: "enums",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.enums.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.enums.codec)}`;
             }
           });
         }
@@ -33986,7 +34340,7 @@ export const plans = {
             type: "attribute",
             attribute: "comptypes",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.comptypes.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.comptypes.codec)}`;
             }
           });
         }
@@ -34011,6 +34365,9 @@ export const plans = {
     }
   },
   ComptypeInput: {
+    "__inputPlan": function ComptypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     schedule: {
       applyPlan($insert, val) {
         $insert.set("schedule", val.get());
@@ -34197,7 +34554,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_foreignKey.attributes.person_id.codec)}`;
             }
           });
         }
@@ -34220,7 +34577,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_foreignKey.attributes.compound_key_1.codec)}`;
             }
           });
         }
@@ -34243,7 +34600,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_foreignKey.attributes.compound_key_2.codec)}`;
             }
           });
         }
@@ -34474,7 +34831,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.person_id_2.codec)}`;
             }
           });
         }
@@ -34497,7 +34854,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.person_id_1.codec)}`;
             }
           });
         }
@@ -34520,7 +34877,7 @@ export const plans = {
             type: "attribute",
             attribute: "extra",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.extra.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.extra.codec)}`;
             }
           });
         }
@@ -34626,6 +34983,16 @@ export const plans = {
     },
     ts($record) {
       return $record.get("ts");
+    }
+  },
+  NotNullTimestamp: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   FuncOutSetofConnection: {
@@ -35021,7 +35388,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.id.codec)}`;
             }
           });
         }
@@ -35044,7 +35411,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_full_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.person_full_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.person_full_name.codec)}`;
             }
           });
         }
@@ -35067,7 +35434,7 @@ export const plans = {
             type: "attribute",
             attribute: "aliases",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.aliases.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.aliases.codec)}`;
             }
           });
         }
@@ -35090,7 +35457,7 @@ export const plans = {
             type: "attribute",
             attribute: "about",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.about.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.about.codec)}`;
             }
           });
         }
@@ -35113,7 +35480,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.email.codec)}`;
             }
           });
         }
@@ -35136,7 +35503,7 @@ export const plans = {
             type: "attribute",
             attribute: "site",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.site.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.site.codec)}`;
             }
           });
         }
@@ -35159,7 +35526,7 @@ export const plans = {
             type: "attribute",
             attribute: "config",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.config.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.config.codec)}`;
             }
           });
         }
@@ -35182,7 +35549,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_ip",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_ip.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_login_from_ip.codec)}`;
             }
           });
         }
@@ -35205,7 +35572,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_subnet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_subnet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_login_from_subnet.codec)}`;
             }
           });
         }
@@ -35228,7 +35595,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_mac",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.user_mac.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.user_mac.codec)}`;
             }
           });
         }
@@ -35251,7 +35618,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.created_at.codec)}`;
             }
           });
         }
@@ -35276,6 +35643,9 @@ export const plans = {
     }
   },
   WrappedUrlInput: {
+    "__inputPlan": function WrappedUrlInput_inputPlan() {
+      return object(Object.create(null));
+    },
     url: {
       applyPlan($insert, val) {
         $insert.set("url", val.get());
@@ -35370,7 +35740,7 @@ export const plans = {
             type: "attribute",
             attribute: "?column?",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nonUpdatableViewAttributes["?column?"].codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nonUpdatableView.attributes["?column?"].codec)}`;
             }
           });
         }
@@ -35491,7 +35861,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), inputsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_inputs.attributes.id.codec)}`;
             }
           });
         }
@@ -35612,7 +35982,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), patchsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_patchs.attributes.id.codec)}`;
             }
           });
         }
@@ -35733,7 +36103,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reserved.attributes.id.codec)}`;
             }
           });
         }
@@ -35854,7 +36224,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedPatchsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reservedPatchs.attributes.id.codec)}`;
             }
           });
         }
@@ -35975,7 +36345,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedInputAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reservedInput.attributes.id.codec)}`;
             }
           });
         }
@@ -36130,7 +36500,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_defaultValue.attributes.id.codec)}`;
             }
           });
         }
@@ -36153,7 +36523,7 @@ export const plans = {
             type: "attribute",
             attribute: "null_value",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.null_value.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_defaultValue.attributes.null_value.codec)}`;
             }
           });
         }
@@ -36276,7 +36646,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_noPrimaryKey.attributes.id.codec)}`;
             }
           });
         }
@@ -36299,7 +36669,7 @@ export const plans = {
             type: "attribute",
             attribute: "str",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.str.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_noPrimaryKey.attributes.str.codec)}`;
             }
           });
         }
@@ -36468,7 +36838,7 @@ export const plans = {
             type: "attribute",
             attribute: "testviewid",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.testviewid.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_testview.attributes.testviewid.codec)}`;
             }
           });
         }
@@ -36491,7 +36861,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_testview.attributes.col1.codec)}`;
             }
           });
         }
@@ -36514,7 +36884,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_testview.attributes.col2.codec)}`;
             }
           });
         }
@@ -36669,7 +37039,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_myTable.attributes.id.codec)}`;
             }
           });
         }
@@ -36692,7 +37062,7 @@ export const plans = {
             type: "attribute",
             attribute: "json_data",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.json_data.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_myTable.attributes.json_data.codec)}`;
             }
           });
         }
@@ -36847,7 +37217,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_personSecret.attributes.person_id.codec)}`;
             }
           });
         }
@@ -36870,7 +37240,7 @@ export const plans = {
             type: "attribute",
             attribute: "sekrit",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.sekrit.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_personSecret.attributes.sekrit.codec)}`;
             }
           });
         }
@@ -37059,7 +37429,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_viewTable.attributes.id.codec)}`;
             }
           });
         }
@@ -37082,7 +37452,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_viewTable.attributes.col1.codec)}`;
             }
           });
         }
@@ -37105,7 +37475,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_viewTable.attributes.col2.codec)}`;
             }
           });
         }
@@ -37328,7 +37698,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.id.codec)}`;
             }
           });
         }
@@ -37351,7 +37721,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.col1.codec)}`;
             }
           });
         }
@@ -37374,7 +37744,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.col2.codec)}`;
             }
           });
         }
@@ -37397,7 +37767,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.col3.codec)}`;
             }
           });
         }
@@ -37620,7 +37990,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.id.codec)}`;
             }
           });
         }
@@ -37643,7 +38013,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.col3.codec)}`;
             }
           });
         }
@@ -37666,7 +38036,7 @@ export const plans = {
             type: "attribute",
             attribute: "col4",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col4.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.col4.codec)}`;
             }
           });
         }
@@ -37689,7 +38059,7 @@ export const plans = {
             type: "attribute",
             attribute: "col5",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col5.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.col5.codec)}`;
             }
           });
         }
@@ -37895,7 +38265,7 @@ export const plans = {
             type: "attribute",
             attribute: "x",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.x.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.x.codec)}`;
             }
           });
         }
@@ -37918,7 +38288,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.name.codec)}`;
             }
           });
         }
@@ -37941,7 +38311,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.description.codec)}`;
             }
           });
         }
@@ -37964,7 +38334,7 @@ export const plans = {
             type: "attribute",
             attribute: "constant",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.constant.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.constant.codec)}`;
             }
           });
         }
@@ -38187,7 +38557,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.id.codec)}`;
             }
           });
         }
@@ -38210,7 +38580,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.nullable_text.codec)}`;
             }
           });
         }
@@ -38233,7 +38603,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_int",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_int.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.nullable_int.codec)}`;
             }
           });
         }
@@ -38256,7 +38626,7 @@ export const plans = {
             type: "attribute",
             attribute: "non_null_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.non_null_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.non_null_text.codec)}`;
             }
           });
         }
@@ -38459,7 +38829,7 @@ export const plans = {
             type: "attribute",
             attribute: "not_null_has_default",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.not_null_has_default.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.not_null_has_default.codec)}`;
             }
           });
         }
@@ -38482,7 +38852,7 @@ export const plans = {
             type: "attribute",
             attribute: "wont_cast_easy",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.wont_cast_easy.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.wont_cast_easy.codec)}`;
             }
           });
         }
@@ -38505,7 +38875,7 @@ export const plans = {
             type: "attribute",
             attribute: "row_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.row_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.row_id.codec)}`;
             }
           });
         }
@@ -38728,7 +39098,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.id.codec)}`;
             }
           });
         }
@@ -38751,7 +39121,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.person_id.codec)}`;
             }
           });
         }
@@ -38774,7 +39144,7 @@ export const plans = {
             type: "attribute",
             attribute: "length_in_metres",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.length_in_metres.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.length_in_metres.codec)}`;
             }
           });
         }
@@ -38797,7 +39167,7 @@ export const plans = {
             type: "attribute",
             attribute: "mood",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.mood.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.mood.codec)}`;
             }
           });
         }
@@ -38952,7 +39322,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_issue756.attributes.id.codec)}`;
             }
           });
         }
@@ -38975,7 +39345,7 @@ export const plans = {
             type: "attribute",
             attribute: "ts",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.ts.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_issue756.attributes.ts.codec)}`;
             }
           });
         }
@@ -42311,6 +42681,11 @@ export const plans = {
       return rootValue();
     }
   },
+  Guid: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
   GuidFnInput: {
     clientMutationId: {
       applyPlan($input, val) {
@@ -42502,6 +42877,9 @@ export const plans = {
     leftArm: undefined
   },
   LeftArmBaseInput: {
+    "__inputPlan": function LeftArmBaseInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -42896,6 +43274,9 @@ export const plans = {
     suffix: undefined
   },
   PostInput: {
+    "__inputPlan": function PostInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43346,6 +43727,9 @@ export const plans = {
     }
   },
   InputInput: {
+    "__inputPlan": function InputInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43413,6 +43797,9 @@ export const plans = {
     }
   },
   PatchInput: {
+    "__inputPlan": function PatchInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43480,6 +43867,9 @@ export const plans = {
     }
   },
   ReservedInput: {
+    "__inputPlan": function ReservedInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43547,6 +43937,9 @@ export const plans = {
     }
   },
   ReservedPatchRecordInput: {
+    "__inputPlan": function ReservedPatchRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43614,6 +44007,9 @@ export const plans = {
     }
   },
   ReservedInputRecordInput: {
+    "__inputPlan": function ReservedInputRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43681,6 +44077,9 @@ export const plans = {
     }
   },
   DefaultValueInput: {
+    "__inputPlan": function DefaultValueInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43735,6 +44134,9 @@ export const plans = {
     }
   },
   ForeignKeyInput: {
+    "__inputPlan": function ForeignKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -43785,6 +44187,9 @@ export const plans = {
     }
   },
   NoPrimaryKeyInput: {
+    "__inputPlan": function NoPrimaryKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43828,6 +44233,9 @@ export const plans = {
     }
   },
   TestviewInput: {
+    "__inputPlan": function TestviewInput_inputPlan() {
+      return object(Object.create(null));
+    },
     testviewid: {
       applyPlan($insert, val) {
         $insert.set("testviewid", val.get());
@@ -43909,6 +44317,9 @@ export const plans = {
     }
   },
   MyTableInput: {
+    "__inputPlan": function MyTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43988,6 +44399,9 @@ export const plans = {
     }
   },
   PersonSecretInput: {
+    "__inputPlan": function PersonSecretInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -44062,6 +44476,9 @@ export const plans = {
     }
   },
   ViewTableInput: {
+    "__inputPlan": function ViewTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44153,6 +44570,9 @@ export const plans = {
     }
   },
   CompoundKeyInput: {
+    "__inputPlan": function CompoundKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId2: {
       applyPlan($insert, val) {
         $insert.set("person_id_2", val.get());
@@ -44234,6 +44654,9 @@ export const plans = {
     }
   },
   SimilarTable1Input: {
+    "__inputPlan": function SimilarTable1Input_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44322,6 +44745,9 @@ export const plans = {
     }
   },
   SimilarTable2Input: {
+    "__inputPlan": function SimilarTable2Input_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44379,6 +44805,9 @@ export const plans = {
     }
   },
   UpdatableViewInput: {
+    "__inputPlan": function UpdatableViewInput_inputPlan() {
+      return object(Object.create(null));
+    },
     x: {
       applyPlan($insert, val) {
         $insert.set("x", val.get());
@@ -44467,6 +44896,9 @@ export const plans = {
     }
   },
   NullTestRecordInput: {
+    "__inputPlan": function NullTestRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44524,6 +44956,9 @@ export const plans = {
     }
   },
   EdgeCaseInput: {
+    "__inputPlan": function EdgeCaseInput_inputPlan() {
+      return object(Object.create(null));
+    },
     notNullHasDefault: {
       applyPlan($insert, val) {
         $insert.set("not_null_has_default", val.get());
@@ -44610,6 +45045,9 @@ export const plans = {
     }
   },
   LeftArmInput: {
+    "__inputPlan": function LeftArmInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44698,6 +45136,9 @@ export const plans = {
     }
   },
   Issue756Input: {
+    "__inputPlan": function Issue756Input_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44835,6 +45276,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44982,6 +45426,9 @@ export const plans = {
     }
   },
   TypeInput: {
+    "__inputPlan": function TypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45384,6 +45831,9 @@ export const plans = {
     }
   },
   InputPatch: {
+    "__inputPlan": function InputPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45464,6 +45914,9 @@ export const plans = {
     }
   },
   PatchPatch: {
+    "__inputPlan": function PatchPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45544,6 +45997,9 @@ export const plans = {
     }
   },
   ReservedPatch: {
+    "__inputPlan": function ReservedPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45624,6 +46080,9 @@ export const plans = {
     }
   },
   ReservedPatchRecordPatch: {
+    "__inputPlan": function ReservedPatchRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45704,6 +46163,9 @@ export const plans = {
     }
   },
   ReservedInputRecordPatch: {
+    "__inputPlan": function ReservedInputRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45784,6 +46246,9 @@ export const plans = {
     }
   },
   DefaultValuePatch: {
+    "__inputPlan": function DefaultValuePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45840,6 +46305,9 @@ export const plans = {
     }
   },
   NoPrimaryKeyPatch: {
+    "__inputPlan": function NoPrimaryKeyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45913,6 +46381,9 @@ export const plans = {
     }
   },
   MyTablePatch: {
+    "__inputPlan": function MyTablePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46005,6 +46476,9 @@ export const plans = {
     }
   },
   PersonSecretPatch: {
+    "__inputPlan": function PersonSecretPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -46092,6 +46566,9 @@ export const plans = {
     }
   },
   ViewTablePatch: {
+    "__inputPlan": function ViewTablePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46196,6 +46673,9 @@ export const plans = {
     }
   },
   CompoundKeyPatch: {
+    "__inputPlan": function CompoundKeyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     personId2: {
       applyPlan($insert, val) {
         $insert.set("person_id_2", val.get());
@@ -46291,6 +46771,9 @@ export const plans = {
     }
   },
   SimilarTable1Patch: {
+    "__inputPlan": function SimilarTable1Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46392,6 +46875,9 @@ export const plans = {
     }
   },
   SimilarTable2Patch: {
+    "__inputPlan": function SimilarTable2Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46493,6 +46979,9 @@ export const plans = {
     }
   },
   NullTestRecordPatch: {
+    "__inputPlan": function NullTestRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46599,6 +47088,9 @@ export const plans = {
     }
   },
   LeftArmPatch: {
+    "__inputPlan": function LeftArmPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46714,6 +47206,9 @@ export const plans = {
     }
   },
   Issue756Patch: {
+    "__inputPlan": function Issue756Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46806,6 +47301,9 @@ export const plans = {
     }
   },
   PostPatch: {
+    "__inputPlan": function PostPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46921,6 +47419,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -47095,6 +47596,9 @@ export const plans = {
     }
   },
   TypePatch: {
+    "__inputPlan": function TypePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/enum_tables.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/enum_tables.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, enumCodec, makeRegistry, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgUpdateSingle, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId } from "grafast";
+import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -58,20 +75,7 @@ const executor = new PgExecutor({
     });
   }
 });
-const extensions = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "enum_tables",
-    name: "abcd"
-  },
-  tags: Object.assign(Object.create(null), {
-    enum: true,
-    enumName: "LetterAToD",
-    behavior: ["-*"]
-  })
-};
-const abcdCodec = recordCodec({
+const spec_abcd = {
   name: "abcd",
   identifier: sql.identifier("enum_tables", "abcd"),
   attributes: Object.assign(Object.create(null), {
@@ -97,24 +101,23 @@ const abcdCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions,
-  executor
-});
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "enum_tables",
-    name: "abcd_view"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "enum_tables",
+      name: "abcd"
+    },
+    tags: Object.assign(Object.create(null), {
+      enum: true,
+      enumName: "LetterAToD",
+      behavior: ["-*"]
+    })
   },
-  tags: Object.assign(Object.create(null), {
-    primaryKey: "letter",
-    enum: true,
-    enumName: "LetterAToDViaView",
-    behavior: ["-*"]
-  })
+  executor: executor
 };
-const abcdViewCodec = recordCodec({
+const abcdCodec = recordCodec(spec_abcd);
+const spec_abcdView = {
   name: "abcdView",
   identifier: sql.identifier("enum_tables", "abcd_view"),
   attributes: Object.assign(Object.create(null), {
@@ -138,22 +141,24 @@ const abcdViewCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions: extensions2,
-  executor
-});
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "enum_tables",
-    name: "simple_enum"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "enum_tables",
+      name: "abcd_view"
+    },
+    tags: Object.assign(Object.create(null), {
+      primaryKey: "letter",
+      enum: true,
+      enumName: "LetterAToDViaView",
+      behavior: ["-*"]
+    })
   },
-  tags: Object.assign(Object.create(null), {
-    enum: true,
-    behavior: ["-*"]
-  })
+  executor: executor
 };
-const simpleEnumCodec = recordCodec({
+const abcdViewCodec = recordCodec(spec_abcdView);
+const spec_simpleEnum = {
   name: "simpleEnum",
   identifier: sql.identifier("enum_tables", "simple_enum"),
   attributes: Object.assign(Object.create(null), {
@@ -177,10 +182,22 @@ const simpleEnumCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions: extensions3,
-  executor
-});
-const letterDescriptionsAttributes_letter_codec_LetterAToDEnum = enumCodec({
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "enum_tables",
+      name: "simple_enum"
+    },
+    tags: Object.assign(Object.create(null), {
+      enum: true,
+      behavior: ["-*"]
+    })
+  },
+  executor: executor
+};
+const simpleEnumCodec = recordCodec(spec_simpleEnum);
+const spec_letterDescriptions_attributes_letter_codec_LetterAToDEnum = enumCodec({
   name: "LetterAToDEnum",
   identifier: TYPES.text.sqlType,
   values: [{
@@ -203,7 +220,7 @@ const letterDescriptionsAttributes_letter_codec_LetterAToDEnum = enumCodec({
     }
   }
 });
-const letterDescriptionsAttributes_letter_via_view_codec_LetterAToDViaViewEnum = enumCodec({
+const spec_letterDescriptions_attributes_letter_via_view_codec_LetterAToDViaViewEnum = enumCodec({
   name: "LetterAToDViaViewEnum",
   identifier: TYPES.text.sqlType,
   values: [{
@@ -226,48 +243,47 @@ const letterDescriptionsAttributes_letter_via_view_codec_LetterAToDViaViewEnum =
     }
   }
 });
-const letterDescriptionsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  letter: {
-    description: undefined,
-    codec: letterDescriptionsAttributes_letter_codec_LetterAToDEnum,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  letter_via_view: {
-    description: undefined,
-    codec: letterDescriptionsAttributes_letter_via_view_codec_LetterAToDViaViewEnum,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  description: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const letterDescriptionsCodec = recordCodec({
+const spec_letterDescriptions = {
   name: "letterDescriptions",
   identifier: sql.identifier("enum_tables", "letter_descriptions"),
-  attributes: letterDescriptionsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    letter: {
+      description: undefined,
+      codec: spec_letterDescriptions_attributes_letter_codec_LetterAToDEnum,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    letter_via_view: {
+      description: undefined,
+      codec: spec_letterDescriptions_attributes_letter_via_view_codec_LetterAToDViaViewEnum,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    description: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -280,9 +296,10 @@ const letterDescriptionsCodec = recordCodec({
       foreignKey: "(letter_via_view) references enum_tables.abcd_view"
     })
   },
-  executor
-});
-const referencingTableAttributes_enum_1_codec_EnumTheFirstEnum = enumCodec({
+  executor: executor
+};
+const letterDescriptionsCodec = recordCodec(spec_letterDescriptions);
+const spec_referencingTable_attributes_enum_1_codec_EnumTheFirstEnum = enumCodec({
   name: "EnumTheFirstEnum",
   identifier: TYPES.text.sqlType,
   values: [{
@@ -305,7 +322,7 @@ const referencingTableAttributes_enum_1_codec_EnumTheFirstEnum = enumCodec({
     }
   }
 });
-const referencingTableAttributes_enum_2_codec_EnumTheSecondEnum = enumCodec({
+const spec_referencingTable_attributes_enum_2_codec_EnumTheSecondEnum = enumCodec({
   name: "EnumTheSecondEnum",
   identifier: TYPES.varchar.sqlType,
   values: [{
@@ -328,7 +345,7 @@ const referencingTableAttributes_enum_2_codec_EnumTheSecondEnum = enumCodec({
     }
   }
 });
-const referencingTableAttributes_enum_3_codec_LotsOfEnumsEnum3Enum = enumCodec({
+const spec_referencingTable_attributes_enum_3_codec_LotsOfEnumsEnum3Enum = enumCodec({
   name: "LotsOfEnumsEnum3Enum",
   identifier: TYPES.bpchar.sqlType,
   values: [{
@@ -351,7 +368,7 @@ const referencingTableAttributes_enum_3_codec_LotsOfEnumsEnum3Enum = enumCodec({
     }
   }
 });
-const referencingTableAttributes_simple_enum_codec_SimpleEnumEnum = enumCodec({
+const spec_referencingTable_attributes_simple_enum_codec_SimpleEnumEnum = enumCodec({
   name: "SimpleEnumEnum",
   identifier: TYPES.text.sqlType,
   values: [{
@@ -374,57 +391,56 @@ const referencingTableAttributes_simple_enum_codec_SimpleEnumEnum = enumCodec({
     }
   }
 });
-const referencingTableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum_1: {
-    description: undefined,
-    codec: referencingTableAttributes_enum_1_codec_EnumTheFirstEnum,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum_2: {
-    description: undefined,
-    codec: referencingTableAttributes_enum_2_codec_EnumTheSecondEnum,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum_3: {
-    description: undefined,
-    codec: referencingTableAttributes_enum_3_codec_LotsOfEnumsEnum3Enum,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  simple_enum: {
-    description: undefined,
-    codec: referencingTableAttributes_simple_enum_codec_SimpleEnumEnum,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const referencingTableCodec = recordCodec({
+const spec_referencingTable = {
   name: "referencingTable",
   identifier: sql.identifier("enum_tables", "referencing_table"),
-  attributes: referencingTableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum_1: {
+      description: undefined,
+      codec: spec_referencingTable_attributes_enum_1_codec_EnumTheFirstEnum,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum_2: {
+      description: undefined,
+      codec: spec_referencingTable_attributes_enum_2_codec_EnumTheSecondEnum,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum_3: {
+      description: undefined,
+      codec: spec_referencingTable_attributes_enum_3_codec_LotsOfEnumsEnum3Enum,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    simple_enum: {
+      description: undefined,
+      codec: spec_referencingTable_attributes_simple_enum_codec_SimpleEnumEnum,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -435,21 +451,10 @@ const referencingTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const extensions12 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "enum_tables",
-    name: "lots_of_enums"
-  },
-  tags: Object.assign(Object.create(null), {
-    omit: true,
-    behavior: ["-*"]
-  })
+  executor: executor
 };
-const lotsOfEnumsCodec = recordCodec({
+const referencingTableCodec = recordCodec(spec_referencingTable);
+const spec_lotsOfEnums = {
   name: "lotsOfEnums",
   identifier: sql.identifier("enum_tables", "lots_of_enums"),
   attributes: Object.assign(Object.create(null), {
@@ -509,9 +514,21 @@ const lotsOfEnumsCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions: extensions12,
-  executor
-});
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "enum_tables",
+      name: "lots_of_enums"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: true,
+      behavior: ["-*"]
+    })
+  },
+  executor: executor
+};
+const lotsOfEnumsCodec = recordCodec(spec_lotsOfEnums);
 const registryConfig_pgResources_abcd_abcd = {
   executor,
   name: "abcd",
@@ -538,7 +555,7 @@ const registryConfig_pgResources_abcd_abcd = {
     tags: {
       enum: true,
       enumName: "LetterAToD",
-      behavior: extensions.tags.behavior
+      behavior: spec_abcd.extensions.tags.behavior
     }
   }
 };
@@ -569,7 +586,7 @@ const registryConfig_pgResources_abcd_view_abcd_view = {
       primaryKey: "letter",
       enum: true,
       enumName: "LetterAToDViaView",
-      behavior: extensions2.tags.behavior
+      behavior: spec_abcdView.extensions.tags.behavior
     }
   }
 };
@@ -598,7 +615,7 @@ const registryConfig_pgResources_simple_enum_simple_enum = {
     },
     tags: {
       enum: true,
-      behavior: extensions3.tags.behavior
+      behavior: spec_simpleEnum.extensions.tags.behavior
     }
   }
 };
@@ -736,7 +753,7 @@ const registryConfig_pgResources_lots_of_enums_lots_of_enums = {
     },
     tags: {
       omit: true,
-      behavior: extensions12.tags.behavior
+      behavior: spec_lotsOfEnums.extensions.tags.behavior
     }
   }
 };
@@ -748,13 +765,13 @@ const registry = makeRegistry({
     simpleEnum: simpleEnumCodec,
     int4: TYPES.int,
     letterDescriptions: letterDescriptionsCodec,
-    LetterAToDEnum: letterDescriptionsAttributes_letter_codec_LetterAToDEnum,
-    LetterAToDViaViewEnum: letterDescriptionsAttributes_letter_via_view_codec_LetterAToDViaViewEnum,
+    LetterAToDEnum: spec_letterDescriptions_attributes_letter_codec_LetterAToDEnum,
+    LetterAToDViaViewEnum: spec_letterDescriptions_attributes_letter_via_view_codec_LetterAToDViaViewEnum,
     referencingTable: referencingTableCodec,
-    EnumTheFirstEnum: referencingTableAttributes_enum_1_codec_EnumTheFirstEnum,
-    EnumTheSecondEnum: referencingTableAttributes_enum_2_codec_EnumTheSecondEnum,
-    LotsOfEnumsEnum3Enum: referencingTableAttributes_enum_3_codec_LotsOfEnumsEnum3Enum,
-    SimpleEnumEnum: referencingTableAttributes_simple_enum_codec_SimpleEnumEnum,
+    EnumTheFirstEnum: spec_referencingTable_attributes_enum_1_codec_EnumTheFirstEnum,
+    EnumTheSecondEnum: spec_referencingTable_attributes_enum_2_codec_EnumTheSecondEnum,
+    LotsOfEnumsEnum3Enum: spec_referencingTable_attributes_enum_3_codec_LotsOfEnumsEnum3Enum,
+    SimpleEnumEnum: spec_referencingTable_attributes_simple_enum_codec_SimpleEnumEnum,
     lotsOfEnums: lotsOfEnumsCodec,
     varchar: TYPES.varchar,
     bpchar: TYPES.bpchar
@@ -1086,6 +1103,9 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
+function CursorSerialize(value) {
+  return "" + value;
+}
 const argDetailsSimple = [{
   graphqlArgName: "t",
   postgresArgName: "t",
@@ -2343,6 +2363,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: CursorSerialize,
+    parseValue: CursorSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -2547,7 +2577,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), letterDescriptionsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_letterDescriptions.attributes.id.codec)}`;
             }
           });
         }
@@ -2570,7 +2600,7 @@ export const plans = {
             type: "attribute",
             attribute: "letter",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), letterDescriptionsAttributes.letter.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_letterDescriptions.attributes.letter.codec)}`;
             }
           });
         }
@@ -2593,7 +2623,7 @@ export const plans = {
             type: "attribute",
             attribute: "letter_via_view",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), letterDescriptionsAttributes.letter_via_view.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_letterDescriptions.attributes.letter_via_view.codec)}`;
             }
           });
         }
@@ -2616,7 +2646,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), letterDescriptionsAttributes.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_letterDescriptions.attributes.description.codec)}`;
             }
           });
         }
@@ -2873,7 +2903,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), referencingTableAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_referencingTable.attributes.id.codec)}`;
             }
           });
         }
@@ -2896,7 +2926,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), referencingTableAttributes.enum_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_referencingTable.attributes.enum_1.codec)}`;
             }
           });
         }
@@ -2919,7 +2949,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), referencingTableAttributes.enum_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_referencingTable.attributes.enum_2.codec)}`;
             }
           });
         }
@@ -2942,7 +2972,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum_3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), referencingTableAttributes.enum_3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_referencingTable.attributes.enum_3.codec)}`;
             }
           });
         }
@@ -2965,7 +2995,7 @@ export const plans = {
             type: "attribute",
             attribute: "simple_enum",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), referencingTableAttributes.simple_enum.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_referencingTable.attributes.simple_enum.codec)}`;
             }
           });
         }
@@ -3258,6 +3288,9 @@ export const plans = {
     t: undefined
   },
   ReferencingTableInput: {
+    "__inputPlan": function ReferencingTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -3353,6 +3386,9 @@ export const plans = {
     }
   },
   LetterDescriptionInput: {
+    "__inputPlan": function LetterDescriptionInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -3498,6 +3534,9 @@ export const plans = {
     }
   },
   LetterDescriptionPatch: {
+    "__inputPlan": function LetterDescriptionPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -3627,6 +3666,9 @@ export const plans = {
     }
   },
   ReferencingTablePatch: {
+    "__inputPlan": function ReferencingTablePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, domainOfCodec, enumCodec, listOfCodec, makeRegistry, pgClassExpression, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectFromRecords, pgSelectSingleFromRecord, pgUpdateSingle, rangeOfCodec, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
+import { GraphQLError, GraphQLInt, GraphQLString, Kind, valueFromASTUntyped } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -404,30 +421,29 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
   executor,
   isAnonymous: true
 });
-const myTableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  json_data: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const myTableCodec = recordCodec({
+const spec_myTable = {
   name: "myTable",
   identifier: sql.identifier("c", "my_table"),
-  attributes: myTableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    json_data: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -438,34 +454,34 @@ const myTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const personSecretAttributes = Object.assign(Object.create(null), {
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  sekrit: {
-    description: "A secret held by the associated Person",
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "secret"
-      }
-    }
-  }
-});
-const personSecretCodec = recordCodec({
+  executor: executor
+};
+const myTableCodec = recordCodec(spec_myTable);
+const spec_personSecret = {
   name: "personSecret",
   identifier: sql.identifier("c", "person_secret"),
-  attributes: personSecretAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    sekrit: {
+      description: "A secret held by the associated Person",
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "secret"
+        }
+      }
+    }
+  }),
   description: "Tracks the person's secret",
   extensions: {
     isTableLike: true,
@@ -479,41 +495,41 @@ const personSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor
-});
-const compoundKeyAttributes = Object.assign(Object.create(null), {
-  person_id_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  extra: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const compoundKeyCodec = recordCodec({
+  executor: executor
+};
+const personSecretCodec = recordCodec(spec_personSecret);
+const spec_compoundKey = {
   name: "compoundKey",
   identifier: sql.identifier("c", "compound_key"),
-  attributes: compoundKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    extra: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -524,50 +540,50 @@ const compoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const nullTestRecordAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_int: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  non_null_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const nullTestRecordCodec = recordCodec({
+  executor: executor
+};
+const compoundKeyCodec = recordCodec(spec_compoundKey);
+const spec_nullTestRecord = {
   name: "nullTestRecord",
   identifier: sql.identifier("c", "null_test_record"),
-  attributes: nullTestRecordAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_int: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    non_null_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -578,41 +594,41 @@ const nullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const edgeCaseAttributes = Object.assign(Object.create(null), {
-  not_null_has_default: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  wont_cast_easy: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  row_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const edgeCaseCodec = recordCodec({
+  executor: executor
+};
+const nullTestRecordCodec = recordCodec(spec_nullTestRecord);
+const spec_edgeCase = {
   name: "edgeCase",
   identifier: sql.identifier("c", "edge_case"),
-  attributes: edgeCaseAttributes,
+  attributes: Object.assign(Object.create(null), {
+    not_null_has_default: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    wont_cast_easy: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    row_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -623,50 +639,50 @@ const edgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const leftArmAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  length_in_metres: {
-    description: undefined,
-    codec: TYPES.float,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  mood: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const leftArmCodec = recordCodec({
+  executor: executor
+};
+const edgeCaseCodec = recordCodec(spec_edgeCase);
+const spec_leftArm = {
   name: "leftArm",
   identifier: sql.identifier("c", "left_arm"),
-  attributes: leftArmAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    length_in_metres: {
+      description: undefined,
+      codec: TYPES.float,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    mood: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Tracks metadata about the left arms of various people",
   extensions: {
     isTableLike: true,
@@ -677,8 +693,9 @@ const leftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const leftArmCodec = recordCodec(spec_leftArm);
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
   extensions: {
@@ -691,30 +708,29 @@ const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp
   },
   notNull: true
 });
-const issue756Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  ts: {
-    description: undefined,
-    codec: notNullTimestampCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const issue756Codec = recordCodec({
+const spec_issue756 = {
   name: "issue756",
   identifier: sql.identifier("c", "issue756"),
-  attributes: issue756Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    ts: {
+      description: undefined,
+      codec: notNullTimestampCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -725,8 +741,9 @@ const issue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const issue756Codec = recordCodec(spec_issue756);
 const colorCodec = enumCodec({
   name: "color",
   identifier: sql.identifier("b", "color"),
@@ -856,7 +873,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
@@ -978,7 +995,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1062,7 +1079,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
@@ -1223,117 +1240,116 @@ const wrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const personAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: "The primary unique identifier for the person",
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_full_name: {
-    description: "The person\u2019s name",
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "name"
-      }
-    }
-  },
-  aliases: {
-    description: undefined,
-    codec: textArrayCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  about: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  email: {
-    description: undefined,
-    codec: emailCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  site: {
-    description: undefined,
-    codec: wrappedUrlCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        deprecated: "Don\u2019t use me"
-      }
-    }
-  },
-  config: {
-    description: undefined,
-    codec: TYPES.hstore,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_login_from_ip: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_login_from_subnet: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  user_mac: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  created_at: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const personCodec = recordCodec({
+const spec_person = {
   name: "person",
   identifier: sql.identifier("c", "person"),
-  attributes: personAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: "The primary unique identifier for the person",
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_full_name: {
+      description: "The person\u2019s name",
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "name"
+        }
+      }
+    },
+    aliases: {
+      description: undefined,
+      codec: textArrayCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    about: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    email: {
+      description: undefined,
+      codec: emailCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    site: {
+      description: undefined,
+      codec: wrappedUrlCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          deprecated: "Don\u2019t use me"
+        }
+      }
+    },
+    config: {
+      description: undefined,
+      codec: TYPES.hstore,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_login_from_ip: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_login_from_subnet: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    user_mac: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    created_at: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Person test comment",
   extensions: {
     isTableLike: true,
@@ -1344,8 +1360,9 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const personCodec = recordCodec(spec_person);
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
@@ -1691,7 +1708,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -1743,7 +1760,7 @@ const byteaArrayCodec = listOfCodec(TYPES.bytea, {
   description: undefined,
   name: "byteaArray"
 });
-const typesAttributes_ltree_codec_ltree = {
+const spec_types_attributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -1755,7 +1772,7 @@ const typesAttributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
+const spec_types_attributes_ltree_array_codec_ltree_ = listOfCodec(spec_types_attributes_ltree_codec_ltree);
 const typesCodec = recordCodec({
   name: "types",
   identifier: sql.identifier("b", "types"),
@@ -2185,7 +2202,7 @@ const typesCodec = recordCodec({
     },
     ltree: {
       description: undefined,
-      codec: typesAttributes_ltree_codec_ltree,
+      codec: spec_types_attributes_ltree_codec_ltree,
       notNull: false,
       hasDefault: false,
       extensions: {
@@ -2194,7 +2211,7 @@ const typesCodec = recordCodec({
     },
     ltree_array: {
       description: undefined,
-      codec: typesAttributes_ltree_array_codec_ltree_,
+      codec: spec_types_attributes_ltree_array_codec_ltree_,
       notNull: false,
       hasDefault: false,
       extensions: {
@@ -2214,7 +2231,7 @@ const typesCodec = recordCodec({
       foreignKey: ["(smallint) references a.post", "(id) references a.post"]
     })
   },
-  executor
+  executor: executor
 });
 const int4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
@@ -2581,8 +2598,8 @@ const registry = makeRegistry({
     int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
     byteaArray: byteaArrayCodec,
-    ltree: typesAttributes_ltree_codec_ltree,
-    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
+    ltree: spec_types_attributes_ltree_codec_ltree,
+    "ltree[]": spec_types_attributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     typesArray: listOfCodec(typesCodec, {
       extensions: {
@@ -7600,8 +7617,71 @@ const makeArgs45 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
+function UUIDSerialize(value) {
+  return "" + value;
+}
+const coerce = string => {
+  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
+    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
+  }
+  return string;
+};
 const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
+function LTreeParseValue(value) {
+  return value;
+}
+const isValidHstoreObject = obj => {
+  if (obj === null) {
+    // Null is okay
+    return true;
+  } else if (typeof obj === "object") {
+    // A hash with string/null values is also okay
+    const keys = Object.keys(obj);
+    for (const key of keys) {
+      const val = obj[key];
+      if (val === null) {
+        // Null is okay
+      } else if (typeof val === "string") {
+        // String is okay
+      } else {
+        // Everything else is invalid.
+        return false;
+      }
+    }
+    return true;
+  } else {
+    // Everything else is invalid.
+    return false;
+  }
+};
+const parseValueLiteral = (ast, variables) => {
+  switch (ast.kind) {
+    case Kind.INT:
+    case Kind.FLOAT:
+      // Number isn't really okay, but we'll coerce it to a string anyway.
+      return String(parseFloat(ast.value));
+    case Kind.STRING:
+      // String is okay.
+      return String(ast.value);
+    case Kind.NULL:
+      // Null is okay.
+      return null;
+    case Kind.VARIABLE:
+      {
+        // Variable is okay if that variable is either a string or null.
+        const name = ast.name.value;
+        const value = variables ? variables[name] : undefined;
+        if (value === null || typeof value === "string") {
+          return value;
+        }
+        return undefined;
+      }
+    default:
+      // Everything else is invalid.
+      return undefined;
+  }
+};
 const resource_frmcdc_postPgResource = registry.pgResources["frmcdc_post"];
 const argDetailsSimple46 = [];
 const makeArgs46 = (args, path = []) => {
@@ -14905,6 +14985,21 @@ export const plans = {
       return $record.get("json_data");
     }
   },
+  JSON: {
+    serialize(value) {
+      return JSON.stringify(value);
+    },
+    parseValue(value) {
+      return JSON.parse(value);
+    },
+    parseLiteral(ast, _variables) {
+      if (ast.kind === Kind.STRING) {
+        return JSON.parse(ast.value);
+      } else {
+        return undefined;
+      }
+    }
+  },
   PersonSecret: {
     __assertStep: assertPgClassSingleStep,
     nodeId($parent) {
@@ -15699,6 +15794,11 @@ export const plans = {
       return $record.get("o");
     }
   },
+  Email: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
   PersonComputedFirstArgInoutOutRecord: {
     __assertStep: assertPgClassSingleStep,
     person($record) {
@@ -15808,6 +15908,19 @@ export const plans = {
     },
     BLUE: {
       value: "blue"
+    }
+  },
+  UUID: {
+    serialize: UUIDSerialize,
+    parseValue(value) {
+      return coerce("" + value);
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // ERRORS: add name to this error
+        throw new GraphQLError(`${"UUID" ?? "This scalar"} can only parse string values (kind = '${ast.kind}')`);
+      }
+      return coerce(ast.value);
     }
   },
   EnumCaps: {
@@ -15936,6 +16049,16 @@ export const plans = {
       return $record.get("is_optimised");
     }
   },
+  Datetime: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PeopleConnection: {
     __assertStep: ConnectionStep,
     nodes($connection) {
@@ -15959,6 +16082,16 @@ export const plans = {
     },
     node($edge) {
       return $edge.node();
+    }
+  },
+  Cursor: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   PageInfo: {
@@ -16603,12 +16736,62 @@ export const plans = {
       return $record.get("ltree_array");
     }
   },
+  BigInt: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigInt" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  BigFloat: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigFloat" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  AnInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
+  AnotherInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
   BigFloatRange: {},
   BigFloatRangeBound: {},
   DateRange: {},
   DateRangeBound: {},
+  Date: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Date" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   AnIntRange: {},
   AnIntRangeBound: {},
+  Time: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Time" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   NestedCompoundType: {
     __assertStep: assertPgClassSingleStep,
     a($record) {
@@ -16634,6 +16817,128 @@ export const plans = {
     }
   },
   Point: {},
+  InternetAddress: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"InternetAddress" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProc: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProc" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProcedure: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProcedure" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOper: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOper" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOperator: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOperator" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegClass: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegClass" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegType: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegType" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegConfig: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegConfig" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegDictionary: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegDictionary" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  Base64EncodedBinary: {
+    serialize(data) {
+      if (Buffer.isBuffer(data)) {
+        return data.toString("base64");
+      } else {
+        throw new Error(`Base64EncodeBinary can only be used with Node.js buffers.`);
+      }
+    },
+    parseValue(data) {
+      if (typeof data === "string") {
+        return Buffer.from(data, "base64");
+      } else {
+        throw new GraphQLError("Base64EncodedBinary can only parse string values.");
+      }
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // TODO: add name to this error
+        throw new GraphQLError("Base64EncodedBinary can only parse string values");
+      }
+      return Buffer.from(ast.value, "base64");
+    }
+  },
+  LTree: {
+    serialize(x) {
+      return x;
+    },
+    parseValue: LTreeParseValue,
+    parseLiteral(node, variables) {
+      return LTreeParseValue(valueFromASTUntyped(node, variables));
+    }
+  },
   TypesEdge: {
     __assertStep: assertEdgeCapableStep,
     cursor($edge) {
@@ -16647,6 +16952,50 @@ export const plans = {
     __assertStep: assertPgClassSingleStep,
     url($record) {
       return $record.get("url");
+    }
+  },
+  NotNullUrl: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
+  KeyValueHash: {
+    serialize(value) {
+      return value;
+    },
+    parseValue(obj) {
+      if (isValidHstoreObject(obj)) {
+        return obj;
+      }
+      throw new GraphQLError(`This is not a valid ${"KeyValueHash"} object, it must be a key/value hash where keys and values are both strings (or null).`);
+    },
+    parseLiteral(ast, variables) {
+      switch (ast.kind) {
+        case Kind.OBJECT:
+          {
+            const value = ast.fields.reduce((memo, field) => {
+              memo[field.name.value] = parseValueLiteral(field.value, variables);
+              return memo;
+            }, Object.create(null));
+            if (!isValidHstoreObject(value)) {
+              return undefined;
+            }
+            return value;
+          }
+        case Kind.NULL:
+          return null;
+        case Kind.VARIABLE:
+          {
+            const name = ast.name.value;
+            const value = variables ? variables[name] : undefined;
+            if (!isValidHstoreObject(value)) {
+              return undefined;
+            }
+            return value;
+          }
+        default:
+          return undefined;
+      }
     }
   },
   LeftArm: {
@@ -16879,7 +17228,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.person_id_2.codec)}`;
             }
           });
         }
@@ -16902,7 +17251,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.person_id_1.codec)}`;
             }
           });
         }
@@ -16925,7 +17274,7 @@ export const plans = {
             type: "attribute",
             attribute: "extra",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.extra.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.extra.codec)}`;
             }
           });
         }
@@ -17080,7 +17429,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_personSecret.attributes.person_id.codec)}`;
             }
           });
         }
@@ -17103,7 +17452,7 @@ export const plans = {
             type: "attribute",
             attribute: "sekrit",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.sekrit.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_personSecret.attributes.sekrit.codec)}`;
             }
           });
         }
@@ -17142,6 +17491,16 @@ export const plans = {
     },
     ts($record) {
       return $record.get("ts");
+    }
+  },
+  NotNullTimestamp: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   FuncOutSetofConnection: {
@@ -17487,7 +17846,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.id.codec)}`;
             }
           });
         }
@@ -17510,7 +17869,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_full_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.person_full_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.person_full_name.codec)}`;
             }
           });
         }
@@ -17533,7 +17892,7 @@ export const plans = {
             type: "attribute",
             attribute: "aliases",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.aliases.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.aliases.codec)}`;
             }
           });
         }
@@ -17556,7 +17915,7 @@ export const plans = {
             type: "attribute",
             attribute: "about",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.about.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.about.codec)}`;
             }
           });
         }
@@ -17579,7 +17938,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.email.codec)}`;
             }
           });
         }
@@ -17602,7 +17961,7 @@ export const plans = {
             type: "attribute",
             attribute: "site",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.site.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.site.codec)}`;
             }
           });
         }
@@ -17625,7 +17984,7 @@ export const plans = {
             type: "attribute",
             attribute: "config",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.config.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.config.codec)}`;
             }
           });
         }
@@ -17648,7 +18007,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_ip",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_ip.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_login_from_ip.codec)}`;
             }
           });
         }
@@ -17671,7 +18030,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_subnet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_subnet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_login_from_subnet.codec)}`;
             }
           });
         }
@@ -17694,7 +18053,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_mac",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.user_mac.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.user_mac.codec)}`;
             }
           });
         }
@@ -17717,7 +18076,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.created_at.codec)}`;
             }
           });
         }
@@ -17742,6 +18101,9 @@ export const plans = {
     }
   },
   WrappedUrlInput: {
+    "__inputPlan": function WrappedUrlInput_inputPlan() {
+      return object(Object.create(null));
+    },
     url: {
       applyPlan($insert, val) {
         $insert.set("url", val.get());
@@ -17896,7 +18258,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_myTable.attributes.id.codec)}`;
             }
           });
         }
@@ -17919,7 +18281,7 @@ export const plans = {
             type: "attribute",
             attribute: "json_data",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.json_data.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_myTable.attributes.json_data.codec)}`;
             }
           });
         }
@@ -18142,7 +18504,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.id.codec)}`;
             }
           });
         }
@@ -18165,7 +18527,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.nullable_text.codec)}`;
             }
           });
         }
@@ -18188,7 +18550,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_int",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_int.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.nullable_int.codec)}`;
             }
           });
         }
@@ -18211,7 +18573,7 @@ export const plans = {
             type: "attribute",
             attribute: "non_null_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.non_null_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.non_null_text.codec)}`;
             }
           });
         }
@@ -18414,7 +18776,7 @@ export const plans = {
             type: "attribute",
             attribute: "not_null_has_default",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.not_null_has_default.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.not_null_has_default.codec)}`;
             }
           });
         }
@@ -18437,7 +18799,7 @@ export const plans = {
             type: "attribute",
             attribute: "wont_cast_easy",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.wont_cast_easy.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.wont_cast_easy.codec)}`;
             }
           });
         }
@@ -18460,7 +18822,7 @@ export const plans = {
             type: "attribute",
             attribute: "row_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.row_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.row_id.codec)}`;
             }
           });
         }
@@ -18683,7 +19045,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.id.codec)}`;
             }
           });
         }
@@ -18706,7 +19068,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.person_id.codec)}`;
             }
           });
         }
@@ -18729,7 +19091,7 @@ export const plans = {
             type: "attribute",
             attribute: "length_in_metres",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.length_in_metres.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.length_in_metres.codec)}`;
             }
           });
         }
@@ -18752,7 +19114,7 @@ export const plans = {
             type: "attribute",
             attribute: "mood",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.mood.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.mood.codec)}`;
             }
           });
         }
@@ -18907,7 +19269,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_issue756.attributes.id.codec)}`;
             }
           });
         }
@@ -18930,7 +19292,7 @@ export const plans = {
             type: "attribute",
             attribute: "ts",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.ts.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_issue756.attributes.ts.codec)}`;
             }
           });
         }
@@ -20562,6 +20924,9 @@ export const plans = {
     leftArm: undefined
   },
   LeftArmBaseInput: {
+    "__inputPlan": function LeftArmBaseInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -20987,6 +21352,9 @@ export const plans = {
     }
   },
   MyTableInput: {
+    "__inputPlan": function MyTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -21071,6 +21439,9 @@ export const plans = {
     }
   },
   PersonSecretInput: {
+    "__inputPlan": function PersonSecretInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -21155,6 +21526,9 @@ export const plans = {
     }
   },
   CompoundKeyInput: {
+    "__inputPlan": function CompoundKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId2: {
       applyPlan($insert, val) {
         $insert.set("person_id_2", val.get());
@@ -21236,6 +21610,9 @@ export const plans = {
     }
   },
   NullTestRecordInput: {
+    "__inputPlan": function NullTestRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -21293,6 +21670,9 @@ export const plans = {
     }
   },
   EdgeCaseInput: {
+    "__inputPlan": function EdgeCaseInput_inputPlan() {
+      return object(Object.create(null));
+    },
     notNullHasDefault: {
       applyPlan($insert, val) {
         $insert.set("not_null_has_default", val.get());
@@ -21379,6 +21759,9 @@ export const plans = {
     }
   },
   LeftArmInput: {
+    "__inputPlan": function LeftArmInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -21467,6 +21850,9 @@ export const plans = {
     }
   },
   Issue756Input: {
+    "__inputPlan": function Issue756Input_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -21541,6 +21927,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -21677,6 +22066,9 @@ export const plans = {
     }
   },
   MyTablePatch: {
+    "__inputPlan": function MyTablePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -21774,6 +22166,9 @@ export const plans = {
     }
   },
   PersonSecretPatch: {
+    "__inputPlan": function PersonSecretPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -21871,6 +22266,9 @@ export const plans = {
     }
   },
   CompoundKeyPatch: {
+    "__inputPlan": function CompoundKeyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     personId2: {
       applyPlan($insert, val) {
         $insert.set("person_id_2", val.get());
@@ -21966,6 +22364,9 @@ export const plans = {
     }
   },
   NullTestRecordPatch: {
+    "__inputPlan": function NullTestRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -22072,6 +22473,9 @@ export const plans = {
     }
   },
   LeftArmPatch: {
+    "__inputPlan": function LeftArmPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -22187,6 +22591,9 @@ export const plans = {
     }
   },
   Issue756Patch: {
+    "__inputPlan": function Issue756Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -22274,6 +22681,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-good.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-good.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, domainOfCodec, enumCodec, listOfCodec, makeRegistry, pgClassExpression, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectFromRecords, pgSelectSingleFromRecord, pgUpdateSingle, rangeOfCodec, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
+import { GraphQLError, GraphQLInt, GraphQLString, Kind, valueFromASTUntyped } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -404,30 +421,29 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
   executor,
   isAnonymous: true
 });
-const myTableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  json_data: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const myTableCodec = recordCodec({
+const spec_myTable = {
   name: "myTable",
   identifier: sql.identifier("c", "my_table"),
-  attributes: myTableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    json_data: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -438,34 +454,34 @@ const myTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const personSecretAttributes = Object.assign(Object.create(null), {
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  sekrit: {
-    description: "A secret held by the associated Person",
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "secret"
-      }
-    }
-  }
-});
-const personSecretCodec = recordCodec({
+  executor: executor
+};
+const myTableCodec = recordCodec(spec_myTable);
+const spec_personSecret = {
   name: "personSecret",
   identifier: sql.identifier("c", "person_secret"),
-  attributes: personSecretAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    sekrit: {
+      description: "A secret held by the associated Person",
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "secret"
+        }
+      }
+    }
+  }),
   description: "Tracks the person's secret",
   extensions: {
     isTableLike: true,
@@ -479,41 +495,41 @@ const personSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor
-});
-const compoundKeyAttributes = Object.assign(Object.create(null), {
-  person_id_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  extra: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const compoundKeyCodec = recordCodec({
+  executor: executor
+};
+const personSecretCodec = recordCodec(spec_personSecret);
+const spec_compoundKey = {
   name: "compoundKey",
   identifier: sql.identifier("c", "compound_key"),
-  attributes: compoundKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    extra: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -524,50 +540,50 @@ const compoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const nullTestRecordAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_int: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  non_null_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const nullTestRecordCodec = recordCodec({
+  executor: executor
+};
+const compoundKeyCodec = recordCodec(spec_compoundKey);
+const spec_nullTestRecord = {
   name: "nullTestRecord",
   identifier: sql.identifier("c", "null_test_record"),
-  attributes: nullTestRecordAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_int: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    non_null_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -578,41 +594,41 @@ const nullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const edgeCaseAttributes = Object.assign(Object.create(null), {
-  not_null_has_default: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  wont_cast_easy: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  row_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const edgeCaseCodec = recordCodec({
+  executor: executor
+};
+const nullTestRecordCodec = recordCodec(spec_nullTestRecord);
+const spec_edgeCase = {
   name: "edgeCase",
   identifier: sql.identifier("c", "edge_case"),
-  attributes: edgeCaseAttributes,
+  attributes: Object.assign(Object.create(null), {
+    not_null_has_default: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    wont_cast_easy: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    row_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -623,50 +639,50 @@ const edgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const leftArmAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  length_in_metres: {
-    description: undefined,
-    codec: TYPES.float,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  mood: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const leftArmCodec = recordCodec({
+  executor: executor
+};
+const edgeCaseCodec = recordCodec(spec_edgeCase);
+const spec_leftArm = {
   name: "leftArm",
   identifier: sql.identifier("c", "left_arm"),
-  attributes: leftArmAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    length_in_metres: {
+      description: undefined,
+      codec: TYPES.float,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    mood: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Tracks metadata about the left arms of various people",
   extensions: {
     isTableLike: true,
@@ -677,8 +693,9 @@ const leftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const leftArmCodec = recordCodec(spec_leftArm);
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
   extensions: {
@@ -691,30 +708,29 @@ const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp
   },
   notNull: true
 });
-const issue756Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  ts: {
-    description: undefined,
-    codec: notNullTimestampCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const issue756Codec = recordCodec({
+const spec_issue756 = {
   name: "issue756",
   identifier: sql.identifier("c", "issue756"),
-  attributes: issue756Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    ts: {
+      description: undefined,
+      codec: notNullTimestampCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -725,8 +741,9 @@ const issue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const issue756Codec = recordCodec(spec_issue756);
 const colorCodec = enumCodec({
   name: "color",
   identifier: sql.identifier("b", "color"),
@@ -856,7 +873,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
@@ -978,7 +995,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1062,7 +1079,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
@@ -1223,117 +1240,116 @@ const wrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const personAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: "The primary unique identifier for the person",
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_full_name: {
-    description: "The person\u2019s name",
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "name"
-      }
-    }
-  },
-  aliases: {
-    description: undefined,
-    codec: textArrayCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  about: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  email: {
-    description: undefined,
-    codec: emailCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  site: {
-    description: undefined,
-    codec: wrappedUrlCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        deprecated: "Don\u2019t use me"
-      }
-    }
-  },
-  config: {
-    description: undefined,
-    codec: TYPES.hstore,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_login_from_ip: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_login_from_subnet: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  user_mac: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  created_at: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const personCodec = recordCodec({
+const spec_person = {
   name: "person",
   identifier: sql.identifier("c", "person"),
-  attributes: personAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: "The primary unique identifier for the person",
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_full_name: {
+      description: "The person\u2019s name",
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "name"
+        }
+      }
+    },
+    aliases: {
+      description: undefined,
+      codec: textArrayCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    about: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    email: {
+      description: undefined,
+      codec: emailCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    site: {
+      description: undefined,
+      codec: wrappedUrlCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          deprecated: "Don\u2019t use me"
+        }
+      }
+    },
+    config: {
+      description: undefined,
+      codec: TYPES.hstore,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_login_from_ip: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_login_from_subnet: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    user_mac: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    created_at: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Person test comment",
   extensions: {
     isTableLike: true,
@@ -1344,8 +1360,9 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const personCodec = recordCodec(spec_person);
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
@@ -1691,7 +1708,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -1743,7 +1760,7 @@ const byteaArrayCodec = listOfCodec(TYPES.bytea, {
   description: undefined,
   name: "byteaArray"
 });
-const typesAttributes_ltree_codec_ltree = {
+const spec_types_attributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -1755,7 +1772,7 @@ const typesAttributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
+const spec_types_attributes_ltree_array_codec_ltree_ = listOfCodec(spec_types_attributes_ltree_codec_ltree);
 const typesCodec = recordCodec({
   name: "types",
   identifier: sql.identifier("b", "types"),
@@ -2185,7 +2202,7 @@ const typesCodec = recordCodec({
     },
     ltree: {
       description: undefined,
-      codec: typesAttributes_ltree_codec_ltree,
+      codec: spec_types_attributes_ltree_codec_ltree,
       notNull: false,
       hasDefault: false,
       extensions: {
@@ -2194,7 +2211,7 @@ const typesCodec = recordCodec({
     },
     ltree_array: {
       description: undefined,
-      codec: typesAttributes_ltree_array_codec_ltree_,
+      codec: spec_types_attributes_ltree_array_codec_ltree_,
       notNull: false,
       hasDefault: false,
       extensions: {
@@ -2214,7 +2231,7 @@ const typesCodec = recordCodec({
       foreignKey: ["(smallint) references a.post", "(id) references a.post"]
     })
   },
-  executor
+  executor: executor
 });
 const int4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
@@ -2579,8 +2596,8 @@ const registry = makeRegistry({
     int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
     byteaArray: byteaArrayCodec,
-    ltree: typesAttributes_ltree_codec_ltree,
-    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
+    ltree: spec_types_attributes_ltree_codec_ltree,
+    "ltree[]": spec_types_attributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     typesArray: listOfCodec(typesCodec, {
       extensions: {
@@ -7598,8 +7615,71 @@ const makeArgs45 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
+function UUIDSerialize(value) {
+  return "" + value;
+}
+const coerce = string => {
+  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
+    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
+  }
+  return string;
+};
 const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
+function LTreeParseValue(value) {
+  return value;
+}
+const isValidHstoreObject = obj => {
+  if (obj === null) {
+    // Null is okay
+    return true;
+  } else if (typeof obj === "object") {
+    // A hash with string/null values is also okay
+    const keys = Object.keys(obj);
+    for (const key of keys) {
+      const val = obj[key];
+      if (val === null) {
+        // Null is okay
+      } else if (typeof val === "string") {
+        // String is okay
+      } else {
+        // Everything else is invalid.
+        return false;
+      }
+    }
+    return true;
+  } else {
+    // Everything else is invalid.
+    return false;
+  }
+};
+const parseValueLiteral = (ast, variables) => {
+  switch (ast.kind) {
+    case Kind.INT:
+    case Kind.FLOAT:
+      // Number isn't really okay, but we'll coerce it to a string anyway.
+      return String(parseFloat(ast.value));
+    case Kind.STRING:
+      // String is okay.
+      return String(ast.value);
+    case Kind.NULL:
+      // Null is okay.
+      return null;
+    case Kind.VARIABLE:
+      {
+        // Variable is okay if that variable is either a string or null.
+        const name = ast.name.value;
+        const value = variables ? variables[name] : undefined;
+        if (value === null || typeof value === "string") {
+          return value;
+        }
+        return undefined;
+      }
+    default:
+      // Everything else is invalid.
+      return undefined;
+  }
+};
 const resource_frmcdc_postPgResource = registry.pgResources["frmcdc_post"];
 const argDetailsSimple46 = [];
 const makeArgs46 = (args, path = []) => {
@@ -14957,6 +15037,21 @@ export const plans = {
       return $record.get("json_data");
     }
   },
+  JSON: {
+    serialize(value) {
+      return JSON.stringify(value);
+    },
+    parseValue(value) {
+      return JSON.parse(value);
+    },
+    parseLiteral(ast, _variables) {
+      if (ast.kind === Kind.STRING) {
+        return JSON.parse(ast.value);
+      } else {
+        return undefined;
+      }
+    }
+  },
   PersonSecret: {
     __assertStep: assertPgClassSingleStep,
     nodeId($parent) {
@@ -15751,6 +15846,11 @@ export const plans = {
       return $record.get("o");
     }
   },
+  Email: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
   PersonComputedFirstArgInoutOutRecord: {
     __assertStep: assertPgClassSingleStep,
     person($record) {
@@ -15860,6 +15960,19 @@ export const plans = {
     },
     BLUE: {
       value: "blue"
+    }
+  },
+  UUID: {
+    serialize: UUIDSerialize,
+    parseValue(value) {
+      return coerce("" + value);
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // ERRORS: add name to this error
+        throw new GraphQLError(`${"UUID" ?? "This scalar"} can only parse string values (kind = '${ast.kind}')`);
+      }
+      return coerce(ast.value);
     }
   },
   EnumCaps: {
@@ -15988,6 +16101,16 @@ export const plans = {
       return $record.get("is_optimised");
     }
   },
+  Datetime: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PeopleConnection: {
     __assertStep: ConnectionStep,
     nodes($connection) {
@@ -16011,6 +16134,16 @@ export const plans = {
     },
     node($edge) {
       return $edge.node();
+    }
+  },
+  Cursor: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   PageInfo: {
@@ -16655,12 +16788,62 @@ export const plans = {
       return $record.get("ltree_array");
     }
   },
+  BigInt: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigInt" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  BigFloat: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigFloat" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  AnInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
+  AnotherInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
   BigFloatRange: {},
   BigFloatRangeBound: {},
   DateRange: {},
   DateRangeBound: {},
+  Date: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Date" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   AnIntRange: {},
   AnIntRangeBound: {},
+  Time: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Time" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   NestedCompoundType: {
     __assertStep: assertPgClassSingleStep,
     a($record) {
@@ -16686,6 +16869,128 @@ export const plans = {
     }
   },
   Point: {},
+  InternetAddress: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"InternetAddress" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProc: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProc" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProcedure: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProcedure" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOper: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOper" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOperator: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOperator" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegClass: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegClass" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegType: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegType" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegConfig: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegConfig" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegDictionary: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegDictionary" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  Base64EncodedBinary: {
+    serialize(data) {
+      if (Buffer.isBuffer(data)) {
+        return data.toString("base64");
+      } else {
+        throw new Error(`Base64EncodeBinary can only be used with Node.js buffers.`);
+      }
+    },
+    parseValue(data) {
+      if (typeof data === "string") {
+        return Buffer.from(data, "base64");
+      } else {
+        throw new GraphQLError("Base64EncodedBinary can only parse string values.");
+      }
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // TODO: add name to this error
+        throw new GraphQLError("Base64EncodedBinary can only parse string values");
+      }
+      return Buffer.from(ast.value, "base64");
+    }
+  },
+  LTree: {
+    serialize(x) {
+      return x;
+    },
+    parseValue: LTreeParseValue,
+    parseLiteral(node, variables) {
+      return LTreeParseValue(valueFromASTUntyped(node, variables));
+    }
+  },
   TypesEdge: {
     __assertStep: assertEdgeCapableStep,
     cursor($edge) {
@@ -16699,6 +17004,50 @@ export const plans = {
     __assertStep: assertPgClassSingleStep,
     url($record) {
       return $record.get("url");
+    }
+  },
+  NotNullUrl: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
+  KeyValueHash: {
+    serialize(value) {
+      return value;
+    },
+    parseValue(obj) {
+      if (isValidHstoreObject(obj)) {
+        return obj;
+      }
+      throw new GraphQLError(`This is not a valid ${"KeyValueHash"} object, it must be a key/value hash where keys and values are both strings (or null).`);
+    },
+    parseLiteral(ast, variables) {
+      switch (ast.kind) {
+        case Kind.OBJECT:
+          {
+            const value = ast.fields.reduce((memo, field) => {
+              memo[field.name.value] = parseValueLiteral(field.value, variables);
+              return memo;
+            }, Object.create(null));
+            if (!isValidHstoreObject(value)) {
+              return undefined;
+            }
+            return value;
+          }
+        case Kind.NULL:
+          return null;
+        case Kind.VARIABLE:
+          {
+            const name = ast.name.value;
+            const value = variables ? variables[name] : undefined;
+            if (!isValidHstoreObject(value)) {
+              return undefined;
+            }
+            return value;
+          }
+        default:
+          return undefined;
+      }
     }
   },
   LeftArm: {
@@ -16931,7 +17280,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.person_id_2.codec)}`;
             }
           });
         }
@@ -16954,7 +17303,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.person_id_1.codec)}`;
             }
           });
         }
@@ -16977,7 +17326,7 @@ export const plans = {
             type: "attribute",
             attribute: "extra",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.extra.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.extra.codec)}`;
             }
           });
         }
@@ -17132,7 +17481,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_personSecret.attributes.person_id.codec)}`;
             }
           });
         }
@@ -17155,7 +17504,7 @@ export const plans = {
             type: "attribute",
             attribute: "sekrit",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.sekrit.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_personSecret.attributes.sekrit.codec)}`;
             }
           });
         }
@@ -17194,6 +17543,16 @@ export const plans = {
     },
     ts($record) {
       return $record.get("ts");
+    }
+  },
+  NotNullTimestamp: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   FuncOutSetofConnection: {
@@ -17539,7 +17898,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.id.codec)}`;
             }
           });
         }
@@ -17562,7 +17921,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_full_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.person_full_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.person_full_name.codec)}`;
             }
           });
         }
@@ -17585,7 +17944,7 @@ export const plans = {
             type: "attribute",
             attribute: "aliases",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.aliases.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.aliases.codec)}`;
             }
           });
         }
@@ -17608,7 +17967,7 @@ export const plans = {
             type: "attribute",
             attribute: "about",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.about.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.about.codec)}`;
             }
           });
         }
@@ -17631,7 +17990,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.email.codec)}`;
             }
           });
         }
@@ -17654,7 +18013,7 @@ export const plans = {
             type: "attribute",
             attribute: "site",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.site.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.site.codec)}`;
             }
           });
         }
@@ -17677,7 +18036,7 @@ export const plans = {
             type: "attribute",
             attribute: "config",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.config.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.config.codec)}`;
             }
           });
         }
@@ -17700,7 +18059,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_ip",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_ip.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_login_from_ip.codec)}`;
             }
           });
         }
@@ -17723,7 +18082,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_subnet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_subnet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_login_from_subnet.codec)}`;
             }
           });
         }
@@ -17746,7 +18105,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_mac",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.user_mac.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.user_mac.codec)}`;
             }
           });
         }
@@ -17769,7 +18128,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.created_at.codec)}`;
             }
           });
         }
@@ -17794,6 +18153,9 @@ export const plans = {
     }
   },
   WrappedUrlInput: {
+    "__inputPlan": function WrappedUrlInput_inputPlan() {
+      return object(Object.create(null));
+    },
     url: {
       applyPlan($insert, val) {
         $insert.set("url", val.get());
@@ -17948,7 +18310,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_myTable.attributes.id.codec)}`;
             }
           });
         }
@@ -17971,7 +18333,7 @@ export const plans = {
             type: "attribute",
             attribute: "json_data",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.json_data.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_myTable.attributes.json_data.codec)}`;
             }
           });
         }
@@ -18194,7 +18556,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.id.codec)}`;
             }
           });
         }
@@ -18217,7 +18579,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.nullable_text.codec)}`;
             }
           });
         }
@@ -18240,7 +18602,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_int",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_int.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.nullable_int.codec)}`;
             }
           });
         }
@@ -18263,7 +18625,7 @@ export const plans = {
             type: "attribute",
             attribute: "non_null_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.non_null_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.non_null_text.codec)}`;
             }
           });
         }
@@ -18466,7 +18828,7 @@ export const plans = {
             type: "attribute",
             attribute: "not_null_has_default",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.not_null_has_default.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.not_null_has_default.codec)}`;
             }
           });
         }
@@ -18489,7 +18851,7 @@ export const plans = {
             type: "attribute",
             attribute: "wont_cast_easy",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.wont_cast_easy.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.wont_cast_easy.codec)}`;
             }
           });
         }
@@ -18512,7 +18874,7 @@ export const plans = {
             type: "attribute",
             attribute: "row_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.row_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.row_id.codec)}`;
             }
           });
         }
@@ -18735,7 +19097,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.id.codec)}`;
             }
           });
         }
@@ -18758,7 +19120,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.person_id.codec)}`;
             }
           });
         }
@@ -18781,7 +19143,7 @@ export const plans = {
             type: "attribute",
             attribute: "length_in_metres",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.length_in_metres.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.length_in_metres.codec)}`;
             }
           });
         }
@@ -18804,7 +19166,7 @@ export const plans = {
             type: "attribute",
             attribute: "mood",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.mood.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.mood.codec)}`;
             }
           });
         }
@@ -18959,7 +19321,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_issue756.attributes.id.codec)}`;
             }
           });
         }
@@ -18982,7 +19344,7 @@ export const plans = {
             type: "attribute",
             attribute: "ts",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.ts.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_issue756.attributes.ts.codec)}`;
             }
           });
         }
@@ -20650,6 +21012,9 @@ export const plans = {
     leftArm: undefined
   },
   LeftArmBaseInput: {
+    "__inputPlan": function LeftArmBaseInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -21075,6 +21440,9 @@ export const plans = {
     }
   },
   MyTableInput: {
+    "__inputPlan": function MyTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -21159,6 +21527,9 @@ export const plans = {
     }
   },
   PersonSecretInput: {
+    "__inputPlan": function PersonSecretInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -21243,6 +21614,9 @@ export const plans = {
     }
   },
   CompoundKeyInput: {
+    "__inputPlan": function CompoundKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId2: {
       applyPlan($insert, val) {
         $insert.set("person_id_2", val.get());
@@ -21324,6 +21698,9 @@ export const plans = {
     }
   },
   NullTestRecordInput: {
+    "__inputPlan": function NullTestRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -21381,6 +21758,9 @@ export const plans = {
     }
   },
   EdgeCaseInput: {
+    "__inputPlan": function EdgeCaseInput_inputPlan() {
+      return object(Object.create(null));
+    },
     notNullHasDefault: {
       applyPlan($insert, val) {
         $insert.set("not_null_has_default", val.get());
@@ -21467,6 +21847,9 @@ export const plans = {
     }
   },
   LeftArmInput: {
+    "__inputPlan": function LeftArmInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -21555,6 +21938,9 @@ export const plans = {
     }
   },
   Issue756Input: {
+    "__inputPlan": function Issue756Input_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -21629,6 +22015,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -21765,6 +22154,9 @@ export const plans = {
     }
   },
   MyTablePatch: {
+    "__inputPlan": function MyTablePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -21862,6 +22254,9 @@ export const plans = {
     }
   },
   PersonSecretPatch: {
+    "__inputPlan": function PersonSecretPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -21959,6 +22354,9 @@ export const plans = {
     }
   },
   CompoundKeyPatch: {
+    "__inputPlan": function CompoundKeyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     personId2: {
       applyPlan($insert, val) {
         $insert.set("person_id_2", val.get());
@@ -22054,6 +22452,9 @@ export const plans = {
     }
   },
   NullTestRecordPatch: {
+    "__inputPlan": function NullTestRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -22160,6 +22561,9 @@ export const plans = {
     }
   },
   LeftArmPatch: {
+    "__inputPlan": function LeftArmPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -22275,6 +22679,9 @@ export const plans = {
     }
   },
   Issue756Patch: {
+    "__inputPlan": function Issue756Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -22362,6 +22769,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, domainOfCodec, enumCodec, listOfCodec, makeRegistry, pgClassExpression, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectFromRecords, pgSelectSingleFromRecord, pgUpdateSingle, rangeOfCodec, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
+import { GraphQLError, GraphQLInt, GraphQLString, Kind, valueFromASTUntyped } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -442,21 +459,20 @@ const textArrayCodec = listOfCodec(TYPES.text, {
   description: undefined,
   name: "textArray"
 });
-const nonUpdatableViewAttributes = Object.assign(Object.create(null), {
-  "?column?": {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const nonUpdatableViewCodec = recordCodec({
+const spec_nonUpdatableView = {
   name: "nonUpdatableView",
   identifier: sql.identifier("a", "non_updatable_view"),
-  attributes: nonUpdatableViewAttributes,
+  attributes: Object.assign(Object.create(null), {
+    "?column?": {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -467,23 +483,23 @@ const nonUpdatableViewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const inputsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const inputsCodec = recordCodec({
+  executor: executor
+};
+const nonUpdatableViewCodec = recordCodec(spec_nonUpdatableView);
+const spec_inputs = {
   name: "inputs",
   identifier: sql.identifier("a", "inputs"),
-  attributes: inputsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Should output as Input",
   extensions: {
     isTableLike: true,
@@ -494,23 +510,23 @@ const inputsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const patchsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const patchsCodec = recordCodec({
+  executor: executor
+};
+const inputsCodec = recordCodec(spec_inputs);
+const spec_patchs = {
   name: "patchs",
   identifier: sql.identifier("a", "patchs"),
-  attributes: patchsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Should output as Patch",
   extensions: {
     isTableLike: true,
@@ -521,23 +537,23 @@ const patchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const reservedAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const reservedCodec = recordCodec({
+  executor: executor
+};
+const patchsCodec = recordCodec(spec_patchs);
+const spec_reserved = {
   name: "reserved",
   identifier: sql.identifier("a", "reserved"),
-  attributes: reservedAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -548,23 +564,23 @@ const reservedCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const reservedPatchsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const reservedPatchsCodec = recordCodec({
+  executor: executor
+};
+const reservedCodec = recordCodec(spec_reserved);
+const spec_reservedPatchs = {
   name: "reservedPatchs",
   identifier: sql.identifier("a", "reservedPatchs"),
-  attributes: reservedPatchsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   extensions: {
     isTableLike: true,
@@ -575,23 +591,23 @@ const reservedPatchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const reservedInputAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const reservedInputCodec = recordCodec({
+  executor: executor
+};
+const reservedPatchsCodec = recordCodec(spec_reservedPatchs);
+const spec_reservedInput = {
   name: "reservedInput",
   identifier: sql.identifier("a", "reserved_input"),
-  attributes: reservedInputAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
   extensions: {
     isTableLike: true,
@@ -602,32 +618,32 @@ const reservedInputCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const defaultValueAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  null_value: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const defaultValueCodec = recordCodec({
+  executor: executor
+};
+const reservedInputCodec = recordCodec(spec_reservedInput);
+const spec_defaultValue = {
   name: "defaultValue",
   identifier: sql.identifier("a", "default_value"),
-  attributes: defaultValueAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    null_value: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -638,41 +654,41 @@ const defaultValueCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const foreignKeyAttributes = Object.assign(Object.create(null), {
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_key_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_key_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const foreignKeyCodec = recordCodec({
+  executor: executor
+};
+const defaultValueCodec = recordCodec(spec_defaultValue);
+const spec_foreignKey = {
   name: "foreignKey",
   identifier: sql.identifier("a", "foreign_key"),
-  attributes: foreignKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_key_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_key_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -683,32 +699,32 @@ const foreignKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  str: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const noPrimaryKeyCodec = recordCodec({
+  executor: executor
+};
+const foreignKeyCodec = recordCodec(spec_foreignKey);
+const spec_noPrimaryKey = {
   name: "noPrimaryKey",
   identifier: sql.identifier("a", "no_primary_key"),
-  attributes: noPrimaryKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    str: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -719,41 +735,41 @@ const noPrimaryKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const testviewAttributes = Object.assign(Object.create(null), {
-  testviewid: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const testviewCodec = recordCodec({
+  executor: executor
+};
+const noPrimaryKeyCodec = recordCodec(spec_noPrimaryKey);
+const spec_testview = {
   name: "testview",
   identifier: sql.identifier("a", "testview"),
-  attributes: testviewAttributes,
+  attributes: Object.assign(Object.create(null), {
+    testviewid: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -764,21 +780,10 @@ const testviewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const extensions12 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "unique_foreign_key"
-  },
-  tags: Object.assign(Object.create(null), {
-    omit: "create,update,delete,all,order,filter",
-    behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy"]
-  })
+  executor: executor
 };
-const uniqueForeignKeyCodec = recordCodec({
+const testviewCodec = recordCodec(spec_testview);
+const spec_uniqueForeignKey = {
   name: "uniqueForeignKey",
   identifier: sql.identifier("a", "unique_foreign_key"),
   attributes: Object.assign(Object.create(null), {
@@ -802,33 +807,44 @@ const uniqueForeignKeyCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions: extensions12,
-  executor
-});
-const myTableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "unique_foreign_key"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: "create,update,delete,all,order,filter",
+      behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy"]
+    })
   },
-  json_data: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const myTableCodec = recordCodec({
+  executor: executor
+};
+const uniqueForeignKeyCodec = recordCodec(spec_uniqueForeignKey);
+const spec_myTable = {
   name: "myTable",
   identifier: sql.identifier("c", "my_table"),
-  attributes: myTableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    json_data: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -839,34 +855,34 @@ const myTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const personSecretAttributes = Object.assign(Object.create(null), {
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  sekrit: {
-    description: "A secret held by the associated Person",
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "secret"
-      }
-    }
-  }
-});
-const personSecretCodec = recordCodec({
+  executor: executor
+};
+const myTableCodec = recordCodec(spec_myTable);
+const spec_personSecret = {
   name: "personSecret",
   identifier: sql.identifier("c", "person_secret"),
-  attributes: personSecretAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    sekrit: {
+      description: "A secret held by the associated Person",
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "secret"
+        }
+      }
+    }
+  }),
   description: "Tracks the person's secret",
   extensions: {
     isTableLike: true,
@@ -879,41 +895,41 @@ const personSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor
-});
-const viewTableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const viewTableCodec = recordCodec({
+  executor: executor
+};
+const personSecretCodec = recordCodec(spec_personSecret);
+const spec_viewTable = {
   name: "viewTable",
   identifier: sql.identifier("a", "view_table"),
-  attributes: viewTableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -924,41 +940,41 @@ const viewTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const compoundKeyAttributes = Object.assign(Object.create(null), {
-  person_id_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  extra: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const compoundKeyCodec = recordCodec({
+  executor: executor
+};
+const viewTableCodec = recordCodec(spec_viewTable);
+const spec_compoundKey = {
   name: "compoundKey",
   identifier: sql.identifier("c", "compound_key"),
-  attributes: compoundKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    extra: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -969,50 +985,50 @@ const compoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const similarTable1Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col3: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const similarTable1Codec = recordCodec({
+  executor: executor
+};
+const compoundKeyCodec = recordCodec(spec_compoundKey);
+const spec_similarTable1 = {
   name: "similarTable1",
   identifier: sql.identifier("a", "similar_table_1"),
-  attributes: similarTable1Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col3: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1023,50 +1039,50 @@ const similarTable1Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const similarTable2Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  col3: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col4: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col5: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const similarTable2Codec = recordCodec({
+  executor: executor
+};
+const similarTable1Codec = recordCodec(spec_similarTable1);
+const spec_similarTable2 = {
   name: "similarTable2",
   identifier: sql.identifier("a", "similar_table_2"),
-  attributes: similarTable2Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    col3: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col4: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col5: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1077,50 +1093,50 @@ const similarTable2Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const updatableViewAttributes = Object.assign(Object.create(null), {
-  x: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  description: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  constant: {
-    description: "This is constantly 2",
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const updatableViewCodec = recordCodec({
+  executor: executor
+};
+const similarTable2Codec = recordCodec(spec_similarTable2);
+const spec_updatableView = {
   name: "updatableView",
   identifier: sql.identifier("b", "updatable_view"),
-  attributes: updatableViewAttributes,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    description: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    constant: {
+      description: "This is constantly 2",
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "YOYOYO!!",
   extensions: {
     isTableLike: true,
@@ -1134,50 +1150,50 @@ const updatableViewCodec = recordCodec({
       unique: "x|@behavior -single -update -delete"
     })
   },
-  executor
-});
-const nullTestRecordAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_int: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  non_null_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const nullTestRecordCodec = recordCodec({
+  executor: executor
+};
+const updatableViewCodec = recordCodec(spec_updatableView);
+const spec_nullTestRecord = {
   name: "nullTestRecord",
   identifier: sql.identifier("c", "null_test_record"),
-  attributes: nullTestRecordAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_int: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    non_null_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1188,8 +1204,9 @@ const nullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const nullTestRecordCodec = recordCodec(spec_nullTestRecord);
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   extensions: {
     pg: {
@@ -1203,39 +1220,38 @@ const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   description: undefined,
   name: "uuidArray"
 });
-const edgeCaseAttributes = Object.assign(Object.create(null), {
-  not_null_has_default: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  wont_cast_easy: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  row_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const edgeCaseCodec = recordCodec({
+const spec_edgeCase = {
   name: "edgeCase",
   identifier: sql.identifier("c", "edge_case"),
-  attributes: edgeCaseAttributes,
+  attributes: Object.assign(Object.create(null), {
+    not_null_has_default: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    wont_cast_easy: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    row_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1246,50 +1262,50 @@ const edgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const leftArmAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  length_in_metres: {
-    description: undefined,
-    codec: TYPES.float,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  mood: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const leftArmCodec = recordCodec({
+  executor: executor
+};
+const edgeCaseCodec = recordCodec(spec_edgeCase);
+const spec_leftArm = {
   name: "leftArm",
   identifier: sql.identifier("c", "left_arm"),
-  attributes: leftArmAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    length_in_metres: {
+      description: undefined,
+      codec: TYPES.float,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    mood: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Tracks metadata about the left arms of various people",
   extensions: {
     isTableLike: true,
@@ -1300,8 +1316,9 @@ const leftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const leftArmCodec = recordCodec(spec_leftArm);
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
   identifier: sql.identifier("b", "jwt_token"),
@@ -1362,7 +1379,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
@@ -1376,30 +1393,29 @@ const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp
   },
   notNull: true
 });
-const issue756Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  ts: {
-    description: undefined,
-    codec: notNullTimestampCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const issue756Codec = recordCodec({
+const spec_issue756 = {
   name: "issue756",
   identifier: sql.identifier("c", "issue756"),
-  attributes: issue756Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    ts: {
+      description: undefined,
+      codec: notNullTimestampCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1410,8 +1426,9 @@ const issue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const issue756Codec = recordCodec(spec_issue756);
 const authPayloadCodec = recordCodec({
   name: "authPayload",
   identifier: sql.identifier("b", "auth_payload"),
@@ -1456,7 +1473,7 @@ const authPayloadCodec = recordCodec({
       foreignKey: "(id) references c.person"
     })
   },
-  executor
+  executor: executor
 });
 const colorCodec = enumCodec({
   name: "color",
@@ -1587,7 +1604,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
@@ -1709,7 +1726,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1724,82 +1741,81 @@ const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   description: undefined,
   name: "comptypeArray"
 });
-const postAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  headline: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  body: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  enums: {
-    description: undefined,
-    codec: anEnumArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  comptypes: {
-    description: undefined,
-    codec: comptypeArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions33 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "post"
-  },
-  tags: Object.assign(Object.create(null), {
-    omit: "create",
-    behavior: ["-insert"]
-  })
-};
-const postCodec = recordCodec({
+const spec_post = {
   name: "post",
   identifier: sql.identifier("a", "post"),
-  attributes: postAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    headline: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    body: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    enums: {
+      description: undefined,
+      codec: anEnumArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    comptypes: {
+      description: undefined,
+      codec: comptypeArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions33,
-  executor
-});
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "post"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: "create",
+      behavior: ["-insert"]
+    })
+  },
+  executor: executor
+};
+const postCodec = recordCodec(spec_post);
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
@@ -1946,117 +1962,116 @@ const wrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const personAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: "The primary unique identifier for the person",
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_full_name: {
-    description: "The person\u2019s name",
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "name"
-      }
-    }
-  },
-  aliases: {
-    description: undefined,
-    codec: textArrayCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  about: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  email: {
-    description: undefined,
-    codec: emailCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  site: {
-    description: undefined,
-    codec: wrappedUrlCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        deprecated: "Don\u2019t use me"
-      }
-    }
-  },
-  config: {
-    description: undefined,
-    codec: TYPES.hstore,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_login_from_ip: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_login_from_subnet: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  user_mac: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  created_at: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const personCodec = recordCodec({
+const spec_person = {
   name: "person",
   identifier: sql.identifier("c", "person"),
-  attributes: personAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: "The primary unique identifier for the person",
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_full_name: {
+      description: "The person\u2019s name",
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "name"
+        }
+      }
+    },
+    aliases: {
+      description: undefined,
+      codec: textArrayCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    about: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    email: {
+      description: undefined,
+      codec: emailCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    site: {
+      description: undefined,
+      codec: wrappedUrlCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          deprecated: "Don\u2019t use me"
+        }
+      }
+    },
+    config: {
+      description: undefined,
+      codec: TYPES.hstore,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_login_from_ip: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_login_from_subnet: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    user_mac: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    created_at: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Person test comment",
   extensions: {
     isTableLike: true,
@@ -2067,8 +2082,9 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const personCodec = recordCodec(spec_person);
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
@@ -2401,7 +2417,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -2453,7 +2469,7 @@ const byteaArrayCodec = listOfCodec(TYPES.bytea, {
   description: undefined,
   name: "byteaArray"
 });
-const typesAttributes_ltree_codec_ltree = {
+const spec_types_attributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -2465,469 +2481,468 @@ const typesAttributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
-const typesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  smallint: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bigint: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numeric: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  decimal: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  boolean: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  varchar: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum_array: {
-    description: undefined,
-    codec: colorArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain: {
-    description: undefined,
-    codec: anIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain2: {
-    description: undefined,
-    codec: anotherIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array: {
-    description: undefined,
-    codec: textArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  json: {
-    description: undefined,
-    codec: TYPES.json,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  jsonb: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_range: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numrange: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  daterange: {
-    description: undefined,
-    codec: daterangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  an_int_range: {
-    description: undefined,
-    codec: anIntRangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamp: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamptz: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  date: {
-    description: undefined,
-    codec: TYPES.date,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  time: {
-    description: undefined,
-    codec: TYPES.time,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timetz: {
-    description: undefined,
-    codec: TYPES.timetz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval_array: {
-    description: undefined,
-    codec: intervalArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  money: {
-    description: undefined,
-    codec: TYPES.money,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  point: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullablePoint: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  inet: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  cidr: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  macaddr: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regproc: {
-    description: undefined,
-    codec: TYPES.regproc,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regprocedure: {
-    description: undefined,
-    codec: TYPES.regprocedure,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoper: {
-    description: undefined,
-    codec: TYPES.regoper,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoperator: {
-    description: undefined,
-    codec: TYPES.regoperator,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regclass: {
-    description: undefined,
-    codec: TYPES.regclass,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regtype: {
-    description: undefined,
-    codec: TYPES.regtype,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regconfig: {
-    description: undefined,
-    codec: TYPES.regconfig,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regdictionary: {
-    description: undefined,
-    codec: TYPES.regdictionary,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array_domain: {
-    description: undefined,
-    codec: textArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  int8_array_domain: {
-    description: undefined,
-    codec: int8ArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea: {
-    description: undefined,
-    codec: TYPES.bytea,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea_array: {
-    description: undefined,
-    codec: byteaArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree: {
-    description: undefined,
-    codec: typesAttributes_ltree_codec_ltree,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree_array: {
-    description: undefined,
-    codec: typesAttributes_ltree_array_codec_ltree_,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions46 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "types"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: ["(smallint) references a.post", "(id) references a.post"]
-  })
-};
-const typesCodec = recordCodec({
+const spec_types_attributes_ltree_array_codec_ltree_ = listOfCodec(spec_types_attributes_ltree_codec_ltree);
+const spec_types = {
   name: "types",
   identifier: sql.identifier("b", "types"),
-  attributes: typesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    smallint: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bigint: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numeric: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    decimal: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    boolean: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    varchar: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum_array: {
+      description: undefined,
+      codec: colorArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain: {
+      description: undefined,
+      codec: anIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain2: {
+      description: undefined,
+      codec: anotherIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array: {
+      description: undefined,
+      codec: textArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    json: {
+      description: undefined,
+      codec: TYPES.json,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    jsonb: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_range: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numrange: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    daterange: {
+      description: undefined,
+      codec: daterangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    an_int_range: {
+      description: undefined,
+      codec: anIntRangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamp: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamptz: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    date: {
+      description: undefined,
+      codec: TYPES.date,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    time: {
+      description: undefined,
+      codec: TYPES.time,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timetz: {
+      description: undefined,
+      codec: TYPES.timetz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval_array: {
+      description: undefined,
+      codec: intervalArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    money: {
+      description: undefined,
+      codec: TYPES.money,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    point: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullablePoint: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    inet: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    cidr: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    macaddr: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regproc: {
+      description: undefined,
+      codec: TYPES.regproc,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regprocedure: {
+      description: undefined,
+      codec: TYPES.regprocedure,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoper: {
+      description: undefined,
+      codec: TYPES.regoper,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoperator: {
+      description: undefined,
+      codec: TYPES.regoperator,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regclass: {
+      description: undefined,
+      codec: TYPES.regclass,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regtype: {
+      description: undefined,
+      codec: TYPES.regtype,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regconfig: {
+      description: undefined,
+      codec: TYPES.regconfig,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regdictionary: {
+      description: undefined,
+      codec: TYPES.regdictionary,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array_domain: {
+      description: undefined,
+      codec: textArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    int8_array_domain: {
+      description: undefined,
+      codec: int8ArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea: {
+      description: undefined,
+      codec: TYPES.bytea,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea_array: {
+      description: undefined,
+      codec: byteaArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree: {
+      description: undefined,
+      codec: spec_types_attributes_ltree_codec_ltree,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree_array: {
+      description: undefined,
+      codec: spec_types_attributes_ltree_array_codec_ltree_,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions46,
-  executor
-});
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "types"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: ["(smallint) references a.post", "(id) references a.post"]
+    })
+  },
+  executor: executor
+};
+const typesCodec = recordCodec(spec_types);
 const int4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
     pg: {
@@ -3120,7 +3135,7 @@ const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
     },
     tags: {
       omit: "create,update,delete,all,order,filter",
-      behavior: extensions12.tags.behavior
+      behavior: spec_uniqueForeignKey.extensions.tags.behavior
     }
   }
 };
@@ -3352,7 +3367,7 @@ const registryConfig_pgResources_post_post = {
     },
     tags: {
       omit: "create",
-      behavior: extensions33.tags.behavior
+      behavior: spec_post.extensions.tags.behavior
     }
   }
 };
@@ -3473,7 +3488,7 @@ const registryConfig_pgResources_types_types = {
       name: "types"
     },
     tags: {
-      foreignKey: extensions46.tags.foreignKey
+      foreignKey: spec_types.extensions.tags.foreignKey
     }
   }
 };
@@ -3596,8 +3611,8 @@ const registry = makeRegistry({
     int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
     byteaArray: byteaArrayCodec,
-    ltree: typesAttributes_ltree_codec_ltree,
-    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
+    ltree: spec_types_attributes_ltree_codec_ltree,
+    "ltree[]": spec_types_attributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     compoundTypeArray: listOfCodec(compoundTypeCodec, {
       extensions: {
@@ -3684,7 +3699,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor
+      executor: executor
     }),
     tablefuncCrosstab3: recordCodec({
       name: "tablefuncCrosstab3",
@@ -3737,7 +3752,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor
+      executor: executor
     }),
     tablefuncCrosstab4: recordCodec({
       name: "tablefuncCrosstab4",
@@ -3799,7 +3814,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor
+      executor: executor
     })
   }),
   pgResources: Object.assign(Object.create(null), {
@@ -12408,6 +12423,15 @@ const makeArgs64 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
+function UUIDSerialize(value) {
+  return "" + value;
+}
+const coerce = string => {
+  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
+    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
+  }
+  return string;
+};
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -12912,6 +12936,60 @@ const makeArgs73 = (args, path = []) => {
 const resource_post_computed_compound_type_arrayPgResource = registry.pgResources["post_computed_compound_type_array"];
 const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
+function LTreeParseValue(value) {
+  return value;
+}
+const isValidHstoreObject = obj => {
+  if (obj === null) {
+    // Null is okay
+    return true;
+  } else if (typeof obj === "object") {
+    // A hash with string/null values is also okay
+    const keys = Object.keys(obj);
+    for (const key of keys) {
+      const val = obj[key];
+      if (val === null) {
+        // Null is okay
+      } else if (typeof val === "string") {
+        // String is okay
+      } else {
+        // Everything else is invalid.
+        return false;
+      }
+    }
+    return true;
+  } else {
+    // Everything else is invalid.
+    return false;
+  }
+};
+const parseValueLiteral = (ast, variables) => {
+  switch (ast.kind) {
+    case Kind.INT:
+    case Kind.FLOAT:
+      // Number isn't really okay, but we'll coerce it to a string anyway.
+      return String(parseFloat(ast.value));
+    case Kind.STRING:
+      // String is okay.
+      return String(ast.value);
+    case Kind.NULL:
+      // Null is okay.
+      return null;
+    case Kind.VARIABLE:
+      {
+        // Variable is okay if that variable is either a string or null.
+        const name = ast.name.value;
+        const value = variables ? variables[name] : undefined;
+        if (value === null || typeof value === "string") {
+          return value;
+        }
+        return undefined;
+      }
+    default:
+      // Everything else is invalid.
+      return undefined;
+  }
+};
 const argDetailsSimple74 = [];
 const makeArgs74 = (args, path = []) => {
   const selectArgs = [];
@@ -29614,6 +29692,11 @@ export const plans = {
       return $record.get("o");
     }
   },
+  Email: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
   PersonComputedFirstArgInoutOutRecord: {
     __assertStep: assertPgClassSingleStep,
     person($record) {
@@ -29723,6 +29806,19 @@ export const plans = {
     },
     BLUE: {
       value: "blue"
+    }
+  },
+  UUID: {
+    serialize: UUIDSerialize,
+    parseValue(value) {
+      return coerce("" + value);
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // ERRORS: add name to this error
+        throw new GraphQLError(`${"UUID" ?? "This scalar"} can only parse string values (kind = '${ast.kind}')`);
+      }
+      return coerce(ast.value);
     }
   },
   EnumCaps: {
@@ -30229,6 +30325,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -30245,6 +30351,9 @@ export const plans = {
     }
   },
   CompoundTypeInput: {
+    "__inputPlan": function CompoundTypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     a: {
       applyPlan($insert, val) {
         $insert.set("a", val.get());
@@ -30373,6 +30482,16 @@ export const plans = {
     },
     isOptimised($record) {
       return $record.get("is_optimised");
+    }
+  },
+  Datetime: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   TypesConnection: {
@@ -30579,12 +30698,77 @@ export const plans = {
       });
     }
   },
+  BigInt: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigInt" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  BigFloat: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigFloat" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  AnInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
+  AnotherInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
+  JSON: {
+    serialize(value) {
+      return JSON.stringify(value);
+    },
+    parseValue(value) {
+      return JSON.parse(value);
+    },
+    parseLiteral(ast, _variables) {
+      if (ast.kind === Kind.STRING) {
+        return JSON.parse(ast.value);
+      } else {
+        return undefined;
+      }
+    }
+  },
   BigFloatRange: {},
   BigFloatRangeBound: {},
   DateRange: {},
   DateRangeBound: {},
+  Date: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Date" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   AnIntRange: {},
   AnIntRangeBound: {},
+  Time: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Time" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   NestedCompoundType: {
     __assertStep: assertPgClassSingleStep,
     a($record) {
@@ -30610,6 +30794,128 @@ export const plans = {
     }
   },
   Point: {},
+  InternetAddress: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"InternetAddress" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProc: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProc" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProcedure: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProcedure" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOper: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOper" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOperator: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOperator" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegClass: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegClass" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegType: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegType" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegConfig: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegConfig" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegDictionary: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegDictionary" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  Base64EncodedBinary: {
+    serialize(data) {
+      if (Buffer.isBuffer(data)) {
+        return data.toString("base64");
+      } else {
+        throw new Error(`Base64EncodeBinary can only be used with Node.js buffers.`);
+      }
+    },
+    parseValue(data) {
+      if (typeof data === "string") {
+        return Buffer.from(data, "base64");
+      } else {
+        throw new GraphQLError("Base64EncodedBinary can only parse string values.");
+      }
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // TODO: add name to this error
+        throw new GraphQLError("Base64EncodedBinary can only parse string values");
+      }
+      return Buffer.from(ast.value, "base64");
+    }
+  },
+  LTree: {
+    serialize(x) {
+      return x;
+    },
+    parseValue: LTreeParseValue,
+    parseLiteral(node, variables) {
+      return LTreeParseValue(valueFromASTUntyped(node, variables));
+    }
+  },
   TypesEdge: {
     __assertStep: assertEdgeCapableStep,
     cursor($edge) {
@@ -31930,7 +32236,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.id.codec)}`;
             }
           });
         }
@@ -31953,7 +32259,7 @@ export const plans = {
             type: "attribute",
             attribute: "smallint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.smallint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.smallint.codec)}`;
             }
           });
         }
@@ -31976,7 +32282,7 @@ export const plans = {
             type: "attribute",
             attribute: "bigint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.bigint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.bigint.codec)}`;
             }
           });
         }
@@ -31999,7 +32305,7 @@ export const plans = {
             type: "attribute",
             attribute: "numeric",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numeric.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.numeric.codec)}`;
             }
           });
         }
@@ -32022,7 +32328,7 @@ export const plans = {
             type: "attribute",
             attribute: "decimal",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.decimal.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.decimal.codec)}`;
             }
           });
         }
@@ -32045,7 +32351,7 @@ export const plans = {
             type: "attribute",
             attribute: "boolean",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.boolean.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.boolean.codec)}`;
             }
           });
         }
@@ -32068,7 +32374,7 @@ export const plans = {
             type: "attribute",
             attribute: "varchar",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.varchar.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.varchar.codec)}`;
             }
           });
         }
@@ -32091,7 +32397,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.enum.codec)}`;
             }
           });
         }
@@ -32114,7 +32420,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.enum_array.codec)}`;
             }
           });
         }
@@ -32137,7 +32443,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.domain.codec)}`;
             }
           });
         }
@@ -32160,7 +32466,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.domain2.codec)}`;
             }
           });
         }
@@ -32183,7 +32489,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.text_array.codec)}`;
             }
           });
         }
@@ -32206,7 +32512,7 @@ export const plans = {
             type: "attribute",
             attribute: "json",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.json.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.json.codec)}`;
             }
           });
         }
@@ -32229,7 +32535,7 @@ export const plans = {
             type: "attribute",
             attribute: "jsonb",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.jsonb.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.jsonb.codec)}`;
             }
           });
         }
@@ -32252,7 +32558,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullable_range.codec)}`;
             }
           });
         }
@@ -32275,7 +32581,7 @@ export const plans = {
             type: "attribute",
             attribute: "numrange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numrange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.numrange.codec)}`;
             }
           });
         }
@@ -32298,7 +32604,7 @@ export const plans = {
             type: "attribute",
             attribute: "daterange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.daterange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.daterange.codec)}`;
             }
           });
         }
@@ -32321,7 +32627,7 @@ export const plans = {
             type: "attribute",
             attribute: "an_int_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.an_int_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.an_int_range.codec)}`;
             }
           });
         }
@@ -32344,7 +32650,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamp",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamp.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.timestamp.codec)}`;
             }
           });
         }
@@ -32367,7 +32673,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamptz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamptz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.timestamptz.codec)}`;
             }
           });
         }
@@ -32390,7 +32696,7 @@ export const plans = {
             type: "attribute",
             attribute: "date",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.date.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.date.codec)}`;
             }
           });
         }
@@ -32413,7 +32719,7 @@ export const plans = {
             type: "attribute",
             attribute: "time",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.time.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.time.codec)}`;
             }
           });
         }
@@ -32436,7 +32742,7 @@ export const plans = {
             type: "attribute",
             attribute: "timetz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timetz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.timetz.codec)}`;
             }
           });
         }
@@ -32459,7 +32765,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.interval.codec)}`;
             }
           });
         }
@@ -32482,7 +32788,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.interval_array.codec)}`;
             }
           });
         }
@@ -32505,7 +32811,7 @@ export const plans = {
             type: "attribute",
             attribute: "money",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.money.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.money.codec)}`;
             }
           });
         }
@@ -32528,7 +32834,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.compound_type.codec)}`;
             }
           });
         }
@@ -32551,7 +32857,7 @@ export const plans = {
             type: "attribute",
             attribute: "nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nested_compound_type.codec)}`;
             }
           });
         }
@@ -32574,7 +32880,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullable_compound_type.codec)}`;
             }
           });
         }
@@ -32597,7 +32903,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullable_nested_compound_type.codec)}`;
             }
           });
         }
@@ -32620,7 +32926,7 @@ export const plans = {
             type: "attribute",
             attribute: "point",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.point.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.point.codec)}`;
             }
           });
         }
@@ -32643,7 +32949,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullablePoint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullablePoint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullablePoint.codec)}`;
             }
           });
         }
@@ -32666,7 +32972,7 @@ export const plans = {
             type: "attribute",
             attribute: "inet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.inet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.inet.codec)}`;
             }
           });
         }
@@ -32689,7 +32995,7 @@ export const plans = {
             type: "attribute",
             attribute: "cidr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.cidr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.cidr.codec)}`;
             }
           });
         }
@@ -32712,7 +33018,7 @@ export const plans = {
             type: "attribute",
             attribute: "macaddr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.macaddr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.macaddr.codec)}`;
             }
           });
         }
@@ -32735,7 +33041,7 @@ export const plans = {
             type: "attribute",
             attribute: "regproc",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regproc.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regproc.codec)}`;
             }
           });
         }
@@ -32758,7 +33064,7 @@ export const plans = {
             type: "attribute",
             attribute: "regprocedure",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regprocedure.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regprocedure.codec)}`;
             }
           });
         }
@@ -32781,7 +33087,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoper",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoper.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regoper.codec)}`;
             }
           });
         }
@@ -32804,7 +33110,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoperator",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoperator.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regoperator.codec)}`;
             }
           });
         }
@@ -32827,7 +33133,7 @@ export const plans = {
             type: "attribute",
             attribute: "regclass",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regclass.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regclass.codec)}`;
             }
           });
         }
@@ -32850,7 +33156,7 @@ export const plans = {
             type: "attribute",
             attribute: "regtype",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regtype.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regtype.codec)}`;
             }
           });
         }
@@ -32873,7 +33179,7 @@ export const plans = {
             type: "attribute",
             attribute: "regconfig",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regconfig.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regconfig.codec)}`;
             }
           });
         }
@@ -32896,7 +33202,7 @@ export const plans = {
             type: "attribute",
             attribute: "regdictionary",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regdictionary.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regdictionary.codec)}`;
             }
           });
         }
@@ -32919,7 +33225,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.text_array_domain.codec)}`;
             }
           });
         }
@@ -32942,7 +33248,7 @@ export const plans = {
             type: "attribute",
             attribute: "int8_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.int8_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.int8_array_domain.codec)}`;
             }
           });
         }
@@ -32965,7 +33271,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.ltree.codec)}`;
             }
           });
         }
@@ -32988,7 +33294,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.ltree_array.codec)}`;
             }
           });
         }
@@ -33022,6 +33328,9 @@ export const plans = {
     inclusive: undefined
   },
   NestedCompoundTypeInput: {
+    "__inputPlan": function NestedCompoundTypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     a: {
       applyPlan($insert, val) {
         $insert.set("a", val.get());
@@ -33516,6 +33825,50 @@ export const plans = {
       return $record.get("url");
     }
   },
+  NotNullUrl: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
+  KeyValueHash: {
+    serialize(value) {
+      return value;
+    },
+    parseValue(obj) {
+      if (isValidHstoreObject(obj)) {
+        return obj;
+      }
+      throw new GraphQLError(`This is not a valid ${"KeyValueHash"} object, it must be a key/value hash where keys and values are both strings (or null).`);
+    },
+    parseLiteral(ast, variables) {
+      switch (ast.kind) {
+        case Kind.OBJECT:
+          {
+            const value = ast.fields.reduce((memo, field) => {
+              memo[field.name.value] = parseValueLiteral(field.value, variables);
+              return memo;
+            }, Object.create(null));
+            if (!isValidHstoreObject(value)) {
+              return undefined;
+            }
+            return value;
+          }
+        case Kind.NULL:
+          return null;
+        case Kind.VARIABLE:
+          {
+            const name = ast.name.value;
+            const value = variables ? variables[name] : undefined;
+            if (!isValidHstoreObject(value)) {
+              return undefined;
+            }
+            return value;
+          }
+        default:
+          return undefined;
+      }
+    }
+  },
   PostsConnection: {
     __assertStep: ConnectionStep,
     nodes($connection) {
@@ -33760,7 +34113,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.id.codec)}`;
             }
           });
         }
@@ -33783,7 +34136,7 @@ export const plans = {
             type: "attribute",
             attribute: "headline",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.headline.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.headline.codec)}`;
             }
           });
         }
@@ -33806,7 +34159,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.body.codec)}`;
             }
           });
         }
@@ -33829,7 +34182,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.author_id.codec)}`;
             }
           });
         }
@@ -33852,7 +34205,7 @@ export const plans = {
             type: "attribute",
             attribute: "enums",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.enums.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.enums.codec)}`;
             }
           });
         }
@@ -33875,7 +34228,7 @@ export const plans = {
             type: "attribute",
             attribute: "comptypes",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.comptypes.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.comptypes.codec)}`;
             }
           });
         }
@@ -33900,6 +34253,9 @@ export const plans = {
     }
   },
   ComptypeInput: {
+    "__inputPlan": function ComptypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     schedule: {
       applyPlan($insert, val) {
         $insert.set("schedule", val.get());
@@ -34086,7 +34442,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_foreignKey.attributes.person_id.codec)}`;
             }
           });
         }
@@ -34109,7 +34465,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_foreignKey.attributes.compound_key_1.codec)}`;
             }
           });
         }
@@ -34132,7 +34488,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_foreignKey.attributes.compound_key_2.codec)}`;
             }
           });
         }
@@ -34363,7 +34719,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.person_id_2.codec)}`;
             }
           });
         }
@@ -34386,7 +34742,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.person_id_1.codec)}`;
             }
           });
         }
@@ -34409,7 +34765,7 @@ export const plans = {
             type: "attribute",
             attribute: "extra",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.extra.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.extra.codec)}`;
             }
           });
         }
@@ -34515,6 +34871,16 @@ export const plans = {
     },
     ts($record) {
       return $record.get("ts");
+    }
+  },
+  NotNullTimestamp: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   FuncOutSetofConnection: {
@@ -34910,7 +35276,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.id.codec)}`;
             }
           });
         }
@@ -34933,7 +35299,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_full_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.person_full_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.person_full_name.codec)}`;
             }
           });
         }
@@ -34956,7 +35322,7 @@ export const plans = {
             type: "attribute",
             attribute: "aliases",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.aliases.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.aliases.codec)}`;
             }
           });
         }
@@ -34979,7 +35345,7 @@ export const plans = {
             type: "attribute",
             attribute: "about",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.about.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.about.codec)}`;
             }
           });
         }
@@ -35002,7 +35368,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.email.codec)}`;
             }
           });
         }
@@ -35025,7 +35391,7 @@ export const plans = {
             type: "attribute",
             attribute: "site",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.site.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.site.codec)}`;
             }
           });
         }
@@ -35048,7 +35414,7 @@ export const plans = {
             type: "attribute",
             attribute: "config",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.config.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.config.codec)}`;
             }
           });
         }
@@ -35071,7 +35437,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_ip",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_ip.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_login_from_ip.codec)}`;
             }
           });
         }
@@ -35094,7 +35460,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_subnet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_subnet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_login_from_subnet.codec)}`;
             }
           });
         }
@@ -35117,7 +35483,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_mac",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.user_mac.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.user_mac.codec)}`;
             }
           });
         }
@@ -35140,7 +35506,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.created_at.codec)}`;
             }
           });
         }
@@ -35165,6 +35531,9 @@ export const plans = {
     }
   },
   WrappedUrlInput: {
+    "__inputPlan": function WrappedUrlInput_inputPlan() {
+      return object(Object.create(null));
+    },
     url: {
       applyPlan($insert, val) {
         $insert.set("url", val.get());
@@ -35259,7 +35628,7 @@ export const plans = {
             type: "attribute",
             attribute: "?column?",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nonUpdatableViewAttributes["?column?"].codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nonUpdatableView.attributes["?column?"].codec)}`;
             }
           });
         }
@@ -35380,7 +35749,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), inputsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_inputs.attributes.id.codec)}`;
             }
           });
         }
@@ -35501,7 +35870,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), patchsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_patchs.attributes.id.codec)}`;
             }
           });
         }
@@ -35622,7 +35991,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reserved.attributes.id.codec)}`;
             }
           });
         }
@@ -35743,7 +36112,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedPatchsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reservedPatchs.attributes.id.codec)}`;
             }
           });
         }
@@ -35864,7 +36233,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedInputAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reservedInput.attributes.id.codec)}`;
             }
           });
         }
@@ -36019,7 +36388,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_defaultValue.attributes.id.codec)}`;
             }
           });
         }
@@ -36042,7 +36411,7 @@ export const plans = {
             type: "attribute",
             attribute: "null_value",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.null_value.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_defaultValue.attributes.null_value.codec)}`;
             }
           });
         }
@@ -36165,7 +36534,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_noPrimaryKey.attributes.id.codec)}`;
             }
           });
         }
@@ -36188,7 +36557,7 @@ export const plans = {
             type: "attribute",
             attribute: "str",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.str.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_noPrimaryKey.attributes.str.codec)}`;
             }
           });
         }
@@ -36357,7 +36726,7 @@ export const plans = {
             type: "attribute",
             attribute: "testviewid",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.testviewid.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_testview.attributes.testviewid.codec)}`;
             }
           });
         }
@@ -36380,7 +36749,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_testview.attributes.col1.codec)}`;
             }
           });
         }
@@ -36403,7 +36772,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_testview.attributes.col2.codec)}`;
             }
           });
         }
@@ -36558,7 +36927,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_myTable.attributes.id.codec)}`;
             }
           });
         }
@@ -36581,7 +36950,7 @@ export const plans = {
             type: "attribute",
             attribute: "json_data",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.json_data.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_myTable.attributes.json_data.codec)}`;
             }
           });
         }
@@ -36736,7 +37105,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_personSecret.attributes.person_id.codec)}`;
             }
           });
         }
@@ -36759,7 +37128,7 @@ export const plans = {
             type: "attribute",
             attribute: "sekrit",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.sekrit.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_personSecret.attributes.sekrit.codec)}`;
             }
           });
         }
@@ -36948,7 +37317,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_viewTable.attributes.id.codec)}`;
             }
           });
         }
@@ -36971,7 +37340,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_viewTable.attributes.col1.codec)}`;
             }
           });
         }
@@ -36994,7 +37363,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_viewTable.attributes.col2.codec)}`;
             }
           });
         }
@@ -37217,7 +37586,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.id.codec)}`;
             }
           });
         }
@@ -37240,7 +37609,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.col1.codec)}`;
             }
           });
         }
@@ -37263,7 +37632,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.col2.codec)}`;
             }
           });
         }
@@ -37286,7 +37655,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.col3.codec)}`;
             }
           });
         }
@@ -37509,7 +37878,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.id.codec)}`;
             }
           });
         }
@@ -37532,7 +37901,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.col3.codec)}`;
             }
           });
         }
@@ -37555,7 +37924,7 @@ export const plans = {
             type: "attribute",
             attribute: "col4",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col4.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.col4.codec)}`;
             }
           });
         }
@@ -37578,7 +37947,7 @@ export const plans = {
             type: "attribute",
             attribute: "col5",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col5.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.col5.codec)}`;
             }
           });
         }
@@ -37784,7 +38153,7 @@ export const plans = {
             type: "attribute",
             attribute: "x",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.x.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.x.codec)}`;
             }
           });
         }
@@ -37807,7 +38176,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.name.codec)}`;
             }
           });
         }
@@ -37830,7 +38199,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.description.codec)}`;
             }
           });
         }
@@ -37853,7 +38222,7 @@ export const plans = {
             type: "attribute",
             attribute: "constant",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.constant.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.constant.codec)}`;
             }
           });
         }
@@ -38076,7 +38445,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.id.codec)}`;
             }
           });
         }
@@ -38099,7 +38468,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.nullable_text.codec)}`;
             }
           });
         }
@@ -38122,7 +38491,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_int",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_int.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.nullable_int.codec)}`;
             }
           });
         }
@@ -38145,7 +38514,7 @@ export const plans = {
             type: "attribute",
             attribute: "non_null_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.non_null_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.non_null_text.codec)}`;
             }
           });
         }
@@ -38348,7 +38717,7 @@ export const plans = {
             type: "attribute",
             attribute: "not_null_has_default",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.not_null_has_default.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.not_null_has_default.codec)}`;
             }
           });
         }
@@ -38371,7 +38740,7 @@ export const plans = {
             type: "attribute",
             attribute: "wont_cast_easy",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.wont_cast_easy.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.wont_cast_easy.codec)}`;
             }
           });
         }
@@ -38394,7 +38763,7 @@ export const plans = {
             type: "attribute",
             attribute: "row_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.row_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.row_id.codec)}`;
             }
           });
         }
@@ -38617,7 +38986,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.id.codec)}`;
             }
           });
         }
@@ -38640,7 +39009,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.person_id.codec)}`;
             }
           });
         }
@@ -38663,7 +39032,7 @@ export const plans = {
             type: "attribute",
             attribute: "length_in_metres",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.length_in_metres.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.length_in_metres.codec)}`;
             }
           });
         }
@@ -38686,7 +39055,7 @@ export const plans = {
             type: "attribute",
             attribute: "mood",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.mood.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.mood.codec)}`;
             }
           });
         }
@@ -38841,7 +39210,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_issue756.attributes.id.codec)}`;
             }
           });
         }
@@ -38864,7 +39233,7 @@ export const plans = {
             type: "attribute",
             attribute: "ts",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.ts.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_issue756.attributes.ts.codec)}`;
             }
           });
         }
@@ -42166,6 +42535,11 @@ export const plans = {
       return rootValue();
     }
   },
+  Guid: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
   GuidFnInput: {
     clientMutationId: {
       applyPlan($input, val) {
@@ -42357,6 +42731,9 @@ export const plans = {
     leftArm: undefined
   },
   LeftArmBaseInput: {
+    "__inputPlan": function LeftArmBaseInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43135,6 +43512,9 @@ export const plans = {
     }
   },
   InputInput: {
+    "__inputPlan": function InputInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43202,6 +43582,9 @@ export const plans = {
     }
   },
   PatchInput: {
+    "__inputPlan": function PatchInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43269,6 +43652,9 @@ export const plans = {
     }
   },
   ReservedInput: {
+    "__inputPlan": function ReservedInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43336,6 +43722,9 @@ export const plans = {
     }
   },
   ReservedPatchRecordInput: {
+    "__inputPlan": function ReservedPatchRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43403,6 +43792,9 @@ export const plans = {
     }
   },
   ReservedInputRecordInput: {
+    "__inputPlan": function ReservedInputRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43470,6 +43862,9 @@ export const plans = {
     }
   },
   DefaultValueInput: {
+    "__inputPlan": function DefaultValueInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43524,6 +43919,9 @@ export const plans = {
     }
   },
   ForeignKeyInput: {
+    "__inputPlan": function ForeignKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -43574,6 +43972,9 @@ export const plans = {
     }
   },
   NoPrimaryKeyInput: {
+    "__inputPlan": function NoPrimaryKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43617,6 +44018,9 @@ export const plans = {
     }
   },
   TestviewInput: {
+    "__inputPlan": function TestviewInput_inputPlan() {
+      return object(Object.create(null));
+    },
     testviewid: {
       applyPlan($insert, val) {
         $insert.set("testviewid", val.get());
@@ -43698,6 +44102,9 @@ export const plans = {
     }
   },
   MyTableInput: {
+    "__inputPlan": function MyTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43777,6 +44184,9 @@ export const plans = {
     }
   },
   PersonSecretInput: {
+    "__inputPlan": function PersonSecretInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -43851,6 +44261,9 @@ export const plans = {
     }
   },
   ViewTableInput: {
+    "__inputPlan": function ViewTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43942,6 +44355,9 @@ export const plans = {
     }
   },
   CompoundKeyInput: {
+    "__inputPlan": function CompoundKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId2: {
       applyPlan($insert, val) {
         $insert.set("person_id_2", val.get());
@@ -44023,6 +44439,9 @@ export const plans = {
     }
   },
   SimilarTable1Input: {
+    "__inputPlan": function SimilarTable1Input_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44111,6 +44530,9 @@ export const plans = {
     }
   },
   SimilarTable2Input: {
+    "__inputPlan": function SimilarTable2Input_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44168,6 +44590,9 @@ export const plans = {
     }
   },
   UpdatableViewInput: {
+    "__inputPlan": function UpdatableViewInput_inputPlan() {
+      return object(Object.create(null));
+    },
     x: {
       applyPlan($insert, val) {
         $insert.set("x", val.get());
@@ -44256,6 +44681,9 @@ export const plans = {
     }
   },
   NullTestRecordInput: {
+    "__inputPlan": function NullTestRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44313,6 +44741,9 @@ export const plans = {
     }
   },
   EdgeCaseInput: {
+    "__inputPlan": function EdgeCaseInput_inputPlan() {
+      return object(Object.create(null));
+    },
     notNullHasDefault: {
       applyPlan($insert, val) {
         $insert.set("not_null_has_default", val.get());
@@ -44399,6 +44830,9 @@ export const plans = {
     }
   },
   LeftArmInput: {
+    "__inputPlan": function LeftArmInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44487,6 +44921,9 @@ export const plans = {
     }
   },
   Issue756Input: {
+    "__inputPlan": function Issue756Input_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44561,6 +44998,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44708,6 +45148,9 @@ export const plans = {
     }
   },
   TypeInput: {
+    "__inputPlan": function TypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45110,6 +45553,9 @@ export const plans = {
     }
   },
   InputPatch: {
+    "__inputPlan": function InputPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45190,6 +45636,9 @@ export const plans = {
     }
   },
   PatchPatch: {
+    "__inputPlan": function PatchPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45270,6 +45719,9 @@ export const plans = {
     }
   },
   ReservedPatch: {
+    "__inputPlan": function ReservedPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45350,6 +45802,9 @@ export const plans = {
     }
   },
   ReservedPatchRecordPatch: {
+    "__inputPlan": function ReservedPatchRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45430,6 +45885,9 @@ export const plans = {
     }
   },
   ReservedInputRecordPatch: {
+    "__inputPlan": function ReservedInputRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45510,6 +45968,9 @@ export const plans = {
     }
   },
   DefaultValuePatch: {
+    "__inputPlan": function DefaultValuePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45566,6 +46027,9 @@ export const plans = {
     }
   },
   NoPrimaryKeyPatch: {
+    "__inputPlan": function NoPrimaryKeyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45639,6 +46103,9 @@ export const plans = {
     }
   },
   MyTablePatch: {
+    "__inputPlan": function MyTablePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45731,6 +46198,9 @@ export const plans = {
     }
   },
   PersonSecretPatch: {
+    "__inputPlan": function PersonSecretPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -45818,6 +46288,9 @@ export const plans = {
     }
   },
   ViewTablePatch: {
+    "__inputPlan": function ViewTablePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45922,6 +46395,9 @@ export const plans = {
     }
   },
   CompoundKeyPatch: {
+    "__inputPlan": function CompoundKeyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     personId2: {
       applyPlan($insert, val) {
         $insert.set("person_id_2", val.get());
@@ -46017,6 +46493,9 @@ export const plans = {
     }
   },
   SimilarTable1Patch: {
+    "__inputPlan": function SimilarTable1Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46118,6 +46597,9 @@ export const plans = {
     }
   },
   SimilarTable2Patch: {
+    "__inputPlan": function SimilarTable2Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46219,6 +46701,9 @@ export const plans = {
     }
   },
   NullTestRecordPatch: {
+    "__inputPlan": function NullTestRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46325,6 +46810,9 @@ export const plans = {
     }
   },
   LeftArmPatch: {
+    "__inputPlan": function LeftArmPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46440,6 +46928,9 @@ export const plans = {
     }
   },
   Issue756Patch: {
+    "__inputPlan": function Issue756Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46532,6 +47023,9 @@ export const plans = {
     }
   },
   PostPatch: {
+    "__inputPlan": function PostPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46647,6 +47141,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46821,6 +47318,9 @@ export const plans = {
     }
   },
   TypePatch: {
+    "__inputPlan": function TypePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, domainOfCodec, enumCodec, listOfCodec, makeRegistry, pgClassExpression, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectFromRecords, pgSelectSingleFromRecord, pgUpdateSingle, rangeOfCodec, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
+import { GraphQLError, GraphQLInt, GraphQLString, Kind, valueFromASTUntyped } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -442,21 +459,20 @@ const textArrayCodec = listOfCodec(TYPES.text, {
   description: undefined,
   name: "textArray"
 });
-const nonUpdatableViewAttributes = Object.assign(Object.create(null), {
-  "?column?": {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const nonUpdatableViewCodec = recordCodec({
+const spec_nonUpdatableView = {
   name: "nonUpdatableView",
   identifier: sql.identifier("a", "non_updatable_view"),
-  attributes: nonUpdatableViewAttributes,
+  attributes: Object.assign(Object.create(null), {
+    "?column?": {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -467,23 +483,23 @@ const nonUpdatableViewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const inputsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const inputsCodec = recordCodec({
+  executor: executor
+};
+const nonUpdatableViewCodec = recordCodec(spec_nonUpdatableView);
+const spec_inputs = {
   name: "inputs",
   identifier: sql.identifier("a", "inputs"),
-  attributes: inputsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Should output as Input",
   extensions: {
     isTableLike: true,
@@ -494,23 +510,23 @@ const inputsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const patchsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const patchsCodec = recordCodec({
+  executor: executor
+};
+const inputsCodec = recordCodec(spec_inputs);
+const spec_patchs = {
   name: "patchs",
   identifier: sql.identifier("a", "patchs"),
-  attributes: patchsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Should output as Patch",
   extensions: {
     isTableLike: true,
@@ -521,23 +537,23 @@ const patchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const reservedAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const reservedCodec = recordCodec({
+  executor: executor
+};
+const patchsCodec = recordCodec(spec_patchs);
+const spec_reserved = {
   name: "reserved",
   identifier: sql.identifier("a", "reserved"),
-  attributes: reservedAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -548,23 +564,23 @@ const reservedCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const reservedPatchsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const reservedPatchsCodec = recordCodec({
+  executor: executor
+};
+const reservedCodec = recordCodec(spec_reserved);
+const spec_reservedPatchs = {
   name: "reservedPatchs",
   identifier: sql.identifier("a", "reservedPatchs"),
-  attributes: reservedPatchsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   extensions: {
     isTableLike: true,
@@ -575,23 +591,23 @@ const reservedPatchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const reservedInputAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const reservedInputCodec = recordCodec({
+  executor: executor
+};
+const reservedPatchsCodec = recordCodec(spec_reservedPatchs);
+const spec_reservedInput = {
   name: "reservedInput",
   identifier: sql.identifier("a", "reserved_input"),
-  attributes: reservedInputAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
   extensions: {
     isTableLike: true,
@@ -602,32 +618,32 @@ const reservedInputCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const defaultValueAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  null_value: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const defaultValueCodec = recordCodec({
+  executor: executor
+};
+const reservedInputCodec = recordCodec(spec_reservedInput);
+const spec_defaultValue = {
   name: "defaultValue",
   identifier: sql.identifier("a", "default_value"),
-  attributes: defaultValueAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    null_value: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -638,41 +654,41 @@ const defaultValueCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const foreignKeyAttributes = Object.assign(Object.create(null), {
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_key_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_key_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const foreignKeyCodec = recordCodec({
+  executor: executor
+};
+const defaultValueCodec = recordCodec(spec_defaultValue);
+const spec_foreignKey = {
   name: "foreignKey",
   identifier: sql.identifier("a", "foreign_key"),
-  attributes: foreignKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_key_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_key_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -683,32 +699,32 @@ const foreignKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  str: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const noPrimaryKeyCodec = recordCodec({
+  executor: executor
+};
+const foreignKeyCodec = recordCodec(spec_foreignKey);
+const spec_noPrimaryKey = {
   name: "noPrimaryKey",
   identifier: sql.identifier("a", "no_primary_key"),
-  attributes: noPrimaryKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    str: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -719,41 +735,41 @@ const noPrimaryKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const testviewAttributes = Object.assign(Object.create(null), {
-  testviewid: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const testviewCodec = recordCodec({
+  executor: executor
+};
+const noPrimaryKeyCodec = recordCodec(spec_noPrimaryKey);
+const spec_testview = {
   name: "testview",
   identifier: sql.identifier("a", "testview"),
-  attributes: testviewAttributes,
+  attributes: Object.assign(Object.create(null), {
+    testviewid: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -764,21 +780,10 @@ const testviewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const extensions12 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "unique_foreign_key"
-  },
-  tags: Object.assign(Object.create(null), {
-    omit: "create,update,delete,all,order,filter",
-    behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy"]
-  })
+  executor: executor
 };
-const uniqueForeignKeyCodec = recordCodec({
+const testviewCodec = recordCodec(spec_testview);
+const spec_uniqueForeignKey = {
   name: "uniqueForeignKey",
   identifier: sql.identifier("a", "unique_foreign_key"),
   attributes: Object.assign(Object.create(null), {
@@ -802,33 +807,44 @@ const uniqueForeignKeyCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions: extensions12,
-  executor
-});
-const myTableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "unique_foreign_key"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: "create,update,delete,all,order,filter",
+      behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy"]
+    })
   },
-  json_data: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const myTableCodec = recordCodec({
+  executor: executor
+};
+const uniqueForeignKeyCodec = recordCodec(spec_uniqueForeignKey);
+const spec_myTable = {
   name: "myTable",
   identifier: sql.identifier("c", "my_table"),
-  attributes: myTableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    json_data: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -839,34 +855,34 @@ const myTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const personSecretAttributes = Object.assign(Object.create(null), {
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  sekrit: {
-    description: "A secret held by the associated Person",
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "secret"
-      }
-    }
-  }
-});
-const personSecretCodec = recordCodec({
+  executor: executor
+};
+const myTableCodec = recordCodec(spec_myTable);
+const spec_personSecret = {
   name: "personSecret",
   identifier: sql.identifier("c", "person_secret"),
-  attributes: personSecretAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    sekrit: {
+      description: "A secret held by the associated Person",
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "secret"
+        }
+      }
+    }
+  }),
   description: "Tracks the person's secret",
   extensions: {
     isTableLike: true,
@@ -879,41 +895,41 @@ const personSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor
-});
-const viewTableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const viewTableCodec = recordCodec({
+  executor: executor
+};
+const personSecretCodec = recordCodec(spec_personSecret);
+const spec_viewTable = {
   name: "viewTable",
   identifier: sql.identifier("a", "view_table"),
-  attributes: viewTableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -924,41 +940,41 @@ const viewTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const compoundKeyAttributes = Object.assign(Object.create(null), {
-  person_id_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  extra: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const compoundKeyCodec = recordCodec({
+  executor: executor
+};
+const viewTableCodec = recordCodec(spec_viewTable);
+const spec_compoundKey = {
   name: "compoundKey",
   identifier: sql.identifier("c", "compound_key"),
-  attributes: compoundKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    extra: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -969,50 +985,50 @@ const compoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const similarTable1Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col3: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const similarTable1Codec = recordCodec({
+  executor: executor
+};
+const compoundKeyCodec = recordCodec(spec_compoundKey);
+const spec_similarTable1 = {
   name: "similarTable1",
   identifier: sql.identifier("a", "similar_table_1"),
-  attributes: similarTable1Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col3: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1023,50 +1039,50 @@ const similarTable1Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const similarTable2Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  col3: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col4: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col5: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const similarTable2Codec = recordCodec({
+  executor: executor
+};
+const similarTable1Codec = recordCodec(spec_similarTable1);
+const spec_similarTable2 = {
   name: "similarTable2",
   identifier: sql.identifier("a", "similar_table_2"),
-  attributes: similarTable2Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    col3: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col4: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col5: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1077,50 +1093,50 @@ const similarTable2Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const updatableViewAttributes = Object.assign(Object.create(null), {
-  x: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  description: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  constant: {
-    description: "This is constantly 2",
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const updatableViewCodec = recordCodec({
+  executor: executor
+};
+const similarTable2Codec = recordCodec(spec_similarTable2);
+const spec_updatableView = {
   name: "updatableView",
   identifier: sql.identifier("b", "updatable_view"),
-  attributes: updatableViewAttributes,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    description: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    constant: {
+      description: "This is constantly 2",
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "YOYOYO!!",
   extensions: {
     isTableLike: true,
@@ -1134,50 +1150,50 @@ const updatableViewCodec = recordCodec({
       unique: "x|@behavior -single -update -delete"
     })
   },
-  executor
-});
-const nullTestRecordAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_int: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  non_null_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const nullTestRecordCodec = recordCodec({
+  executor: executor
+};
+const updatableViewCodec = recordCodec(spec_updatableView);
+const spec_nullTestRecord = {
   name: "nullTestRecord",
   identifier: sql.identifier("c", "null_test_record"),
-  attributes: nullTestRecordAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_int: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    non_null_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1188,8 +1204,9 @@ const nullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const nullTestRecordCodec = recordCodec(spec_nullTestRecord);
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   extensions: {
     pg: {
@@ -1203,39 +1220,38 @@ const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   description: undefined,
   name: "uuidArray"
 });
-const edgeCaseAttributes = Object.assign(Object.create(null), {
-  not_null_has_default: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  wont_cast_easy: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  row_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const edgeCaseCodec = recordCodec({
+const spec_edgeCase = {
   name: "edgeCase",
   identifier: sql.identifier("c", "edge_case"),
-  attributes: edgeCaseAttributes,
+  attributes: Object.assign(Object.create(null), {
+    not_null_has_default: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    wont_cast_easy: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    row_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1246,50 +1262,50 @@ const edgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const leftArmAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  length_in_metres: {
-    description: undefined,
-    codec: TYPES.float,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  mood: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const leftArmCodec = recordCodec({
+  executor: executor
+};
+const edgeCaseCodec = recordCodec(spec_edgeCase);
+const spec_leftArm = {
   name: "leftArm",
   identifier: sql.identifier("c", "left_arm"),
-  attributes: leftArmAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    length_in_metres: {
+      description: undefined,
+      codec: TYPES.float,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    mood: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Tracks metadata about the left arms of various people",
   extensions: {
     isTableLike: true,
@@ -1300,8 +1316,9 @@ const leftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const leftArmCodec = recordCodec(spec_leftArm);
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
   identifier: sql.identifier("b", "jwt_token"),
@@ -1362,7 +1379,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
@@ -1376,30 +1393,29 @@ const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp
   },
   notNull: true
 });
-const issue756Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  ts: {
-    description: undefined,
-    codec: notNullTimestampCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const issue756Codec = recordCodec({
+const spec_issue756 = {
   name: "issue756",
   identifier: sql.identifier("c", "issue756"),
-  attributes: issue756Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    ts: {
+      description: undefined,
+      codec: notNullTimestampCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1410,8 +1426,9 @@ const issue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const issue756Codec = recordCodec(spec_issue756);
 const authPayloadCodec = recordCodec({
   name: "authPayload",
   identifier: sql.identifier("b", "auth_payload"),
@@ -1456,7 +1473,7 @@ const authPayloadCodec = recordCodec({
       foreignKey: "(id) references c.person"
     })
   },
-  executor
+  executor: executor
 });
 const colorCodec = enumCodec({
   name: "color",
@@ -1587,7 +1604,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
@@ -1709,7 +1726,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1724,66 +1741,65 @@ const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   description: undefined,
   name: "comptypeArray"
 });
-const postAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  headline: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  body: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  enums: {
-    description: undefined,
-    codec: anEnumArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  comptypes: {
-    description: undefined,
-    codec: comptypeArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const postCodec = recordCodec({
+const spec_post = {
   name: "post",
   identifier: sql.identifier("a", "post"),
-  attributes: postAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    headline: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    body: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    enums: {
+      description: undefined,
+      codec: anEnumArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    comptypes: {
+      description: undefined,
+      codec: comptypeArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1794,8 +1810,9 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const postCodec = recordCodec(spec_post);
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
@@ -1942,117 +1959,116 @@ const wrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const personAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: "The primary unique identifier for the person",
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_full_name: {
-    description: "The person\u2019s name",
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "name"
-      }
-    }
-  },
-  aliases: {
-    description: undefined,
-    codec: textArrayCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  about: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  email: {
-    description: undefined,
-    codec: emailCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  site: {
-    description: undefined,
-    codec: wrappedUrlCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        deprecated: "Don\u2019t use me"
-      }
-    }
-  },
-  config: {
-    description: undefined,
-    codec: TYPES.hstore,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_login_from_ip: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_login_from_subnet: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  user_mac: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  created_at: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const personCodec = recordCodec({
+const spec_person = {
   name: "person",
   identifier: sql.identifier("c", "person"),
-  attributes: personAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: "The primary unique identifier for the person",
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_full_name: {
+      description: "The person\u2019s name",
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "name"
+        }
+      }
+    },
+    aliases: {
+      description: undefined,
+      codec: textArrayCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    about: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    email: {
+      description: undefined,
+      codec: emailCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    site: {
+      description: undefined,
+      codec: wrappedUrlCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          deprecated: "Don\u2019t use me"
+        }
+      }
+    },
+    config: {
+      description: undefined,
+      codec: TYPES.hstore,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_login_from_ip: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_login_from_subnet: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    user_mac: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    created_at: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Person test comment",
   extensions: {
     isTableLike: true,
@@ -2063,8 +2079,9 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const personCodec = recordCodec(spec_person);
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
@@ -2397,7 +2414,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -2449,7 +2466,7 @@ const byteaArrayCodec = listOfCodec(TYPES.bytea, {
   description: undefined,
   name: "byteaArray"
 });
-const typesAttributes_ltree_codec_ltree = {
+const spec_types_attributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -2461,469 +2478,468 @@ const typesAttributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
-const typesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  smallint: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bigint: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numeric: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  decimal: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  boolean: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  varchar: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum_array: {
-    description: undefined,
-    codec: colorArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain: {
-    description: undefined,
-    codec: anIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain2: {
-    description: undefined,
-    codec: anotherIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array: {
-    description: undefined,
-    codec: textArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  json: {
-    description: undefined,
-    codec: TYPES.json,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  jsonb: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_range: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numrange: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  daterange: {
-    description: undefined,
-    codec: daterangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  an_int_range: {
-    description: undefined,
-    codec: anIntRangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamp: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamptz: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  date: {
-    description: undefined,
-    codec: TYPES.date,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  time: {
-    description: undefined,
-    codec: TYPES.time,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timetz: {
-    description: undefined,
-    codec: TYPES.timetz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval_array: {
-    description: undefined,
-    codec: intervalArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  money: {
-    description: undefined,
-    codec: TYPES.money,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  point: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullablePoint: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  inet: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  cidr: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  macaddr: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regproc: {
-    description: undefined,
-    codec: TYPES.regproc,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regprocedure: {
-    description: undefined,
-    codec: TYPES.regprocedure,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoper: {
-    description: undefined,
-    codec: TYPES.regoper,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoperator: {
-    description: undefined,
-    codec: TYPES.regoperator,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regclass: {
-    description: undefined,
-    codec: TYPES.regclass,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regtype: {
-    description: undefined,
-    codec: TYPES.regtype,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regconfig: {
-    description: undefined,
-    codec: TYPES.regconfig,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regdictionary: {
-    description: undefined,
-    codec: TYPES.regdictionary,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array_domain: {
-    description: undefined,
-    codec: textArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  int8_array_domain: {
-    description: undefined,
-    codec: int8ArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea: {
-    description: undefined,
-    codec: TYPES.bytea,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea_array: {
-    description: undefined,
-    codec: byteaArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree: {
-    description: undefined,
-    codec: typesAttributes_ltree_codec_ltree,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree_array: {
-    description: undefined,
-    codec: typesAttributes_ltree_array_codec_ltree_,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions46 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "types"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: ["(smallint) references a.post", "(id) references a.post"]
-  })
-};
-const typesCodec = recordCodec({
+const spec_types_attributes_ltree_array_codec_ltree_ = listOfCodec(spec_types_attributes_ltree_codec_ltree);
+const spec_types = {
   name: "types",
   identifier: sql.identifier("b", "types"),
-  attributes: typesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    smallint: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bigint: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numeric: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    decimal: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    boolean: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    varchar: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum_array: {
+      description: undefined,
+      codec: colorArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain: {
+      description: undefined,
+      codec: anIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain2: {
+      description: undefined,
+      codec: anotherIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array: {
+      description: undefined,
+      codec: textArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    json: {
+      description: undefined,
+      codec: TYPES.json,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    jsonb: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_range: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numrange: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    daterange: {
+      description: undefined,
+      codec: daterangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    an_int_range: {
+      description: undefined,
+      codec: anIntRangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamp: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamptz: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    date: {
+      description: undefined,
+      codec: TYPES.date,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    time: {
+      description: undefined,
+      codec: TYPES.time,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timetz: {
+      description: undefined,
+      codec: TYPES.timetz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval_array: {
+      description: undefined,
+      codec: intervalArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    money: {
+      description: undefined,
+      codec: TYPES.money,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    point: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullablePoint: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    inet: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    cidr: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    macaddr: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regproc: {
+      description: undefined,
+      codec: TYPES.regproc,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regprocedure: {
+      description: undefined,
+      codec: TYPES.regprocedure,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoper: {
+      description: undefined,
+      codec: TYPES.regoper,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoperator: {
+      description: undefined,
+      codec: TYPES.regoperator,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regclass: {
+      description: undefined,
+      codec: TYPES.regclass,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regtype: {
+      description: undefined,
+      codec: TYPES.regtype,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regconfig: {
+      description: undefined,
+      codec: TYPES.regconfig,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regdictionary: {
+      description: undefined,
+      codec: TYPES.regdictionary,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array_domain: {
+      description: undefined,
+      codec: textArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    int8_array_domain: {
+      description: undefined,
+      codec: int8ArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea: {
+      description: undefined,
+      codec: TYPES.bytea,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea_array: {
+      description: undefined,
+      codec: byteaArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree: {
+      description: undefined,
+      codec: spec_types_attributes_ltree_codec_ltree,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree_array: {
+      description: undefined,
+      codec: spec_types_attributes_ltree_array_codec_ltree_,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions46,
-  executor
-});
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "types"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: ["(smallint) references a.post", "(id) references a.post"]
+    })
+  },
+  executor: executor
+};
+const typesCodec = recordCodec(spec_types);
 const int4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
     pg: {
@@ -3116,7 +3132,7 @@ const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
     },
     tags: {
       omit: "create,update,delete,all,order,filter",
-      behavior: extensions12.tags.behavior
+      behavior: spec_uniqueForeignKey.extensions.tags.behavior
     }
   }
 };
@@ -3466,7 +3482,7 @@ const registryConfig_pgResources_types_types = {
       name: "types"
     },
     tags: {
-      foreignKey: extensions46.tags.foreignKey
+      foreignKey: spec_types.extensions.tags.foreignKey
     }
   }
 };
@@ -3589,8 +3605,8 @@ const registry = makeRegistry({
     int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
     byteaArray: byteaArrayCodec,
-    ltree: typesAttributes_ltree_codec_ltree,
-    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
+    ltree: spec_types_attributes_ltree_codec_ltree,
+    "ltree[]": spec_types_attributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     compoundTypeArray: listOfCodec(compoundTypeCodec, {
       extensions: {
@@ -3677,7 +3693,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor
+      executor: executor
     }),
     tablefuncCrosstab3: recordCodec({
       name: "tablefuncCrosstab3",
@@ -3730,7 +3746,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor
+      executor: executor
     }),
     tablefuncCrosstab4: recordCodec({
       name: "tablefuncCrosstab4",
@@ -3792,7 +3808,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor
+      executor: executor
     })
   }),
   pgResources: Object.assign(Object.create(null), {
@@ -12401,6 +12417,15 @@ const makeArgs64 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
+function UUIDSerialize(value) {
+  return "" + value;
+}
+const coerce = string => {
+  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
+    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
+  }
+  return string;
+};
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -12905,6 +12930,60 @@ const makeArgs73 = (args, path = []) => {
 const resource_post_computed_compound_type_arrayPgResource = registry.pgResources["post_computed_compound_type_array"];
 const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
+function LTreeParseValue(value) {
+  return value;
+}
+const isValidHstoreObject = obj => {
+  if (obj === null) {
+    // Null is okay
+    return true;
+  } else if (typeof obj === "object") {
+    // A hash with string/null values is also okay
+    const keys = Object.keys(obj);
+    for (const key of keys) {
+      const val = obj[key];
+      if (val === null) {
+        // Null is okay
+      } else if (typeof val === "string") {
+        // String is okay
+      } else {
+        // Everything else is invalid.
+        return false;
+      }
+    }
+    return true;
+  } else {
+    // Everything else is invalid.
+    return false;
+  }
+};
+const parseValueLiteral = (ast, variables) => {
+  switch (ast.kind) {
+    case Kind.INT:
+    case Kind.FLOAT:
+      // Number isn't really okay, but we'll coerce it to a string anyway.
+      return String(parseFloat(ast.value));
+    case Kind.STRING:
+      // String is okay.
+      return String(ast.value);
+    case Kind.NULL:
+      // Null is okay.
+      return null;
+    case Kind.VARIABLE:
+      {
+        // Variable is okay if that variable is either a string or null.
+        const name = ast.name.value;
+        const value = variables ? variables[name] : undefined;
+        if (value === null || typeof value === "string") {
+          return value;
+        }
+        return undefined;
+      }
+    default:
+      // Everything else is invalid.
+      return undefined;
+  }
+};
 const argDetailsSimple74 = [];
 const makeArgs74 = (args, path = []) => {
   const selectArgs = [];
@@ -29753,6 +29832,11 @@ export const plans = {
       return $record.get("o");
     }
   },
+  Email: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
   PersonComputedFirstArgInoutOutRecord: {
     __assertStep: assertPgClassSingleStep,
     person($record) {
@@ -29862,6 +29946,19 @@ export const plans = {
     },
     BLUE: {
       value: "blue"
+    }
+  },
+  UUID: {
+    serialize: UUIDSerialize,
+    parseValue(value) {
+      return coerce("" + value);
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // ERRORS: add name to this error
+        throw new GraphQLError(`${"UUID" ?? "This scalar"} can only parse string values (kind = '${ast.kind}')`);
+      }
+      return coerce(ast.value);
     }
   },
   EnumCaps: {
@@ -30368,6 +30465,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -30384,6 +30491,9 @@ export const plans = {
     }
   },
   CompoundTypeInput: {
+    "__inputPlan": function CompoundTypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     a: {
       applyPlan($insert, val) {
         $insert.set("a", val.get());
@@ -30512,6 +30622,16 @@ export const plans = {
     },
     isOptimised($record) {
       return $record.get("is_optimised");
+    }
+  },
+  Datetime: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   TypesConnection: {
@@ -30718,12 +30838,77 @@ export const plans = {
       });
     }
   },
+  BigInt: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigInt" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  BigFloat: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigFloat" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  AnInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
+  AnotherInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
+  JSON: {
+    serialize(value) {
+      return JSON.stringify(value);
+    },
+    parseValue(value) {
+      return JSON.parse(value);
+    },
+    parseLiteral(ast, _variables) {
+      if (ast.kind === Kind.STRING) {
+        return JSON.parse(ast.value);
+      } else {
+        return undefined;
+      }
+    }
+  },
   BigFloatRange: {},
   BigFloatRangeBound: {},
   DateRange: {},
   DateRangeBound: {},
+  Date: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Date" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   AnIntRange: {},
   AnIntRangeBound: {},
+  Time: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Time" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   NestedCompoundType: {
     __assertStep: assertPgClassSingleStep,
     a($record) {
@@ -30749,6 +30934,128 @@ export const plans = {
     }
   },
   Point: {},
+  InternetAddress: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"InternetAddress" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProc: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProc" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProcedure: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProcedure" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOper: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOper" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOperator: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOperator" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegClass: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegClass" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegType: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegType" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegConfig: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegConfig" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegDictionary: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegDictionary" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  Base64EncodedBinary: {
+    serialize(data) {
+      if (Buffer.isBuffer(data)) {
+        return data.toString("base64");
+      } else {
+        throw new Error(`Base64EncodeBinary can only be used with Node.js buffers.`);
+      }
+    },
+    parseValue(data) {
+      if (typeof data === "string") {
+        return Buffer.from(data, "base64");
+      } else {
+        throw new GraphQLError("Base64EncodedBinary can only parse string values.");
+      }
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // TODO: add name to this error
+        throw new GraphQLError("Base64EncodedBinary can only parse string values");
+      }
+      return Buffer.from(ast.value, "base64");
+    }
+  },
+  LTree: {
+    serialize(x) {
+      return x;
+    },
+    parseValue: LTreeParseValue,
+    parseLiteral(node, variables) {
+      return LTreeParseValue(valueFromASTUntyped(node, variables));
+    }
+  },
   TypesEdge: {
     __assertStep: assertEdgeCapableStep,
     cursor($edge) {
@@ -32069,7 +32376,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.id.codec)}`;
             }
           });
         }
@@ -32092,7 +32399,7 @@ export const plans = {
             type: "attribute",
             attribute: "smallint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.smallint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.smallint.codec)}`;
             }
           });
         }
@@ -32115,7 +32422,7 @@ export const plans = {
             type: "attribute",
             attribute: "bigint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.bigint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.bigint.codec)}`;
             }
           });
         }
@@ -32138,7 +32445,7 @@ export const plans = {
             type: "attribute",
             attribute: "numeric",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numeric.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.numeric.codec)}`;
             }
           });
         }
@@ -32161,7 +32468,7 @@ export const plans = {
             type: "attribute",
             attribute: "decimal",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.decimal.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.decimal.codec)}`;
             }
           });
         }
@@ -32184,7 +32491,7 @@ export const plans = {
             type: "attribute",
             attribute: "boolean",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.boolean.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.boolean.codec)}`;
             }
           });
         }
@@ -32207,7 +32514,7 @@ export const plans = {
             type: "attribute",
             attribute: "varchar",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.varchar.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.varchar.codec)}`;
             }
           });
         }
@@ -32230,7 +32537,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.enum.codec)}`;
             }
           });
         }
@@ -32253,7 +32560,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.enum_array.codec)}`;
             }
           });
         }
@@ -32276,7 +32583,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.domain.codec)}`;
             }
           });
         }
@@ -32299,7 +32606,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.domain2.codec)}`;
             }
           });
         }
@@ -32322,7 +32629,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.text_array.codec)}`;
             }
           });
         }
@@ -32345,7 +32652,7 @@ export const plans = {
             type: "attribute",
             attribute: "json",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.json.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.json.codec)}`;
             }
           });
         }
@@ -32368,7 +32675,7 @@ export const plans = {
             type: "attribute",
             attribute: "jsonb",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.jsonb.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.jsonb.codec)}`;
             }
           });
         }
@@ -32391,7 +32698,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullable_range.codec)}`;
             }
           });
         }
@@ -32414,7 +32721,7 @@ export const plans = {
             type: "attribute",
             attribute: "numrange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numrange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.numrange.codec)}`;
             }
           });
         }
@@ -32437,7 +32744,7 @@ export const plans = {
             type: "attribute",
             attribute: "daterange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.daterange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.daterange.codec)}`;
             }
           });
         }
@@ -32460,7 +32767,7 @@ export const plans = {
             type: "attribute",
             attribute: "an_int_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.an_int_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.an_int_range.codec)}`;
             }
           });
         }
@@ -32483,7 +32790,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamp",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamp.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.timestamp.codec)}`;
             }
           });
         }
@@ -32506,7 +32813,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamptz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamptz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.timestamptz.codec)}`;
             }
           });
         }
@@ -32529,7 +32836,7 @@ export const plans = {
             type: "attribute",
             attribute: "date",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.date.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.date.codec)}`;
             }
           });
         }
@@ -32552,7 +32859,7 @@ export const plans = {
             type: "attribute",
             attribute: "time",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.time.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.time.codec)}`;
             }
           });
         }
@@ -32575,7 +32882,7 @@ export const plans = {
             type: "attribute",
             attribute: "timetz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timetz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.timetz.codec)}`;
             }
           });
         }
@@ -32598,7 +32905,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.interval.codec)}`;
             }
           });
         }
@@ -32621,7 +32928,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.interval_array.codec)}`;
             }
           });
         }
@@ -32644,7 +32951,7 @@ export const plans = {
             type: "attribute",
             attribute: "money",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.money.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.money.codec)}`;
             }
           });
         }
@@ -32667,7 +32974,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.compound_type.codec)}`;
             }
           });
         }
@@ -32690,7 +32997,7 @@ export const plans = {
             type: "attribute",
             attribute: "nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nested_compound_type.codec)}`;
             }
           });
         }
@@ -32713,7 +33020,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullable_compound_type.codec)}`;
             }
           });
         }
@@ -32736,7 +33043,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullable_nested_compound_type.codec)}`;
             }
           });
         }
@@ -32759,7 +33066,7 @@ export const plans = {
             type: "attribute",
             attribute: "point",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.point.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.point.codec)}`;
             }
           });
         }
@@ -32782,7 +33089,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullablePoint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullablePoint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullablePoint.codec)}`;
             }
           });
         }
@@ -32805,7 +33112,7 @@ export const plans = {
             type: "attribute",
             attribute: "inet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.inet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.inet.codec)}`;
             }
           });
         }
@@ -32828,7 +33135,7 @@ export const plans = {
             type: "attribute",
             attribute: "cidr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.cidr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.cidr.codec)}`;
             }
           });
         }
@@ -32851,7 +33158,7 @@ export const plans = {
             type: "attribute",
             attribute: "macaddr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.macaddr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.macaddr.codec)}`;
             }
           });
         }
@@ -32874,7 +33181,7 @@ export const plans = {
             type: "attribute",
             attribute: "regproc",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regproc.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regproc.codec)}`;
             }
           });
         }
@@ -32897,7 +33204,7 @@ export const plans = {
             type: "attribute",
             attribute: "regprocedure",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regprocedure.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regprocedure.codec)}`;
             }
           });
         }
@@ -32920,7 +33227,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoper",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoper.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regoper.codec)}`;
             }
           });
         }
@@ -32943,7 +33250,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoperator",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoperator.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regoperator.codec)}`;
             }
           });
         }
@@ -32966,7 +33273,7 @@ export const plans = {
             type: "attribute",
             attribute: "regclass",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regclass.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regclass.codec)}`;
             }
           });
         }
@@ -32989,7 +33296,7 @@ export const plans = {
             type: "attribute",
             attribute: "regtype",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regtype.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regtype.codec)}`;
             }
           });
         }
@@ -33012,7 +33319,7 @@ export const plans = {
             type: "attribute",
             attribute: "regconfig",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regconfig.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regconfig.codec)}`;
             }
           });
         }
@@ -33035,7 +33342,7 @@ export const plans = {
             type: "attribute",
             attribute: "regdictionary",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regdictionary.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regdictionary.codec)}`;
             }
           });
         }
@@ -33058,7 +33365,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.text_array_domain.codec)}`;
             }
           });
         }
@@ -33081,7 +33388,7 @@ export const plans = {
             type: "attribute",
             attribute: "int8_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.int8_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.int8_array_domain.codec)}`;
             }
           });
         }
@@ -33104,7 +33411,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.ltree.codec)}`;
             }
           });
         }
@@ -33127,7 +33434,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.ltree_array.codec)}`;
             }
           });
         }
@@ -33161,6 +33468,9 @@ export const plans = {
     inclusive: undefined
   },
   NestedCompoundTypeInput: {
+    "__inputPlan": function NestedCompoundTypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     a: {
       applyPlan($insert, val) {
         $insert.set("a", val.get());
@@ -33655,6 +33965,50 @@ export const plans = {
       return $record.get("url");
     }
   },
+  NotNullUrl: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
+  KeyValueHash: {
+    serialize(value) {
+      return value;
+    },
+    parseValue(obj) {
+      if (isValidHstoreObject(obj)) {
+        return obj;
+      }
+      throw new GraphQLError(`This is not a valid ${"KeyValueHash"} object, it must be a key/value hash where keys and values are both strings (or null).`);
+    },
+    parseLiteral(ast, variables) {
+      switch (ast.kind) {
+        case Kind.OBJECT:
+          {
+            const value = ast.fields.reduce((memo, field) => {
+              memo[field.name.value] = parseValueLiteral(field.value, variables);
+              return memo;
+            }, Object.create(null));
+            if (!isValidHstoreObject(value)) {
+              return undefined;
+            }
+            return value;
+          }
+        case Kind.NULL:
+          return null;
+        case Kind.VARIABLE:
+          {
+            const name = ast.name.value;
+            const value = variables ? variables[name] : undefined;
+            if (!isValidHstoreObject(value)) {
+              return undefined;
+            }
+            return value;
+          }
+        default:
+          return undefined;
+      }
+    }
+  },
   PostsConnection: {
     __assertStep: ConnectionStep,
     nodes($connection) {
@@ -33899,7 +34253,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.id.codec)}`;
             }
           });
         }
@@ -33922,7 +34276,7 @@ export const plans = {
             type: "attribute",
             attribute: "headline",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.headline.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.headline.codec)}`;
             }
           });
         }
@@ -33945,7 +34299,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.body.codec)}`;
             }
           });
         }
@@ -33968,7 +34322,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.author_id.codec)}`;
             }
           });
         }
@@ -33991,7 +34345,7 @@ export const plans = {
             type: "attribute",
             attribute: "enums",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.enums.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.enums.codec)}`;
             }
           });
         }
@@ -34014,7 +34368,7 @@ export const plans = {
             type: "attribute",
             attribute: "comptypes",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.comptypes.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.comptypes.codec)}`;
             }
           });
         }
@@ -34039,6 +34393,9 @@ export const plans = {
     }
   },
   ComptypeInput: {
+    "__inputPlan": function ComptypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     schedule: {
       applyPlan($insert, val) {
         $insert.set("schedule", val.get());
@@ -34225,7 +34582,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_foreignKey.attributes.person_id.codec)}`;
             }
           });
         }
@@ -34248,7 +34605,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_foreignKey.attributes.compound_key_1.codec)}`;
             }
           });
         }
@@ -34271,7 +34628,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_foreignKey.attributes.compound_key_2.codec)}`;
             }
           });
         }
@@ -34502,7 +34859,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.person_id_2.codec)}`;
             }
           });
         }
@@ -34525,7 +34882,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.person_id_1.codec)}`;
             }
           });
         }
@@ -34548,7 +34905,7 @@ export const plans = {
             type: "attribute",
             attribute: "extra",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.extra.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.extra.codec)}`;
             }
           });
         }
@@ -34654,6 +35011,16 @@ export const plans = {
     },
     ts($record) {
       return $record.get("ts");
+    }
+  },
+  NotNullTimestamp: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   FuncOutSetofConnection: {
@@ -35049,7 +35416,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.id.codec)}`;
             }
           });
         }
@@ -35072,7 +35439,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_full_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.person_full_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.person_full_name.codec)}`;
             }
           });
         }
@@ -35095,7 +35462,7 @@ export const plans = {
             type: "attribute",
             attribute: "aliases",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.aliases.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.aliases.codec)}`;
             }
           });
         }
@@ -35118,7 +35485,7 @@ export const plans = {
             type: "attribute",
             attribute: "about",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.about.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.about.codec)}`;
             }
           });
         }
@@ -35141,7 +35508,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.email.codec)}`;
             }
           });
         }
@@ -35164,7 +35531,7 @@ export const plans = {
             type: "attribute",
             attribute: "site",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.site.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.site.codec)}`;
             }
           });
         }
@@ -35187,7 +35554,7 @@ export const plans = {
             type: "attribute",
             attribute: "config",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.config.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.config.codec)}`;
             }
           });
         }
@@ -35210,7 +35577,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_ip",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_ip.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_login_from_ip.codec)}`;
             }
           });
         }
@@ -35233,7 +35600,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_subnet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_subnet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_login_from_subnet.codec)}`;
             }
           });
         }
@@ -35256,7 +35623,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_mac",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.user_mac.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.user_mac.codec)}`;
             }
           });
         }
@@ -35279,7 +35646,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.created_at.codec)}`;
             }
           });
         }
@@ -35304,6 +35671,9 @@ export const plans = {
     }
   },
   WrappedUrlInput: {
+    "__inputPlan": function WrappedUrlInput_inputPlan() {
+      return object(Object.create(null));
+    },
     url: {
       applyPlan($insert, val) {
         $insert.set("url", val.get());
@@ -35398,7 +35768,7 @@ export const plans = {
             type: "attribute",
             attribute: "?column?",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nonUpdatableViewAttributes["?column?"].codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nonUpdatableView.attributes["?column?"].codec)}`;
             }
           });
         }
@@ -35519,7 +35889,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), inputsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_inputs.attributes.id.codec)}`;
             }
           });
         }
@@ -35640,7 +36010,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), patchsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_patchs.attributes.id.codec)}`;
             }
           });
         }
@@ -35761,7 +36131,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reserved.attributes.id.codec)}`;
             }
           });
         }
@@ -35882,7 +36252,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedPatchsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reservedPatchs.attributes.id.codec)}`;
             }
           });
         }
@@ -36003,7 +36373,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedInputAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reservedInput.attributes.id.codec)}`;
             }
           });
         }
@@ -36158,7 +36528,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_defaultValue.attributes.id.codec)}`;
             }
           });
         }
@@ -36181,7 +36551,7 @@ export const plans = {
             type: "attribute",
             attribute: "null_value",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.null_value.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_defaultValue.attributes.null_value.codec)}`;
             }
           });
         }
@@ -36304,7 +36674,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_noPrimaryKey.attributes.id.codec)}`;
             }
           });
         }
@@ -36327,7 +36697,7 @@ export const plans = {
             type: "attribute",
             attribute: "str",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.str.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_noPrimaryKey.attributes.str.codec)}`;
             }
           });
         }
@@ -36496,7 +36866,7 @@ export const plans = {
             type: "attribute",
             attribute: "testviewid",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.testviewid.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_testview.attributes.testviewid.codec)}`;
             }
           });
         }
@@ -36519,7 +36889,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_testview.attributes.col1.codec)}`;
             }
           });
         }
@@ -36542,7 +36912,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_testview.attributes.col2.codec)}`;
             }
           });
         }
@@ -36697,7 +37067,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_myTable.attributes.id.codec)}`;
             }
           });
         }
@@ -36720,7 +37090,7 @@ export const plans = {
             type: "attribute",
             attribute: "json_data",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.json_data.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_myTable.attributes.json_data.codec)}`;
             }
           });
         }
@@ -36875,7 +37245,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_personSecret.attributes.person_id.codec)}`;
             }
           });
         }
@@ -36898,7 +37268,7 @@ export const plans = {
             type: "attribute",
             attribute: "sekrit",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.sekrit.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_personSecret.attributes.sekrit.codec)}`;
             }
           });
         }
@@ -37087,7 +37457,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_viewTable.attributes.id.codec)}`;
             }
           });
         }
@@ -37110,7 +37480,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_viewTable.attributes.col1.codec)}`;
             }
           });
         }
@@ -37133,7 +37503,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_viewTable.attributes.col2.codec)}`;
             }
           });
         }
@@ -37356,7 +37726,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.id.codec)}`;
             }
           });
         }
@@ -37379,7 +37749,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.col1.codec)}`;
             }
           });
         }
@@ -37402,7 +37772,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.col2.codec)}`;
             }
           });
         }
@@ -37425,7 +37795,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.col3.codec)}`;
             }
           });
         }
@@ -37648,7 +38018,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.id.codec)}`;
             }
           });
         }
@@ -37671,7 +38041,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.col3.codec)}`;
             }
           });
         }
@@ -37694,7 +38064,7 @@ export const plans = {
             type: "attribute",
             attribute: "col4",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col4.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.col4.codec)}`;
             }
           });
         }
@@ -37717,7 +38087,7 @@ export const plans = {
             type: "attribute",
             attribute: "col5",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col5.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.col5.codec)}`;
             }
           });
         }
@@ -37923,7 +38293,7 @@ export const plans = {
             type: "attribute",
             attribute: "x",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.x.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.x.codec)}`;
             }
           });
         }
@@ -37946,7 +38316,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.name.codec)}`;
             }
           });
         }
@@ -37969,7 +38339,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.description.codec)}`;
             }
           });
         }
@@ -37992,7 +38362,7 @@ export const plans = {
             type: "attribute",
             attribute: "constant",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.constant.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.constant.codec)}`;
             }
           });
         }
@@ -38215,7 +38585,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.id.codec)}`;
             }
           });
         }
@@ -38238,7 +38608,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.nullable_text.codec)}`;
             }
           });
         }
@@ -38261,7 +38631,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_int",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_int.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.nullable_int.codec)}`;
             }
           });
         }
@@ -38284,7 +38654,7 @@ export const plans = {
             type: "attribute",
             attribute: "non_null_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.non_null_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.non_null_text.codec)}`;
             }
           });
         }
@@ -38487,7 +38857,7 @@ export const plans = {
             type: "attribute",
             attribute: "not_null_has_default",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.not_null_has_default.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.not_null_has_default.codec)}`;
             }
           });
         }
@@ -38510,7 +38880,7 @@ export const plans = {
             type: "attribute",
             attribute: "wont_cast_easy",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.wont_cast_easy.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.wont_cast_easy.codec)}`;
             }
           });
         }
@@ -38533,7 +38903,7 @@ export const plans = {
             type: "attribute",
             attribute: "row_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.row_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.row_id.codec)}`;
             }
           });
         }
@@ -38756,7 +39126,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.id.codec)}`;
             }
           });
         }
@@ -38779,7 +39149,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.person_id.codec)}`;
             }
           });
         }
@@ -38802,7 +39172,7 @@ export const plans = {
             type: "attribute",
             attribute: "length_in_metres",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.length_in_metres.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.length_in_metres.codec)}`;
             }
           });
         }
@@ -38825,7 +39195,7 @@ export const plans = {
             type: "attribute",
             attribute: "mood",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.mood.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.mood.codec)}`;
             }
           });
         }
@@ -38980,7 +39350,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_issue756.attributes.id.codec)}`;
             }
           });
         }
@@ -39003,7 +39373,7 @@ export const plans = {
             type: "attribute",
             attribute: "ts",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.ts.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_issue756.attributes.ts.codec)}`;
             }
           });
         }
@@ -42339,6 +42709,11 @@ export const plans = {
       return rootValue();
     }
   },
+  Guid: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
   GuidFnInput: {
     clientMutationId: {
       applyPlan($input, val) {
@@ -42530,6 +42905,9 @@ export const plans = {
     leftArm: undefined
   },
   LeftArmBaseInput: {
+    "__inputPlan": function LeftArmBaseInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -42924,6 +43302,9 @@ export const plans = {
     suffix: undefined
   },
   PostInput: {
+    "__inputPlan": function PostInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43374,6 +43755,9 @@ export const plans = {
     }
   },
   InputInput: {
+    "__inputPlan": function InputInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43441,6 +43825,9 @@ export const plans = {
     }
   },
   PatchInput: {
+    "__inputPlan": function PatchInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43508,6 +43895,9 @@ export const plans = {
     }
   },
   ReservedInput: {
+    "__inputPlan": function ReservedInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43575,6 +43965,9 @@ export const plans = {
     }
   },
   ReservedPatchRecordInput: {
+    "__inputPlan": function ReservedPatchRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43642,6 +44035,9 @@ export const plans = {
     }
   },
   ReservedInputRecordInput: {
+    "__inputPlan": function ReservedInputRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43709,6 +44105,9 @@ export const plans = {
     }
   },
   DefaultValueInput: {
+    "__inputPlan": function DefaultValueInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43763,6 +44162,9 @@ export const plans = {
     }
   },
   ForeignKeyInput: {
+    "__inputPlan": function ForeignKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -43813,6 +44215,9 @@ export const plans = {
     }
   },
   NoPrimaryKeyInput: {
+    "__inputPlan": function NoPrimaryKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43856,6 +44261,9 @@ export const plans = {
     }
   },
   TestviewInput: {
+    "__inputPlan": function TestviewInput_inputPlan() {
+      return object(Object.create(null));
+    },
     testviewid: {
       applyPlan($insert, val) {
         $insert.set("testviewid", val.get());
@@ -43937,6 +44345,9 @@ export const plans = {
     }
   },
   MyTableInput: {
+    "__inputPlan": function MyTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44016,6 +44427,9 @@ export const plans = {
     }
   },
   PersonSecretInput: {
+    "__inputPlan": function PersonSecretInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -44090,6 +44504,9 @@ export const plans = {
     }
   },
   ViewTableInput: {
+    "__inputPlan": function ViewTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44181,6 +44598,9 @@ export const plans = {
     }
   },
   CompoundKeyInput: {
+    "__inputPlan": function CompoundKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId2: {
       applyPlan($insert, val) {
         $insert.set("person_id_2", val.get());
@@ -44262,6 +44682,9 @@ export const plans = {
     }
   },
   SimilarTable1Input: {
+    "__inputPlan": function SimilarTable1Input_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44350,6 +44773,9 @@ export const plans = {
     }
   },
   SimilarTable2Input: {
+    "__inputPlan": function SimilarTable2Input_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44407,6 +44833,9 @@ export const plans = {
     }
   },
   UpdatableViewInput: {
+    "__inputPlan": function UpdatableViewInput_inputPlan() {
+      return object(Object.create(null));
+    },
     x: {
       applyPlan($insert, val) {
         $insert.set("x", val.get());
@@ -44495,6 +44924,9 @@ export const plans = {
     }
   },
   NullTestRecordInput: {
+    "__inputPlan": function NullTestRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44552,6 +44984,9 @@ export const plans = {
     }
   },
   EdgeCaseInput: {
+    "__inputPlan": function EdgeCaseInput_inputPlan() {
+      return object(Object.create(null));
+    },
     notNullHasDefault: {
       applyPlan($insert, val) {
         $insert.set("not_null_has_default", val.get());
@@ -44638,6 +45073,9 @@ export const plans = {
     }
   },
   LeftArmInput: {
+    "__inputPlan": function LeftArmInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44726,6 +45164,9 @@ export const plans = {
     }
   },
   Issue756Input: {
+    "__inputPlan": function Issue756Input_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44863,6 +45304,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45010,6 +45454,9 @@ export const plans = {
     }
   },
   TypeInput: {
+    "__inputPlan": function TypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45412,6 +45859,9 @@ export const plans = {
     }
   },
   InputPatch: {
+    "__inputPlan": function InputPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45492,6 +45942,9 @@ export const plans = {
     }
   },
   PatchPatch: {
+    "__inputPlan": function PatchPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45572,6 +46025,9 @@ export const plans = {
     }
   },
   ReservedPatch: {
+    "__inputPlan": function ReservedPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45652,6 +46108,9 @@ export const plans = {
     }
   },
   ReservedPatchRecordPatch: {
+    "__inputPlan": function ReservedPatchRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45732,6 +46191,9 @@ export const plans = {
     }
   },
   ReservedInputRecordPatch: {
+    "__inputPlan": function ReservedInputRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45812,6 +46274,9 @@ export const plans = {
     }
   },
   DefaultValuePatch: {
+    "__inputPlan": function DefaultValuePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45868,6 +46333,9 @@ export const plans = {
     }
   },
   NoPrimaryKeyPatch: {
+    "__inputPlan": function NoPrimaryKeyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45941,6 +46409,9 @@ export const plans = {
     }
   },
   MyTablePatch: {
+    "__inputPlan": function MyTablePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46033,6 +46504,9 @@ export const plans = {
     }
   },
   PersonSecretPatch: {
+    "__inputPlan": function PersonSecretPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -46120,6 +46594,9 @@ export const plans = {
     }
   },
   ViewTablePatch: {
+    "__inputPlan": function ViewTablePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46224,6 +46701,9 @@ export const plans = {
     }
   },
   CompoundKeyPatch: {
+    "__inputPlan": function CompoundKeyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     personId2: {
       applyPlan($insert, val) {
         $insert.set("person_id_2", val.get());
@@ -46319,6 +46799,9 @@ export const plans = {
     }
   },
   SimilarTable1Patch: {
+    "__inputPlan": function SimilarTable1Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46420,6 +46903,9 @@ export const plans = {
     }
   },
   SimilarTable2Patch: {
+    "__inputPlan": function SimilarTable2Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46521,6 +47007,9 @@ export const plans = {
     }
   },
   NullTestRecordPatch: {
+    "__inputPlan": function NullTestRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46627,6 +47116,9 @@ export const plans = {
     }
   },
   LeftArmPatch: {
+    "__inputPlan": function LeftArmPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46742,6 +47234,9 @@ export const plans = {
     }
   },
   Issue756Patch: {
+    "__inputPlan": function Issue756Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46834,6 +47329,9 @@ export const plans = {
     }
   },
   PostPatch: {
+    "__inputPlan": function PostPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46949,6 +47447,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -47123,6 +47624,9 @@ export const plans = {
     }
   },
   TypePatch: {
+    "__inputPlan": function TypePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, domainOfCodec, enumCodec, listOfCodec, makeRegistry, pgClassExpression, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectFromRecords, pgSelectSingleFromRecord, pgUpdateSingle, rangeOfCodec, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
+import { GraphQLError, GraphQLInt, GraphQLString, Kind, valueFromASTUntyped } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -468,23 +485,22 @@ const nonUpdatableViewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const inputsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const inputsCodec = recordCodec({
+const spec_inputs = {
   name: "inputs",
   identifier: sql.identifier("a", "inputs"),
-  attributes: inputsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Should output as Input",
   extensions: {
     isTableLike: true,
@@ -495,23 +511,23 @@ const inputsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const patchsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const patchsCodec = recordCodec({
+  executor: executor
+};
+const inputsCodec = recordCodec(spec_inputs);
+const spec_patchs = {
   name: "patchs",
   identifier: sql.identifier("a", "patchs"),
-  attributes: patchsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Should output as Patch",
   extensions: {
     isTableLike: true,
@@ -522,23 +538,23 @@ const patchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const reservedAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const reservedCodec = recordCodec({
+  executor: executor
+};
+const patchsCodec = recordCodec(spec_patchs);
+const spec_reserved = {
   name: "reserved",
   identifier: sql.identifier("a", "reserved"),
-  attributes: reservedAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -549,23 +565,23 @@ const reservedCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const reservedPatchsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const reservedPatchsCodec = recordCodec({
+  executor: executor
+};
+const reservedCodec = recordCodec(spec_reserved);
+const spec_reservedPatchs = {
   name: "reservedPatchs",
   identifier: sql.identifier("a", "reservedPatchs"),
-  attributes: reservedPatchsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   extensions: {
     isTableLike: true,
@@ -576,23 +592,23 @@ const reservedPatchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const reservedInputAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const reservedInputCodec = recordCodec({
+  executor: executor
+};
+const reservedPatchsCodec = recordCodec(spec_reservedPatchs);
+const spec_reservedInput = {
   name: "reservedInput",
   identifier: sql.identifier("a", "reserved_input"),
-  attributes: reservedInputAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
   extensions: {
     isTableLike: true,
@@ -603,34 +619,34 @@ const reservedInputCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const defaultValueAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  null_value: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  }
-});
-const defaultValueCodec = recordCodec({
+  executor: executor
+};
+const reservedInputCodec = recordCodec(spec_reservedInput);
+const spec_defaultValue = {
   name: "defaultValue",
   identifier: sql.identifier("a", "default_value"),
-  attributes: defaultValueAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    null_value: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -641,8 +657,9 @@ const defaultValueCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const defaultValueCodec = recordCodec(spec_defaultValue);
 const foreignKeyCodec = recordCodec({
   name: "foreignKey",
   identifier: sql.identifier("a", "foreign_key"),
@@ -691,34 +708,33 @@ const foreignKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  str: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  }
-});
-const noPrimaryKeyCodec = recordCodec({
+const spec_noPrimaryKey = {
   name: "noPrimaryKey",
   identifier: sql.identifier("a", "no_primary_key"),
-  attributes: noPrimaryKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    str: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -729,8 +745,9 @@ const noPrimaryKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const noPrimaryKeyCodec = recordCodec(spec_noPrimaryKey);
 const testviewCodec = recordCodec({
   name: "testview",
   identifier: sql.identifier("a", "testview"),
@@ -779,21 +796,9 @@ const testviewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const extensions12 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "unique_foreign_key"
-  },
-  tags: Object.assign(Object.create(null), {
-    omit: "create,update,delete,all,order,filter",
-    behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy"]
-  })
-};
-const uniqueForeignKeyCodec = recordCodec({
+const spec_uniqueForeignKey = {
   name: "uniqueForeignKey",
   identifier: sql.identifier("a", "unique_foreign_key"),
   attributes: Object.assign(Object.create(null), {
@@ -819,35 +824,46 @@ const uniqueForeignKeyCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions: extensions12,
-  executor
-});
-const myTableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "unique_foreign_key"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: "create,update,delete,all,order,filter",
+      behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy"]
+    })
   },
-  json_data: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  }
-});
-const myTableCodec = recordCodec({
+  executor: executor
+};
+const uniqueForeignKeyCodec = recordCodec(spec_uniqueForeignKey);
+const spec_myTable = {
   name: "myTable",
   identifier: sql.identifier("c", "my_table"),
-  attributes: myTableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    json_data: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -858,35 +874,35 @@ const myTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const personSecretAttributes = Object.assign(Object.create(null), {
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  sekrit: {
-    description: "A secret held by the associated Person",
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "secret",
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  }
-});
-const personSecretCodec = recordCodec({
+  executor: executor
+};
+const myTableCodec = recordCodec(spec_myTable);
+const spec_personSecret = {
   name: "personSecret",
   identifier: sql.identifier("c", "person_secret"),
-  attributes: personSecretAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    sekrit: {
+      description: "A secret held by the associated Person",
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "secret",
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    }
+  }),
   description: "Tracks the person's secret",
   extensions: {
     isTableLike: true,
@@ -899,45 +915,45 @@ const personSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor
-});
-const viewTableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  }
-});
-const viewTableCodec = recordCodec({
+  executor: executor
+};
+const personSecretCodec = recordCodec(spec_personSecret);
+const spec_viewTable = {
   name: "viewTable",
   identifier: sql.identifier("a", "view_table"),
-  attributes: viewTableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -948,45 +964,45 @@ const viewTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const compoundKeyAttributes = Object.assign(Object.create(null), {
-  person_id_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  person_id_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  extra: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  }
-});
-const compoundKeyCodec = recordCodec({
+  executor: executor
+};
+const viewTableCodec = recordCodec(spec_viewTable);
+const spec_compoundKey = {
   name: "compoundKey",
   identifier: sql.identifier("c", "compound_key"),
-  attributes: compoundKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    person_id_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    extra: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -997,56 +1013,56 @@ const compoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const similarTable1Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  col3: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  }
-});
-const similarTable1Codec = recordCodec({
+  executor: executor
+};
+const compoundKeyCodec = recordCodec(spec_compoundKey);
+const spec_similarTable1 = {
   name: "similarTable1",
   identifier: sql.identifier("a", "similar_table_1"),
-  attributes: similarTable1Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    col3: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1057,56 +1073,56 @@ const similarTable1Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const similarTable2Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  col3: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  col4: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  col5: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  }
-});
-const similarTable2Codec = recordCodec({
+  executor: executor
+};
+const similarTable1Codec = recordCodec(spec_similarTable1);
+const spec_similarTable2 = {
   name: "similarTable2",
   identifier: sql.identifier("a", "similar_table_2"),
-  attributes: similarTable2Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    col3: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    col4: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    col5: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1117,8 +1133,9 @@ const similarTable2Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const similarTable2Codec = recordCodec(spec_similarTable2);
 const updatableViewCodec = recordCodec({
   name: "updatableView",
   identifier: sql.identifier("b", "updatable_view"),
@@ -1181,56 +1198,55 @@ const updatableViewCodec = recordCodec({
       unique: "x|@behavior -single -update -delete"
     })
   },
-  executor
+  executor: executor
 });
-const nullTestRecordAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  nullable_int: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  non_null_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  }
-});
-const nullTestRecordCodec = recordCodec({
+const spec_nullTestRecord = {
   name: "nullTestRecord",
   identifier: sql.identifier("c", "null_test_record"),
-  attributes: nullTestRecordAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    nullable_int: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    non_null_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1241,8 +1257,9 @@ const nullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const nullTestRecordCodec = recordCodec(spec_nullTestRecord);
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   extensions: {
     pg: {
@@ -1304,54 +1321,53 @@ const edgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const leftArmAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  length_in_metres: {
-    description: undefined,
-    codec: TYPES.float,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  mood: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  }
-});
-const leftArmCodec = recordCodec({
+const spec_leftArm = {
   name: "leftArm",
   identifier: sql.identifier("c", "left_arm"),
-  attributes: leftArmAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    length_in_metres: {
+      description: undefined,
+      codec: TYPES.float,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    mood: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    }
+  }),
   description: "Tracks metadata about the left arms of various people",
   extensions: {
     isTableLike: true,
@@ -1362,8 +1378,9 @@ const leftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const leftArmCodec = recordCodec(spec_leftArm);
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
   identifier: sql.identifier("b", "jwt_token"),
@@ -1434,7 +1451,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
@@ -1448,32 +1465,31 @@ const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp
   },
   notNull: true
 });
-const issue756Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  ts: {
-    description: undefined,
-    codec: notNullTimestampCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  }
-});
-const issue756Codec = recordCodec({
+const spec_issue756 = {
   name: "issue756",
   identifier: sql.identifier("c", "issue756"),
-  attributes: issue756Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    ts: {
+      description: undefined,
+      codec: notNullTimestampCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1484,8 +1500,9 @@ const issue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const issue756Codec = recordCodec(spec_issue756);
 const authPayloadCodec = recordCodec({
   name: "authPayload",
   identifier: sql.identifier("b", "auth_payload"),
@@ -1536,7 +1553,7 @@ const authPayloadCodec = recordCodec({
       foreignKey: "(id) references c.person"
     })
   },
-  executor
+  executor: executor
 });
 const colorCodec = enumCodec({
   name: "color",
@@ -1683,7 +1700,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
@@ -1809,7 +1826,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1824,74 +1841,73 @@ const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   description: undefined,
   name: "comptypeArray"
 });
-const postAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  headline: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  body: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  enums: {
-    description: undefined,
-    codec: anEnumArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  comptypes: {
-    description: undefined,
-    codec: comptypeArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  }
-});
-const postCodec = recordCodec({
+const spec_post = {
   name: "post",
   identifier: sql.identifier("a", "post"),
-  attributes: postAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    headline: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    body: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    enums: {
+      description: undefined,
+      codec: anEnumArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    comptypes: {
+      description: undefined,
+      codec: comptypeArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1902,8 +1918,9 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const postCodec = recordCodec(spec_post);
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
@@ -2052,133 +2069,132 @@ const wrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const personAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: "The primary unique identifier for the person",
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_full_name: {
-    description: "The person\u2019s name",
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "name",
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  aliases: {
-    description: undefined,
-    codec: textArrayCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  about: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  email: {
-    description: undefined,
-    codec: emailCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  site: {
-    description: undefined,
-    codec: wrappedUrlCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        deprecated: "Don\u2019t use me",
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  config: {
-    description: undefined,
-    codec: TYPES.hstore,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  last_login_from_ip: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  last_login_from_subnet: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  user_mac: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  created_at: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  }
-});
-const personCodec = recordCodec({
+const spec_person = {
   name: "person",
   identifier: sql.identifier("c", "person"),
-  attributes: personAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: "The primary unique identifier for the person",
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_full_name: {
+      description: "The person\u2019s name",
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "name",
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    aliases: {
+      description: undefined,
+      codec: textArrayCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    about: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    email: {
+      description: undefined,
+      codec: emailCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    site: {
+      description: undefined,
+      codec: wrappedUrlCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          deprecated: "Don\u2019t use me",
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    config: {
+      description: undefined,
+      codec: TYPES.hstore,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    last_login_from_ip: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    last_login_from_subnet: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    user_mac: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    created_at: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    }
+  }),
   description: "Person test comment",
   extensions: {
     isTableLike: true,
@@ -2189,8 +2205,9 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const personCodec = recordCodec(spec_person);
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
@@ -2529,7 +2546,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -2581,7 +2598,7 @@ const byteaArrayCodec = listOfCodec(TYPES.bytea, {
   description: undefined,
   name: "byteaArray"
 });
-const typesAttributes_ltree_codec_ltree = {
+const spec_types_attributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -2593,565 +2610,564 @@ const typesAttributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
-const typesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  smallint: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  bigint: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  numeric: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  decimal: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  boolean: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  varchar: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  enum: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  enum_array: {
-    description: undefined,
-    codec: colorArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  domain: {
-    description: undefined,
-    codec: anIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  domain2: {
-    description: undefined,
-    codec: anotherIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  text_array: {
-    description: undefined,
-    codec: textArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  json: {
-    description: undefined,
-    codec: TYPES.json,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  jsonb: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  nullable_range: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  numrange: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  daterange: {
-    description: undefined,
-    codec: daterangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  an_int_range: {
-    description: undefined,
-    codec: anIntRangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  timestamp: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  timestamptz: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  date: {
-    description: undefined,
-    codec: TYPES.date,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  time: {
-    description: undefined,
-    codec: TYPES.time,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  timetz: {
-    description: undefined,
-    codec: TYPES.timetz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  interval: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  interval_array: {
-    description: undefined,
-    codec: intervalArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  money: {
-    description: undefined,
-    codec: TYPES.money,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  nullable_compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  nullable_nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  point: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  nullablePoint: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  inet: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  cidr: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  macaddr: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  regproc: {
-    description: undefined,
-    codec: TYPES.regproc,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  regprocedure: {
-    description: undefined,
-    codec: TYPES.regprocedure,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  regoper: {
-    description: undefined,
-    codec: TYPES.regoper,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  regoperator: {
-    description: undefined,
-    codec: TYPES.regoperator,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  regclass: {
-    description: undefined,
-    codec: TYPES.regclass,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  regtype: {
-    description: undefined,
-    codec: TYPES.regtype,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  regconfig: {
-    description: undefined,
-    codec: TYPES.regconfig,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  regdictionary: {
-    description: undefined,
-    codec: TYPES.regdictionary,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  text_array_domain: {
-    description: undefined,
-    codec: textArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  int8_array_domain: {
-    description: undefined,
-    codec: int8ArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  bytea: {
-    description: undefined,
-    codec: TYPES.bytea,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  bytea_array: {
-    description: undefined,
-    codec: byteaArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  ltree: {
-    description: undefined,
-    codec: typesAttributes_ltree_codec_ltree,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  },
-  ltree_array: {
-    description: undefined,
-    codec: typesAttributes_ltree_array_codec_ltree_,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        behavior: ["-filterBy -orderBy"]
-      }
-    }
-  }
-});
-const extensions46 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "types"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: ["(smallint) references a.post", "(id) references a.post"]
-  })
-};
-const typesCodec = recordCodec({
+const spec_types_attributes_ltree_array_codec_ltree_ = listOfCodec(spec_types_attributes_ltree_codec_ltree);
+const spec_types = {
   name: "types",
   identifier: sql.identifier("b", "types"),
-  attributes: typesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    smallint: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    bigint: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    numeric: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    decimal: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    boolean: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    varchar: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    enum: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    enum_array: {
+      description: undefined,
+      codec: colorArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    domain: {
+      description: undefined,
+      codec: anIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    domain2: {
+      description: undefined,
+      codec: anotherIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    text_array: {
+      description: undefined,
+      codec: textArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    json: {
+      description: undefined,
+      codec: TYPES.json,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    jsonb: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    nullable_range: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    numrange: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    daterange: {
+      description: undefined,
+      codec: daterangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    an_int_range: {
+      description: undefined,
+      codec: anIntRangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    timestamp: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    timestamptz: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    date: {
+      description: undefined,
+      codec: TYPES.date,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    time: {
+      description: undefined,
+      codec: TYPES.time,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    timetz: {
+      description: undefined,
+      codec: TYPES.timetz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    interval: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    interval_array: {
+      description: undefined,
+      codec: intervalArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    money: {
+      description: undefined,
+      codec: TYPES.money,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    nullable_compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    nullable_nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    point: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    nullablePoint: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    inet: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    cidr: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    macaddr: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    regproc: {
+      description: undefined,
+      codec: TYPES.regproc,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    regprocedure: {
+      description: undefined,
+      codec: TYPES.regprocedure,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    regoper: {
+      description: undefined,
+      codec: TYPES.regoper,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    regoperator: {
+      description: undefined,
+      codec: TYPES.regoperator,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    regclass: {
+      description: undefined,
+      codec: TYPES.regclass,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    regtype: {
+      description: undefined,
+      codec: TYPES.regtype,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    regconfig: {
+      description: undefined,
+      codec: TYPES.regconfig,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    regdictionary: {
+      description: undefined,
+      codec: TYPES.regdictionary,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    text_array_domain: {
+      description: undefined,
+      codec: textArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    int8_array_domain: {
+      description: undefined,
+      codec: int8ArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    bytea: {
+      description: undefined,
+      codec: TYPES.bytea,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    bytea_array: {
+      description: undefined,
+      codec: byteaArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    ltree: {
+      description: undefined,
+      codec: spec_types_attributes_ltree_codec_ltree,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    },
+    ltree_array: {
+      description: undefined,
+      codec: spec_types_attributes_ltree_array_codec_ltree_,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          behavior: ["-filterBy -orderBy"]
+        }
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions46,
-  executor
-});
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "types"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: ["(smallint) references a.post", "(id) references a.post"]
+    })
+  },
+  executor: executor
+};
+const typesCodec = recordCodec(spec_types);
 const int4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
     pg: {
@@ -3344,7 +3360,7 @@ const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
     },
     tags: {
       omit: "create,update,delete,all,order,filter",
-      behavior: extensions12.tags.behavior
+      behavior: spec_uniqueForeignKey.extensions.tags.behavior
     }
   }
 };
@@ -3693,7 +3709,7 @@ const registryConfig_pgResources_types_types = {
       name: "types"
     },
     tags: {
-      foreignKey: extensions46.tags.foreignKey
+      foreignKey: spec_types.extensions.tags.foreignKey
     }
   }
 };
@@ -3816,8 +3832,8 @@ const registry = makeRegistry({
     int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
     byteaArray: byteaArrayCodec,
-    ltree: typesAttributes_ltree_codec_ltree,
-    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
+    ltree: spec_types_attributes_ltree_codec_ltree,
+    "ltree[]": spec_types_attributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     compoundTypeArray: listOfCodec(compoundTypeCodec, {
       extensions: {
@@ -3910,7 +3926,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor
+      executor: executor
     }),
     tablefuncCrosstab3: recordCodec({
       name: "tablefuncCrosstab3",
@@ -3971,7 +3987,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor
+      executor: executor
     }),
     tablefuncCrosstab4: recordCodec({
       name: "tablefuncCrosstab4",
@@ -4043,7 +4059,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor
+      executor: executor
     })
   }),
   pgResources: Object.assign(Object.create(null), {
@@ -12625,6 +12641,15 @@ const makeArgs64 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
+function UUIDSerialize(value) {
+  return "" + value;
+}
+const coerce = string => {
+  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
+    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
+  }
+  return string;
+};
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -13129,6 +13154,60 @@ const makeArgs73 = (args, path = []) => {
 const resource_post_computed_compound_type_arrayPgResource = registry.pgResources["post_computed_compound_type_array"];
 const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
+function LTreeParseValue(value) {
+  return value;
+}
+const isValidHstoreObject = obj => {
+  if (obj === null) {
+    // Null is okay
+    return true;
+  } else if (typeof obj === "object") {
+    // A hash with string/null values is also okay
+    const keys = Object.keys(obj);
+    for (const key of keys) {
+      const val = obj[key];
+      if (val === null) {
+        // Null is okay
+      } else if (typeof val === "string") {
+        // String is okay
+      } else {
+        // Everything else is invalid.
+        return false;
+      }
+    }
+    return true;
+  } else {
+    // Everything else is invalid.
+    return false;
+  }
+};
+const parseValueLiteral = (ast, variables) => {
+  switch (ast.kind) {
+    case Kind.INT:
+    case Kind.FLOAT:
+      // Number isn't really okay, but we'll coerce it to a string anyway.
+      return String(parseFloat(ast.value));
+    case Kind.STRING:
+      // String is okay.
+      return String(ast.value);
+    case Kind.NULL:
+      // Null is okay.
+      return null;
+    case Kind.VARIABLE:
+      {
+        // Variable is okay if that variable is either a string or null.
+        const name = ast.name.value;
+        const value = variables ? variables[name] : undefined;
+        if (value === null || typeof value === "string") {
+          return value;
+        }
+        return undefined;
+      }
+    default:
+      // Everything else is invalid.
+      return undefined;
+  }
+};
 const argDetailsSimple74 = [];
 const makeArgs74 = (args, path = []) => {
   const selectArgs = [];
@@ -29190,6 +29269,11 @@ export const plans = {
       return $record.get("o");
     }
   },
+  Email: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
   PersonComputedFirstArgInoutOutRecord: {
     __assertStep: assertPgClassSingleStep,
     person($record) {
@@ -29299,6 +29383,19 @@ export const plans = {
     },
     BLUE: {
       value: "blue"
+    }
+  },
+  UUID: {
+    serialize: UUIDSerialize,
+    parseValue(value) {
+      return coerce("" + value);
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // ERRORS: add name to this error
+        throw new GraphQLError(`${"UUID" ?? "This scalar"} can only parse string values (kind = '${ast.kind}')`);
+      }
+      return coerce(ast.value);
     }
   },
   EnumCaps: {
@@ -29805,6 +29902,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -29821,6 +29928,9 @@ export const plans = {
     }
   },
   CompoundTypeInput: {
+    "__inputPlan": function CompoundTypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     a: {
       applyPlan($insert, val) {
         $insert.set("a", val.get());
@@ -29949,6 +30059,16 @@ export const plans = {
     },
     isOptimised($record) {
       return $record.get("is_optimised");
+    }
+  },
+  Datetime: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   TypesConnection: {
@@ -30155,12 +30275,77 @@ export const plans = {
       });
     }
   },
+  BigInt: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigInt" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  BigFloat: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigFloat" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  AnInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
+  AnotherInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
+  JSON: {
+    serialize(value) {
+      return JSON.stringify(value);
+    },
+    parseValue(value) {
+      return JSON.parse(value);
+    },
+    parseLiteral(ast, _variables) {
+      if (ast.kind === Kind.STRING) {
+        return JSON.parse(ast.value);
+      } else {
+        return undefined;
+      }
+    }
+  },
   BigFloatRange: {},
   BigFloatRangeBound: {},
   DateRange: {},
   DateRangeBound: {},
+  Date: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Date" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   AnIntRange: {},
   AnIntRangeBound: {},
+  Time: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Time" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   NestedCompoundType: {
     __assertStep: assertPgClassSingleStep,
     a($record) {
@@ -30186,6 +30371,128 @@ export const plans = {
     }
   },
   Point: {},
+  InternetAddress: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"InternetAddress" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProc: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProc" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProcedure: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProcedure" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOper: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOper" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOperator: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOperator" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegClass: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegClass" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegType: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegType" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegConfig: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegConfig" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegDictionary: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegDictionary" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  Base64EncodedBinary: {
+    serialize(data) {
+      if (Buffer.isBuffer(data)) {
+        return data.toString("base64");
+      } else {
+        throw new Error(`Base64EncodeBinary can only be used with Node.js buffers.`);
+      }
+    },
+    parseValue(data) {
+      if (typeof data === "string") {
+        return Buffer.from(data, "base64");
+      } else {
+        throw new GraphQLError("Base64EncodedBinary can only parse string values.");
+      }
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // TODO: add name to this error
+        throw new GraphQLError("Base64EncodedBinary can only parse string values");
+      }
+      return Buffer.from(ast.value, "base64");
+    }
+  },
+  LTree: {
+    serialize(x) {
+      return x;
+    },
+    parseValue: LTreeParseValue,
+    parseLiteral(node, variables) {
+      return LTreeParseValue(valueFromASTUntyped(node, variables));
+    }
+  },
   TypesEdge: {
     __assertStep: assertEdgeCapableStep,
     cursor($edge) {
@@ -30282,7 +30589,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.id.codec)}`;
             }
           });
         }
@@ -30487,6 +30794,50 @@ export const plans = {
       return $record.get("url");
     }
   },
+  NotNullUrl: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
+  KeyValueHash: {
+    serialize(value) {
+      return value;
+    },
+    parseValue(obj) {
+      if (isValidHstoreObject(obj)) {
+        return obj;
+      }
+      throw new GraphQLError(`This is not a valid ${"KeyValueHash"} object, it must be a key/value hash where keys and values are both strings (or null).`);
+    },
+    parseLiteral(ast, variables) {
+      switch (ast.kind) {
+        case Kind.OBJECT:
+          {
+            const value = ast.fields.reduce((memo, field) => {
+              memo[field.name.value] = parseValueLiteral(field.value, variables);
+              return memo;
+            }, Object.create(null));
+            if (!isValidHstoreObject(value)) {
+              return undefined;
+            }
+            return value;
+          }
+        case Kind.NULL:
+          return null;
+        case Kind.VARIABLE:
+          {
+            const name = ast.name.value;
+            const value = variables ? variables[name] : undefined;
+            if (!isValidHstoreObject(value)) {
+              return undefined;
+            }
+            return value;
+          }
+        default:
+          return undefined;
+      }
+    }
+  },
   PostsConnection: {
     __assertStep: ConnectionStep,
     nodes($connection) {
@@ -30663,7 +31014,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.id.codec)}`;
             }
           });
         }
@@ -30686,7 +31037,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.author_id.codec)}`;
             }
           });
         }
@@ -30864,7 +31215,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.person_id_1.codec)}`;
             }
           });
         }
@@ -30970,6 +31321,16 @@ export const plans = {
     },
     ts($record) {
       return $record.get("ts");
+    }
+  },
+  NotNullTimestamp: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   FuncOutSetofConnection: {
@@ -31365,7 +31726,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.id.codec)}`;
             }
           });
         }
@@ -31388,7 +31749,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.email.codec)}`;
             }
           });
         }
@@ -31560,7 +31921,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), inputsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_inputs.attributes.id.codec)}`;
             }
           });
         }
@@ -31681,7 +32042,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), patchsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_patchs.attributes.id.codec)}`;
             }
           });
         }
@@ -31802,7 +32163,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reserved.attributes.id.codec)}`;
             }
           });
         }
@@ -31923,7 +32284,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedPatchsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reservedPatchs.attributes.id.codec)}`;
             }
           });
         }
@@ -32044,7 +32405,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedInputAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reservedInput.attributes.id.codec)}`;
             }
           });
         }
@@ -32165,7 +32526,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_defaultValue.attributes.id.codec)}`;
             }
           });
         }
@@ -32307,7 +32668,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_noPrimaryKey.attributes.id.codec)}`;
             }
           });
         }
@@ -32470,7 +32831,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_myTable.attributes.id.codec)}`;
             }
           });
         }
@@ -32591,7 +32952,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_personSecret.attributes.person_id.codec)}`;
             }
           });
         }
@@ -32712,7 +33073,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_viewTable.attributes.id.codec)}`;
             }
           });
         }
@@ -32833,7 +33194,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.id.codec)}`;
             }
           });
         }
@@ -32954,7 +33315,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.id.codec)}`;
             }
           });
         }
@@ -33120,7 +33481,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.id.codec)}`;
             }
           });
         }
@@ -33351,7 +33712,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.id.codec)}`;
             }
           });
         }
@@ -33374,7 +33735,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.person_id.codec)}`;
             }
           });
         }
@@ -33495,7 +33856,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_issue756.attributes.id.codec)}`;
             }
           });
         }
@@ -36831,6 +37192,11 @@ export const plans = {
       return rootValue();
     }
   },
+  Guid: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
   GuidFnInput: {
     clientMutationId: {
       applyPlan($input, val) {
@@ -37022,6 +37388,9 @@ export const plans = {
     leftArm: undefined
   },
   LeftArmBaseInput: {
+    "__inputPlan": function LeftArmBaseInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -37416,6 +37785,9 @@ export const plans = {
     suffix: undefined
   },
   PostInput: {
+    "__inputPlan": function PostInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -37460,6 +37832,9 @@ export const plans = {
     }
   },
   ComptypeInput: {
+    "__inputPlan": function ComptypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     schedule: {
       applyPlan($insert, val) {
         $insert.set("schedule", val.get());
@@ -37882,6 +38257,9 @@ export const plans = {
     }
   },
   InputInput: {
+    "__inputPlan": function InputInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -37949,6 +38327,9 @@ export const plans = {
     }
   },
   PatchInput: {
+    "__inputPlan": function PatchInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -38016,6 +38397,9 @@ export const plans = {
     }
   },
   ReservedInput: {
+    "__inputPlan": function ReservedInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -38083,6 +38467,9 @@ export const plans = {
     }
   },
   ReservedPatchRecordInput: {
+    "__inputPlan": function ReservedPatchRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -38150,6 +38537,9 @@ export const plans = {
     }
   },
   ReservedInputRecordInput: {
+    "__inputPlan": function ReservedInputRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -38217,6 +38607,9 @@ export const plans = {
     }
   },
   DefaultValueInput: {
+    "__inputPlan": function DefaultValueInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -38271,6 +38664,9 @@ export const plans = {
     }
   },
   ForeignKeyInput: {
+    "__inputPlan": function ForeignKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -38321,6 +38717,9 @@ export const plans = {
     }
   },
   NoPrimaryKeyInput: {
+    "__inputPlan": function NoPrimaryKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -38364,6 +38763,9 @@ export const plans = {
     }
   },
   TestviewInput: {
+    "__inputPlan": function TestviewInput_inputPlan() {
+      return object(Object.create(null));
+    },
     testviewid: {
       applyPlan($insert, val) {
         $insert.set("testviewid", val.get());
@@ -38445,6 +38847,9 @@ export const plans = {
     }
   },
   MyTableInput: {
+    "__inputPlan": function MyTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -38524,6 +38929,9 @@ export const plans = {
     }
   },
   PersonSecretInput: {
+    "__inputPlan": function PersonSecretInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -38598,6 +39006,9 @@ export const plans = {
     }
   },
   ViewTableInput: {
+    "__inputPlan": function ViewTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -38689,6 +39100,9 @@ export const plans = {
     }
   },
   CompoundKeyInput: {
+    "__inputPlan": function CompoundKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId2: {
       applyPlan($insert, val) {
         $insert.set("person_id_2", val.get());
@@ -38770,6 +39184,9 @@ export const plans = {
     }
   },
   SimilarTable1Input: {
+    "__inputPlan": function SimilarTable1Input_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -38858,6 +39275,9 @@ export const plans = {
     }
   },
   SimilarTable2Input: {
+    "__inputPlan": function SimilarTable2Input_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -38915,6 +39335,9 @@ export const plans = {
     }
   },
   UpdatableViewInput: {
+    "__inputPlan": function UpdatableViewInput_inputPlan() {
+      return object(Object.create(null));
+    },
     x: {
       applyPlan($insert, val) {
         $insert.set("x", val.get());
@@ -39003,6 +39426,9 @@ export const plans = {
     }
   },
   NullTestRecordInput: {
+    "__inputPlan": function NullTestRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -39060,6 +39486,9 @@ export const plans = {
     }
   },
   EdgeCaseInput: {
+    "__inputPlan": function EdgeCaseInput_inputPlan() {
+      return object(Object.create(null));
+    },
     notNullHasDefault: {
       applyPlan($insert, val) {
         $insert.set("not_null_has_default", val.get());
@@ -39146,6 +39575,9 @@ export const plans = {
     }
   },
   LeftArmInput: {
+    "__inputPlan": function LeftArmInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -39234,6 +39666,9 @@ export const plans = {
     }
   },
   Issue756Input: {
+    "__inputPlan": function Issue756Input_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -39371,6 +39806,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -39450,6 +39888,9 @@ export const plans = {
     }
   },
   WrappedUrlInput: {
+    "__inputPlan": function WrappedUrlInput_inputPlan() {
+      return object(Object.create(null));
+    },
     url: {
       applyPlan($insert, val) {
         $insert.set("url", val.get());
@@ -39527,6 +39968,9 @@ export const plans = {
     }
   },
   TypeInput: {
+    "__inputPlan": function TypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -39896,6 +40340,9 @@ export const plans = {
     inclusive: undefined
   },
   NestedCompoundTypeInput: {
+    "__inputPlan": function NestedCompoundTypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     a: {
       applyPlan($insert, val) {
         $insert.set("a", val.get());
@@ -39980,6 +40427,9 @@ export const plans = {
     }
   },
   InputPatch: {
+    "__inputPlan": function InputPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -40060,6 +40510,9 @@ export const plans = {
     }
   },
   PatchPatch: {
+    "__inputPlan": function PatchPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -40140,6 +40593,9 @@ export const plans = {
     }
   },
   ReservedPatch: {
+    "__inputPlan": function ReservedPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -40220,6 +40676,9 @@ export const plans = {
     }
   },
   ReservedPatchRecordPatch: {
+    "__inputPlan": function ReservedPatchRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -40300,6 +40759,9 @@ export const plans = {
     }
   },
   ReservedInputRecordPatch: {
+    "__inputPlan": function ReservedInputRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -40380,6 +40842,9 @@ export const plans = {
     }
   },
   DefaultValuePatch: {
+    "__inputPlan": function DefaultValuePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -40436,6 +40901,9 @@ export const plans = {
     }
   },
   NoPrimaryKeyPatch: {
+    "__inputPlan": function NoPrimaryKeyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -40509,6 +40977,9 @@ export const plans = {
     }
   },
   MyTablePatch: {
+    "__inputPlan": function MyTablePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -40601,6 +41072,9 @@ export const plans = {
     }
   },
   PersonSecretPatch: {
+    "__inputPlan": function PersonSecretPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -40688,6 +41162,9 @@ export const plans = {
     }
   },
   ViewTablePatch: {
+    "__inputPlan": function ViewTablePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -40792,6 +41269,9 @@ export const plans = {
     }
   },
   CompoundKeyPatch: {
+    "__inputPlan": function CompoundKeyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     personId2: {
       applyPlan($insert, val) {
         $insert.set("person_id_2", val.get());
@@ -40887,6 +41367,9 @@ export const plans = {
     }
   },
   SimilarTable1Patch: {
+    "__inputPlan": function SimilarTable1Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -40988,6 +41471,9 @@ export const plans = {
     }
   },
   SimilarTable2Patch: {
+    "__inputPlan": function SimilarTable2Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -41089,6 +41575,9 @@ export const plans = {
     }
   },
   NullTestRecordPatch: {
+    "__inputPlan": function NullTestRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -41195,6 +41684,9 @@ export const plans = {
     }
   },
   LeftArmPatch: {
+    "__inputPlan": function LeftArmPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -41310,6 +41802,9 @@ export const plans = {
     }
   },
   Issue756Patch: {
+    "__inputPlan": function Issue756Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -41402,6 +41897,9 @@ export const plans = {
     }
   },
   PostPatch: {
+    "__inputPlan": function PostPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -41517,6 +42015,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -41691,6 +42192,9 @@ export const plans = {
     }
   },
   TypePatch: {
+    "__inputPlan": function TypePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/indexes.index_expressions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/indexes.index_expressions.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgExecutor, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, makeRegistry, recordCodec } from "@dataplan/pg";
 import { ConnectionStep, SafeError, access, assertEdgeCapableStep, assertPageInfoCapableStep, connection, constant, context, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue } from "grafast";
+import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,53 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
-  }
-});
-const employeeAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  first_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -87,10 +75,38 @@ const executor = new PgExecutor({
     });
   }
 });
-const employeeCodec = recordCodec({
+const spec_employee = {
   name: "employee",
   identifier: sql.identifier("index_expressions", "employee"),
-  attributes: employeeAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    first_name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -101,8 +117,9 @@ const employeeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const employeeCodec = recordCodec(spec_employee);
 const employeeUniques = [{
   isPrimary: true,
   attributes: ["id"],
@@ -208,6 +225,9 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
+function CursorSerialize(value) {
+  return "" + value;
+}
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
   """
@@ -489,6 +509,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: CursorSerialize,
+    parseValue: CursorSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -659,7 +689,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), employeeAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_employee.attributes.id.codec)}`;
             }
           });
         }
@@ -682,7 +712,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), employeeAttributes.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_employee.attributes.first_name.codec)}`;
             }
           });
         }
@@ -705,7 +735,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), employeeAttributes.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_employee.attributes.last_name.codec)}`;
             }
           });
         }

--- a/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, domainOfCodec, enumCodec, listOfCodec, makeRegistry, pgClassExpression, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectFromRecords, pgSelectSingleFromRecord, pgUpdateSingle, rangeOfCodec, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
+import { GraphQLError, GraphQLInt, GraphQLString, Kind, valueFromASTUntyped } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Q",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -442,21 +459,20 @@ const textArrayCodec = listOfCodec(TYPES.text, {
   description: undefined,
   name: "textArray"
 });
-const nonUpdatableViewAttributes = Object.assign(Object.create(null), {
-  "?column?": {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const nonUpdatableViewCodec = recordCodec({
+const spec_nonUpdatableView = {
   name: "nonUpdatableView",
   identifier: sql.identifier("a", "non_updatable_view"),
-  attributes: nonUpdatableViewAttributes,
+  attributes: Object.assign(Object.create(null), {
+    "?column?": {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -467,23 +483,23 @@ const nonUpdatableViewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const inputsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const inputsCodec = recordCodec({
+  executor: executor
+};
+const nonUpdatableViewCodec = recordCodec(spec_nonUpdatableView);
+const spec_inputs = {
   name: "inputs",
   identifier: sql.identifier("a", "inputs"),
-  attributes: inputsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Should output as Input",
   extensions: {
     isTableLike: true,
@@ -494,23 +510,23 @@ const inputsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const patchsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const patchsCodec = recordCodec({
+  executor: executor
+};
+const inputsCodec = recordCodec(spec_inputs);
+const spec_patchs = {
   name: "patchs",
   identifier: sql.identifier("a", "patchs"),
-  attributes: patchsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Should output as Patch",
   extensions: {
     isTableLike: true,
@@ -521,23 +537,23 @@ const patchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const reservedAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const reservedCodec = recordCodec({
+  executor: executor
+};
+const patchsCodec = recordCodec(spec_patchs);
+const spec_reserved = {
   name: "reserved",
   identifier: sql.identifier("a", "reserved"),
-  attributes: reservedAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -548,23 +564,23 @@ const reservedCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const reservedPatchsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const reservedPatchsCodec = recordCodec({
+  executor: executor
+};
+const reservedCodec = recordCodec(spec_reserved);
+const spec_reservedPatchs = {
   name: "reservedPatchs",
   identifier: sql.identifier("a", "reservedPatchs"),
-  attributes: reservedPatchsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   extensions: {
     isTableLike: true,
@@ -575,23 +591,23 @@ const reservedPatchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const reservedInputAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const reservedInputCodec = recordCodec({
+  executor: executor
+};
+const reservedPatchsCodec = recordCodec(spec_reservedPatchs);
+const spec_reservedInput = {
   name: "reservedInput",
   identifier: sql.identifier("a", "reserved_input"),
-  attributes: reservedInputAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
   extensions: {
     isTableLike: true,
@@ -602,32 +618,32 @@ const reservedInputCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const defaultValueAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  null_value: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const defaultValueCodec = recordCodec({
+  executor: executor
+};
+const reservedInputCodec = recordCodec(spec_reservedInput);
+const spec_defaultValue = {
   name: "defaultValue",
   identifier: sql.identifier("a", "default_value"),
-  attributes: defaultValueAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    null_value: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -638,41 +654,41 @@ const defaultValueCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const foreignKeyAttributes = Object.assign(Object.create(null), {
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_key_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_key_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const foreignKeyCodec = recordCodec({
+  executor: executor
+};
+const defaultValueCodec = recordCodec(spec_defaultValue);
+const spec_foreignKey = {
   name: "foreignKey",
   identifier: sql.identifier("a", "foreign_key"),
-  attributes: foreignKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_key_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_key_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -683,32 +699,32 @@ const foreignKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  str: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const noPrimaryKeyCodec = recordCodec({
+  executor: executor
+};
+const foreignKeyCodec = recordCodec(spec_foreignKey);
+const spec_noPrimaryKey = {
   name: "noPrimaryKey",
   identifier: sql.identifier("a", "no_primary_key"),
-  attributes: noPrimaryKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    str: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -719,41 +735,41 @@ const noPrimaryKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const testviewAttributes = Object.assign(Object.create(null), {
-  testviewid: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const testviewCodec = recordCodec({
+  executor: executor
+};
+const noPrimaryKeyCodec = recordCodec(spec_noPrimaryKey);
+const spec_testview = {
   name: "testview",
   identifier: sql.identifier("a", "testview"),
-  attributes: testviewAttributes,
+  attributes: Object.assign(Object.create(null), {
+    testviewid: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -764,21 +780,10 @@ const testviewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const extensions12 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "unique_foreign_key"
-  },
-  tags: Object.assign(Object.create(null), {
-    omit: "create,update,delete,all,order,filter",
-    behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy"]
-  })
+  executor: executor
 };
-const uniqueForeignKeyCodec = recordCodec({
+const testviewCodec = recordCodec(spec_testview);
+const spec_uniqueForeignKey = {
   name: "uniqueForeignKey",
   identifier: sql.identifier("a", "unique_foreign_key"),
   attributes: Object.assign(Object.create(null), {
@@ -802,33 +807,44 @@ const uniqueForeignKeyCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions: extensions12,
-  executor
-});
-const myTableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "unique_foreign_key"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: "create,update,delete,all,order,filter",
+      behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy"]
+    })
   },
-  json_data: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const myTableCodec = recordCodec({
+  executor: executor
+};
+const uniqueForeignKeyCodec = recordCodec(spec_uniqueForeignKey);
+const spec_myTable = {
   name: "myTable",
   identifier: sql.identifier("c", "my_table"),
-  attributes: myTableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    json_data: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -839,34 +855,34 @@ const myTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const personSecretAttributes = Object.assign(Object.create(null), {
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  sekrit: {
-    description: "A secret held by the associated Person",
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "secret"
-      }
-    }
-  }
-});
-const personSecretCodec = recordCodec({
+  executor: executor
+};
+const myTableCodec = recordCodec(spec_myTable);
+const spec_personSecret = {
   name: "personSecret",
   identifier: sql.identifier("c", "person_secret"),
-  attributes: personSecretAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    sekrit: {
+      description: "A secret held by the associated Person",
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "secret"
+        }
+      }
+    }
+  }),
   description: "Tracks the person's secret",
   extensions: {
     isTableLike: true,
@@ -879,41 +895,41 @@ const personSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor
-});
-const viewTableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const viewTableCodec = recordCodec({
+  executor: executor
+};
+const personSecretCodec = recordCodec(spec_personSecret);
+const spec_viewTable = {
   name: "viewTable",
   identifier: sql.identifier("a", "view_table"),
-  attributes: viewTableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -924,41 +940,41 @@ const viewTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const compoundKeyAttributes = Object.assign(Object.create(null), {
-  person_id_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  extra: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const compoundKeyCodec = recordCodec({
+  executor: executor
+};
+const viewTableCodec = recordCodec(spec_viewTable);
+const spec_compoundKey = {
   name: "compoundKey",
   identifier: sql.identifier("c", "compound_key"),
-  attributes: compoundKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    extra: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -969,50 +985,50 @@ const compoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const similarTable1Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col3: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const similarTable1Codec = recordCodec({
+  executor: executor
+};
+const compoundKeyCodec = recordCodec(spec_compoundKey);
+const spec_similarTable1 = {
   name: "similarTable1",
   identifier: sql.identifier("a", "similar_table_1"),
-  attributes: similarTable1Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col3: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1023,50 +1039,50 @@ const similarTable1Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const similarTable2Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  col3: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col4: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col5: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const similarTable2Codec = recordCodec({
+  executor: executor
+};
+const similarTable1Codec = recordCodec(spec_similarTable1);
+const spec_similarTable2 = {
   name: "similarTable2",
   identifier: sql.identifier("a", "similar_table_2"),
-  attributes: similarTable2Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    col3: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col4: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col5: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1077,50 +1093,50 @@ const similarTable2Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const updatableViewAttributes = Object.assign(Object.create(null), {
-  x: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  description: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  constant: {
-    description: "This is constantly 2",
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const updatableViewCodec = recordCodec({
+  executor: executor
+};
+const similarTable2Codec = recordCodec(spec_similarTable2);
+const spec_updatableView = {
   name: "updatableView",
   identifier: sql.identifier("b", "updatable_view"),
-  attributes: updatableViewAttributes,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    description: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    constant: {
+      description: "This is constantly 2",
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "YOYOYO!!",
   extensions: {
     isTableLike: true,
@@ -1134,50 +1150,50 @@ const updatableViewCodec = recordCodec({
       unique: "x|@behavior -single -update -delete"
     })
   },
-  executor
-});
-const nullTestRecordAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_int: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  non_null_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const nullTestRecordCodec = recordCodec({
+  executor: executor
+};
+const updatableViewCodec = recordCodec(spec_updatableView);
+const spec_nullTestRecord = {
   name: "nullTestRecord",
   identifier: sql.identifier("c", "null_test_record"),
-  attributes: nullTestRecordAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_int: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    non_null_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1188,8 +1204,9 @@ const nullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const nullTestRecordCodec = recordCodec(spec_nullTestRecord);
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   extensions: {
     pg: {
@@ -1203,39 +1220,38 @@ const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   description: undefined,
   name: "uuidArray"
 });
-const edgeCaseAttributes = Object.assign(Object.create(null), {
-  not_null_has_default: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  wont_cast_easy: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  row_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const edgeCaseCodec = recordCodec({
+const spec_edgeCase = {
   name: "edgeCase",
   identifier: sql.identifier("c", "edge_case"),
-  attributes: edgeCaseAttributes,
+  attributes: Object.assign(Object.create(null), {
+    not_null_has_default: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    wont_cast_easy: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    row_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1246,50 +1262,50 @@ const edgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const leftArmAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  length_in_metres: {
-    description: undefined,
-    codec: TYPES.float,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  mood: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const leftArmCodec = recordCodec({
+  executor: executor
+};
+const edgeCaseCodec = recordCodec(spec_edgeCase);
+const spec_leftArm = {
   name: "leftArm",
   identifier: sql.identifier("c", "left_arm"),
-  attributes: leftArmAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    length_in_metres: {
+      description: undefined,
+      codec: TYPES.float,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    mood: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Tracks metadata about the left arms of various people",
   extensions: {
     isTableLike: true,
@@ -1300,8 +1316,9 @@ const leftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const leftArmCodec = recordCodec(spec_leftArm);
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
   identifier: sql.identifier("b", "jwt_token"),
@@ -1362,7 +1379,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
@@ -1376,30 +1393,29 @@ const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp
   },
   notNull: true
 });
-const issue756Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  ts: {
-    description: undefined,
-    codec: notNullTimestampCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const issue756Codec = recordCodec({
+const spec_issue756 = {
   name: "issue756",
   identifier: sql.identifier("c", "issue756"),
-  attributes: issue756Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    ts: {
+      description: undefined,
+      codec: notNullTimestampCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1410,8 +1426,9 @@ const issue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const issue756Codec = recordCodec(spec_issue756);
 const authPayloadCodec = recordCodec({
   name: "authPayload",
   identifier: sql.identifier("b", "auth_payload"),
@@ -1456,7 +1473,7 @@ const authPayloadCodec = recordCodec({
       foreignKey: "(id) references c.person"
     })
   },
-  executor
+  executor: executor
 });
 const colorCodec = enumCodec({
   name: "color",
@@ -1587,7 +1604,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
@@ -1709,7 +1726,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1724,66 +1741,65 @@ const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   description: undefined,
   name: "comptypeArray"
 });
-const postAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  headline: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  body: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  enums: {
-    description: undefined,
-    codec: anEnumArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  comptypes: {
-    description: undefined,
-    codec: comptypeArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const postCodec = recordCodec({
+const spec_post = {
   name: "post",
   identifier: sql.identifier("a", "post"),
-  attributes: postAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    headline: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    body: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    enums: {
+      description: undefined,
+      codec: anEnumArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    comptypes: {
+      description: undefined,
+      codec: comptypeArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1794,8 +1810,9 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const postCodec = recordCodec(spec_post);
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
@@ -1942,117 +1959,116 @@ const wrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const personAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: "The primary unique identifier for the person",
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_full_name: {
-    description: "The person\u2019s name",
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "name"
-      }
-    }
-  },
-  aliases: {
-    description: undefined,
-    codec: textArrayCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  about: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  email: {
-    description: undefined,
-    codec: emailCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  site: {
-    description: undefined,
-    codec: wrappedUrlCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        deprecated: "Don\u2019t use me"
-      }
-    }
-  },
-  config: {
-    description: undefined,
-    codec: TYPES.hstore,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_login_from_ip: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_login_from_subnet: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  user_mac: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  created_at: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const personCodec = recordCodec({
+const spec_person = {
   name: "person",
   identifier: sql.identifier("c", "person"),
-  attributes: personAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: "The primary unique identifier for the person",
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_full_name: {
+      description: "The person\u2019s name",
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "name"
+        }
+      }
+    },
+    aliases: {
+      description: undefined,
+      codec: textArrayCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    about: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    email: {
+      description: undefined,
+      codec: emailCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    site: {
+      description: undefined,
+      codec: wrappedUrlCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          deprecated: "Don\u2019t use me"
+        }
+      }
+    },
+    config: {
+      description: undefined,
+      codec: TYPES.hstore,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_login_from_ip: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_login_from_subnet: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    user_mac: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    created_at: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Person test comment",
   extensions: {
     isTableLike: true,
@@ -2063,8 +2079,9 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const personCodec = recordCodec(spec_person);
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
@@ -2397,7 +2414,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -2449,7 +2466,7 @@ const byteaArrayCodec = listOfCodec(TYPES.bytea, {
   description: undefined,
   name: "byteaArray"
 });
-const typesAttributes_ltree_codec_ltree = {
+const spec_types_attributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -2461,469 +2478,468 @@ const typesAttributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
-const typesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  smallint: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bigint: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numeric: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  decimal: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  boolean: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  varchar: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum_array: {
-    description: undefined,
-    codec: colorArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain: {
-    description: undefined,
-    codec: anIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain2: {
-    description: undefined,
-    codec: anotherIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array: {
-    description: undefined,
-    codec: textArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  json: {
-    description: undefined,
-    codec: TYPES.json,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  jsonb: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_range: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numrange: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  daterange: {
-    description: undefined,
-    codec: daterangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  an_int_range: {
-    description: undefined,
-    codec: anIntRangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamp: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamptz: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  date: {
-    description: undefined,
-    codec: TYPES.date,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  time: {
-    description: undefined,
-    codec: TYPES.time,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timetz: {
-    description: undefined,
-    codec: TYPES.timetz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval_array: {
-    description: undefined,
-    codec: intervalArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  money: {
-    description: undefined,
-    codec: TYPES.money,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  point: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullablePoint: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  inet: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  cidr: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  macaddr: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regproc: {
-    description: undefined,
-    codec: TYPES.regproc,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regprocedure: {
-    description: undefined,
-    codec: TYPES.regprocedure,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoper: {
-    description: undefined,
-    codec: TYPES.regoper,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoperator: {
-    description: undefined,
-    codec: TYPES.regoperator,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regclass: {
-    description: undefined,
-    codec: TYPES.regclass,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regtype: {
-    description: undefined,
-    codec: TYPES.regtype,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regconfig: {
-    description: undefined,
-    codec: TYPES.regconfig,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regdictionary: {
-    description: undefined,
-    codec: TYPES.regdictionary,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array_domain: {
-    description: undefined,
-    codec: textArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  int8_array_domain: {
-    description: undefined,
-    codec: int8ArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea: {
-    description: undefined,
-    codec: TYPES.bytea,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea_array: {
-    description: undefined,
-    codec: byteaArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree: {
-    description: undefined,
-    codec: typesAttributes_ltree_codec_ltree,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree_array: {
-    description: undefined,
-    codec: typesAttributes_ltree_array_codec_ltree_,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions46 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "types"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: ["(smallint) references a.post", "(id) references a.post"]
-  })
-};
-const typesCodec = recordCodec({
+const spec_types_attributes_ltree_array_codec_ltree_ = listOfCodec(spec_types_attributes_ltree_codec_ltree);
+const spec_types = {
   name: "types",
   identifier: sql.identifier("b", "types"),
-  attributes: typesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    smallint: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bigint: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numeric: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    decimal: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    boolean: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    varchar: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum_array: {
+      description: undefined,
+      codec: colorArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain: {
+      description: undefined,
+      codec: anIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain2: {
+      description: undefined,
+      codec: anotherIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array: {
+      description: undefined,
+      codec: textArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    json: {
+      description: undefined,
+      codec: TYPES.json,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    jsonb: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_range: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numrange: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    daterange: {
+      description: undefined,
+      codec: daterangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    an_int_range: {
+      description: undefined,
+      codec: anIntRangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamp: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamptz: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    date: {
+      description: undefined,
+      codec: TYPES.date,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    time: {
+      description: undefined,
+      codec: TYPES.time,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timetz: {
+      description: undefined,
+      codec: TYPES.timetz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval_array: {
+      description: undefined,
+      codec: intervalArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    money: {
+      description: undefined,
+      codec: TYPES.money,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    point: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullablePoint: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    inet: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    cidr: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    macaddr: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regproc: {
+      description: undefined,
+      codec: TYPES.regproc,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regprocedure: {
+      description: undefined,
+      codec: TYPES.regprocedure,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoper: {
+      description: undefined,
+      codec: TYPES.regoper,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoperator: {
+      description: undefined,
+      codec: TYPES.regoperator,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regclass: {
+      description: undefined,
+      codec: TYPES.regclass,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regtype: {
+      description: undefined,
+      codec: TYPES.regtype,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regconfig: {
+      description: undefined,
+      codec: TYPES.regconfig,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regdictionary: {
+      description: undefined,
+      codec: TYPES.regdictionary,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array_domain: {
+      description: undefined,
+      codec: textArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    int8_array_domain: {
+      description: undefined,
+      codec: int8ArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea: {
+      description: undefined,
+      codec: TYPES.bytea,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea_array: {
+      description: undefined,
+      codec: byteaArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree: {
+      description: undefined,
+      codec: spec_types_attributes_ltree_codec_ltree,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree_array: {
+      description: undefined,
+      codec: spec_types_attributes_ltree_array_codec_ltree_,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions46,
-  executor
-});
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "types"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: ["(smallint) references a.post", "(id) references a.post"]
+    })
+  },
+  executor: executor
+};
+const typesCodec = recordCodec(spec_types);
 const int4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
     pg: {
@@ -3116,7 +3132,7 @@ const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
     },
     tags: {
       omit: "create,update,delete,all,order,filter",
-      behavior: extensions12.tags.behavior
+      behavior: spec_uniqueForeignKey.extensions.tags.behavior
     }
   }
 };
@@ -3465,7 +3481,7 @@ const registryConfig_pgResources_types_types = {
       name: "types"
     },
     tags: {
-      foreignKey: extensions46.tags.foreignKey
+      foreignKey: spec_types.extensions.tags.foreignKey
     }
   }
 };
@@ -3588,8 +3604,8 @@ const registry = makeRegistry({
     int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
     byteaArray: byteaArrayCodec,
-    ltree: typesAttributes_ltree_codec_ltree,
-    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
+    ltree: spec_types_attributes_ltree_codec_ltree,
+    "ltree[]": spec_types_attributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     compoundTypeArray: listOfCodec(compoundTypeCodec, {
       extensions: {
@@ -3676,7 +3692,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor
+      executor: executor
     }),
     tablefuncCrosstab3: recordCodec({
       name: "tablefuncCrosstab3",
@@ -3729,7 +3745,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor
+      executor: executor
     }),
     tablefuncCrosstab4: recordCodec({
       name: "tablefuncCrosstab4",
@@ -3791,7 +3807,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor
+      executor: executor
     })
   }),
   pgResources: Object.assign(Object.create(null), {
@@ -12373,6 +12389,15 @@ const makeArgs64 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
+function UUIDSerialize(value) {
+  return "" + value;
+}
+const coerce = string => {
+  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
+    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
+  }
+  return string;
+};
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -12877,6 +12902,60 @@ const makeArgs73 = (args, path = []) => {
 const resource_post_computed_compound_type_arrayPgResource = registry.pgResources["post_computed_compound_type_array"];
 const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
+function LTreeParseValue(value) {
+  return value;
+}
+const isValidHstoreObject = obj => {
+  if (obj === null) {
+    // Null is okay
+    return true;
+  } else if (typeof obj === "object") {
+    // A hash with string/null values is also okay
+    const keys = Object.keys(obj);
+    for (const key of keys) {
+      const val = obj[key];
+      if (val === null) {
+        // Null is okay
+      } else if (typeof val === "string") {
+        // String is okay
+      } else {
+        // Everything else is invalid.
+        return false;
+      }
+    }
+    return true;
+  } else {
+    // Everything else is invalid.
+    return false;
+  }
+};
+const parseValueLiteral = (ast, variables) => {
+  switch (ast.kind) {
+    case Kind.INT:
+    case Kind.FLOAT:
+      // Number isn't really okay, but we'll coerce it to a string anyway.
+      return String(parseFloat(ast.value));
+    case Kind.STRING:
+      // String is okay.
+      return String(ast.value);
+    case Kind.NULL:
+      // Null is okay.
+      return null;
+    case Kind.VARIABLE:
+      {
+        // Variable is okay if that variable is either a string or null.
+        const name = ast.name.value;
+        const value = variables ? variables[name] : undefined;
+        if (value === null || typeof value === "string") {
+          return value;
+        }
+        return undefined;
+      }
+    default:
+      // Everything else is invalid.
+      return undefined;
+  }
+};
 const argDetailsSimple74 = [];
 const makeArgs74 = (args, path = []) => {
   const selectArgs = [];
@@ -29730,6 +29809,11 @@ export const plans = {
       return $record.get("o");
     }
   },
+  Email: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
   PersonComputedFirstArgInoutOutRecord: {
     __assertStep: assertPgClassSingleStep,
     person($record) {
@@ -29839,6 +29923,19 @@ export const plans = {
     },
     BLUE: {
       value: "blue"
+    }
+  },
+  UUID: {
+    serialize: UUIDSerialize,
+    parseValue(value) {
+      return coerce("" + value);
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // ERRORS: add name to this error
+        throw new GraphQLError(`${"UUID" ?? "This scalar"} can only parse string values (kind = '${ast.kind}')`);
+      }
+      return coerce(ast.value);
     }
   },
   EnumCaps: {
@@ -30345,6 +30442,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PI: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -30361,6 +30468,9 @@ export const plans = {
     }
   },
   CompoundTypeInput: {
+    "__inputPlan": function CompoundTypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     a: {
       applyPlan($insert, val) {
         $insert.set("a", val.get());
@@ -30489,6 +30599,16 @@ export const plans = {
     },
     isOptimised($record) {
       return $record.get("is_optimised");
+    }
+  },
+  Datetime: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   TypesConnection: {
@@ -30695,12 +30815,77 @@ export const plans = {
       });
     }
   },
+  BigInt: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigInt" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  BigFloat: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigFloat" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  AnInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
+  AnotherInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
+  JSON: {
+    serialize(value) {
+      return JSON.stringify(value);
+    },
+    parseValue(value) {
+      return JSON.parse(value);
+    },
+    parseLiteral(ast, _variables) {
+      if (ast.kind === Kind.STRING) {
+        return JSON.parse(ast.value);
+      } else {
+        return undefined;
+      }
+    }
+  },
   BigFloatRange: {},
   BigFloatRangeBound: {},
   DateRange: {},
   DateRangeBound: {},
+  Date: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Date" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   AnIntRange: {},
   AnIntRangeBound: {},
+  Time: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Time" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   NestedCompoundType: {
     __assertStep: assertPgClassSingleStep,
     a($record) {
@@ -30726,6 +30911,128 @@ export const plans = {
     }
   },
   P: {},
+  InternetAddress: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"InternetAddress" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProc: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProc" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProcedure: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProcedure" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOper: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOper" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOperator: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOperator" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegClass: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegClass" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegType: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegType" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegConfig: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegConfig" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegDictionary: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegDictionary" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  Base64EncodedBinary: {
+    serialize(data) {
+      if (Buffer.isBuffer(data)) {
+        return data.toString("base64");
+      } else {
+        throw new Error(`Base64EncodeBinary can only be used with Node.js buffers.`);
+      }
+    },
+    parseValue(data) {
+      if (typeof data === "string") {
+        return Buffer.from(data, "base64");
+      } else {
+        throw new GraphQLError("Base64EncodedBinary can only parse string values.");
+      }
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // TODO: add name to this error
+        throw new GraphQLError("Base64EncodedBinary can only parse string values");
+      }
+      return Buffer.from(ast.value, "base64");
+    }
+  },
+  LTree: {
+    serialize(x) {
+      return x;
+    },
+    parseValue: LTreeParseValue,
+    parseLiteral(node, variables) {
+      return LTreeParseValue(valueFromASTUntyped(node, variables));
+    }
+  },
   TypesEdge: {
     __assertStep: assertEdgeCapableStep,
     cursor($edge) {
@@ -32046,7 +32353,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.id.codec)}`;
             }
           });
         }
@@ -32069,7 +32376,7 @@ export const plans = {
             type: "attribute",
             attribute: "smallint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.smallint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.smallint.codec)}`;
             }
           });
         }
@@ -32092,7 +32399,7 @@ export const plans = {
             type: "attribute",
             attribute: "bigint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.bigint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.bigint.codec)}`;
             }
           });
         }
@@ -32115,7 +32422,7 @@ export const plans = {
             type: "attribute",
             attribute: "numeric",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numeric.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.numeric.codec)}`;
             }
           });
         }
@@ -32138,7 +32445,7 @@ export const plans = {
             type: "attribute",
             attribute: "decimal",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.decimal.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.decimal.codec)}`;
             }
           });
         }
@@ -32161,7 +32468,7 @@ export const plans = {
             type: "attribute",
             attribute: "boolean",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.boolean.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.boolean.codec)}`;
             }
           });
         }
@@ -32184,7 +32491,7 @@ export const plans = {
             type: "attribute",
             attribute: "varchar",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.varchar.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.varchar.codec)}`;
             }
           });
         }
@@ -32207,7 +32514,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.enum.codec)}`;
             }
           });
         }
@@ -32230,7 +32537,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.enum_array.codec)}`;
             }
           });
         }
@@ -32253,7 +32560,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.domain.codec)}`;
             }
           });
         }
@@ -32276,7 +32583,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.domain2.codec)}`;
             }
           });
         }
@@ -32299,7 +32606,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.text_array.codec)}`;
             }
           });
         }
@@ -32322,7 +32629,7 @@ export const plans = {
             type: "attribute",
             attribute: "json",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.json.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.json.codec)}`;
             }
           });
         }
@@ -32345,7 +32652,7 @@ export const plans = {
             type: "attribute",
             attribute: "jsonb",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.jsonb.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.jsonb.codec)}`;
             }
           });
         }
@@ -32368,7 +32675,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullable_range.codec)}`;
             }
           });
         }
@@ -32391,7 +32698,7 @@ export const plans = {
             type: "attribute",
             attribute: "numrange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numrange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.numrange.codec)}`;
             }
           });
         }
@@ -32414,7 +32721,7 @@ export const plans = {
             type: "attribute",
             attribute: "daterange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.daterange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.daterange.codec)}`;
             }
           });
         }
@@ -32437,7 +32744,7 @@ export const plans = {
             type: "attribute",
             attribute: "an_int_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.an_int_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.an_int_range.codec)}`;
             }
           });
         }
@@ -32460,7 +32767,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamp",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamp.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.timestamp.codec)}`;
             }
           });
         }
@@ -32483,7 +32790,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamptz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamptz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.timestamptz.codec)}`;
             }
           });
         }
@@ -32506,7 +32813,7 @@ export const plans = {
             type: "attribute",
             attribute: "date",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.date.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.date.codec)}`;
             }
           });
         }
@@ -32529,7 +32836,7 @@ export const plans = {
             type: "attribute",
             attribute: "time",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.time.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.time.codec)}`;
             }
           });
         }
@@ -32552,7 +32859,7 @@ export const plans = {
             type: "attribute",
             attribute: "timetz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timetz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.timetz.codec)}`;
             }
           });
         }
@@ -32575,7 +32882,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.interval.codec)}`;
             }
           });
         }
@@ -32598,7 +32905,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.interval_array.codec)}`;
             }
           });
         }
@@ -32621,7 +32928,7 @@ export const plans = {
             type: "attribute",
             attribute: "money",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.money.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.money.codec)}`;
             }
           });
         }
@@ -32644,7 +32951,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.compound_type.codec)}`;
             }
           });
         }
@@ -32667,7 +32974,7 @@ export const plans = {
             type: "attribute",
             attribute: "nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nested_compound_type.codec)}`;
             }
           });
         }
@@ -32690,7 +32997,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullable_compound_type.codec)}`;
             }
           });
         }
@@ -32713,7 +33020,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullable_nested_compound_type.codec)}`;
             }
           });
         }
@@ -32736,7 +33043,7 @@ export const plans = {
             type: "attribute",
             attribute: "point",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.point.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.point.codec)}`;
             }
           });
         }
@@ -32759,7 +33066,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullablePoint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullablePoint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullablePoint.codec)}`;
             }
           });
         }
@@ -32782,7 +33089,7 @@ export const plans = {
             type: "attribute",
             attribute: "inet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.inet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.inet.codec)}`;
             }
           });
         }
@@ -32805,7 +33112,7 @@ export const plans = {
             type: "attribute",
             attribute: "cidr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.cidr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.cidr.codec)}`;
             }
           });
         }
@@ -32828,7 +33135,7 @@ export const plans = {
             type: "attribute",
             attribute: "macaddr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.macaddr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.macaddr.codec)}`;
             }
           });
         }
@@ -32851,7 +33158,7 @@ export const plans = {
             type: "attribute",
             attribute: "regproc",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regproc.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regproc.codec)}`;
             }
           });
         }
@@ -32874,7 +33181,7 @@ export const plans = {
             type: "attribute",
             attribute: "regprocedure",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regprocedure.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regprocedure.codec)}`;
             }
           });
         }
@@ -32897,7 +33204,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoper",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoper.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regoper.codec)}`;
             }
           });
         }
@@ -32920,7 +33227,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoperator",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoperator.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regoperator.codec)}`;
             }
           });
         }
@@ -32943,7 +33250,7 @@ export const plans = {
             type: "attribute",
             attribute: "regclass",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regclass.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regclass.codec)}`;
             }
           });
         }
@@ -32966,7 +33273,7 @@ export const plans = {
             type: "attribute",
             attribute: "regtype",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regtype.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regtype.codec)}`;
             }
           });
         }
@@ -32989,7 +33296,7 @@ export const plans = {
             type: "attribute",
             attribute: "regconfig",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regconfig.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regconfig.codec)}`;
             }
           });
         }
@@ -33012,7 +33319,7 @@ export const plans = {
             type: "attribute",
             attribute: "regdictionary",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regdictionary.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regdictionary.codec)}`;
             }
           });
         }
@@ -33035,7 +33342,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.text_array_domain.codec)}`;
             }
           });
         }
@@ -33058,7 +33365,7 @@ export const plans = {
             type: "attribute",
             attribute: "int8_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.int8_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.int8_array_domain.codec)}`;
             }
           });
         }
@@ -33081,7 +33388,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.ltree.codec)}`;
             }
           });
         }
@@ -33104,7 +33411,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.ltree_array.codec)}`;
             }
           });
         }
@@ -33138,6 +33445,9 @@ export const plans = {
     inclusive: undefined
   },
   NestedCompoundTypeInput: {
+    "__inputPlan": function NestedCompoundTypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     a: {
       applyPlan($insert, val) {
         $insert.set("a", val.get());
@@ -33632,6 +33942,50 @@ export const plans = {
       return $record.get("url");
     }
   },
+  NotNullUrl: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
+  KeyValueHash: {
+    serialize(value) {
+      return value;
+    },
+    parseValue(obj) {
+      if (isValidHstoreObject(obj)) {
+        return obj;
+      }
+      throw new GraphQLError(`This is not a valid ${"KeyValueHash"} object, it must be a key/value hash where keys and values are both strings (or null).`);
+    },
+    parseLiteral(ast, variables) {
+      switch (ast.kind) {
+        case Kind.OBJECT:
+          {
+            const value = ast.fields.reduce((memo, field) => {
+              memo[field.name.value] = parseValueLiteral(field.value, variables);
+              return memo;
+            }, Object.create(null));
+            if (!isValidHstoreObject(value)) {
+              return undefined;
+            }
+            return value;
+          }
+        case Kind.NULL:
+          return null;
+        case Kind.VARIABLE:
+          {
+            const name = ast.name.value;
+            const value = variables ? variables[name] : undefined;
+            if (!isValidHstoreObject(value)) {
+              return undefined;
+            }
+            return value;
+          }
+        default:
+          return undefined;
+      }
+    }
+  },
   PostsConnection: {
     __assertStep: ConnectionStep,
     nodes($connection) {
@@ -33876,7 +34230,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.id.codec)}`;
             }
           });
         }
@@ -33899,7 +34253,7 @@ export const plans = {
             type: "attribute",
             attribute: "headline",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.headline.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.headline.codec)}`;
             }
           });
         }
@@ -33922,7 +34276,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.body.codec)}`;
             }
           });
         }
@@ -33945,7 +34299,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.author_id.codec)}`;
             }
           });
         }
@@ -33968,7 +34322,7 @@ export const plans = {
             type: "attribute",
             attribute: "enums",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.enums.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.enums.codec)}`;
             }
           });
         }
@@ -33991,7 +34345,7 @@ export const plans = {
             type: "attribute",
             attribute: "comptypes",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.comptypes.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.comptypes.codec)}`;
             }
           });
         }
@@ -34016,6 +34370,9 @@ export const plans = {
     }
   },
   ComptypeInput: {
+    "__inputPlan": function ComptypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     schedule: {
       applyPlan($insert, val) {
         $insert.set("schedule", val.get());
@@ -34202,7 +34559,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_foreignKey.attributes.person_id.codec)}`;
             }
           });
         }
@@ -34225,7 +34582,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_foreignKey.attributes.compound_key_1.codec)}`;
             }
           });
         }
@@ -34248,7 +34605,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_foreignKey.attributes.compound_key_2.codec)}`;
             }
           });
         }
@@ -34479,7 +34836,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.person_id_2.codec)}`;
             }
           });
         }
@@ -34502,7 +34859,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.person_id_1.codec)}`;
             }
           });
         }
@@ -34525,7 +34882,7 @@ export const plans = {
             type: "attribute",
             attribute: "extra",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.extra.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.extra.codec)}`;
             }
           });
         }
@@ -34631,6 +34988,16 @@ export const plans = {
     },
     ts($record) {
       return $record.get("ts");
+    }
+  },
+  NotNullTimestamp: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   FuncOutSetofConnection: {
@@ -35026,7 +35393,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.id.codec)}`;
             }
           });
         }
@@ -35049,7 +35416,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_full_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.person_full_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.person_full_name.codec)}`;
             }
           });
         }
@@ -35072,7 +35439,7 @@ export const plans = {
             type: "attribute",
             attribute: "aliases",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.aliases.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.aliases.codec)}`;
             }
           });
         }
@@ -35095,7 +35462,7 @@ export const plans = {
             type: "attribute",
             attribute: "about",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.about.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.about.codec)}`;
             }
           });
         }
@@ -35118,7 +35485,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.email.codec)}`;
             }
           });
         }
@@ -35141,7 +35508,7 @@ export const plans = {
             type: "attribute",
             attribute: "site",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.site.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.site.codec)}`;
             }
           });
         }
@@ -35164,7 +35531,7 @@ export const plans = {
             type: "attribute",
             attribute: "config",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.config.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.config.codec)}`;
             }
           });
         }
@@ -35187,7 +35554,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_ip",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_ip.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_login_from_ip.codec)}`;
             }
           });
         }
@@ -35210,7 +35577,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_subnet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_subnet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_login_from_subnet.codec)}`;
             }
           });
         }
@@ -35233,7 +35600,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_mac",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.user_mac.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.user_mac.codec)}`;
             }
           });
         }
@@ -35256,7 +35623,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.created_at.codec)}`;
             }
           });
         }
@@ -35281,6 +35648,9 @@ export const plans = {
     }
   },
   WrappedUrlInput: {
+    "__inputPlan": function WrappedUrlInput_inputPlan() {
+      return object(Object.create(null));
+    },
     url: {
       applyPlan($insert, val) {
         $insert.set("url", val.get());
@@ -35375,7 +35745,7 @@ export const plans = {
             type: "attribute",
             attribute: "?column?",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nonUpdatableViewAttributes["?column?"].codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nonUpdatableView.attributes["?column?"].codec)}`;
             }
           });
         }
@@ -35496,7 +35866,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), inputsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_inputs.attributes.id.codec)}`;
             }
           });
         }
@@ -35617,7 +35987,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), patchsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_patchs.attributes.id.codec)}`;
             }
           });
         }
@@ -35738,7 +36108,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reserved.attributes.id.codec)}`;
             }
           });
         }
@@ -35859,7 +36229,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedPatchsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reservedPatchs.attributes.id.codec)}`;
             }
           });
         }
@@ -35980,7 +36350,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedInputAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reservedInput.attributes.id.codec)}`;
             }
           });
         }
@@ -36135,7 +36505,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_defaultValue.attributes.id.codec)}`;
             }
           });
         }
@@ -36158,7 +36528,7 @@ export const plans = {
             type: "attribute",
             attribute: "null_value",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.null_value.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_defaultValue.attributes.null_value.codec)}`;
             }
           });
         }
@@ -36281,7 +36651,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_noPrimaryKey.attributes.id.codec)}`;
             }
           });
         }
@@ -36304,7 +36674,7 @@ export const plans = {
             type: "attribute",
             attribute: "str",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.str.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_noPrimaryKey.attributes.str.codec)}`;
             }
           });
         }
@@ -36473,7 +36843,7 @@ export const plans = {
             type: "attribute",
             attribute: "testviewid",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.testviewid.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_testview.attributes.testviewid.codec)}`;
             }
           });
         }
@@ -36496,7 +36866,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_testview.attributes.col1.codec)}`;
             }
           });
         }
@@ -36519,7 +36889,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_testview.attributes.col2.codec)}`;
             }
           });
         }
@@ -36674,7 +37044,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_myTable.attributes.id.codec)}`;
             }
           });
         }
@@ -36697,7 +37067,7 @@ export const plans = {
             type: "attribute",
             attribute: "json_data",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.json_data.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_myTable.attributes.json_data.codec)}`;
             }
           });
         }
@@ -36852,7 +37222,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_personSecret.attributes.person_id.codec)}`;
             }
           });
         }
@@ -36875,7 +37245,7 @@ export const plans = {
             type: "attribute",
             attribute: "sekrit",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.sekrit.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_personSecret.attributes.sekrit.codec)}`;
             }
           });
         }
@@ -37064,7 +37434,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_viewTable.attributes.id.codec)}`;
             }
           });
         }
@@ -37087,7 +37457,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_viewTable.attributes.col1.codec)}`;
             }
           });
         }
@@ -37110,7 +37480,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_viewTable.attributes.col2.codec)}`;
             }
           });
         }
@@ -37333,7 +37703,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.id.codec)}`;
             }
           });
         }
@@ -37356,7 +37726,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.col1.codec)}`;
             }
           });
         }
@@ -37379,7 +37749,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.col2.codec)}`;
             }
           });
         }
@@ -37402,7 +37772,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.col3.codec)}`;
             }
           });
         }
@@ -37625,7 +37995,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.id.codec)}`;
             }
           });
         }
@@ -37648,7 +38018,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.col3.codec)}`;
             }
           });
         }
@@ -37671,7 +38041,7 @@ export const plans = {
             type: "attribute",
             attribute: "col4",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col4.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.col4.codec)}`;
             }
           });
         }
@@ -37694,7 +38064,7 @@ export const plans = {
             type: "attribute",
             attribute: "col5",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col5.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.col5.codec)}`;
             }
           });
         }
@@ -37900,7 +38270,7 @@ export const plans = {
             type: "attribute",
             attribute: "x",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.x.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.x.codec)}`;
             }
           });
         }
@@ -37923,7 +38293,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.name.codec)}`;
             }
           });
         }
@@ -37946,7 +38316,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.description.codec)}`;
             }
           });
         }
@@ -37969,7 +38339,7 @@ export const plans = {
             type: "attribute",
             attribute: "constant",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.constant.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.constant.codec)}`;
             }
           });
         }
@@ -38192,7 +38562,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.id.codec)}`;
             }
           });
         }
@@ -38215,7 +38585,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.nullable_text.codec)}`;
             }
           });
         }
@@ -38238,7 +38608,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_int",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_int.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.nullable_int.codec)}`;
             }
           });
         }
@@ -38261,7 +38631,7 @@ export const plans = {
             type: "attribute",
             attribute: "non_null_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.non_null_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.non_null_text.codec)}`;
             }
           });
         }
@@ -38464,7 +38834,7 @@ export const plans = {
             type: "attribute",
             attribute: "not_null_has_default",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.not_null_has_default.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.not_null_has_default.codec)}`;
             }
           });
         }
@@ -38487,7 +38857,7 @@ export const plans = {
             type: "attribute",
             attribute: "wont_cast_easy",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.wont_cast_easy.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.wont_cast_easy.codec)}`;
             }
           });
         }
@@ -38510,7 +38880,7 @@ export const plans = {
             type: "attribute",
             attribute: "row_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.row_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.row_id.codec)}`;
             }
           });
         }
@@ -38733,7 +39103,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.id.codec)}`;
             }
           });
         }
@@ -38756,7 +39126,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.person_id.codec)}`;
             }
           });
         }
@@ -38779,7 +39149,7 @@ export const plans = {
             type: "attribute",
             attribute: "length_in_metres",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.length_in_metres.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.length_in_metres.codec)}`;
             }
           });
         }
@@ -38802,7 +39172,7 @@ export const plans = {
             type: "attribute",
             attribute: "mood",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.mood.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.mood.codec)}`;
             }
           });
         }
@@ -38957,7 +39327,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_issue756.attributes.id.codec)}`;
             }
           });
         }
@@ -38980,7 +39350,7 @@ export const plans = {
             type: "attribute",
             attribute: "ts",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.ts.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_issue756.attributes.ts.codec)}`;
             }
           });
         }
@@ -42316,6 +42686,11 @@ export const plans = {
       return rootValue();
     }
   },
+  Guid: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
   GuidFnInput: {
     clientMutationId: {
       applyPlan($input, val) {
@@ -42507,6 +42882,9 @@ export const plans = {
     leftArm: undefined
   },
   LeftArmBaseInput: {
+    "__inputPlan": function LeftArmBaseInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -42901,6 +43279,9 @@ export const plans = {
     suffix: undefined
   },
   PostInput: {
+    "__inputPlan": function PostInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43351,6 +43732,9 @@ export const plans = {
     }
   },
   InputInput: {
+    "__inputPlan": function InputInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43418,6 +43802,9 @@ export const plans = {
     }
   },
   PatchInput: {
+    "__inputPlan": function PatchInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43485,6 +43872,9 @@ export const plans = {
     }
   },
   ReservedInput: {
+    "__inputPlan": function ReservedInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43552,6 +43942,9 @@ export const plans = {
     }
   },
   ReservedPatchRecordInput: {
+    "__inputPlan": function ReservedPatchRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43619,6 +44012,9 @@ export const plans = {
     }
   },
   ReservedInputRecordInput: {
+    "__inputPlan": function ReservedInputRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43686,6 +44082,9 @@ export const plans = {
     }
   },
   DefaultValueInput: {
+    "__inputPlan": function DefaultValueInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43740,6 +44139,9 @@ export const plans = {
     }
   },
   ForeignKeyInput: {
+    "__inputPlan": function ForeignKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -43790,6 +44192,9 @@ export const plans = {
     }
   },
   NoPrimaryKeyInput: {
+    "__inputPlan": function NoPrimaryKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43833,6 +44238,9 @@ export const plans = {
     }
   },
   TestviewInput: {
+    "__inputPlan": function TestviewInput_inputPlan() {
+      return object(Object.create(null));
+    },
     testviewid: {
       applyPlan($insert, val) {
         $insert.set("testviewid", val.get());
@@ -43914,6 +44322,9 @@ export const plans = {
     }
   },
   MyTableInput: {
+    "__inputPlan": function MyTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43993,6 +44404,9 @@ export const plans = {
     }
   },
   PersonSecretInput: {
+    "__inputPlan": function PersonSecretInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -44067,6 +44481,9 @@ export const plans = {
     }
   },
   ViewTableInput: {
+    "__inputPlan": function ViewTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44158,6 +44575,9 @@ export const plans = {
     }
   },
   CompoundKeyInput: {
+    "__inputPlan": function CompoundKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId2: {
       applyPlan($insert, val) {
         $insert.set("person_id_2", val.get());
@@ -44239,6 +44659,9 @@ export const plans = {
     }
   },
   SimilarTable1Input: {
+    "__inputPlan": function SimilarTable1Input_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44327,6 +44750,9 @@ export const plans = {
     }
   },
   SimilarTable2Input: {
+    "__inputPlan": function SimilarTable2Input_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44384,6 +44810,9 @@ export const plans = {
     }
   },
   UpdatableViewInput: {
+    "__inputPlan": function UpdatableViewInput_inputPlan() {
+      return object(Object.create(null));
+    },
     x: {
       applyPlan($insert, val) {
         $insert.set("x", val.get());
@@ -44472,6 +44901,9 @@ export const plans = {
     }
   },
   NullTestRecordInput: {
+    "__inputPlan": function NullTestRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44529,6 +44961,9 @@ export const plans = {
     }
   },
   EdgeCaseInput: {
+    "__inputPlan": function EdgeCaseInput_inputPlan() {
+      return object(Object.create(null));
+    },
     notNullHasDefault: {
       applyPlan($insert, val) {
         $insert.set("not_null_has_default", val.get());
@@ -44615,6 +45050,9 @@ export const plans = {
     }
   },
   LeftArmInput: {
+    "__inputPlan": function LeftArmInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44703,6 +45141,9 @@ export const plans = {
     }
   },
   Issue756Input: {
+    "__inputPlan": function Issue756Input_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44840,6 +45281,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44987,6 +45431,9 @@ export const plans = {
     }
   },
   TypeInput: {
+    "__inputPlan": function TypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45389,6 +45836,9 @@ export const plans = {
     }
   },
   InputPatch: {
+    "__inputPlan": function InputPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45469,6 +45919,9 @@ export const plans = {
     }
   },
   PatchPatch: {
+    "__inputPlan": function PatchPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45549,6 +46002,9 @@ export const plans = {
     }
   },
   ReservedPatch: {
+    "__inputPlan": function ReservedPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45629,6 +46085,9 @@ export const plans = {
     }
   },
   ReservedPatchRecordPatch: {
+    "__inputPlan": function ReservedPatchRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45709,6 +46168,9 @@ export const plans = {
     }
   },
   ReservedInputRecordPatch: {
+    "__inputPlan": function ReservedInputRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45789,6 +46251,9 @@ export const plans = {
     }
   },
   DefaultValuePatch: {
+    "__inputPlan": function DefaultValuePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45845,6 +46310,9 @@ export const plans = {
     }
   },
   NoPrimaryKeyPatch: {
+    "__inputPlan": function NoPrimaryKeyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45918,6 +46386,9 @@ export const plans = {
     }
   },
   MyTablePatch: {
+    "__inputPlan": function MyTablePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46010,6 +46481,9 @@ export const plans = {
     }
   },
   PersonSecretPatch: {
+    "__inputPlan": function PersonSecretPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -46097,6 +46571,9 @@ export const plans = {
     }
   },
   ViewTablePatch: {
+    "__inputPlan": function ViewTablePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46201,6 +46678,9 @@ export const plans = {
     }
   },
   CompoundKeyPatch: {
+    "__inputPlan": function CompoundKeyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     personId2: {
       applyPlan($insert, val) {
         $insert.set("person_id_2", val.get());
@@ -46296,6 +46776,9 @@ export const plans = {
     }
   },
   SimilarTable1Patch: {
+    "__inputPlan": function SimilarTable1Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46397,6 +46880,9 @@ export const plans = {
     }
   },
   SimilarTable2Patch: {
+    "__inputPlan": function SimilarTable2Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46498,6 +46984,9 @@ export const plans = {
     }
   },
   NullTestRecordPatch: {
+    "__inputPlan": function NullTestRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46604,6 +47093,9 @@ export const plans = {
     }
   },
   LeftArmPatch: {
+    "__inputPlan": function LeftArmPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46719,6 +47211,9 @@ export const plans = {
     }
   },
   Issue756Patch: {
+    "__inputPlan": function Issue756Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46811,6 +47306,9 @@ export const plans = {
     }
   },
   PostPatch: {
+    "__inputPlan": function PostPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46926,6 +47424,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -47100,6 +47601,9 @@ export const plans = {
     }
   },
   TypePatch: {
+    "__inputPlan": function TypePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/js-reserved.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/js-reserved.1.export.mjs
@@ -1,15 +1,24 @@
 import { PgDeleteSingleStep, PgExecutor, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, enumCodec, makeRegistry, pgClassExpression, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectSingleFromRecord, pgUpdateSingle, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
+import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler_codec_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const itemTypeCodec = enumCodec({
   name: "itemType",
@@ -25,49 +34,6 @@ const itemTypeCodec = enumCodec({
     tags: Object.create(null)
   }
 });
-const relationalTopicsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    },
-    identicalVia: "relationalItemsByMyId"
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  type: {
-    codec: itemTypeCodec,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  },
-  constructor: {
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  }
-});
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -78,10 +44,52 @@ const executor = new PgExecutor({
     });
   }
 });
-const relationalTopicsCodec = recordCodec({
+const spec_relationalTopics = {
   name: "relationalTopics",
   identifier: sql.identifier("js_reserved", "relational_topics"),
-  attributes: relationalTopicsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      },
+      identicalVia: "relationalItemsByMyId"
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    type: {
+      codec: itemTypeCodec,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    },
+    constructor: {
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -93,41 +101,41 @@ const relationalTopicsCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor
-});
-const __proto__Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  brand: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const __proto__Codec = recordCodec({
+  executor: executor
+};
+const relationalTopicsCodec = recordCodec(spec_relationalTopics);
+const spec___proto__ = {
   name: "__proto__",
   identifier: sql.identifier("js_reserved", "__proto__"),
-  attributes: __proto__Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    brand: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -138,41 +146,41 @@ const __proto__Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const buildingAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  constructor: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const buildingCodec = recordCodec({
+  executor: executor
+};
+const __proto__Codec = recordCodec(spec___proto__);
+const spec_building = {
   name: "building",
   identifier: sql.identifier("js_reserved", "building"),
-  attributes: buildingAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    constructor: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -183,41 +191,41 @@ const buildingCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const constructorAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  export: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const constructorCodec = recordCodec({
+  executor: executor
+};
+const buildingCodec = recordCodec(spec_building);
+const spec_constructor = {
   name: "constructor",
   identifier: sql.identifier("js_reserved", "constructor"),
-  attributes: constructorAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    export: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -228,41 +236,41 @@ const constructorCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const cropAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  yield: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  amount: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const cropCodec = recordCodec({
+  executor: executor
+};
+const constructorCodec = recordCodec(spec_constructor);
+const spec_crop = {
   name: "crop",
   identifier: sql.identifier("js_reserved", "crop"),
-  attributes: cropAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    yield: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    amount: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -273,41 +281,41 @@ const cropCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const machineAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  input: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  constructor: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const machineCodec = recordCodec({
+  executor: executor
+};
+const cropCodec = recordCodec(spec_crop);
+const spec_machine = {
   name: "machine",
   identifier: sql.identifier("js_reserved", "machine"),
-  attributes: machineAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    input: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    constructor: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -318,41 +326,41 @@ const machineCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const materialAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  class: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  valueOf: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const materialCodec = recordCodec({
+  executor: executor
+};
+const machineCodec = recordCodec(spec_machine);
+const spec_material = {
   name: "material",
   identifier: sql.identifier("js_reserved", "material"),
-  attributes: materialAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    class: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    valueOf: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -363,41 +371,41 @@ const materialCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const nullAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  hasOwnProperty: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  break: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const nullCodec = recordCodec({
+  executor: executor
+};
+const materialCodec = recordCodec(spec_material);
+const spec_null = {
   name: "null",
   identifier: sql.identifier("js_reserved", "null"),
-  attributes: nullAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    hasOwnProperty: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    break: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -408,37 +416,37 @@ const nullCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const projectAttributes = Object.fromEntries([["id", {
-  description: undefined,
-  codec: TYPES.int,
-  notNull: true,
-  hasDefault: true,
-  extensions: {
-    tags: {}
-  }
-}], ["brand", {
-  description: undefined,
-  codec: TYPES.text,
-  notNull: false,
-  hasDefault: false,
-  extensions: {
-    tags: {}
-  }
-}], ["__proto__", {
-  description: undefined,
-  codec: TYPES.text,
-  notNull: false,
-  hasDefault: false,
-  extensions: {
-    tags: {}
-  }
-}]]);
-const projectCodec = recordCodec({
+  executor: executor
+};
+const nullCodec = recordCodec(spec_null);
+const spec_project = {
   name: "project",
   identifier: sql.identifier("js_reserved", "project"),
-  attributes: projectAttributes,
+  attributes: Object.fromEntries([["id", {
+    description: undefined,
+    codec: TYPES.int,
+    notNull: true,
+    hasDefault: true,
+    extensions: {
+      tags: {}
+    }
+  }], ["brand", {
+    description: undefined,
+    codec: TYPES.text,
+    notNull: false,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  }], ["__proto__", {
+    description: undefined,
+    codec: TYPES.text,
+    notNull: false,
+    hasDefault: false,
+    extensions: {
+      tags: {}
+    }
+  }]]),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -449,64 +457,64 @@ const projectCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const relationalStatusAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    },
-    identicalVia: "relationalItemsByMyId"
-  },
-  description: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  note: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  type: {
-    codec: itemTypeCodec,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalTopicsAttributes.type.extensions.tags
-    }
-  },
-  constructor: {
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalTopicsAttributes.constructor.extensions.tags
-    }
-  }
-});
-const relationalStatusCodec = recordCodec({
+  executor: executor
+};
+const projectCodec = recordCodec(spec_project);
+const spec_relationalStatus = {
   name: "relationalStatus",
   identifier: sql.identifier("js_reserved", "relational_status"),
-  attributes: relationalStatusAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      },
+      identicalVia: "relationalItemsByMyId"
+    },
+    description: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    note: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    type: {
+      codec: itemTypeCodec,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalTopics.attributes.type.extensions.tags
+      }
+    },
+    constructor: {
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalTopics.attributes.constructor.extensions.tags
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -518,41 +526,41 @@ const relationalStatusCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor
-});
-const yieldAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  crop: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  export: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const yieldCodec = recordCodec({
+  executor: executor
+};
+const relationalStatusCodec = recordCodec(spec_relationalStatus);
+const spec_yield = {
   name: "yield",
   identifier: sql.identifier("js_reserved", "yield"),
-  attributes: yieldAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    crop: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    export: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -563,50 +571,50 @@ const yieldCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const reservedAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  null: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  case: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  do: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const reservedCodec = recordCodec({
+  executor: executor
+};
+const yieldCodec = recordCodec(spec_yield);
+const spec_reserved = {
   name: "reserved",
   identifier: sql.identifier("js_reserved", "reserved"),
-  attributes: reservedAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    null: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    case: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    do: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -617,57 +625,73 @@ const reservedCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const relationalItemsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  type: {
-    description: undefined,
-    codec: itemTypeCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: relationalTopicsAttributes.type.extensions.tags
-    }
-  },
-  constructor: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: relationalTopicsAttributes.constructor.extensions.tags
-    }
-  }
-});
-const extensions14 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "js_reserved",
-    name: "relational_items"
-  },
-  tags: Object.assign(Object.create(null), {
-    interface: "mode:relational type:type",
-    type: ["TOPIC references:relational_topics", "STATUS references:relational_status"]
-  })
+  executor: executor
 };
-const relationalItemsCodec = recordCodec({
+const reservedCodec = recordCodec(spec_reserved);
+const spec_relationalItems = {
   name: "relationalItems",
   identifier: sql.identifier("js_reserved", "relational_items"),
-  attributes: relationalItemsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    type: {
+      description: undefined,
+      codec: itemTypeCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: spec_relationalTopics.attributes.type.extensions.tags
+      }
+    },
+    constructor: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: spec_relationalTopics.attributes.constructor.extensions.tags
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions14,
-  executor
-});
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "js_reserved",
+      name: "relational_items"
+    },
+    tags: Object.assign(Object.create(null), {
+      interface: "mode:relational type:type",
+      type: ["TOPIC references:relational_topics", "STATUS references:relational_status"]
+    })
+  },
+  executor: executor,
+  polymorphism: {
+    mode: "relational",
+    typeAttributes: ["type"],
+    types: Object.assign(Object.create(null), {
+      TOPIC: {
+        name: "RelationalTopic",
+        references: "relational_topics",
+        relationName: "relationalTopicsByTheirId"
+      },
+      STATUS: {
+        name: "RelationalStatus",
+        references: "relational_status",
+        relationName: "relationalStatusByTheirId"
+      }
+    })
+  }
+};
+const relationalItemsCodec = recordCodec(spec_relationalItems);
 const awaitFunctionIdentifer = sql.identifier("js_reserved", "await");
 const caseFunctionIdentifer = sql.identifier("js_reserved", "case");
 const valueOfFunctionIdentifer = sql.identifier("js_reserved", "valueOf");
@@ -968,7 +992,7 @@ const registryConfig_pgResources_relational_items_relational_items = {
     },
     tags: {
       interface: "mode:relational type:type",
-      type: extensions14.tags.type
+      type: spec_relationalItems.extensions.tags.type
     }
   }
 };
@@ -1453,22 +1477,30 @@ const handler = {
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   base64JSON: handler_codec_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const building_buildingPgResource = registry.pgResources["building"];
@@ -1549,6 +1581,9 @@ const specFromRecord3 = $record => {
     return memo;
   }, Object.create(null));
 };
+function CursorSerialize(value) {
+  return "" + value;
+}
 const handler4 = {
   typeName: "RelationalStatus",
   codec: handler_codec_base64JSON,
@@ -6955,6 +6990,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: CursorSerialize,
+    parseValue: CursorSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -7125,7 +7170,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), machineAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_machine.attributes.id.codec)}`;
             }
           });
         }
@@ -7148,7 +7193,7 @@ export const plans = {
             type: "attribute",
             attribute: "input",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), machineAttributes.input.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_machine.attributes.input.codec)}`;
             }
           });
         }
@@ -7171,7 +7216,7 @@ export const plans = {
             type: "attribute",
             attribute: "constructor",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), machineAttributes.constructor.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_machine.attributes.constructor.codec)}`;
             }
           });
         }
@@ -7360,7 +7405,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.id.codec)}`;
             }
           });
         }
@@ -7383,7 +7428,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.type.codec)}`;
             }
           });
         }
@@ -7406,7 +7451,7 @@ export const plans = {
             type: "attribute",
             attribute: "constructor",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.constructor.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.constructor.codec)}`;
             }
           });
         }
@@ -9391,7 +9436,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.id.codec)}`;
             }
           });
         }
@@ -9414,7 +9459,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.title.codec)}`;
             }
           });
         }
@@ -9437,7 +9482,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.type.codec)}`;
             }
           });
         }
@@ -9460,7 +9505,7 @@ export const plans = {
             type: "attribute",
             attribute: "constructor",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.constructor.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.constructor.codec)}`;
             }
           });
         }
@@ -9649,7 +9694,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), __proto__Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec___proto__.attributes.id.codec)}`;
             }
           });
         }
@@ -9672,7 +9717,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), __proto__Attributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec___proto__.attributes.name.codec)}`;
             }
           });
         }
@@ -9695,7 +9740,7 @@ export const plans = {
             type: "attribute",
             attribute: "brand",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), __proto__Attributes.brand.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec___proto__.attributes.brand.codec)}`;
             }
           });
         }
@@ -9884,7 +9929,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), buildingAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_building.attributes.id.codec)}`;
             }
           });
         }
@@ -9907,7 +9952,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), buildingAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_building.attributes.name.codec)}`;
             }
           });
         }
@@ -9930,7 +9975,7 @@ export const plans = {
             type: "attribute",
             attribute: "constructor",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), buildingAttributes.constructor.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_building.attributes.constructor.codec)}`;
             }
           });
         }
@@ -10119,7 +10164,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), constructorAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_constructor.attributes.id.codec)}`;
             }
           });
         }
@@ -10142,7 +10187,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), constructorAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_constructor.attributes.name.codec)}`;
             }
           });
         }
@@ -10165,7 +10210,7 @@ export const plans = {
             type: "attribute",
             attribute: "export",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), constructorAttributes.export.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_constructor.attributes.export.codec)}`;
             }
           });
         }
@@ -10354,7 +10399,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cropAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_crop.attributes.id.codec)}`;
             }
           });
         }
@@ -10377,7 +10422,7 @@ export const plans = {
             type: "attribute",
             attribute: "yield",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cropAttributes.yield.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_crop.attributes.yield.codec)}`;
             }
           });
         }
@@ -10400,7 +10445,7 @@ export const plans = {
             type: "attribute",
             attribute: "amount",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cropAttributes.amount.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_crop.attributes.amount.codec)}`;
             }
           });
         }
@@ -10589,7 +10634,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), materialAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_material.attributes.id.codec)}`;
             }
           });
         }
@@ -10612,7 +10657,7 @@ export const plans = {
             type: "attribute",
             attribute: "class",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), materialAttributes.class.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_material.attributes.class.codec)}`;
             }
           });
         }
@@ -10635,7 +10680,7 @@ export const plans = {
             type: "attribute",
             attribute: "valueOf",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), materialAttributes.valueOf.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_material.attributes.valueOf.codec)}`;
             }
           });
         }
@@ -10824,7 +10869,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_null.attributes.id.codec)}`;
             }
           });
         }
@@ -10847,7 +10892,7 @@ export const plans = {
             type: "attribute",
             attribute: "hasOwnProperty",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullAttributes.hasOwnProperty.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_null.attributes.hasOwnProperty.codec)}`;
             }
           });
         }
@@ -10870,7 +10915,7 @@ export const plans = {
             type: "attribute",
             attribute: "break",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullAttributes.break.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_null.attributes.break.codec)}`;
             }
           });
         }
@@ -11059,7 +11104,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), projectAttributes["id"].codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_project.attributes["id"].codec)}`;
             }
           });
         }
@@ -11082,7 +11127,7 @@ export const plans = {
             type: "attribute",
             attribute: "brand",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), projectAttributes["brand"].codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_project.attributes["brand"].codec)}`;
             }
           });
         }
@@ -11105,7 +11150,7 @@ export const plans = {
             type: "attribute",
             attribute: "__proto__",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), projectAttributes["__proto__"].codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_project.attributes["__proto__"].codec)}`;
             }
           });
         }
@@ -11362,7 +11407,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalStatusAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalStatus.attributes.id.codec)}`;
             }
           });
         }
@@ -11385,7 +11430,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalStatusAttributes.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalStatus.attributes.description.codec)}`;
             }
           });
         }
@@ -11408,7 +11453,7 @@ export const plans = {
             type: "attribute",
             attribute: "note",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalStatusAttributes.note.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalStatus.attributes.note.codec)}`;
             }
           });
         }
@@ -11431,7 +11476,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalStatusAttributes.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalStatus.attributes.type.codec)}`;
             }
           });
         }
@@ -11454,7 +11499,7 @@ export const plans = {
             type: "attribute",
             attribute: "constructor",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalStatusAttributes.constructor.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalStatus.attributes.constructor.codec)}`;
             }
           });
         }
@@ -11643,7 +11688,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), yieldAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_yield.attributes.id.codec)}`;
             }
           });
         }
@@ -11666,7 +11711,7 @@ export const plans = {
             type: "attribute",
             attribute: "crop",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), yieldAttributes.crop.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_yield.attributes.crop.codec)}`;
             }
           });
         }
@@ -11689,7 +11734,7 @@ export const plans = {
             type: "attribute",
             attribute: "export",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), yieldAttributes.export.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_yield.attributes.export.codec)}`;
             }
           });
         }
@@ -11912,7 +11957,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reserved.attributes.id.codec)}`;
             }
           });
         }
@@ -11935,7 +11980,7 @@ export const plans = {
             type: "attribute",
             attribute: "null",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedAttributes.null.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reserved.attributes.null.codec)}`;
             }
           });
         }
@@ -11958,7 +12003,7 @@ export const plans = {
             type: "attribute",
             attribute: "case",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedAttributes.case.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reserved.attributes.case.codec)}`;
             }
           });
         }
@@ -11981,7 +12026,7 @@ export const plans = {
             type: "attribute",
             attribute: "do",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedAttributes.do.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reserved.attributes.do.codec)}`;
             }
           });
         }
@@ -13415,6 +13460,9 @@ export const plans = {
     }
   },
   _Proto__Input: {
+    "__inputPlan": function _Proto__Input_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -13496,6 +13544,9 @@ export const plans = {
     }
   },
   BuildingInput: {
+    "__inputPlan": function BuildingInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -13577,6 +13628,9 @@ export const plans = {
     }
   },
   ConstructorInput: {
+    "__inputPlan": function ConstructorInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -13658,6 +13712,9 @@ export const plans = {
     }
   },
   CropInput: {
+    "__inputPlan": function CropInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -13743,6 +13800,9 @@ export const plans = {
     }
   },
   MachineInput: {
+    "__inputPlan": function MachineInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -13824,6 +13884,9 @@ export const plans = {
     }
   },
   MaterialInput: {
+    "__inputPlan": function MaterialInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -13905,6 +13968,9 @@ export const plans = {
     }
   },
   NullInput: {
+    "__inputPlan": function NullInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -13986,6 +14052,9 @@ export const plans = {
     }
   },
   ProjectInput: {
+    "__inputPlan": function ProjectInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -14067,6 +14136,9 @@ export const plans = {
     }
   },
   YieldInput: {
+    "__inputPlan": function YieldInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -14148,6 +14220,9 @@ export const plans = {
     }
   },
   ReservedInput: {
+    "__inputPlan": function ReservedInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -14235,6 +14310,9 @@ export const plans = {
     }
   },
   _ProtoPatch: {
+    "__inputPlan": function _ProtoPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -14343,6 +14421,9 @@ export const plans = {
     }
   },
   BuildingPatch: {
+    "__inputPlan": function BuildingPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -14451,6 +14532,9 @@ export const plans = {
     }
   },
   ConstructorPatch: {
+    "__inputPlan": function ConstructorPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -14573,6 +14657,9 @@ export const plans = {
     }
   },
   CropPatch: {
+    "__inputPlan": function CropPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -14685,6 +14772,9 @@ export const plans = {
     }
   },
   MachinePatch: {
+    "__inputPlan": function MachinePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -14779,6 +14869,9 @@ export const plans = {
     }
   },
   MaterialPatch: {
+    "__inputPlan": function MaterialPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -14901,6 +14994,9 @@ export const plans = {
     }
   },
   NullPatch: {
+    "__inputPlan": function NullPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -15023,6 +15119,9 @@ export const plans = {
     }
   },
   ProjectPatch: {
+    "__inputPlan": function ProjectPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -15131,6 +15230,9 @@ export const plans = {
     }
   },
   YieldPatch: {
+    "__inputPlan": function YieldPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -15239,6 +15341,9 @@ export const plans = {
     }
   },
   ReservedPatch: {
+    "__inputPlan": function ReservedPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/jwt.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/jwt.1.export.mjs
@@ -1,6 +1,6 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, domainOfCodec, enumCodec, listOfCodec, makeRegistry, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectSingleFromRecord, pgUpdateSingle, rangeOfCodec, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId } from "grafast";
-import { valueFromASTUntyped } from "graphql";
+import { GraphQLError, GraphQLInt, GraphQLString, Kind, valueFromASTUntyped } from "graphql";
 import jsonwebtoken from "jsonwebtoken";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
@@ -8,12 +8,16 @@ const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -30,24 +34,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const guidCodec = domainOfCodec(TYPES.varchar, "guid", sql.identifier("b", "guid"), {
@@ -62,44 +78,6 @@ const guidCodec = domainOfCodec(TYPES.varchar, "guid", sql.identifier("b", "guid
   },
   notNull: false
 });
-const updatableViewAttributes = Object.assign(Object.create(null), {
-  x: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  description: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  constant: {
-    description: "This is constantly 2",
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -110,10 +88,47 @@ const executor = new PgExecutor({
     });
   }
 });
-const updatableViewCodec = recordCodec({
+const spec_updatableView = {
   name: "updatableView",
   identifier: sql.identifier("b", "updatable_view"),
-  attributes: updatableViewAttributes,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    description: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    constant: {
+      description: "This is constantly 2",
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "YOYOYO!!",
   extensions: {
     isTableLike: true,
@@ -127,8 +142,9 @@ const updatableViewCodec = recordCodec({
       unique: "x|@behavior -single -update -delete"
     })
   },
-  executor
-});
+  executor: executor
+};
+const updatableViewCodec = recordCodec(spec_updatableView);
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
   identifier: sql.identifier("b", "jwt_token"),
@@ -191,7 +207,7 @@ const jwtTokenCodec = recordCodec({
       behavior: ["-table", "jwt"]
     })
   },
-  executor
+  executor: executor
 });
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   extensions: {
@@ -250,7 +266,7 @@ const authPayloadCodec = recordCodec({
       foreignKey: "(id) references c.person"
     })
   },
-  executor
+  executor: executor
 });
 const colorCodec = enumCodec({
   name: "color",
@@ -381,7 +397,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const colorArrayCodec = listOfCodec(colorCodec, {
   extensions: {
@@ -521,7 +537,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -573,7 +589,7 @@ const byteaArrayCodec = listOfCodec(TYPES.bytea, {
   description: undefined,
   name: "byteaArray"
 });
-const typesAttributes_ltree_codec_ltree = {
+const spec_types_attributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -585,469 +601,468 @@ const typesAttributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
-const typesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  smallint: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bigint: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numeric: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  decimal: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  boolean: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  varchar: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum_array: {
-    description: undefined,
-    codec: colorArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain: {
-    description: undefined,
-    codec: anIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain2: {
-    description: undefined,
-    codec: anotherIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array: {
-    description: undefined,
-    codec: textArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  json: {
-    description: undefined,
-    codec: TYPES.json,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  jsonb: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_range: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numrange: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  daterange: {
-    description: undefined,
-    codec: daterangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  an_int_range: {
-    description: undefined,
-    codec: anIntRangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamp: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamptz: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  date: {
-    description: undefined,
-    codec: TYPES.date,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  time: {
-    description: undefined,
-    codec: TYPES.time,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timetz: {
-    description: undefined,
-    codec: TYPES.timetz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval_array: {
-    description: undefined,
-    codec: intervalArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  money: {
-    description: undefined,
-    codec: TYPES.money,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  point: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullablePoint: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  inet: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  cidr: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  macaddr: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regproc: {
-    description: undefined,
-    codec: TYPES.regproc,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regprocedure: {
-    description: undefined,
-    codec: TYPES.regprocedure,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoper: {
-    description: undefined,
-    codec: TYPES.regoper,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoperator: {
-    description: undefined,
-    codec: TYPES.regoperator,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regclass: {
-    description: undefined,
-    codec: TYPES.regclass,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regtype: {
-    description: undefined,
-    codec: TYPES.regtype,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regconfig: {
-    description: undefined,
-    codec: TYPES.regconfig,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regdictionary: {
-    description: undefined,
-    codec: TYPES.regdictionary,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array_domain: {
-    description: undefined,
-    codec: textArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  int8_array_domain: {
-    description: undefined,
-    codec: int8ArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea: {
-    description: undefined,
-    codec: TYPES.bytea,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea_array: {
-    description: undefined,
-    codec: byteaArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree: {
-    description: undefined,
-    codec: typesAttributes_ltree_codec_ltree,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree_array: {
-    description: undefined,
-    codec: typesAttributes_ltree_array_codec_ltree_,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions17 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "types"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: ["(smallint) references a.post", "(id) references a.post"]
-  })
-};
-const typesCodec = recordCodec({
+const spec_types_attributes_ltree_array_codec_ltree_ = listOfCodec(spec_types_attributes_ltree_codec_ltree);
+const spec_types = {
   name: "types",
   identifier: sql.identifier("b", "types"),
-  attributes: typesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    smallint: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bigint: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numeric: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    decimal: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    boolean: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    varchar: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum_array: {
+      description: undefined,
+      codec: colorArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain: {
+      description: undefined,
+      codec: anIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain2: {
+      description: undefined,
+      codec: anotherIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array: {
+      description: undefined,
+      codec: textArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    json: {
+      description: undefined,
+      codec: TYPES.json,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    jsonb: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_range: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numrange: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    daterange: {
+      description: undefined,
+      codec: daterangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    an_int_range: {
+      description: undefined,
+      codec: anIntRangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamp: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamptz: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    date: {
+      description: undefined,
+      codec: TYPES.date,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    time: {
+      description: undefined,
+      codec: TYPES.time,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timetz: {
+      description: undefined,
+      codec: TYPES.timetz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval_array: {
+      description: undefined,
+      codec: intervalArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    money: {
+      description: undefined,
+      codec: TYPES.money,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    point: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullablePoint: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    inet: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    cidr: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    macaddr: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regproc: {
+      description: undefined,
+      codec: TYPES.regproc,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regprocedure: {
+      description: undefined,
+      codec: TYPES.regprocedure,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoper: {
+      description: undefined,
+      codec: TYPES.regoper,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoperator: {
+      description: undefined,
+      codec: TYPES.regoperator,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regclass: {
+      description: undefined,
+      codec: TYPES.regclass,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regtype: {
+      description: undefined,
+      codec: TYPES.regtype,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regconfig: {
+      description: undefined,
+      codec: TYPES.regconfig,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regdictionary: {
+      description: undefined,
+      codec: TYPES.regdictionary,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array_domain: {
+      description: undefined,
+      codec: textArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    int8_array_domain: {
+      description: undefined,
+      codec: int8ArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea: {
+      description: undefined,
+      codec: TYPES.bytea,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea_array: {
+      description: undefined,
+      codec: byteaArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree: {
+      description: undefined,
+      codec: spec_types_attributes_ltree_codec_ltree,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree_array: {
+      description: undefined,
+      codec: spec_types_attributes_ltree_array_codec_ltree_,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions17,
-  executor
-});
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "types"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: ["(smallint) references a.post", "(id) references a.post"]
+    })
+  },
+  executor: executor
+};
+const typesCodec = recordCodec(spec_types);
 const notNullUrlCodec = domainOfCodec(TYPES.varchar, "notNullUrl", sql.identifier("b", "not_null_url"), {
   description: undefined,
   extensions: {
@@ -1121,7 +1136,7 @@ const registryConfig_pgResources_types_types = {
       name: "types"
     },
     tags: {
-      foreignKey: extensions17.tags.foreignKey
+      foreignKey: spec_types.extensions.tags.foreignKey
     }
   }
 };
@@ -1185,8 +1200,8 @@ const registry = makeRegistry({
     int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
     byteaArray: byteaArrayCodec,
-    ltree: typesAttributes_ltree_codec_ltree,
-    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
+    ltree: spec_types_attributes_ltree_codec_ltree,
+    "ltree[]": spec_types_attributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     jwtTokenArray: listOfCodec(jwtTokenCodec, {
       extensions: {
@@ -1253,7 +1268,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor
+      executor: executor
     })
   }),
   pgResources: Object.assign(Object.create(null), {
@@ -2264,6 +2279,18 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
 };
 const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
+function BigIntSerialize(value) {
+  return "" + value;
+}
+const coerce = string => {
+  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
+    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
+  }
+  return string;
+};
+function LTreeParseValue(value) {
+  return value;
+}
 const argDetailsSimple6 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -3159,9 +3186,6 @@ const specFromArgs2 = args => {
   return specFromNodeId(nodeIdHandlerByTypeName.Type, $nodeId);
 };
 const attributeNames = ["role", "exp", "a", "b", "c"];
-function JwtTokenParseValue(value) {
-  return value;
-}
 const resource_frmcdc_jwtTokenPgResource = registry.pgResources["frmcdc_jwtToken"];
 export const typeDefs = /* GraphQL */`"""The root query type which gives access points into the data universe."""
 type Query implements Node {
@@ -5260,6 +5284,26 @@ export const plans = {
       return $record.get("ltree_array");
     }
   },
+  BigInt: {
+    serialize: BigIntSerialize,
+    parseValue: BigIntSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigInt" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  BigFloat: {
+    serialize: BigIntSerialize,
+    parseValue: BigIntSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigFloat" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   Color: {
     RED: {
       value: "red"
@@ -5271,12 +5315,67 @@ export const plans = {
       value: "blue"
     }
   },
+  AnInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
+  AnotherInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
+  JSON: {
+    serialize(value) {
+      return JSON.stringify(value);
+    },
+    parseValue(value) {
+      return JSON.parse(value);
+    },
+    parseLiteral(ast, _variables) {
+      if (ast.kind === Kind.STRING) {
+        return JSON.parse(ast.value);
+      } else {
+        return undefined;
+      }
+    }
+  },
   BigFloatRange: {},
   BigFloatRangeBound: {},
   DateRange: {},
   DateRangeBound: {},
+  Date: {
+    serialize: BigIntSerialize,
+    parseValue: BigIntSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Date" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   AnIntRange: {},
   AnIntRangeBound: {},
+  Datetime: {
+    serialize: BigIntSerialize,
+    parseValue: BigIntSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  Time: {
+    serialize: BigIntSerialize,
+    parseValue: BigIntSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Time" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   Interval: {
     __assertStep: assertExecutableStep,
     seconds($r) {
@@ -5325,6 +5424,19 @@ export const plans = {
       return $record.get("foo_bar");
     }
   },
+  UUID: {
+    serialize: BigIntSerialize,
+    parseValue(value) {
+      return coerce("" + value);
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // ERRORS: add name to this error
+        throw new GraphQLError(`${"UUID" ?? "This scalar"} can only parse string values (kind = '${ast.kind}')`);
+      }
+      return coerce(ast.value);
+    }
+  },
   EnumCaps: {
     _0_BAR: {
       value: "0_BAR"
@@ -5366,7 +5478,132 @@ export const plans = {
     }
   },
   Point: {},
+  InternetAddress: {
+    serialize: BigIntSerialize,
+    parseValue: BigIntSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"InternetAddress" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProc: {
+    serialize: BigIntSerialize,
+    parseValue: BigIntSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProc" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProcedure: {
+    serialize: BigIntSerialize,
+    parseValue: BigIntSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProcedure" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOper: {
+    serialize: BigIntSerialize,
+    parseValue: BigIntSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOper" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOperator: {
+    serialize: BigIntSerialize,
+    parseValue: BigIntSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOperator" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegClass: {
+    serialize: BigIntSerialize,
+    parseValue: BigIntSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegClass" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegType: {
+    serialize: BigIntSerialize,
+    parseValue: BigIntSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegType" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegConfig: {
+    serialize: BigIntSerialize,
+    parseValue: BigIntSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegConfig" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegDictionary: {
+    serialize: BigIntSerialize,
+    parseValue: BigIntSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegDictionary" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  Base64EncodedBinary: {
+    serialize(data) {
+      if (Buffer.isBuffer(data)) {
+        return data.toString("base64");
+      } else {
+        throw new Error(`Base64EncodeBinary can only be used with Node.js buffers.`);
+      }
+    },
+    parseValue(data) {
+      if (typeof data === "string") {
+        return Buffer.from(data, "base64");
+      } else {
+        throw new GraphQLError("Base64EncodedBinary can only parse string values.");
+      }
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // TODO: add name to this error
+        throw new GraphQLError("Base64EncodedBinary can only parse string values");
+      }
+      return Buffer.from(ast.value, "base64");
+    }
+  },
+  LTree: {
+    serialize(x) {
+      return x;
+    },
+    parseValue: LTreeParseValue,
+    parseLiteral(node, variables) {
+      return LTreeParseValue(valueFromASTUntyped(node, variables));
+    }
+  },
   CompoundTypeInput: {
+    "__inputPlan": function CompoundTypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     a: {
       applyPlan($insert, val) {
         $insert.set("a", val.get());
@@ -5455,6 +5692,16 @@ export const plans = {
     },
     node($edge) {
       return $edge.node();
+    }
+  },
+  Cursor: {
+    serialize: BigIntSerialize,
+    parseValue: BigIntSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   PageInfo: {
@@ -5669,7 +5916,7 @@ export const plans = {
             type: "attribute",
             attribute: "x",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.x.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.x.codec)}`;
             }
           });
         }
@@ -5692,7 +5939,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.name.codec)}`;
             }
           });
         }
@@ -5715,7 +5962,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.description.codec)}`;
             }
           });
         }
@@ -5738,7 +5985,7 @@ export const plans = {
             type: "attribute",
             attribute: "constant",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.constant.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.constant.codec)}`;
             }
           });
         }
@@ -7058,7 +7305,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.id.codec)}`;
             }
           });
         }
@@ -7081,7 +7328,7 @@ export const plans = {
             type: "attribute",
             attribute: "smallint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.smallint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.smallint.codec)}`;
             }
           });
         }
@@ -7104,7 +7351,7 @@ export const plans = {
             type: "attribute",
             attribute: "bigint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.bigint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.bigint.codec)}`;
             }
           });
         }
@@ -7127,7 +7374,7 @@ export const plans = {
             type: "attribute",
             attribute: "numeric",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numeric.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.numeric.codec)}`;
             }
           });
         }
@@ -7150,7 +7397,7 @@ export const plans = {
             type: "attribute",
             attribute: "decimal",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.decimal.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.decimal.codec)}`;
             }
           });
         }
@@ -7173,7 +7420,7 @@ export const plans = {
             type: "attribute",
             attribute: "boolean",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.boolean.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.boolean.codec)}`;
             }
           });
         }
@@ -7196,7 +7443,7 @@ export const plans = {
             type: "attribute",
             attribute: "varchar",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.varchar.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.varchar.codec)}`;
             }
           });
         }
@@ -7219,7 +7466,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.enum.codec)}`;
             }
           });
         }
@@ -7242,7 +7489,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.enum_array.codec)}`;
             }
           });
         }
@@ -7265,7 +7512,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.domain.codec)}`;
             }
           });
         }
@@ -7288,7 +7535,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.domain2.codec)}`;
             }
           });
         }
@@ -7311,7 +7558,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.text_array.codec)}`;
             }
           });
         }
@@ -7334,7 +7581,7 @@ export const plans = {
             type: "attribute",
             attribute: "json",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.json.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.json.codec)}`;
             }
           });
         }
@@ -7357,7 +7604,7 @@ export const plans = {
             type: "attribute",
             attribute: "jsonb",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.jsonb.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.jsonb.codec)}`;
             }
           });
         }
@@ -7380,7 +7627,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullable_range.codec)}`;
             }
           });
         }
@@ -7403,7 +7650,7 @@ export const plans = {
             type: "attribute",
             attribute: "numrange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numrange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.numrange.codec)}`;
             }
           });
         }
@@ -7426,7 +7673,7 @@ export const plans = {
             type: "attribute",
             attribute: "daterange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.daterange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.daterange.codec)}`;
             }
           });
         }
@@ -7449,7 +7696,7 @@ export const plans = {
             type: "attribute",
             attribute: "an_int_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.an_int_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.an_int_range.codec)}`;
             }
           });
         }
@@ -7472,7 +7719,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamp",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamp.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.timestamp.codec)}`;
             }
           });
         }
@@ -7495,7 +7742,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamptz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamptz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.timestamptz.codec)}`;
             }
           });
         }
@@ -7518,7 +7765,7 @@ export const plans = {
             type: "attribute",
             attribute: "date",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.date.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.date.codec)}`;
             }
           });
         }
@@ -7541,7 +7788,7 @@ export const plans = {
             type: "attribute",
             attribute: "time",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.time.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.time.codec)}`;
             }
           });
         }
@@ -7564,7 +7811,7 @@ export const plans = {
             type: "attribute",
             attribute: "timetz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timetz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.timetz.codec)}`;
             }
           });
         }
@@ -7587,7 +7834,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.interval.codec)}`;
             }
           });
         }
@@ -7610,7 +7857,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.interval_array.codec)}`;
             }
           });
         }
@@ -7633,7 +7880,7 @@ export const plans = {
             type: "attribute",
             attribute: "money",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.money.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.money.codec)}`;
             }
           });
         }
@@ -7656,7 +7903,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.compound_type.codec)}`;
             }
           });
         }
@@ -7679,7 +7926,7 @@ export const plans = {
             type: "attribute",
             attribute: "nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nested_compound_type.codec)}`;
             }
           });
         }
@@ -7702,7 +7949,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullable_compound_type.codec)}`;
             }
           });
         }
@@ -7725,7 +7972,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullable_nested_compound_type.codec)}`;
             }
           });
         }
@@ -7748,7 +7995,7 @@ export const plans = {
             type: "attribute",
             attribute: "point",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.point.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.point.codec)}`;
             }
           });
         }
@@ -7771,7 +8018,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullablePoint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullablePoint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullablePoint.codec)}`;
             }
           });
         }
@@ -7794,7 +8041,7 @@ export const plans = {
             type: "attribute",
             attribute: "inet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.inet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.inet.codec)}`;
             }
           });
         }
@@ -7817,7 +8064,7 @@ export const plans = {
             type: "attribute",
             attribute: "cidr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.cidr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.cidr.codec)}`;
             }
           });
         }
@@ -7840,7 +8087,7 @@ export const plans = {
             type: "attribute",
             attribute: "macaddr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.macaddr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.macaddr.codec)}`;
             }
           });
         }
@@ -7863,7 +8110,7 @@ export const plans = {
             type: "attribute",
             attribute: "regproc",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regproc.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regproc.codec)}`;
             }
           });
         }
@@ -7886,7 +8133,7 @@ export const plans = {
             type: "attribute",
             attribute: "regprocedure",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regprocedure.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regprocedure.codec)}`;
             }
           });
         }
@@ -7909,7 +8156,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoper",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoper.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regoper.codec)}`;
             }
           });
         }
@@ -7932,7 +8179,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoperator",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoperator.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regoperator.codec)}`;
             }
           });
         }
@@ -7955,7 +8202,7 @@ export const plans = {
             type: "attribute",
             attribute: "regclass",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regclass.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regclass.codec)}`;
             }
           });
         }
@@ -7978,7 +8225,7 @@ export const plans = {
             type: "attribute",
             attribute: "regtype",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regtype.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regtype.codec)}`;
             }
           });
         }
@@ -8001,7 +8248,7 @@ export const plans = {
             type: "attribute",
             attribute: "regconfig",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regconfig.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regconfig.codec)}`;
             }
           });
         }
@@ -8024,7 +8271,7 @@ export const plans = {
             type: "attribute",
             attribute: "regdictionary",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regdictionary.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regdictionary.codec)}`;
             }
           });
         }
@@ -8047,7 +8294,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.text_array_domain.codec)}`;
             }
           });
         }
@@ -8070,7 +8317,7 @@ export const plans = {
             type: "attribute",
             attribute: "int8_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.int8_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.int8_array_domain.codec)}`;
             }
           });
         }
@@ -8093,7 +8340,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.ltree.codec)}`;
             }
           });
         }
@@ -8116,7 +8363,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.ltree_array.codec)}`;
             }
           });
         }
@@ -8150,6 +8397,9 @@ export const plans = {
     inclusive: undefined
   },
   NestedCompoundTypeInput: {
+    "__inputPlan": function NestedCompoundTypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     a: {
       applyPlan($insert, val) {
         $insert.set("a", val.get());
@@ -8653,6 +8903,11 @@ export const plans = {
       return rootValue();
     }
   },
+  Guid: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
   GuidFnInput: {
     clientMutationId: {
       applyPlan($input, val) {
@@ -8693,9 +8948,9 @@ export const plans = {
       });
       return jsonwebtoken.sign(token, "secret", options);
     },
-    parseValue: JwtTokenParseValue,
+    parseValue: LTreeParseValue,
     parseLiteral(node, variables) {
-      return JwtTokenParseValue(valueFromASTUntyped(node, variables));
+      return LTreeParseValue(valueFromASTUntyped(node, variables));
     },
     plan($in) {
       const $record = $in;
@@ -9003,6 +9258,9 @@ export const plans = {
     }
   },
   UpdatableViewInput: {
+    "__inputPlan": function UpdatableViewInput_inputPlan() {
+      return object(Object.create(null));
+    },
     x: {
       applyPlan($insert, val) {
         $insert.set("x", val.get());
@@ -9091,6 +9349,9 @@ export const plans = {
     }
   },
   TypeInput: {
+    "__inputPlan": function TypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -9493,6 +9754,9 @@ export const plans = {
     }
   },
   TypePatch: {
+    "__inputPlan": function TypePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/network_types.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/network_types.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, makeRegistry, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgUpdateSingle, recordCodec } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId } from "grafast";
+import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,62 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
-  }
-});
-const networkAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  inet: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  cidr: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  macaddr: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -96,10 +75,47 @@ const executor = new PgExecutor({
     });
   }
 });
-const networkCodec = recordCodec({
+const spec_network = {
   name: "network",
   identifier: sql.identifier("network_types", "network"),
-  attributes: networkAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    inet: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    cidr: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    macaddr: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -110,8 +126,9 @@ const networkCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const networkCodec = recordCodec(spec_network);
 const networkUniques = [{
   isPrimary: true,
   attributes: ["id"],
@@ -220,6 +237,9 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
+function InternetAddressSerialize(value) {
+  return "" + value;
+}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Network, $nodeId);
@@ -698,6 +718,16 @@ export const plans = {
       return $record.get("macaddr");
     }
   },
+  InternetAddress: {
+    serialize: InternetAddressSerialize,
+    parseValue: InternetAddressSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"InternetAddress" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   NetworksConnection: {
     __assertStep: ConnectionStep,
     nodes($connection) {
@@ -721,6 +751,16 @@ export const plans = {
     },
     node($edge) {
       return $edge.node();
+    }
+  },
+  Cursor: {
+    serialize: InternetAddressSerialize,
+    parseValue: InternetAddressSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   PageInfo: {
@@ -927,7 +967,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), networkAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_network.attributes.id.codec)}`;
             }
           });
         }
@@ -950,7 +990,7 @@ export const plans = {
             type: "attribute",
             attribute: "inet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), networkAttributes.inet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_network.attributes.inet.codec)}`;
             }
           });
         }
@@ -973,7 +1013,7 @@ export const plans = {
             type: "attribute",
             attribute: "cidr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), networkAttributes.cidr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_network.attributes.cidr.codec)}`;
             }
           });
         }
@@ -996,7 +1036,7 @@ export const plans = {
             type: "attribute",
             attribute: "macaddr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), networkAttributes.macaddr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_network.attributes.macaddr.codec)}`;
             }
           });
         }
@@ -1152,6 +1192,9 @@ export const plans = {
     }
   },
   NetworkInput: {
+    "__inputPlan": function NetworkInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -1239,6 +1282,9 @@ export const plans = {
     }
   },
   NetworkPatch: {
+    "__inputPlan": function NetworkPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, domainOfCodec, enumCodec, listOfCodec, makeRegistry, pgClassExpression, pgSelectFromRecord, pgSelectFromRecords, pgSelectSingleFromRecord, rangeOfCodec, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, stepAMayDependOnStepB } from "grafast";
+import { GraphQLError, GraphQLInt, GraphQLString, Kind, valueFromASTUntyped } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -404,30 +421,29 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
   executor,
   isAnonymous: true
 });
-const myTableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  json_data: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const myTableCodec = recordCodec({
+const spec_myTable = {
   name: "myTable",
   identifier: sql.identifier("c", "my_table"),
-  attributes: myTableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    json_data: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -438,34 +454,34 @@ const myTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const personSecretAttributes = Object.assign(Object.create(null), {
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  sekrit: {
-    description: "A secret held by the associated Person",
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "secret"
-      }
-    }
-  }
-});
-const personSecretCodec = recordCodec({
+  executor: executor
+};
+const myTableCodec = recordCodec(spec_myTable);
+const spec_personSecret = {
   name: "personSecret",
   identifier: sql.identifier("c", "person_secret"),
-  attributes: personSecretAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    sekrit: {
+      description: "A secret held by the associated Person",
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "secret"
+        }
+      }
+    }
+  }),
   description: "Tracks the person's secret",
   extensions: {
     isTableLike: true,
@@ -478,41 +494,41 @@ const personSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor
-});
-const compoundKeyAttributes = Object.assign(Object.create(null), {
-  person_id_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  extra: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const compoundKeyCodec = recordCodec({
+  executor: executor
+};
+const personSecretCodec = recordCodec(spec_personSecret);
+const spec_compoundKey = {
   name: "compoundKey",
   identifier: sql.identifier("c", "compound_key"),
-  attributes: compoundKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    extra: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -523,50 +539,50 @@ const compoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const nullTestRecordAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_int: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  non_null_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const nullTestRecordCodec = recordCodec({
+  executor: executor
+};
+const compoundKeyCodec = recordCodec(spec_compoundKey);
+const spec_nullTestRecord = {
   name: "nullTestRecord",
   identifier: sql.identifier("c", "null_test_record"),
-  attributes: nullTestRecordAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_int: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    non_null_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -577,41 +593,41 @@ const nullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const edgeCaseAttributes = Object.assign(Object.create(null), {
-  not_null_has_default: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  wont_cast_easy: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  row_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const edgeCaseCodec = recordCodec({
+  executor: executor
+};
+const nullTestRecordCodec = recordCodec(spec_nullTestRecord);
+const spec_edgeCase = {
   name: "edgeCase",
   identifier: sql.identifier("c", "edge_case"),
-  attributes: edgeCaseAttributes,
+  attributes: Object.assign(Object.create(null), {
+    not_null_has_default: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    wont_cast_easy: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    row_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -622,50 +638,50 @@ const edgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const leftArmAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  length_in_metres: {
-    description: undefined,
-    codec: TYPES.float,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  mood: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const leftArmCodec = recordCodec({
+  executor: executor
+};
+const edgeCaseCodec = recordCodec(spec_edgeCase);
+const spec_leftArm = {
   name: "leftArm",
   identifier: sql.identifier("c", "left_arm"),
-  attributes: leftArmAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    length_in_metres: {
+      description: undefined,
+      codec: TYPES.float,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    mood: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Tracks metadata about the left arms of various people",
   extensions: {
     isTableLike: true,
@@ -676,8 +692,9 @@ const leftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const leftArmCodec = recordCodec(spec_leftArm);
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
   extensions: {
@@ -690,30 +707,29 @@ const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp
   },
   notNull: true
 });
-const issue756Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  ts: {
-    description: undefined,
-    codec: notNullTimestampCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const issue756Codec = recordCodec({
+const spec_issue756 = {
   name: "issue756",
   identifier: sql.identifier("c", "issue756"),
-  attributes: issue756Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    ts: {
+      description: undefined,
+      codec: notNullTimestampCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -724,8 +740,9 @@ const issue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const issue756Codec = recordCodec(spec_issue756);
 const colorCodec = enumCodec({
   name: "color",
   identifier: sql.identifier("b", "color"),
@@ -855,7 +872,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
@@ -977,7 +994,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1061,7 +1078,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
@@ -1222,117 +1239,116 @@ const wrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const personAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: "The primary unique identifier for the person",
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_full_name: {
-    description: "The person\u2019s name",
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "name"
-      }
-    }
-  },
-  aliases: {
-    description: undefined,
-    codec: textArrayCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  about: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  email: {
-    description: undefined,
-    codec: emailCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  site: {
-    description: undefined,
-    codec: wrappedUrlCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        deprecated: "Don\u2019t use me"
-      }
-    }
-  },
-  config: {
-    description: undefined,
-    codec: TYPES.hstore,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_login_from_ip: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_login_from_subnet: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  user_mac: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  created_at: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const personCodec = recordCodec({
+const spec_person = {
   name: "person",
   identifier: sql.identifier("c", "person"),
-  attributes: personAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: "The primary unique identifier for the person",
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_full_name: {
+      description: "The person\u2019s name",
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "name"
+        }
+      }
+    },
+    aliases: {
+      description: undefined,
+      codec: textArrayCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    about: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    email: {
+      description: undefined,
+      codec: emailCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    site: {
+      description: undefined,
+      codec: wrappedUrlCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          deprecated: "Don\u2019t use me"
+        }
+      }
+    },
+    config: {
+      description: undefined,
+      codec: TYPES.hstore,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_login_from_ip: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_login_from_subnet: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    user_mac: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    created_at: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Person test comment",
   extensions: {
     isTableLike: true,
@@ -1343,8 +1359,9 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const personCodec = recordCodec(spec_person);
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
@@ -1690,7 +1707,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -1742,7 +1759,7 @@ const byteaArrayCodec = listOfCodec(TYPES.bytea, {
   description: undefined,
   name: "byteaArray"
 });
-const typesAttributes_ltree_codec_ltree = {
+const spec_types_attributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -1754,7 +1771,7 @@ const typesAttributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
+const spec_types_attributes_ltree_array_codec_ltree_ = listOfCodec(spec_types_attributes_ltree_codec_ltree);
 const typesCodec = recordCodec({
   name: "types",
   identifier: sql.identifier("b", "types"),
@@ -2184,7 +2201,7 @@ const typesCodec = recordCodec({
     },
     ltree: {
       description: undefined,
-      codec: typesAttributes_ltree_codec_ltree,
+      codec: spec_types_attributes_ltree_codec_ltree,
       notNull: false,
       hasDefault: false,
       extensions: {
@@ -2193,7 +2210,7 @@ const typesCodec = recordCodec({
     },
     ltree_array: {
       description: undefined,
-      codec: typesAttributes_ltree_array_codec_ltree_,
+      codec: spec_types_attributes_ltree_array_codec_ltree_,
       notNull: false,
       hasDefault: false,
       extensions: {
@@ -2213,7 +2230,7 @@ const typesCodec = recordCodec({
       foreignKey: ["(smallint) references a.post", "(id) references a.post"]
     })
   },
-  executor
+  executor: executor
 });
 const int4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
@@ -2570,8 +2587,8 @@ const registry = makeRegistry({
     int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
     byteaArray: byteaArrayCodec,
-    ltree: typesAttributes_ltree_codec_ltree,
-    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
+    ltree: spec_types_attributes_ltree_codec_ltree,
+    "ltree[]": spec_types_attributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     typesArray: listOfCodec(typesCodec, {
       extensions: {
@@ -7559,8 +7576,71 @@ const makeArgs45 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
+function UUIDSerialize(value) {
+  return "" + value;
+}
+const coerce = string => {
+  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
+    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
+  }
+  return string;
+};
 const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
+function LTreeParseValue(value) {
+  return value;
+}
+const isValidHstoreObject = obj => {
+  if (obj === null) {
+    // Null is okay
+    return true;
+  } else if (typeof obj === "object") {
+    // A hash with string/null values is also okay
+    const keys = Object.keys(obj);
+    for (const key of keys) {
+      const val = obj[key];
+      if (val === null) {
+        // Null is okay
+      } else if (typeof val === "string") {
+        // String is okay
+      } else {
+        // Everything else is invalid.
+        return false;
+      }
+    }
+    return true;
+  } else {
+    // Everything else is invalid.
+    return false;
+  }
+};
+const parseValueLiteral = (ast, variables) => {
+  switch (ast.kind) {
+    case Kind.INT:
+    case Kind.FLOAT:
+      // Number isn't really okay, but we'll coerce it to a string anyway.
+      return String(parseFloat(ast.value));
+    case Kind.STRING:
+      // String is okay.
+      return String(ast.value);
+    case Kind.NULL:
+      // Null is okay.
+      return null;
+    case Kind.VARIABLE:
+      {
+        // Variable is okay if that variable is either a string or null.
+        const name = ast.name.value;
+        const value = variables ? variables[name] : undefined;
+        if (value === null || typeof value === "string") {
+          return value;
+        }
+        return undefined;
+      }
+    default:
+      // Everything else is invalid.
+      return undefined;
+  }
+};
 const resource_frmcdc_postPgResource = registry.pgResources["frmcdc_post"];
 const argDetailsSimple46 = [];
 const makeArgs46 = (args, path = []) => {
@@ -13197,6 +13277,21 @@ export const plans = {
       return $record.get("json_data");
     }
   },
+  JSON: {
+    serialize(value) {
+      return JSON.stringify(value);
+    },
+    parseValue(value) {
+      return JSON.parse(value);
+    },
+    parseLiteral(ast, _variables) {
+      if (ast.kind === Kind.STRING) {
+        return JSON.parse(ast.value);
+      } else {
+        return undefined;
+      }
+    }
+  },
   PersonSecret: {
     __assertStep: assertPgClassSingleStep,
     nodeId($parent) {
@@ -13930,6 +14025,11 @@ export const plans = {
       return $record.get("o");
     }
   },
+  Email: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
   PersonComputedFirstArgInoutOutRecord: {
     __assertStep: assertPgClassSingleStep,
     person($record) {
@@ -14039,6 +14139,19 @@ export const plans = {
     },
     BLUE: {
       value: "blue"
+    }
+  },
+  UUID: {
+    serialize: UUIDSerialize,
+    parseValue(value) {
+      return coerce("" + value);
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // ERRORS: add name to this error
+        throw new GraphQLError(`${"UUID" ?? "This scalar"} can only parse string values (kind = '${ast.kind}')`);
+      }
+      return coerce(ast.value);
     }
   },
   EnumCaps: {
@@ -14167,6 +14280,16 @@ export const plans = {
       return $record.get("is_optimised");
     }
   },
+  Datetime: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PeopleConnection: {
     __assertStep: ConnectionStep,
     nodes($connection) {
@@ -14190,6 +14313,16 @@ export const plans = {
     },
     node($edge) {
       return $edge.node();
+    }
+  },
+  Cursor: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   PageInfo: {
@@ -14834,12 +14967,62 @@ export const plans = {
       return $record.get("ltree_array");
     }
   },
+  BigInt: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigInt" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  BigFloat: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigFloat" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  AnInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
+  AnotherInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
   BigFloatRange: {},
   BigFloatRangeBound: {},
   DateRange: {},
   DateRangeBound: {},
+  Date: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Date" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   AnIntRange: {},
   AnIntRangeBound: {},
+  Time: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Time" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   NestedCompoundType: {
     __assertStep: assertPgClassSingleStep,
     a($record) {
@@ -14865,6 +15048,128 @@ export const plans = {
     }
   },
   Point: {},
+  InternetAddress: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"InternetAddress" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProc: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProc" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProcedure: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProcedure" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOper: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOper" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOperator: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOperator" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegClass: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegClass" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegType: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegType" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegConfig: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegConfig" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegDictionary: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegDictionary" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  Base64EncodedBinary: {
+    serialize(data) {
+      if (Buffer.isBuffer(data)) {
+        return data.toString("base64");
+      } else {
+        throw new Error(`Base64EncodeBinary can only be used with Node.js buffers.`);
+      }
+    },
+    parseValue(data) {
+      if (typeof data === "string") {
+        return Buffer.from(data, "base64");
+      } else {
+        throw new GraphQLError("Base64EncodedBinary can only parse string values.");
+      }
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // TODO: add name to this error
+        throw new GraphQLError("Base64EncodedBinary can only parse string values");
+      }
+      return Buffer.from(ast.value, "base64");
+    }
+  },
+  LTree: {
+    serialize(x) {
+      return x;
+    },
+    parseValue: LTreeParseValue,
+    parseLiteral(node, variables) {
+      return LTreeParseValue(valueFromASTUntyped(node, variables));
+    }
+  },
   TypesEdge: {
     __assertStep: assertEdgeCapableStep,
     cursor($edge) {
@@ -14878,6 +15183,50 @@ export const plans = {
     __assertStep: assertPgClassSingleStep,
     url($record) {
       return $record.get("url");
+    }
+  },
+  NotNullUrl: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
+  KeyValueHash: {
+    serialize(value) {
+      return value;
+    },
+    parseValue(obj) {
+      if (isValidHstoreObject(obj)) {
+        return obj;
+      }
+      throw new GraphQLError(`This is not a valid ${"KeyValueHash"} object, it must be a key/value hash where keys and values are both strings (or null).`);
+    },
+    parseLiteral(ast, variables) {
+      switch (ast.kind) {
+        case Kind.OBJECT:
+          {
+            const value = ast.fields.reduce((memo, field) => {
+              memo[field.name.value] = parseValueLiteral(field.value, variables);
+              return memo;
+            }, Object.create(null));
+            if (!isValidHstoreObject(value)) {
+              return undefined;
+            }
+            return value;
+          }
+        case Kind.NULL:
+          return null;
+        case Kind.VARIABLE:
+          {
+            const name = ast.name.value;
+            const value = variables ? variables[name] : undefined;
+            if (!isValidHstoreObject(value)) {
+              return undefined;
+            }
+            return value;
+          }
+        default:
+          return undefined;
+      }
     }
   },
   LeftArm: {
@@ -15110,7 +15459,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.person_id_2.codec)}`;
             }
           });
         }
@@ -15133,7 +15482,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.person_id_1.codec)}`;
             }
           });
         }
@@ -15156,7 +15505,7 @@ export const plans = {
             type: "attribute",
             attribute: "extra",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.extra.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.extra.codec)}`;
             }
           });
         }
@@ -15195,6 +15544,16 @@ export const plans = {
     },
     ts($record) {
       return $record.get("ts");
+    }
+  },
+  NotNullTimestamp: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   FuncOutSetofConnection: {
@@ -15540,7 +15899,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.id.codec)}`;
             }
           });
         }
@@ -15563,7 +15922,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_full_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.person_full_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.person_full_name.codec)}`;
             }
           });
         }
@@ -15586,7 +15945,7 @@ export const plans = {
             type: "attribute",
             attribute: "aliases",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.aliases.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.aliases.codec)}`;
             }
           });
         }
@@ -15609,7 +15968,7 @@ export const plans = {
             type: "attribute",
             attribute: "about",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.about.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.about.codec)}`;
             }
           });
         }
@@ -15632,7 +15991,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.email.codec)}`;
             }
           });
         }
@@ -15655,7 +16014,7 @@ export const plans = {
             type: "attribute",
             attribute: "site",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.site.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.site.codec)}`;
             }
           });
         }
@@ -15678,7 +16037,7 @@ export const plans = {
             type: "attribute",
             attribute: "config",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.config.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.config.codec)}`;
             }
           });
         }
@@ -15701,7 +16060,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_ip",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_ip.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_login_from_ip.codec)}`;
             }
           });
         }
@@ -15724,7 +16083,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_subnet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_subnet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_login_from_subnet.codec)}`;
             }
           });
         }
@@ -15747,7 +16106,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_mac",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.user_mac.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.user_mac.codec)}`;
             }
           });
         }
@@ -15770,7 +16129,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.created_at.codec)}`;
             }
           });
         }
@@ -15795,6 +16154,9 @@ export const plans = {
     }
   },
   WrappedUrlInput: {
+    "__inputPlan": function WrappedUrlInput_inputPlan() {
+      return object(Object.create(null));
+    },
     url: {
       applyPlan($insert, val) {
         $insert.set("url", val.get());
@@ -15949,7 +16311,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_myTable.attributes.id.codec)}`;
             }
           });
         }
@@ -15972,7 +16334,7 @@ export const plans = {
             type: "attribute",
             attribute: "json_data",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.json_data.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_myTable.attributes.json_data.codec)}`;
             }
           });
         }
@@ -16127,7 +16489,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_personSecret.attributes.person_id.codec)}`;
             }
           });
         }
@@ -16150,7 +16512,7 @@ export const plans = {
             type: "attribute",
             attribute: "sekrit",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.sekrit.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_personSecret.attributes.sekrit.codec)}`;
             }
           });
         }
@@ -16373,7 +16735,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.id.codec)}`;
             }
           });
         }
@@ -16396,7 +16758,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.nullable_text.codec)}`;
             }
           });
         }
@@ -16419,7 +16781,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_int",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_int.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.nullable_int.codec)}`;
             }
           });
         }
@@ -16442,7 +16804,7 @@ export const plans = {
             type: "attribute",
             attribute: "non_null_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.non_null_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.non_null_text.codec)}`;
             }
           });
         }
@@ -16645,7 +17007,7 @@ export const plans = {
             type: "attribute",
             attribute: "not_null_has_default",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.not_null_has_default.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.not_null_has_default.codec)}`;
             }
           });
         }
@@ -16668,7 +17030,7 @@ export const plans = {
             type: "attribute",
             attribute: "wont_cast_easy",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.wont_cast_easy.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.wont_cast_easy.codec)}`;
             }
           });
         }
@@ -16691,7 +17053,7 @@ export const plans = {
             type: "attribute",
             attribute: "row_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.row_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.row_id.codec)}`;
             }
           });
         }
@@ -16914,7 +17276,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.id.codec)}`;
             }
           });
         }
@@ -16937,7 +17299,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.person_id.codec)}`;
             }
           });
         }
@@ -16960,7 +17322,7 @@ export const plans = {
             type: "attribute",
             attribute: "length_in_metres",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.length_in_metres.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.length_in_metres.codec)}`;
             }
           });
         }
@@ -16983,7 +17345,7 @@ export const plans = {
             type: "attribute",
             attribute: "mood",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.mood.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.mood.codec)}`;
             }
           });
         }
@@ -17138,7 +17500,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_issue756.attributes.id.codec)}`;
             }
           });
         }
@@ -17161,7 +17523,7 @@ export const plans = {
             type: "attribute",
             attribute: "ts",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.ts.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_issue756.attributes.ts.codec)}`;
             }
           });
         }
@@ -18107,6 +18469,9 @@ export const plans = {
     leftArm: undefined
   },
   LeftArmBaseInput: {
+    "__inputPlan": function LeftArmBaseInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, makeRegistry, pgClassExpression, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectSingleFromRecord, pgUpdateSingle, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
+import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -84,25 +101,24 @@ const flambleCodec = recordCodec({
       name: "flamble"
     })
   },
-  executor
+  executor: executor
 });
-const renamed_tableAttributes = Object.assign(Object.create(null), {
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "colA"
-      }
-    }
-  }
-});
-const renamed_tableCodec = recordCodec({
+const spec_renamed_table = {
   name: "renamed_table",
   identifier: sql.identifier("d", "original_table"),
-  attributes: renamed_tableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "colA"
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -115,32 +131,32 @@ const renamed_tableCodec = recordCodec({
       name: "renamed_table"
     })
   },
-  executor
-});
-const filmsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const filmsCodec = recordCodec({
+  executor: executor
+};
+const renamed_tableCodec = recordCodec(spec_renamed_table);
+const spec_films = {
   name: "films",
   identifier: sql.identifier("d", "films"),
-  attributes: filmsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -151,32 +167,32 @@ const filmsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const studiosAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const studiosCodec = recordCodec({
+  executor: executor
+};
+const filmsCodec = recordCodec(spec_films);
+const spec_studios = {
   name: "studios",
   identifier: sql.identifier("d", "studios"),
-  attributes: studiosAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -187,41 +203,41 @@ const studiosCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const postAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  body: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const postCodec = recordCodec({
+  executor: executor
+};
+const studiosCodec = recordCodec(spec_studios);
+const spec_post = {
   name: "post",
   identifier: sql.identifier("d", "post"),
-  attributes: postAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    body: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -232,41 +248,41 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const tvEpisodesAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  show_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const tvEpisodesCodec = recordCodec({
+  executor: executor
+};
+const postCodec = recordCodec(spec_post);
+const spec_tvEpisodes = {
   name: "tvEpisodes",
   identifier: sql.identifier("d", "tv_episodes"),
-  attributes: tvEpisodesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    show_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -277,41 +293,41 @@ const tvEpisodesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const tvShowsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  studio_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const tvShowsCodec = recordCodec({
+  executor: executor
+};
+const tvEpisodesCodec = recordCodec(spec_tvEpisodes);
+const spec_tvShows = {
   name: "tvShows",
   identifier: sql.identifier("d", "tv_shows"),
-  attributes: tvShowsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    studio_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -322,8 +338,9 @@ const tvShowsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const tvShowsCodec = recordCodec(spec_tvShows);
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
   identifier: sql.identifier("d", "jwt_token"),
@@ -366,125 +383,124 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const personAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  first_name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col_no_create: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create",
-        behavior: ["-insert"]
-      }
-    }
-  },
-  col_no_update: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "update",
-        behavior: ["-update"]
-      }
-    }
-  },
-  col_no_order: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "order",
-        behavior: ["-order -orderBy"]
-      }
-    }
-  },
-  col_no_filter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "filter",
-        behavior: ["-filter -filterBy"]
-      }
-    }
-  },
-  col_no_create_update: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create,update",
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  col_no_create_update_order_filter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create,update,order,filter",
-        behavior: ["-insert -update -order -orderBy -filter -filterBy"]
-      }
-    }
-  },
-  col_no_anything: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: true,
-        behavior: ["-*"]
-      }
-    }
-  }
-});
-const personCodec = recordCodec({
+const spec_person = {
   name: "person",
   identifier: sql.identifier("d", "person"),
-  attributes: personAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    first_name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col_no_create: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create",
+          behavior: ["-insert"]
+        }
+      }
+    },
+    col_no_update: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "update",
+          behavior: ["-update"]
+        }
+      }
+    },
+    col_no_order: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "order",
+          behavior: ["-order -orderBy"]
+        }
+      }
+    },
+    col_no_filter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "filter",
+          behavior: ["-filter -filterBy"]
+        }
+      }
+    },
+    col_no_create_update: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create,update",
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    col_no_create_update_order_filter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create,update,order,filter",
+          behavior: ["-insert -update -order -orderBy -filter -filterBy"]
+        }
+      }
+    },
+    col_no_anything: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: true,
+          behavior: ["-*"]
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -495,8 +511,9 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const personCodec = recordCodec(spec_person);
 const original_functionFunctionIdentifer = sql.identifier("d", "original_function");
 const getflambleFunctionIdentifer = sql.identifier("d", "getflamble");
 const filmsUniques = [{
@@ -1366,6 +1383,9 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
+function CursorSerialize(value) {
+  return "" + value;
+}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -4527,6 +4547,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: CursorSerialize,
+    parseValue: CursorSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -4697,7 +4727,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.code.codec)}`;
             }
           });
         }
@@ -4720,7 +4750,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.title.codec)}`;
             }
           });
         }
@@ -4743,7 +4773,7 @@ export const plans = {
             type: "attribute",
             attribute: "show_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.show_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.show_id.codec)}`;
             }
           });
         }
@@ -4916,7 +4946,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.code.codec)}`;
             }
           });
         }
@@ -4939,7 +4969,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.title.codec)}`;
             }
           });
         }
@@ -4962,7 +4992,7 @@ export const plans = {
             type: "attribute",
             attribute: "studio_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.studio_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.studio_id.codec)}`;
             }
           });
         }
@@ -5296,7 +5326,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.id.codec)}`;
             }
           });
         }
@@ -5319,7 +5349,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.body.codec)}`;
             }
           });
         }
@@ -5342,7 +5372,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.author_id.codec)}`;
             }
           });
         }
@@ -5437,7 +5467,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), renamed_tableAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_renamed_table.attributes.col1.codec)}`;
             }
           });
         }
@@ -5592,7 +5622,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_films.attributes.code.codec)}`;
             }
           });
         }
@@ -5615,7 +5645,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_films.attributes.title.codec)}`;
             }
           });
         }
@@ -5770,7 +5800,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_studios.attributes.id.codec)}`;
             }
           });
         }
@@ -5793,7 +5823,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_studios.attributes.name.codec)}`;
             }
           });
         }
@@ -6118,7 +6148,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.id.codec)}`;
             }
           });
         }
@@ -6141,7 +6171,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.first_name.codec)}`;
             }
           });
         }
@@ -6164,7 +6194,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_name.codec)}`;
             }
           });
         }
@@ -6187,7 +6217,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_create.codec)}`;
             }
           });
         }
@@ -6210,7 +6240,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_update.codec)}`;
             }
           });
         }
@@ -6233,7 +6263,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_order",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_order.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_order.codec)}`;
             }
           });
         }
@@ -6256,7 +6286,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_create_update.codec)}`;
             }
           });
         }
@@ -6916,6 +6946,9 @@ export const plans = {
     }
   },
   RenamedTableInput: {
+    "__inputPlan": function RenamedTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     colA: {
       applyPlan($insert, val) {
         $insert.set("col1", val.get());
@@ -6983,6 +7016,9 @@ export const plans = {
     }
   },
   FilmInput: {
+    "__inputPlan": function FilmInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7057,6 +7093,9 @@ export const plans = {
     }
   },
   StudioInput: {
+    "__inputPlan": function StudioInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7136,6 +7175,9 @@ export const plans = {
     }
   },
   PostInput: {
+    "__inputPlan": function PostInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7222,6 +7264,9 @@ export const plans = {
     }
   },
   TvEpisodeInput: {
+    "__inputPlan": function TvEpisodeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7308,6 +7353,9 @@ export const plans = {
     }
   },
   TvShowInput: {
+    "__inputPlan": function TvShowInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7389,6 +7437,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7490,6 +7541,9 @@ export const plans = {
     }
   },
   FilmPatch: {
+    "__inputPlan": function FilmPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7577,6 +7631,9 @@ export const plans = {
     }
   },
   StudioPatch: {
+    "__inputPlan": function StudioPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7669,6 +7726,9 @@ export const plans = {
     }
   },
   PostPatch: {
+    "__inputPlan": function PostPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7768,6 +7828,9 @@ export const plans = {
     }
   },
   TvEpisodePatch: {
+    "__inputPlan": function TvEpisodePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7867,6 +7930,9 @@ export const plans = {
     }
   },
   TvShowPatch: {
+    "__inputPlan": function TvShowPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7961,6 +8027,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, makeRegistry, pgClassExpression, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectSingleFromRecord, pgUpdateSingle, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
+import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -84,25 +101,24 @@ const flambleCodec = recordCodec({
       name: "flamble"
     })
   },
-  executor
+  executor: executor
 });
-const renamed_tableAttributes = Object.assign(Object.create(null), {
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "colA"
-      }
-    }
-  }
-});
-const renamed_tableCodec = recordCodec({
+const spec_renamed_table = {
   name: "renamed_table",
   identifier: sql.identifier("d", "original_table"),
-  attributes: renamed_tableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "colA"
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -115,32 +131,32 @@ const renamed_tableCodec = recordCodec({
       name: "renamed_table"
     })
   },
-  executor
-});
-const filmsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const filmsCodec = recordCodec({
+  executor: executor
+};
+const renamed_tableCodec = recordCodec(spec_renamed_table);
+const spec_films = {
   name: "films",
   identifier: sql.identifier("d", "films"),
-  attributes: filmsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -151,32 +167,32 @@ const filmsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const studiosAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const studiosCodec = recordCodec({
+  executor: executor
+};
+const filmsCodec = recordCodec(spec_films);
+const spec_studios = {
   name: "studios",
   identifier: sql.identifier("d", "studios"),
-  attributes: studiosAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -187,41 +203,41 @@ const studiosCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const postAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  body: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const postCodec = recordCodec({
+  executor: executor
+};
+const studiosCodec = recordCodec(spec_studios);
+const spec_post = {
   name: "post",
   identifier: sql.identifier("d", "post"),
-  attributes: postAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    body: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -232,41 +248,41 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const tvEpisodesAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  show_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const tvEpisodesCodec = recordCodec({
+  executor: executor
+};
+const postCodec = recordCodec(spec_post);
+const spec_tvEpisodes = {
   name: "tvEpisodes",
   identifier: sql.identifier("d", "tv_episodes"),
-  attributes: tvEpisodesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    show_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -277,44 +293,44 @@ const tvEpisodesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const tvShowsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        omit: "create",
-        behavior: ["-insert"]
-      }
-    }
-  },
-  studio_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const tvShowsCodec = recordCodec({
+  executor: executor
+};
+const tvEpisodesCodec = recordCodec(spec_tvEpisodes);
+const spec_tvShows = {
   name: "tvShows",
   identifier: sql.identifier("d", "tv_shows"),
-  attributes: tvShowsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          omit: "create",
+          behavior: ["-insert"]
+        }
+      }
+    },
+    studio_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -325,8 +341,9 @@ const tvShowsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const tvShowsCodec = recordCodec(spec_tvShows);
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
   identifier: sql.identifier("d", "jwt_token"),
@@ -369,125 +386,124 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const personAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  first_name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col_no_create: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create",
-        behavior: ["-insert"]
-      }
-    }
-  },
-  col_no_update: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "update",
-        behavior: ["-update"]
-      }
-    }
-  },
-  col_no_order: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "order",
-        behavior: ["-order -orderBy"]
-      }
-    }
-  },
-  col_no_filter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "filter",
-        behavior: ["-filter -filterBy"]
-      }
-    }
-  },
-  col_no_create_update: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create,update",
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  col_no_create_update_order_filter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create,update,order,filter",
-        behavior: ["-insert -update -order -orderBy -filter -filterBy"]
-      }
-    }
-  },
-  col_no_anything: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: true,
-        behavior: ["-*"]
-      }
-    }
-  }
-});
-const personCodec = recordCodec({
+const spec_person = {
   name: "person",
   identifier: sql.identifier("d", "person"),
-  attributes: personAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    first_name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col_no_create: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create",
+          behavior: ["-insert"]
+        }
+      }
+    },
+    col_no_update: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "update",
+          behavior: ["-update"]
+        }
+      }
+    },
+    col_no_order: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "order",
+          behavior: ["-order -orderBy"]
+        }
+      }
+    },
+    col_no_filter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "filter",
+          behavior: ["-filter -filterBy"]
+        }
+      }
+    },
+    col_no_create_update: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create,update",
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    col_no_create_update_order_filter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create,update,order,filter",
+          behavior: ["-insert -update -order -orderBy -filter -filterBy"]
+        }
+      }
+    },
+    col_no_anything: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: true,
+          behavior: ["-*"]
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -498,8 +514,9 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const personCodec = recordCodec(spec_person);
 const original_functionFunctionIdentifer = sql.identifier("d", "original_function");
 const getflambleFunctionIdentifer = sql.identifier("d", "getflamble");
 const filmsUniques = [{
@@ -1369,6 +1386,9 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
+function CursorSerialize(value) {
+  return "" + value;
+}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -4529,6 +4549,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: CursorSerialize,
+    parseValue: CursorSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -4699,7 +4729,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.code.codec)}`;
             }
           });
         }
@@ -4722,7 +4752,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.title.codec)}`;
             }
           });
         }
@@ -4745,7 +4775,7 @@ export const plans = {
             type: "attribute",
             attribute: "show_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.show_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.show_id.codec)}`;
             }
           });
         }
@@ -4918,7 +4948,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.code.codec)}`;
             }
           });
         }
@@ -4941,7 +4971,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.title.codec)}`;
             }
           });
         }
@@ -4964,7 +4994,7 @@ export const plans = {
             type: "attribute",
             attribute: "studio_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.studio_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.studio_id.codec)}`;
             }
           });
         }
@@ -5298,7 +5328,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.id.codec)}`;
             }
           });
         }
@@ -5321,7 +5351,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.body.codec)}`;
             }
           });
         }
@@ -5344,7 +5374,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.author_id.codec)}`;
             }
           });
         }
@@ -5439,7 +5469,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), renamed_tableAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_renamed_table.attributes.col1.codec)}`;
             }
           });
         }
@@ -5594,7 +5624,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_films.attributes.code.codec)}`;
             }
           });
         }
@@ -5617,7 +5647,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_films.attributes.title.codec)}`;
             }
           });
         }
@@ -5772,7 +5802,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_studios.attributes.id.codec)}`;
             }
           });
         }
@@ -5795,7 +5825,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_studios.attributes.name.codec)}`;
             }
           });
         }
@@ -6120,7 +6150,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.id.codec)}`;
             }
           });
         }
@@ -6143,7 +6173,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.first_name.codec)}`;
             }
           });
         }
@@ -6166,7 +6196,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_name.codec)}`;
             }
           });
         }
@@ -6189,7 +6219,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_create.codec)}`;
             }
           });
         }
@@ -6212,7 +6242,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_update.codec)}`;
             }
           });
         }
@@ -6235,7 +6265,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_order",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_order.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_order.codec)}`;
             }
           });
         }
@@ -6258,7 +6288,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_create_update.codec)}`;
             }
           });
         }
@@ -6918,6 +6948,9 @@ export const plans = {
     }
   },
   RenamedTableInput: {
+    "__inputPlan": function RenamedTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     colA: {
       applyPlan($insert, val) {
         $insert.set("col1", val.get());
@@ -6985,6 +7018,9 @@ export const plans = {
     }
   },
   FilmInput: {
+    "__inputPlan": function FilmInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7059,6 +7095,9 @@ export const plans = {
     }
   },
   StudioInput: {
+    "__inputPlan": function StudioInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7138,6 +7177,9 @@ export const plans = {
     }
   },
   PostInput: {
+    "__inputPlan": function PostInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7224,6 +7266,9 @@ export const plans = {
     }
   },
   TvEpisodeInput: {
+    "__inputPlan": function TvEpisodeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7310,6 +7355,9 @@ export const plans = {
     }
   },
   TvShowInput: {
+    "__inputPlan": function TvShowInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7384,6 +7432,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7485,6 +7536,9 @@ export const plans = {
     }
   },
   FilmPatch: {
+    "__inputPlan": function FilmPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7572,6 +7626,9 @@ export const plans = {
     }
   },
   StudioPatch: {
+    "__inputPlan": function StudioPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7664,6 +7721,9 @@ export const plans = {
     }
   },
   PostPatch: {
+    "__inputPlan": function PostPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7763,6 +7823,9 @@ export const plans = {
     }
   },
   TvEpisodePatch: {
+    "__inputPlan": function TvEpisodePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7862,6 +7925,9 @@ export const plans = {
     }
   },
   TvShowPatch: {
+    "__inputPlan": function TvShowPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7956,6 +8022,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.execute.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.execute.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, makeRegistry, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgUpdateSingle, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId } from "grafast";
+import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -84,25 +101,24 @@ const flambleCodec = recordCodec({
       name: "flamble"
     })
   },
-  executor
+  executor: executor
 });
-const renamed_tableAttributes = Object.assign(Object.create(null), {
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "colA"
-      }
-    }
-  }
-});
-const renamed_tableCodec = recordCodec({
+const spec_renamed_table = {
   name: "renamed_table",
   identifier: sql.identifier("d", "original_table"),
-  attributes: renamed_tableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "colA"
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -115,32 +131,32 @@ const renamed_tableCodec = recordCodec({
       name: "renamed_table"
     })
   },
-  executor
-});
-const filmsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const filmsCodec = recordCodec({
+  executor: executor
+};
+const renamed_tableCodec = recordCodec(spec_renamed_table);
+const spec_films = {
   name: "films",
   identifier: sql.identifier("d", "films"),
-  attributes: filmsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -151,32 +167,32 @@ const filmsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const studiosAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const studiosCodec = recordCodec({
+  executor: executor
+};
+const filmsCodec = recordCodec(spec_films);
+const spec_studios = {
   name: "studios",
   identifier: sql.identifier("d", "studios"),
-  attributes: studiosAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -187,41 +203,41 @@ const studiosCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const postAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  body: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const postCodec = recordCodec({
+  executor: executor
+};
+const studiosCodec = recordCodec(spec_studios);
+const spec_post = {
   name: "post",
   identifier: sql.identifier("d", "post"),
-  attributes: postAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    body: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -232,41 +248,41 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const tvEpisodesAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  show_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const tvEpisodesCodec = recordCodec({
+  executor: executor
+};
+const postCodec = recordCodec(spec_post);
+const spec_tvEpisodes = {
   name: "tvEpisodes",
   identifier: sql.identifier("d", "tv_episodes"),
-  attributes: tvEpisodesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    show_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -277,41 +293,41 @@ const tvEpisodesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const tvShowsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  studio_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const tvShowsCodec = recordCodec({
+  executor: executor
+};
+const tvEpisodesCodec = recordCodec(spec_tvEpisodes);
+const spec_tvShows = {
   name: "tvShows",
   identifier: sql.identifier("d", "tv_shows"),
-  attributes: tvShowsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    studio_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -322,8 +338,9 @@ const tvShowsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const tvShowsCodec = recordCodec(spec_tvShows);
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
   identifier: sql.identifier("d", "jwt_token"),
@@ -366,125 +383,124 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const personAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  first_name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col_no_create: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create",
-        behavior: ["-insert"]
-      }
-    }
-  },
-  col_no_update: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "update",
-        behavior: ["-update"]
-      }
-    }
-  },
-  col_no_order: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "order",
-        behavior: ["-order -orderBy"]
-      }
-    }
-  },
-  col_no_filter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "filter",
-        behavior: ["-filter -filterBy"]
-      }
-    }
-  },
-  col_no_create_update: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create,update",
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  col_no_create_update_order_filter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create,update,order,filter",
-        behavior: ["-insert -update -order -orderBy -filter -filterBy"]
-      }
-    }
-  },
-  col_no_anything: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: true,
-        behavior: ["-*"]
-      }
-    }
-  }
-});
-const personCodec = recordCodec({
+const spec_person = {
   name: "person",
   identifier: sql.identifier("d", "person"),
-  attributes: personAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    first_name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col_no_create: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create",
+          behavior: ["-insert"]
+        }
+      }
+    },
+    col_no_update: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "update",
+          behavior: ["-update"]
+        }
+      }
+    },
+    col_no_order: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "order",
+          behavior: ["-order -orderBy"]
+        }
+      }
+    },
+    col_no_filter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "filter",
+          behavior: ["-filter -filterBy"]
+        }
+      }
+    },
+    col_no_create_update: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create,update",
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    col_no_create_update_order_filter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create,update,order,filter",
+          behavior: ["-insert -update -order -orderBy -filter -filterBy"]
+        }
+      }
+    },
+    col_no_anything: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: true,
+          behavior: ["-*"]
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -495,8 +511,9 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const personCodec = recordCodec(spec_person);
 const original_functionFunctionIdentifer = sql.identifier("d", "original_function");
 const getflambleFunctionIdentifer = sql.identifier("d", "getflamble");
 const filmsUniques = [{
@@ -1302,6 +1319,9 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
+function CursorSerialize(value) {
+  return "" + value;
+}
 const argDetailsSimple3 = [];
 const makeArgs3 = (args, path = []) => {
   const selectArgs = [];
@@ -4404,6 +4424,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: CursorSerialize,
+    parseValue: CursorSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -4574,7 +4604,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.code.codec)}`;
             }
           });
         }
@@ -4597,7 +4627,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.title.codec)}`;
             }
           });
         }
@@ -4620,7 +4650,7 @@ export const plans = {
             type: "attribute",
             attribute: "show_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.show_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.show_id.codec)}`;
             }
           });
         }
@@ -4793,7 +4823,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.code.codec)}`;
             }
           });
         }
@@ -4816,7 +4846,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.title.codec)}`;
             }
           });
         }
@@ -4839,7 +4869,7 @@ export const plans = {
             type: "attribute",
             attribute: "studio_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.studio_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.studio_id.codec)}`;
             }
           });
         }
@@ -5139,7 +5169,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.id.codec)}`;
             }
           });
         }
@@ -5162,7 +5192,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.body.codec)}`;
             }
           });
         }
@@ -5185,7 +5215,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.author_id.codec)}`;
             }
           });
         }
@@ -5280,7 +5310,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), renamed_tableAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_renamed_table.attributes.col1.codec)}`;
             }
           });
         }
@@ -5435,7 +5465,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_films.attributes.code.codec)}`;
             }
           });
         }
@@ -5458,7 +5488,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_films.attributes.title.codec)}`;
             }
           });
         }
@@ -5613,7 +5643,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_studios.attributes.id.codec)}`;
             }
           });
         }
@@ -5636,7 +5666,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_studios.attributes.name.codec)}`;
             }
           });
         }
@@ -5961,7 +5991,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.id.codec)}`;
             }
           });
         }
@@ -5984,7 +6014,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.first_name.codec)}`;
             }
           });
         }
@@ -6007,7 +6037,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_name.codec)}`;
             }
           });
         }
@@ -6030,7 +6060,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_create.codec)}`;
             }
           });
         }
@@ -6053,7 +6083,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_update.codec)}`;
             }
           });
         }
@@ -6076,7 +6106,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_order",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_order.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_order.codec)}`;
             }
           });
         }
@@ -6099,7 +6129,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_create_update.codec)}`;
             }
           });
         }
@@ -6759,6 +6789,9 @@ export const plans = {
     }
   },
   RenamedTableInput: {
+    "__inputPlan": function RenamedTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     colA: {
       applyPlan($insert, val) {
         $insert.set("col1", val.get());
@@ -6826,6 +6859,9 @@ export const plans = {
     }
   },
   FilmInput: {
+    "__inputPlan": function FilmInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -6900,6 +6936,9 @@ export const plans = {
     }
   },
   StudioInput: {
+    "__inputPlan": function StudioInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -6979,6 +7018,9 @@ export const plans = {
     }
   },
   PostInput: {
+    "__inputPlan": function PostInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7065,6 +7107,9 @@ export const plans = {
     }
   },
   TvEpisodeInput: {
+    "__inputPlan": function TvEpisodeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7151,6 +7196,9 @@ export const plans = {
     }
   },
   TvShowInput: {
+    "__inputPlan": function TvShowInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7232,6 +7280,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7333,6 +7384,9 @@ export const plans = {
     }
   },
   FilmPatch: {
+    "__inputPlan": function FilmPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7420,6 +7474,9 @@ export const plans = {
     }
   },
   StudioPatch: {
+    "__inputPlan": function StudioPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7512,6 +7569,9 @@ export const plans = {
     }
   },
   PostPatch: {
+    "__inputPlan": function PostPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7611,6 +7671,9 @@ export const plans = {
     }
   },
   TvEpisodePatch: {
+    "__inputPlan": function TvEpisodePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7710,6 +7773,9 @@ export const plans = {
     }
   },
   TvShowPatch: {
+    "__inputPlan": function TvShowPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7804,6 +7870,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.loads-title.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.loads-title.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, makeRegistry, pgClassExpression, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectSingleFromRecord, pgUpdateSingle, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
+import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -84,25 +101,24 @@ const flambleCodec = recordCodec({
       name: "flamble"
     })
   },
-  executor
+  executor: executor
 });
-const renamed_tableAttributes = Object.assign(Object.create(null), {
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "colA"
-      }
-    }
-  }
-});
-const renamed_tableCodec = recordCodec({
+const spec_renamed_table = {
   name: "renamed_table",
   identifier: sql.identifier("d", "original_table"),
-  attributes: renamed_tableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "colA"
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -115,32 +131,32 @@ const renamed_tableCodec = recordCodec({
       name: "renamed_table"
     })
   },
-  executor
-});
-const filmsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const filmsCodec = recordCodec({
+  executor: executor
+};
+const renamed_tableCodec = recordCodec(spec_renamed_table);
+const spec_films = {
   name: "films",
   identifier: sql.identifier("d", "films"),
-  attributes: filmsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -151,32 +167,32 @@ const filmsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const studiosAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const studiosCodec = recordCodec({
+  executor: executor
+};
+const filmsCodec = recordCodec(spec_films);
+const spec_studios = {
   name: "studios",
   identifier: sql.identifier("d", "studios"),
-  attributes: studiosAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -187,41 +203,41 @@ const studiosCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const postAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  body: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const postCodec = recordCodec({
+  executor: executor
+};
+const studiosCodec = recordCodec(spec_studios);
+const spec_post = {
   name: "post",
   identifier: sql.identifier("d", "post"),
-  attributes: postAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    body: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -232,41 +248,41 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const tvEpisodesAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  show_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const tvEpisodesCodec = recordCodec({
+  executor: executor
+};
+const postCodec = recordCodec(spec_post);
+const spec_tvEpisodes = {
   name: "tvEpisodes",
   identifier: sql.identifier("d", "tv_episodes"),
-  attributes: tvEpisodesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    show_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -277,44 +293,44 @@ const tvEpisodesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const tvShowsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        omit: "read,create,update,delete,all,many",
-        behavior: ["-select -node -insert -update -delete -query:resource:list -query:resource:connection -singularRelation:resource:list -singularRelation:resource:connection -manyRelation:resource:list -manyRelation:resource:connection"]
-      }
-    }
-  },
-  studio_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const tvShowsCodec = recordCodec({
+  executor: executor
+};
+const tvEpisodesCodec = recordCodec(spec_tvEpisodes);
+const spec_tvShows = {
   name: "tvShows",
   identifier: sql.identifier("d", "tv_shows"),
-  attributes: tvShowsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          omit: "read,create,update,delete,all,many",
+          behavior: ["-select -node -insert -update -delete -query:resource:list -query:resource:connection -singularRelation:resource:list -singularRelation:resource:connection -manyRelation:resource:list -manyRelation:resource:connection"]
+        }
+      }
+    },
+    studio_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -325,8 +341,9 @@ const tvShowsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const tvShowsCodec = recordCodec(spec_tvShows);
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
   identifier: sql.identifier("d", "jwt_token"),
@@ -369,125 +386,124 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const personAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  first_name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col_no_create: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create",
-        behavior: ["-insert"]
-      }
-    }
-  },
-  col_no_update: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "update",
-        behavior: ["-update"]
-      }
-    }
-  },
-  col_no_order: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "order",
-        behavior: ["-order -orderBy"]
-      }
-    }
-  },
-  col_no_filter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "filter",
-        behavior: ["-filter -filterBy"]
-      }
-    }
-  },
-  col_no_create_update: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create,update",
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  col_no_create_update_order_filter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create,update,order,filter",
-        behavior: ["-insert -update -order -orderBy -filter -filterBy"]
-      }
-    }
-  },
-  col_no_anything: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: true,
-        behavior: ["-*"]
-      }
-    }
-  }
-});
-const personCodec = recordCodec({
+const spec_person = {
   name: "person",
   identifier: sql.identifier("d", "person"),
-  attributes: personAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    first_name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col_no_create: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create",
+          behavior: ["-insert"]
+        }
+      }
+    },
+    col_no_update: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "update",
+          behavior: ["-update"]
+        }
+      }
+    },
+    col_no_order: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "order",
+          behavior: ["-order -orderBy"]
+        }
+      }
+    },
+    col_no_filter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "filter",
+          behavior: ["-filter -filterBy"]
+        }
+      }
+    },
+    col_no_create_update: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create,update",
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    col_no_create_update_order_filter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create,update,order,filter",
+          behavior: ["-insert -update -order -orderBy -filter -filterBy"]
+        }
+      }
+    },
+    col_no_anything: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: true,
+          behavior: ["-*"]
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -498,8 +514,9 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const personCodec = recordCodec(spec_person);
 const original_functionFunctionIdentifer = sql.identifier("d", "original_function");
 const getflambleFunctionIdentifer = sql.identifier("d", "getflamble");
 const filmsUniques = [{
@@ -1369,6 +1386,9 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
+function CursorSerialize(value) {
+  return "" + value;
+}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -4524,6 +4544,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: CursorSerialize,
+    parseValue: CursorSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -4694,7 +4724,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.code.codec)}`;
             }
           });
         }
@@ -4717,7 +4747,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.title.codec)}`;
             }
           });
         }
@@ -4740,7 +4770,7 @@ export const plans = {
             type: "attribute",
             attribute: "show_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.show_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.show_id.codec)}`;
             }
           });
         }
@@ -4913,7 +4943,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.code.codec)}`;
             }
           });
         }
@@ -4936,7 +4966,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.title.codec)}`;
             }
           });
         }
@@ -4959,7 +4989,7 @@ export const plans = {
             type: "attribute",
             attribute: "studio_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.studio_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.studio_id.codec)}`;
             }
           });
         }
@@ -5293,7 +5323,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.id.codec)}`;
             }
           });
         }
@@ -5316,7 +5346,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.body.codec)}`;
             }
           });
         }
@@ -5339,7 +5369,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.author_id.codec)}`;
             }
           });
         }
@@ -5434,7 +5464,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), renamed_tableAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_renamed_table.attributes.col1.codec)}`;
             }
           });
         }
@@ -5589,7 +5619,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_films.attributes.code.codec)}`;
             }
           });
         }
@@ -5612,7 +5642,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_films.attributes.title.codec)}`;
             }
           });
         }
@@ -5767,7 +5797,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_studios.attributes.id.codec)}`;
             }
           });
         }
@@ -5790,7 +5820,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_studios.attributes.name.codec)}`;
             }
           });
         }
@@ -6115,7 +6145,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.id.codec)}`;
             }
           });
         }
@@ -6138,7 +6168,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.first_name.codec)}`;
             }
           });
         }
@@ -6161,7 +6191,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_name.codec)}`;
             }
           });
         }
@@ -6184,7 +6214,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_create.codec)}`;
             }
           });
         }
@@ -6207,7 +6237,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_update.codec)}`;
             }
           });
         }
@@ -6230,7 +6260,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_order",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_order.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_order.codec)}`;
             }
           });
         }
@@ -6253,7 +6283,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_create_update.codec)}`;
             }
           });
         }
@@ -6913,6 +6943,9 @@ export const plans = {
     }
   },
   RenamedTableInput: {
+    "__inputPlan": function RenamedTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     colA: {
       applyPlan($insert, val) {
         $insert.set("col1", val.get());
@@ -6980,6 +7013,9 @@ export const plans = {
     }
   },
   FilmInput: {
+    "__inputPlan": function FilmInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7054,6 +7090,9 @@ export const plans = {
     }
   },
   StudioInput: {
+    "__inputPlan": function StudioInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7133,6 +7172,9 @@ export const plans = {
     }
   },
   PostInput: {
+    "__inputPlan": function PostInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7219,6 +7261,9 @@ export const plans = {
     }
   },
   TvEpisodeInput: {
+    "__inputPlan": function TvEpisodeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7305,6 +7350,9 @@ export const plans = {
     }
   },
   TvShowInput: {
+    "__inputPlan": function TvShowInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7379,6 +7427,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7480,6 +7531,9 @@ export const plans = {
     }
   },
   FilmPatch: {
+    "__inputPlan": function FilmPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7567,6 +7621,9 @@ export const plans = {
     }
   },
   StudioPatch: {
+    "__inputPlan": function StudioPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7659,6 +7716,9 @@ export const plans = {
     }
   },
   PostPatch: {
+    "__inputPlan": function PostPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7758,6 +7818,9 @@ export const plans = {
     }
   },
   TvEpisodePatch: {
+    "__inputPlan": function TvEpisodePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7857,6 +7920,9 @@ export const plans = {
     }
   },
   TvShowPatch: {
+    "__inputPlan": function TvShowPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7944,6 +8010,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.shows-title-asterisk.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.shows-title-asterisk.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, makeRegistry, pgClassExpression, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectSingleFromRecord, pgUpdateSingle, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
+import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -84,25 +101,24 @@ const flambleCodec = recordCodec({
       name: "flamble"
     })
   },
-  executor
+  executor: executor
 });
-const renamed_tableAttributes = Object.assign(Object.create(null), {
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "colA"
-      }
-    }
-  }
-});
-const renamed_tableCodec = recordCodec({
+const spec_renamed_table = {
   name: "renamed_table",
   identifier: sql.identifier("d", "original_table"),
-  attributes: renamed_tableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "colA"
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -115,32 +131,32 @@ const renamed_tableCodec = recordCodec({
       name: "renamed_table"
     })
   },
-  executor
-});
-const filmsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const filmsCodec = recordCodec({
+  executor: executor
+};
+const renamed_tableCodec = recordCodec(spec_renamed_table);
+const spec_films = {
   name: "films",
   identifier: sql.identifier("d", "films"),
-  attributes: filmsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -151,32 +167,32 @@ const filmsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const studiosAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const studiosCodec = recordCodec({
+  executor: executor
+};
+const filmsCodec = recordCodec(spec_films);
+const spec_studios = {
   name: "studios",
   identifier: sql.identifier("d", "studios"),
-  attributes: studiosAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -187,41 +203,41 @@ const studiosCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const postAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  body: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const postCodec = recordCodec({
+  executor: executor
+};
+const studiosCodec = recordCodec(spec_studios);
+const spec_post = {
   name: "post",
   identifier: sql.identifier("d", "post"),
-  attributes: postAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    body: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -232,44 +248,44 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const tvEpisodesAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        omit: true,
-        behavior: ["-*"]
-      }
-    }
-  },
-  show_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const tvEpisodesCodec = recordCodec({
+  executor: executor
+};
+const postCodec = recordCodec(spec_post);
+const spec_tvEpisodes = {
   name: "tvEpisodes",
   identifier: sql.identifier("d", "tv_episodes"),
-  attributes: tvEpisodesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          omit: true,
+          behavior: ["-*"]
+        }
+      }
+    },
+    show_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -280,44 +296,44 @@ const tvEpisodesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const tvShowsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        omit: "*",
-        behavior: ["-*"]
-      }
-    }
-  },
-  studio_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const tvShowsCodec = recordCodec({
+  executor: executor
+};
+const tvEpisodesCodec = recordCodec(spec_tvEpisodes);
+const spec_tvShows = {
   name: "tvShows",
   identifier: sql.identifier("d", "tv_shows"),
-  attributes: tvShowsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          omit: "*",
+          behavior: ["-*"]
+        }
+      }
+    },
+    studio_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -328,8 +344,9 @@ const tvShowsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const tvShowsCodec = recordCodec(spec_tvShows);
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
   identifier: sql.identifier("d", "jwt_token"),
@@ -372,125 +389,124 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const personAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  first_name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col_no_create: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create",
-        behavior: ["-insert"]
-      }
-    }
-  },
-  col_no_update: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "update",
-        behavior: ["-update"]
-      }
-    }
-  },
-  col_no_order: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "order",
-        behavior: ["-order -orderBy"]
-      }
-    }
-  },
-  col_no_filter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "filter",
-        behavior: ["-filter -filterBy"]
-      }
-    }
-  },
-  col_no_create_update: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create,update",
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  col_no_create_update_order_filter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create,update,order,filter",
-        behavior: ["-insert -update -order -orderBy -filter -filterBy"]
-      }
-    }
-  },
-  col_no_anything: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: true,
-        behavior: ["-*"]
-      }
-    }
-  }
-});
-const personCodec = recordCodec({
+const spec_person = {
   name: "person",
   identifier: sql.identifier("d", "person"),
-  attributes: personAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    first_name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col_no_create: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create",
+          behavior: ["-insert"]
+        }
+      }
+    },
+    col_no_update: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "update",
+          behavior: ["-update"]
+        }
+      }
+    },
+    col_no_order: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "order",
+          behavior: ["-order -orderBy"]
+        }
+      }
+    },
+    col_no_filter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "filter",
+          behavior: ["-filter -filterBy"]
+        }
+      }
+    },
+    col_no_create_update: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create,update",
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    col_no_create_update_order_filter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create,update,order,filter",
+          behavior: ["-insert -update -order -orderBy -filter -filterBy"]
+        }
+      }
+    },
+    col_no_anything: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: true,
+          behavior: ["-*"]
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -501,8 +517,9 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const personCodec = recordCodec(spec_person);
 const original_functionFunctionIdentifer = sql.identifier("d", "original_function");
 const getflambleFunctionIdentifer = sql.identifier("d", "getflamble");
 const filmsUniques = [{
@@ -1372,6 +1389,9 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
+function CursorSerialize(value) {
+  return "" + value;
+}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -4511,6 +4531,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: CursorSerialize,
+    parseValue: CursorSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -4647,7 +4677,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.code.codec)}`;
             }
           });
         }
@@ -4670,7 +4700,7 @@ export const plans = {
             type: "attribute",
             attribute: "show_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.show_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.show_id.codec)}`;
             }
           });
         }
@@ -4809,7 +4839,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.code.codec)}`;
             }
           });
         }
@@ -4832,7 +4862,7 @@ export const plans = {
             type: "attribute",
             attribute: "studio_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.studio_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.studio_id.codec)}`;
             }
           });
         }
@@ -5166,7 +5196,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.id.codec)}`;
             }
           });
         }
@@ -5189,7 +5219,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.body.codec)}`;
             }
           });
         }
@@ -5212,7 +5242,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.author_id.codec)}`;
             }
           });
         }
@@ -5307,7 +5337,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), renamed_tableAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_renamed_table.attributes.col1.codec)}`;
             }
           });
         }
@@ -5462,7 +5492,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_films.attributes.code.codec)}`;
             }
           });
         }
@@ -5485,7 +5515,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_films.attributes.title.codec)}`;
             }
           });
         }
@@ -5640,7 +5670,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_studios.attributes.id.codec)}`;
             }
           });
         }
@@ -5663,7 +5693,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_studios.attributes.name.codec)}`;
             }
           });
         }
@@ -5988,7 +6018,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.id.codec)}`;
             }
           });
         }
@@ -6011,7 +6041,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.first_name.codec)}`;
             }
           });
         }
@@ -6034,7 +6064,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_name.codec)}`;
             }
           });
         }
@@ -6057,7 +6087,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_create.codec)}`;
             }
           });
         }
@@ -6080,7 +6110,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_update.codec)}`;
             }
           });
         }
@@ -6103,7 +6133,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_order",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_order.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_order.codec)}`;
             }
           });
         }
@@ -6126,7 +6156,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_create_update.codec)}`;
             }
           });
         }
@@ -6786,6 +6816,9 @@ export const plans = {
     }
   },
   RenamedTableInput: {
+    "__inputPlan": function RenamedTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     colA: {
       applyPlan($insert, val) {
         $insert.set("col1", val.get());
@@ -6853,6 +6886,9 @@ export const plans = {
     }
   },
   FilmInput: {
+    "__inputPlan": function FilmInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -6927,6 +6963,9 @@ export const plans = {
     }
   },
   StudioInput: {
+    "__inputPlan": function StudioInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7006,6 +7045,9 @@ export const plans = {
     }
   },
   PostInput: {
+    "__inputPlan": function PostInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7092,6 +7134,9 @@ export const plans = {
     }
   },
   TvEpisodeInput: {
+    "__inputPlan": function TvEpisodeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7171,6 +7216,9 @@ export const plans = {
     }
   },
   TvShowInput: {
+    "__inputPlan": function TvShowInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7245,6 +7293,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7346,6 +7397,9 @@ export const plans = {
     }
   },
   FilmPatch: {
+    "__inputPlan": function FilmPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7433,6 +7487,9 @@ export const plans = {
     }
   },
   StudioPatch: {
+    "__inputPlan": function StudioPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7525,6 +7582,9 @@ export const plans = {
     }
   },
   PostPatch: {
+    "__inputPlan": function PostPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7624,6 +7684,9 @@ export const plans = {
     }
   },
   TvEpisodePatch: {
+    "__inputPlan": function TvEpisodePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7716,6 +7779,9 @@ export const plans = {
     }
   },
   TvShowPatch: {
+    "__inputPlan": function TvShowPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7803,6 +7869,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.title-order.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.title-order.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, makeRegistry, pgClassExpression, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectSingleFromRecord, pgUpdateSingle, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
+import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -84,25 +101,24 @@ const flambleCodec = recordCodec({
       name: "flamble"
     })
   },
-  executor
+  executor: executor
 });
-const renamed_tableAttributes = Object.assign(Object.create(null), {
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "colA"
-      }
-    }
-  }
-});
-const renamed_tableCodec = recordCodec({
+const spec_renamed_table = {
   name: "renamed_table",
   identifier: sql.identifier("d", "original_table"),
-  attributes: renamed_tableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "colA"
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -115,32 +131,32 @@ const renamed_tableCodec = recordCodec({
       name: "renamed_table"
     })
   },
-  executor
-});
-const filmsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const filmsCodec = recordCodec({
+  executor: executor
+};
+const renamed_tableCodec = recordCodec(spec_renamed_table);
+const spec_films = {
   name: "films",
   identifier: sql.identifier("d", "films"),
-  attributes: filmsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -151,32 +167,32 @@ const filmsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const studiosAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const studiosCodec = recordCodec({
+  executor: executor
+};
+const filmsCodec = recordCodec(spec_films);
+const spec_studios = {
   name: "studios",
   identifier: sql.identifier("d", "studios"),
-  attributes: studiosAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -187,41 +203,41 @@ const studiosCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const postAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  body: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const postCodec = recordCodec({
+  executor: executor
+};
+const studiosCodec = recordCodec(spec_studios);
+const spec_post = {
   name: "post",
   identifier: sql.identifier("d", "post"),
-  attributes: postAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    body: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -232,44 +248,44 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const tvEpisodesAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        omit: "order",
-        behavior: ["-order -orderBy"]
-      }
-    }
-  },
-  show_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const tvEpisodesCodec = recordCodec({
+  executor: executor
+};
+const postCodec = recordCodec(spec_post);
+const spec_tvEpisodes = {
   name: "tvEpisodes",
   identifier: sql.identifier("d", "tv_episodes"),
-  attributes: tvEpisodesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          omit: "order",
+          behavior: ["-order -orderBy"]
+        }
+      }
+    },
+    show_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -280,41 +296,41 @@ const tvEpisodesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const tvShowsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  studio_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const tvShowsCodec = recordCodec({
+  executor: executor
+};
+const tvEpisodesCodec = recordCodec(spec_tvEpisodes);
+const spec_tvShows = {
   name: "tvShows",
   identifier: sql.identifier("d", "tv_shows"),
-  attributes: tvShowsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    studio_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -325,8 +341,9 @@ const tvShowsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const tvShowsCodec = recordCodec(spec_tvShows);
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
   identifier: sql.identifier("d", "jwt_token"),
@@ -369,125 +386,124 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const personAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  first_name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col_no_create: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create",
-        behavior: ["-insert"]
-      }
-    }
-  },
-  col_no_update: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "update",
-        behavior: ["-update"]
-      }
-    }
-  },
-  col_no_order: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "order",
-        behavior: ["-order -orderBy"]
-      }
-    }
-  },
-  col_no_filter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "filter",
-        behavior: ["-filter -filterBy"]
-      }
-    }
-  },
-  col_no_create_update: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create,update",
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  col_no_create_update_order_filter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create,update,order,filter",
-        behavior: ["-insert -update -order -orderBy -filter -filterBy"]
-      }
-    }
-  },
-  col_no_anything: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: true,
-        behavior: ["-*"]
-      }
-    }
-  }
-});
-const personCodec = recordCodec({
+const spec_person = {
   name: "person",
   identifier: sql.identifier("d", "person"),
-  attributes: personAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    first_name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col_no_create: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create",
+          behavior: ["-insert"]
+        }
+      }
+    },
+    col_no_update: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "update",
+          behavior: ["-update"]
+        }
+      }
+    },
+    col_no_order: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "order",
+          behavior: ["-order -orderBy"]
+        }
+      }
+    },
+    col_no_filter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "filter",
+          behavior: ["-filter -filterBy"]
+        }
+      }
+    },
+    col_no_create_update: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create,update",
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    col_no_create_update_order_filter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create,update,order,filter",
+          behavior: ["-insert -update -order -orderBy -filter -filterBy"]
+        }
+      }
+    },
+    col_no_anything: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: true,
+          behavior: ["-*"]
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -498,8 +514,9 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const personCodec = recordCodec(spec_person);
 const original_functionFunctionIdentifer = sql.identifier("d", "original_function");
 const getflambleFunctionIdentifer = sql.identifier("d", "getflamble");
 const filmsUniques = [{
@@ -1369,6 +1386,9 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
+function CursorSerialize(value) {
+  return "" + value;
+}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -4528,6 +4548,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: CursorSerialize,
+    parseValue: CursorSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -4664,7 +4694,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.code.codec)}`;
             }
           });
         }
@@ -4687,7 +4717,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.title.codec)}`;
             }
           });
         }
@@ -4710,7 +4740,7 @@ export const plans = {
             type: "attribute",
             attribute: "show_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.show_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.show_id.codec)}`;
             }
           });
         }
@@ -4883,7 +4913,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.code.codec)}`;
             }
           });
         }
@@ -4906,7 +4936,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.title.codec)}`;
             }
           });
         }
@@ -4929,7 +4959,7 @@ export const plans = {
             type: "attribute",
             attribute: "studio_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.studio_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.studio_id.codec)}`;
             }
           });
         }
@@ -5263,7 +5293,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.id.codec)}`;
             }
           });
         }
@@ -5286,7 +5316,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.body.codec)}`;
             }
           });
         }
@@ -5309,7 +5339,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.author_id.codec)}`;
             }
           });
         }
@@ -5404,7 +5434,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), renamed_tableAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_renamed_table.attributes.col1.codec)}`;
             }
           });
         }
@@ -5559,7 +5589,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_films.attributes.code.codec)}`;
             }
           });
         }
@@ -5582,7 +5612,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_films.attributes.title.codec)}`;
             }
           });
         }
@@ -5737,7 +5767,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_studios.attributes.id.codec)}`;
             }
           });
         }
@@ -5760,7 +5790,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_studios.attributes.name.codec)}`;
             }
           });
         }
@@ -6085,7 +6115,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.id.codec)}`;
             }
           });
         }
@@ -6108,7 +6138,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.first_name.codec)}`;
             }
           });
         }
@@ -6131,7 +6161,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_name.codec)}`;
             }
           });
         }
@@ -6154,7 +6184,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_create.codec)}`;
             }
           });
         }
@@ -6177,7 +6207,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_update.codec)}`;
             }
           });
         }
@@ -6200,7 +6230,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_order",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_order.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_order.codec)}`;
             }
           });
         }
@@ -6223,7 +6253,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_create_update.codec)}`;
             }
           });
         }
@@ -6883,6 +6913,9 @@ export const plans = {
     }
   },
   RenamedTableInput: {
+    "__inputPlan": function RenamedTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     colA: {
       applyPlan($insert, val) {
         $insert.set("col1", val.get());
@@ -6950,6 +6983,9 @@ export const plans = {
     }
   },
   FilmInput: {
+    "__inputPlan": function FilmInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7024,6 +7060,9 @@ export const plans = {
     }
   },
   StudioInput: {
+    "__inputPlan": function StudioInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7103,6 +7142,9 @@ export const plans = {
     }
   },
   PostInput: {
+    "__inputPlan": function PostInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7189,6 +7231,9 @@ export const plans = {
     }
   },
   TvEpisodeInput: {
+    "__inputPlan": function TvEpisodeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7275,6 +7320,9 @@ export const plans = {
     }
   },
   TvShowInput: {
+    "__inputPlan": function TvShowInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7356,6 +7404,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7457,6 +7508,9 @@ export const plans = {
     }
   },
   FilmPatch: {
+    "__inputPlan": function FilmPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7544,6 +7598,9 @@ export const plans = {
     }
   },
   StudioPatch: {
+    "__inputPlan": function StudioPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7636,6 +7693,9 @@ export const plans = {
     }
   },
   PostPatch: {
+    "__inputPlan": function PostPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7735,6 +7795,9 @@ export const plans = {
     }
   },
   TvEpisodePatch: {
+    "__inputPlan": function TvEpisodePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7834,6 +7897,9 @@ export const plans = {
     }
   },
   TvShowPatch: {
+    "__inputPlan": function TvShowPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7928,6 +7994,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.update-title.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.update-title.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, makeRegistry, pgClassExpression, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectSingleFromRecord, pgUpdateSingle, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
+import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -84,25 +101,24 @@ const flambleCodec = recordCodec({
       name: "flamble"
     })
   },
-  executor
+  executor: executor
 });
-const renamed_tableAttributes = Object.assign(Object.create(null), {
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "colA"
-      }
-    }
-  }
-});
-const renamed_tableCodec = recordCodec({
+const spec_renamed_table = {
   name: "renamed_table",
   identifier: sql.identifier("d", "original_table"),
-  attributes: renamed_tableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "colA"
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -115,32 +131,32 @@ const renamed_tableCodec = recordCodec({
       name: "renamed_table"
     })
   },
-  executor
-});
-const filmsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const filmsCodec = recordCodec({
+  executor: executor
+};
+const renamed_tableCodec = recordCodec(spec_renamed_table);
+const spec_films = {
   name: "films",
   identifier: sql.identifier("d", "films"),
-  attributes: filmsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -151,32 +167,32 @@ const filmsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const studiosAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const studiosCodec = recordCodec({
+  executor: executor
+};
+const filmsCodec = recordCodec(spec_films);
+const spec_studios = {
   name: "studios",
   identifier: sql.identifier("d", "studios"),
-  attributes: studiosAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -187,41 +203,41 @@ const studiosCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const postAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  body: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const postCodec = recordCodec({
+  executor: executor
+};
+const studiosCodec = recordCodec(spec_studios);
+const spec_post = {
   name: "post",
   identifier: sql.identifier("d", "post"),
-  attributes: postAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    body: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -232,41 +248,41 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const tvEpisodesAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  show_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const tvEpisodesCodec = recordCodec({
+  executor: executor
+};
+const postCodec = recordCodec(spec_post);
+const spec_tvEpisodes = {
   name: "tvEpisodes",
   identifier: sql.identifier("d", "tv_episodes"),
-  attributes: tvEpisodesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    show_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -277,44 +293,44 @@ const tvEpisodesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const tvShowsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        omit: "update",
-        behavior: ["-update"]
-      }
-    }
-  },
-  studio_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const tvShowsCodec = recordCodec({
+  executor: executor
+};
+const tvEpisodesCodec = recordCodec(spec_tvEpisodes);
+const spec_tvShows = {
   name: "tvShows",
   identifier: sql.identifier("d", "tv_shows"),
-  attributes: tvShowsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          omit: "update",
+          behavior: ["-update"]
+        }
+      }
+    },
+    studio_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -325,8 +341,9 @@ const tvShowsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const tvShowsCodec = recordCodec(spec_tvShows);
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
   identifier: sql.identifier("d", "jwt_token"),
@@ -369,125 +386,124 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const personAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  first_name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col_no_create: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create",
-        behavior: ["-insert"]
-      }
-    }
-  },
-  col_no_update: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "update",
-        behavior: ["-update"]
-      }
-    }
-  },
-  col_no_order: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "order",
-        behavior: ["-order -orderBy"]
-      }
-    }
-  },
-  col_no_filter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "filter",
-        behavior: ["-filter -filterBy"]
-      }
-    }
-  },
-  col_no_create_update: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create,update",
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  col_no_create_update_order_filter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create,update,order,filter",
-        behavior: ["-insert -update -order -orderBy -filter -filterBy"]
-      }
-    }
-  },
-  col_no_anything: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: true,
-        behavior: ["-*"]
-      }
-    }
-  }
-});
-const personCodec = recordCodec({
+const spec_person = {
   name: "person",
   identifier: sql.identifier("d", "person"),
-  attributes: personAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    first_name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col_no_create: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create",
+          behavior: ["-insert"]
+        }
+      }
+    },
+    col_no_update: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "update",
+          behavior: ["-update"]
+        }
+      }
+    },
+    col_no_order: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "order",
+          behavior: ["-order -orderBy"]
+        }
+      }
+    },
+    col_no_filter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "filter",
+          behavior: ["-filter -filterBy"]
+        }
+      }
+    },
+    col_no_create_update: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create,update",
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    col_no_create_update_order_filter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create,update,order,filter",
+          behavior: ["-insert -update -order -orderBy -filter -filterBy"]
+        }
+      }
+    },
+    col_no_anything: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: true,
+          behavior: ["-*"]
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -498,8 +514,9 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const personCodec = recordCodec(spec_person);
 const original_functionFunctionIdentifer = sql.identifier("d", "original_function");
 const getflambleFunctionIdentifer = sql.identifier("d", "getflamble");
 const filmsUniques = [{
@@ -1369,6 +1386,9 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
+function CursorSerialize(value) {
+  return "" + value;
+}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -4529,6 +4549,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: CursorSerialize,
+    parseValue: CursorSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -4699,7 +4729,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.code.codec)}`;
             }
           });
         }
@@ -4722,7 +4752,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.title.codec)}`;
             }
           });
         }
@@ -4745,7 +4775,7 @@ export const plans = {
             type: "attribute",
             attribute: "show_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.show_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.show_id.codec)}`;
             }
           });
         }
@@ -4918,7 +4948,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.code.codec)}`;
             }
           });
         }
@@ -4941,7 +4971,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.title.codec)}`;
             }
           });
         }
@@ -4964,7 +4994,7 @@ export const plans = {
             type: "attribute",
             attribute: "studio_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.studio_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.studio_id.codec)}`;
             }
           });
         }
@@ -5298,7 +5328,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.id.codec)}`;
             }
           });
         }
@@ -5321,7 +5351,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.body.codec)}`;
             }
           });
         }
@@ -5344,7 +5374,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.author_id.codec)}`;
             }
           });
         }
@@ -5439,7 +5469,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), renamed_tableAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_renamed_table.attributes.col1.codec)}`;
             }
           });
         }
@@ -5594,7 +5624,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_films.attributes.code.codec)}`;
             }
           });
         }
@@ -5617,7 +5647,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_films.attributes.title.codec)}`;
             }
           });
         }
@@ -5772,7 +5802,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_studios.attributes.id.codec)}`;
             }
           });
         }
@@ -5795,7 +5825,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_studios.attributes.name.codec)}`;
             }
           });
         }
@@ -6120,7 +6150,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.id.codec)}`;
             }
           });
         }
@@ -6143,7 +6173,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.first_name.codec)}`;
             }
           });
         }
@@ -6166,7 +6196,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_name.codec)}`;
             }
           });
         }
@@ -6189,7 +6219,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_create.codec)}`;
             }
           });
         }
@@ -6212,7 +6242,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_update.codec)}`;
             }
           });
         }
@@ -6235,7 +6265,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_order",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_order.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_order.codec)}`;
             }
           });
         }
@@ -6258,7 +6288,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_create_update.codec)}`;
             }
           });
         }
@@ -6918,6 +6948,9 @@ export const plans = {
     }
   },
   RenamedTableInput: {
+    "__inputPlan": function RenamedTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     colA: {
       applyPlan($insert, val) {
         $insert.set("col1", val.get());
@@ -6985,6 +7018,9 @@ export const plans = {
     }
   },
   FilmInput: {
+    "__inputPlan": function FilmInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7059,6 +7095,9 @@ export const plans = {
     }
   },
   StudioInput: {
+    "__inputPlan": function StudioInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7138,6 +7177,9 @@ export const plans = {
     }
   },
   PostInput: {
+    "__inputPlan": function PostInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7224,6 +7266,9 @@ export const plans = {
     }
   },
   TvEpisodeInput: {
+    "__inputPlan": function TvEpisodeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7310,6 +7355,9 @@ export const plans = {
     }
   },
   TvShowInput: {
+    "__inputPlan": function TvShowInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7391,6 +7439,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7492,6 +7543,9 @@ export const plans = {
     }
   },
   FilmPatch: {
+    "__inputPlan": function FilmPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7579,6 +7633,9 @@ export const plans = {
     }
   },
   StudioPatch: {
+    "__inputPlan": function StudioPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7671,6 +7728,9 @@ export const plans = {
     }
   },
   PostPatch: {
+    "__inputPlan": function PostPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7770,6 +7830,9 @@ export const plans = {
     }
   },
   TvEpisodePatch: {
+    "__inputPlan": function TvEpisodePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7869,6 +7932,9 @@ export const plans = {
     }
   },
   TvShowPatch: {
+    "__inputPlan": function TvShowPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7956,6 +8022,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, makeRegistry, pgClassExpression, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectSingleFromRecord, pgUpdateSingle, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
+import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -84,25 +101,24 @@ const flambleCodec = recordCodec({
       name: "flamble"
     })
   },
-  executor
+  executor: executor
 });
-const renamed_tableAttributes = Object.assign(Object.create(null), {
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "colA"
-      }
-    }
-  }
-});
-const renamed_tableCodec = recordCodec({
+const spec_renamed_table = {
   name: "renamed_table",
   identifier: sql.identifier("d", "original_table"),
-  attributes: renamed_tableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "colA"
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -115,72 +131,71 @@ const renamed_tableCodec = recordCodec({
       name: "renamed_table"
     })
   },
-  executor
-});
-const filmsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "films"
-  },
-  tags: Object.assign(Object.create(null), {
-    omit: "create,update,delete",
-    behavior: ["-insert -update -delete"]
-  })
+  executor: executor
 };
-const filmsCodec = recordCodec({
+const renamed_tableCodec = recordCodec(spec_renamed_table);
+const spec_films = {
   name: "films",
   identifier: sql.identifier("d", "films"),
-  attributes: filmsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions3,
-  executor
-});
-const studiosAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "films"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: "create,update,delete",
+      behavior: ["-insert -update -delete"]
+    })
   },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const studiosCodec = recordCodec({
+  executor: executor
+};
+const filmsCodec = recordCodec(spec_films);
+const spec_studios = {
   name: "studios",
   identifier: sql.identifier("d", "studios"),
-  attributes: studiosAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -191,41 +206,41 @@ const studiosCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const postAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  body: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const postCodec = recordCodec({
+  executor: executor
+};
+const studiosCodec = recordCodec(spec_studios);
+const spec_post = {
   name: "post",
   identifier: sql.identifier("d", "post"),
-  attributes: postAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    body: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -236,41 +251,41 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const tvEpisodesAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  show_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const tvEpisodesCodec = recordCodec({
+  executor: executor
+};
+const postCodec = recordCodec(spec_post);
+const spec_tvEpisodes = {
   name: "tvEpisodes",
   identifier: sql.identifier("d", "tv_episodes"),
-  attributes: tvEpisodesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    show_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -281,41 +296,41 @@ const tvEpisodesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const tvShowsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  studio_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const tvShowsCodec = recordCodec({
+  executor: executor
+};
+const tvEpisodesCodec = recordCodec(spec_tvEpisodes);
+const spec_tvShows = {
   name: "tvShows",
   identifier: sql.identifier("d", "tv_shows"),
-  attributes: tvShowsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    studio_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -326,8 +341,9 @@ const tvShowsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const tvShowsCodec = recordCodec(spec_tvShows);
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
   identifier: sql.identifier("d", "jwt_token"),
@@ -370,125 +386,124 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const personAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  first_name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col_no_create: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create",
-        behavior: ["-insert"]
-      }
-    }
-  },
-  col_no_update: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "update",
-        behavior: ["-update"]
-      }
-    }
-  },
-  col_no_order: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "order",
-        behavior: ["-order -orderBy"]
-      }
-    }
-  },
-  col_no_filter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "filter",
-        behavior: ["-filter -filterBy"]
-      }
-    }
-  },
-  col_no_create_update: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create,update",
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  col_no_create_update_order_filter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create,update,order,filter",
-        behavior: ["-insert -update -order -orderBy -filter -filterBy"]
-      }
-    }
-  },
-  col_no_anything: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: true,
-        behavior: ["-*"]
-      }
-    }
-  }
-});
-const personCodec = recordCodec({
+const spec_person = {
   name: "person",
   identifier: sql.identifier("d", "person"),
-  attributes: personAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    first_name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col_no_create: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create",
+          behavior: ["-insert"]
+        }
+      }
+    },
+    col_no_update: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "update",
+          behavior: ["-update"]
+        }
+      }
+    },
+    col_no_order: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "order",
+          behavior: ["-order -orderBy"]
+        }
+      }
+    },
+    col_no_filter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "filter",
+          behavior: ["-filter -filterBy"]
+        }
+      }
+    },
+    col_no_create_update: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create,update",
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    col_no_create_update_order_filter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create,update,order,filter",
+          behavior: ["-insert -update -order -orderBy -filter -filterBy"]
+        }
+      }
+    },
+    col_no_anything: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: true,
+          behavior: ["-*"]
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -499,8 +514,9 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const personCodec = recordCodec(spec_person);
 const original_functionFunctionIdentifer = sql.identifier("d", "original_function");
 const getflambleFunctionIdentifer = sql.identifier("d", "getflamble");
 const filmsUniques = [{
@@ -775,7 +791,7 @@ const registry = makeRegistry({
         },
         tags: {
           omit: "create,update,delete",
-          behavior: extensions3.tags.behavior
+          behavior: spec_films.extensions.tags.behavior
         }
       }
     },
@@ -1373,6 +1389,9 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
+function CursorSerialize(value) {
+  return "" + value;
+}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -4334,6 +4353,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: CursorSerialize,
+    parseValue: CursorSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -4504,7 +4533,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.code.codec)}`;
             }
           });
         }
@@ -4527,7 +4556,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.title.codec)}`;
             }
           });
         }
@@ -4550,7 +4579,7 @@ export const plans = {
             type: "attribute",
             attribute: "show_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.show_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.show_id.codec)}`;
             }
           });
         }
@@ -4723,7 +4752,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.code.codec)}`;
             }
           });
         }
@@ -4746,7 +4775,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.title.codec)}`;
             }
           });
         }
@@ -4769,7 +4798,7 @@ export const plans = {
             type: "attribute",
             attribute: "studio_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.studio_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.studio_id.codec)}`;
             }
           });
         }
@@ -5103,7 +5132,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.id.codec)}`;
             }
           });
         }
@@ -5126,7 +5155,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.body.codec)}`;
             }
           });
         }
@@ -5149,7 +5178,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.author_id.codec)}`;
             }
           });
         }
@@ -5244,7 +5273,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), renamed_tableAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_renamed_table.attributes.col1.codec)}`;
             }
           });
         }
@@ -5399,7 +5428,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_films.attributes.code.codec)}`;
             }
           });
         }
@@ -5422,7 +5451,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_films.attributes.title.codec)}`;
             }
           });
         }
@@ -5577,7 +5606,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_studios.attributes.id.codec)}`;
             }
           });
         }
@@ -5600,7 +5629,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_studios.attributes.name.codec)}`;
             }
           });
         }
@@ -5925,7 +5954,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.id.codec)}`;
             }
           });
         }
@@ -5948,7 +5977,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.first_name.codec)}`;
             }
           });
         }
@@ -5971,7 +6000,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_name.codec)}`;
             }
           });
         }
@@ -5994,7 +6023,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_create.codec)}`;
             }
           });
         }
@@ -6017,7 +6046,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_update.codec)}`;
             }
           });
         }
@@ -6040,7 +6069,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_order",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_order.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_order.codec)}`;
             }
           });
         }
@@ -6063,7 +6092,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_create_update.codec)}`;
             }
           });
         }
@@ -6638,6 +6667,9 @@ export const plans = {
     }
   },
   RenamedTableInput: {
+    "__inputPlan": function RenamedTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     colA: {
       applyPlan($insert, val) {
         $insert.set("col1", val.get());
@@ -6705,6 +6737,9 @@ export const plans = {
     }
   },
   StudioInput: {
+    "__inputPlan": function StudioInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -6784,6 +6819,9 @@ export const plans = {
     }
   },
   PostInput: {
+    "__inputPlan": function PostInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -6870,6 +6908,9 @@ export const plans = {
     }
   },
   TvEpisodeInput: {
+    "__inputPlan": function TvEpisodeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -6956,6 +6997,9 @@ export const plans = {
     }
   },
   TvShowInput: {
+    "__inputPlan": function TvShowInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7037,6 +7081,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7138,6 +7185,9 @@ export const plans = {
     }
   },
   StudioPatch: {
+    "__inputPlan": function StudioPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7230,6 +7280,9 @@ export const plans = {
     }
   },
   PostPatch: {
+    "__inputPlan": function PostPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7329,6 +7382,9 @@ export const plans = {
     }
   },
   TvEpisodePatch: {
+    "__inputPlan": function TvEpisodePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7428,6 +7484,9 @@ export const plans = {
     }
   },
   TvShowPatch: {
+    "__inputPlan": function TvShowPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7522,6 +7581,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.constraints.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.constraints.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, makeRegistry, pgClassExpression, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectSingleFromRecord, pgUpdateSingle, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
+import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -84,25 +101,24 @@ const flambleCodec = recordCodec({
       name: "flamble"
     })
   },
-  executor
+  executor: executor
 });
-const renamed_tableAttributes = Object.assign(Object.create(null), {
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "colA"
-      }
-    }
-  }
-});
-const renamed_tableCodec = recordCodec({
+const spec_renamed_table = {
   name: "renamed_table",
   identifier: sql.identifier("d", "original_table"),
-  attributes: renamed_tableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "colA"
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -115,32 +131,32 @@ const renamed_tableCodec = recordCodec({
       name: "renamed_table"
     })
   },
-  executor
-});
-const filmsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const filmsCodec = recordCodec({
+  executor: executor
+};
+const renamed_tableCodec = recordCodec(spec_renamed_table);
+const spec_films = {
   name: "films",
   identifier: sql.identifier("d", "films"),
-  attributes: filmsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -151,32 +167,32 @@ const filmsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const studiosAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const studiosCodec = recordCodec({
+  executor: executor
+};
+const filmsCodec = recordCodec(spec_films);
+const spec_studios = {
   name: "studios",
   identifier: sql.identifier("d", "studios"),
-  attributes: studiosAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -187,41 +203,41 @@ const studiosCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const postAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  body: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const postCodec = recordCodec({
+  executor: executor
+};
+const studiosCodec = recordCodec(spec_studios);
+const spec_post = {
   name: "post",
   identifier: sql.identifier("d", "post"),
-  attributes: postAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    body: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -232,90 +248,89 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const tvEpisodesAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  show_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_episodes"
-  },
-  tags: Object.assign(Object.create(null), {
-    omit: "many",
-    behavior: ["-singularRelation:resource:list -singularRelation:resource:connection -manyRelation:resource:list -manyRelation:resource:connection"]
-  })
+  executor: executor
 };
-const tvEpisodesCodec = recordCodec({
+const postCodec = recordCodec(spec_post);
+const spec_tvEpisodes = {
   name: "tvEpisodes",
   identifier: sql.identifier("d", "tv_episodes"),
-  attributes: tvEpisodesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    show_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions6,
-  executor
-});
-const tvShowsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_episodes"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: "many",
+      behavior: ["-singularRelation:resource:list -singularRelation:resource:connection -manyRelation:resource:list -manyRelation:resource:connection"]
+    })
   },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  studio_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const tvShowsCodec = recordCodec({
+  executor: executor
+};
+const tvEpisodesCodec = recordCodec(spec_tvEpisodes);
+const spec_tvShows = {
   name: "tvShows",
   identifier: sql.identifier("d", "tv_shows"),
-  attributes: tvShowsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    studio_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -326,8 +341,9 @@ const tvShowsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const tvShowsCodec = recordCodec(spec_tvShows);
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
   identifier: sql.identifier("d", "jwt_token"),
@@ -370,125 +386,124 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const personAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  first_name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col_no_create: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create",
-        behavior: ["-insert"]
-      }
-    }
-  },
-  col_no_update: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "update",
-        behavior: ["-update"]
-      }
-    }
-  },
-  col_no_order: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "order",
-        behavior: ["-order -orderBy"]
-      }
-    }
-  },
-  col_no_filter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "filter",
-        behavior: ["-filter -filterBy"]
-      }
-    }
-  },
-  col_no_create_update: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create,update",
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  col_no_create_update_order_filter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create,update,order,filter",
-        behavior: ["-insert -update -order -orderBy -filter -filterBy"]
-      }
-    }
-  },
-  col_no_anything: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: true,
-        behavior: ["-*"]
-      }
-    }
-  }
-});
-const personCodec = recordCodec({
+const spec_person = {
   name: "person",
   identifier: sql.identifier("d", "person"),
-  attributes: personAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    first_name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col_no_create: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create",
+          behavior: ["-insert"]
+        }
+      }
+    },
+    col_no_update: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "update",
+          behavior: ["-update"]
+        }
+      }
+    },
+    col_no_order: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "order",
+          behavior: ["-order -orderBy"]
+        }
+      }
+    },
+    col_no_filter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "filter",
+          behavior: ["-filter -filterBy"]
+        }
+      }
+    },
+    col_no_create_update: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create,update",
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    col_no_create_update_order_filter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create,update,order,filter",
+          behavior: ["-insert -update -order -orderBy -filter -filterBy"]
+        }
+      }
+    },
+    col_no_anything: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: true,
+          behavior: ["-*"]
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -499,8 +514,9 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const personCodec = recordCodec(spec_person);
 const original_functionFunctionIdentifer = sql.identifier("d", "original_function");
 const getflambleFunctionIdentifer = sql.identifier("d", "getflamble");
 const filmsUniques = [{
@@ -591,7 +607,7 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
     },
     tags: {
       omit: "many",
-      behavior: extensions6.tags.behavior
+      behavior: spec_tvEpisodes.extensions.tags.behavior
     }
   }
 };
@@ -1423,6 +1439,9 @@ const makeArgs4 = (args, path = []) => {
   }
   return selectArgs;
 };
+function CursorSerialize(value) {
+  return "" + value;
+}
 const argDetailsSimple5 = [];
 const makeArgs5 = (args, path = []) => {
   const selectArgs = [];
@@ -4410,6 +4429,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: CursorSerialize,
+    parseValue: CursorSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -4511,7 +4540,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), renamed_tableAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_renamed_table.attributes.col1.codec)}`;
             }
           });
         }
@@ -4666,7 +4695,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_films.attributes.code.codec)}`;
             }
           });
         }
@@ -4689,7 +4718,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_films.attributes.title.codec)}`;
             }
           });
         }
@@ -4844,7 +4873,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_studios.attributes.id.codec)}`;
             }
           });
         }
@@ -4867,7 +4896,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_studios.attributes.name.codec)}`;
             }
           });
         }
@@ -5031,7 +5060,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.id.codec)}`;
             }
           });
         }
@@ -5054,7 +5083,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.body.codec)}`;
             }
           });
         }
@@ -5077,7 +5106,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.author_id.codec)}`;
             }
           });
         }
@@ -5266,7 +5295,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.code.codec)}`;
             }
           });
         }
@@ -5289,7 +5318,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.title.codec)}`;
             }
           });
         }
@@ -5312,7 +5341,7 @@ export const plans = {
             type: "attribute",
             attribute: "show_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.show_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.show_id.codec)}`;
             }
           });
         }
@@ -5501,7 +5530,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.code.codec)}`;
             }
           });
         }
@@ -5524,7 +5553,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.title.codec)}`;
             }
           });
         }
@@ -5547,7 +5576,7 @@ export const plans = {
             type: "attribute",
             attribute: "studio_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.studio_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.studio_id.codec)}`;
             }
           });
         }
@@ -5872,7 +5901,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.id.codec)}`;
             }
           });
         }
@@ -5895,7 +5924,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.first_name.codec)}`;
             }
           });
         }
@@ -5918,7 +5947,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_name.codec)}`;
             }
           });
         }
@@ -5941,7 +5970,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_create.codec)}`;
             }
           });
         }
@@ -5964,7 +5993,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_update.codec)}`;
             }
           });
         }
@@ -5987,7 +6016,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_order",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_order.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_order.codec)}`;
             }
           });
         }
@@ -6010,7 +6039,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_create_update.codec)}`;
             }
           });
         }
@@ -6670,6 +6699,9 @@ export const plans = {
     }
   },
   RenamedTableInput: {
+    "__inputPlan": function RenamedTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     colA: {
       applyPlan($insert, val) {
         $insert.set("col1", val.get());
@@ -6737,6 +6769,9 @@ export const plans = {
     }
   },
   FilmInput: {
+    "__inputPlan": function FilmInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -6811,6 +6846,9 @@ export const plans = {
     }
   },
   StudioInput: {
+    "__inputPlan": function StudioInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -6890,6 +6928,9 @@ export const plans = {
     }
   },
   PostInput: {
+    "__inputPlan": function PostInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -6976,6 +7017,9 @@ export const plans = {
     }
   },
   TvEpisodeInput: {
+    "__inputPlan": function TvEpisodeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7062,6 +7106,9 @@ export const plans = {
     }
   },
   TvShowInput: {
+    "__inputPlan": function TvShowInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7143,6 +7190,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7244,6 +7294,9 @@ export const plans = {
     }
   },
   FilmPatch: {
+    "__inputPlan": function FilmPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7331,6 +7384,9 @@ export const plans = {
     }
   },
   StudioPatch: {
+    "__inputPlan": function StudioPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7423,6 +7479,9 @@ export const plans = {
     }
   },
   PostPatch: {
+    "__inputPlan": function PostPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7522,6 +7581,9 @@ export const plans = {
     }
   },
   TvEpisodePatch: {
+    "__inputPlan": function TvEpisodePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7621,6 +7683,9 @@ export const plans = {
     }
   },
   TvShowPatch: {
+    "__inputPlan": function TvShowPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7715,6 +7780,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-create.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-create.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, makeRegistry, pgClassExpression, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectSingleFromRecord, pgUpdateSingle, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
+import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -84,25 +101,24 @@ const flambleCodec = recordCodec({
       name: "flamble"
     })
   },
-  executor
+  executor: executor
 });
-const renamed_tableAttributes = Object.assign(Object.create(null), {
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "colA"
-      }
-    }
-  }
-});
-const renamed_tableCodec = recordCodec({
+const spec_renamed_table = {
   name: "renamed_table",
   identifier: sql.identifier("d", "original_table"),
-  attributes: renamed_tableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "colA"
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -115,72 +131,71 @@ const renamed_tableCodec = recordCodec({
       name: "renamed_table"
     })
   },
-  executor
-});
-const filmsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "films"
-  },
-  tags: Object.assign(Object.create(null), {
-    omit: "create",
-    behavior: ["-insert"]
-  })
+  executor: executor
 };
-const filmsCodec = recordCodec({
+const renamed_tableCodec = recordCodec(spec_renamed_table);
+const spec_films = {
   name: "films",
   identifier: sql.identifier("d", "films"),
-  attributes: filmsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions3,
-  executor
-});
-const studiosAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "films"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: "create",
+      behavior: ["-insert"]
+    })
   },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const studiosCodec = recordCodec({
+  executor: executor
+};
+const filmsCodec = recordCodec(spec_films);
+const spec_studios = {
   name: "studios",
   identifier: sql.identifier("d", "studios"),
-  attributes: studiosAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -191,41 +206,41 @@ const studiosCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const postAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  body: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const postCodec = recordCodec({
+  executor: executor
+};
+const studiosCodec = recordCodec(spec_studios);
+const spec_post = {
   name: "post",
   identifier: sql.identifier("d", "post"),
-  attributes: postAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    body: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -236,41 +251,41 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const tvEpisodesAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  show_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const tvEpisodesCodec = recordCodec({
+  executor: executor
+};
+const postCodec = recordCodec(spec_post);
+const spec_tvEpisodes = {
   name: "tvEpisodes",
   identifier: sql.identifier("d", "tv_episodes"),
-  attributes: tvEpisodesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    show_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -281,41 +296,41 @@ const tvEpisodesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const tvShowsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  studio_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const tvShowsCodec = recordCodec({
+  executor: executor
+};
+const tvEpisodesCodec = recordCodec(spec_tvEpisodes);
+const spec_tvShows = {
   name: "tvShows",
   identifier: sql.identifier("d", "tv_shows"),
-  attributes: tvShowsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    studio_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -326,8 +341,9 @@ const tvShowsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const tvShowsCodec = recordCodec(spec_tvShows);
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
   identifier: sql.identifier("d", "jwt_token"),
@@ -370,125 +386,124 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const personAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  first_name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col_no_create: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create",
-        behavior: ["-insert"]
-      }
-    }
-  },
-  col_no_update: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "update",
-        behavior: ["-update"]
-      }
-    }
-  },
-  col_no_order: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "order",
-        behavior: ["-order -orderBy"]
-      }
-    }
-  },
-  col_no_filter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "filter",
-        behavior: ["-filter -filterBy"]
-      }
-    }
-  },
-  col_no_create_update: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create,update",
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  col_no_create_update_order_filter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create,update,order,filter",
-        behavior: ["-insert -update -order -orderBy -filter -filterBy"]
-      }
-    }
-  },
-  col_no_anything: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: true,
-        behavior: ["-*"]
-      }
-    }
-  }
-});
-const personCodec = recordCodec({
+const spec_person = {
   name: "person",
   identifier: sql.identifier("d", "person"),
-  attributes: personAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    first_name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col_no_create: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create",
+          behavior: ["-insert"]
+        }
+      }
+    },
+    col_no_update: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "update",
+          behavior: ["-update"]
+        }
+      }
+    },
+    col_no_order: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "order",
+          behavior: ["-order -orderBy"]
+        }
+      }
+    },
+    col_no_filter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "filter",
+          behavior: ["-filter -filterBy"]
+        }
+      }
+    },
+    col_no_create_update: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create,update",
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    col_no_create_update_order_filter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create,update,order,filter",
+          behavior: ["-insert -update -order -orderBy -filter -filterBy"]
+        }
+      }
+    },
+    col_no_anything: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: true,
+          behavior: ["-*"]
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -499,8 +514,9 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const personCodec = recordCodec(spec_person);
 const original_functionFunctionIdentifer = sql.identifier("d", "original_function");
 const getflambleFunctionIdentifer = sql.identifier("d", "getflamble");
 const filmsUniques = [{
@@ -775,7 +791,7 @@ const registry = makeRegistry({
         },
         tags: {
           omit: "create",
-          behavior: extensions3.tags.behavior
+          behavior: spec_films.extensions.tags.behavior
         }
       }
     },
@@ -1373,6 +1389,9 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
+function CursorSerialize(value) {
+  return "" + value;
+}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -4485,6 +4504,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: CursorSerialize,
+    parseValue: CursorSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -4655,7 +4684,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.code.codec)}`;
             }
           });
         }
@@ -4678,7 +4707,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.title.codec)}`;
             }
           });
         }
@@ -4701,7 +4730,7 @@ export const plans = {
             type: "attribute",
             attribute: "show_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.show_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.show_id.codec)}`;
             }
           });
         }
@@ -4874,7 +4903,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.code.codec)}`;
             }
           });
         }
@@ -4897,7 +4926,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.title.codec)}`;
             }
           });
         }
@@ -4920,7 +4949,7 @@ export const plans = {
             type: "attribute",
             attribute: "studio_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.studio_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.studio_id.codec)}`;
             }
           });
         }
@@ -5254,7 +5283,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.id.codec)}`;
             }
           });
         }
@@ -5277,7 +5306,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.body.codec)}`;
             }
           });
         }
@@ -5300,7 +5329,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.author_id.codec)}`;
             }
           });
         }
@@ -5395,7 +5424,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), renamed_tableAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_renamed_table.attributes.col1.codec)}`;
             }
           });
         }
@@ -5550,7 +5579,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_films.attributes.code.codec)}`;
             }
           });
         }
@@ -5573,7 +5602,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_films.attributes.title.codec)}`;
             }
           });
         }
@@ -5728,7 +5757,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_studios.attributes.id.codec)}`;
             }
           });
         }
@@ -5751,7 +5780,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_studios.attributes.name.codec)}`;
             }
           });
         }
@@ -6076,7 +6105,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.id.codec)}`;
             }
           });
         }
@@ -6099,7 +6128,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.first_name.codec)}`;
             }
           });
         }
@@ -6122,7 +6151,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_name.codec)}`;
             }
           });
         }
@@ -6145,7 +6174,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_create.codec)}`;
             }
           });
         }
@@ -6168,7 +6197,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_update.codec)}`;
             }
           });
         }
@@ -6191,7 +6220,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_order",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_order.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_order.codec)}`;
             }
           });
         }
@@ -6214,7 +6243,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_create_update.codec)}`;
             }
           });
         }
@@ -6857,6 +6886,9 @@ export const plans = {
     }
   },
   RenamedTableInput: {
+    "__inputPlan": function RenamedTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     colA: {
       applyPlan($insert, val) {
         $insert.set("col1", val.get());
@@ -6924,6 +6956,9 @@ export const plans = {
     }
   },
   StudioInput: {
+    "__inputPlan": function StudioInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7003,6 +7038,9 @@ export const plans = {
     }
   },
   PostInput: {
+    "__inputPlan": function PostInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7089,6 +7127,9 @@ export const plans = {
     }
   },
   TvEpisodeInput: {
+    "__inputPlan": function TvEpisodeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7175,6 +7216,9 @@ export const plans = {
     }
   },
   TvShowInput: {
+    "__inputPlan": function TvShowInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7256,6 +7300,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7357,6 +7404,9 @@ export const plans = {
     }
   },
   FilmPatch: {
+    "__inputPlan": function FilmPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7444,6 +7494,9 @@ export const plans = {
     }
   },
   StudioPatch: {
+    "__inputPlan": function StudioPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7536,6 +7589,9 @@ export const plans = {
     }
   },
   PostPatch: {
+    "__inputPlan": function PostPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7635,6 +7691,9 @@ export const plans = {
     }
   },
   TvEpisodePatch: {
+    "__inputPlan": function TvEpisodePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7734,6 +7793,9 @@ export const plans = {
     }
   },
   TvShowPatch: {
+    "__inputPlan": function TvShowPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7828,6 +7890,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-delete.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-delete.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, makeRegistry, pgClassExpression, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectSingleFromRecord, pgUpdateSingle, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
+import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -84,25 +101,24 @@ const flambleCodec = recordCodec({
       name: "flamble"
     })
   },
-  executor
+  executor: executor
 });
-const renamed_tableAttributes = Object.assign(Object.create(null), {
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "colA"
-      }
-    }
-  }
-});
-const renamed_tableCodec = recordCodec({
+const spec_renamed_table = {
   name: "renamed_table",
   identifier: sql.identifier("d", "original_table"),
-  attributes: renamed_tableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "colA"
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -115,72 +131,71 @@ const renamed_tableCodec = recordCodec({
       name: "renamed_table"
     })
   },
-  executor
-});
-const filmsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "films"
-  },
-  tags: Object.assign(Object.create(null), {
-    omit: "delete",
-    behavior: ["-delete"]
-  })
+  executor: executor
 };
-const filmsCodec = recordCodec({
+const renamed_tableCodec = recordCodec(spec_renamed_table);
+const spec_films = {
   name: "films",
   identifier: sql.identifier("d", "films"),
-  attributes: filmsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions3,
-  executor
-});
-const studiosAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "films"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: "delete",
+      behavior: ["-delete"]
+    })
   },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const studiosCodec = recordCodec({
+  executor: executor
+};
+const filmsCodec = recordCodec(spec_films);
+const spec_studios = {
   name: "studios",
   identifier: sql.identifier("d", "studios"),
-  attributes: studiosAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -191,41 +206,41 @@ const studiosCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const postAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  body: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const postCodec = recordCodec({
+  executor: executor
+};
+const studiosCodec = recordCodec(spec_studios);
+const spec_post = {
   name: "post",
   identifier: sql.identifier("d", "post"),
-  attributes: postAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    body: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -236,41 +251,41 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const tvEpisodesAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  show_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const tvEpisodesCodec = recordCodec({
+  executor: executor
+};
+const postCodec = recordCodec(spec_post);
+const spec_tvEpisodes = {
   name: "tvEpisodes",
   identifier: sql.identifier("d", "tv_episodes"),
-  attributes: tvEpisodesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    show_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -281,41 +296,41 @@ const tvEpisodesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const tvShowsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  studio_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const tvShowsCodec = recordCodec({
+  executor: executor
+};
+const tvEpisodesCodec = recordCodec(spec_tvEpisodes);
+const spec_tvShows = {
   name: "tvShows",
   identifier: sql.identifier("d", "tv_shows"),
-  attributes: tvShowsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    studio_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -326,8 +341,9 @@ const tvShowsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const tvShowsCodec = recordCodec(spec_tvShows);
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
   identifier: sql.identifier("d", "jwt_token"),
@@ -370,125 +386,124 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const personAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  first_name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col_no_create: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create",
-        behavior: ["-insert"]
-      }
-    }
-  },
-  col_no_update: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "update",
-        behavior: ["-update"]
-      }
-    }
-  },
-  col_no_order: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "order",
-        behavior: ["-order -orderBy"]
-      }
-    }
-  },
-  col_no_filter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "filter",
-        behavior: ["-filter -filterBy"]
-      }
-    }
-  },
-  col_no_create_update: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create,update",
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  col_no_create_update_order_filter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create,update,order,filter",
-        behavior: ["-insert -update -order -orderBy -filter -filterBy"]
-      }
-    }
-  },
-  col_no_anything: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: true,
-        behavior: ["-*"]
-      }
-    }
-  }
-});
-const personCodec = recordCodec({
+const spec_person = {
   name: "person",
   identifier: sql.identifier("d", "person"),
-  attributes: personAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    first_name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col_no_create: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create",
+          behavior: ["-insert"]
+        }
+      }
+    },
+    col_no_update: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "update",
+          behavior: ["-update"]
+        }
+      }
+    },
+    col_no_order: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "order",
+          behavior: ["-order -orderBy"]
+        }
+      }
+    },
+    col_no_filter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "filter",
+          behavior: ["-filter -filterBy"]
+        }
+      }
+    },
+    col_no_create_update: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create,update",
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    col_no_create_update_order_filter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create,update,order,filter",
+          behavior: ["-insert -update -order -orderBy -filter -filterBy"]
+        }
+      }
+    },
+    col_no_anything: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: true,
+          behavior: ["-*"]
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -499,8 +514,9 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const personCodec = recordCodec(spec_person);
 const original_functionFunctionIdentifer = sql.identifier("d", "original_function");
 const getflambleFunctionIdentifer = sql.identifier("d", "getflamble");
 const filmsUniques = [{
@@ -775,7 +791,7 @@ const registry = makeRegistry({
         },
         tags: {
           omit: "delete",
-          behavior: extensions3.tags.behavior
+          behavior: spec_films.extensions.tags.behavior
         }
       }
     },
@@ -1373,6 +1389,9 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
+function CursorSerialize(value) {
+  return "" + value;
+}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -4466,6 +4485,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: CursorSerialize,
+    parseValue: CursorSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -4636,7 +4665,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.code.codec)}`;
             }
           });
         }
@@ -4659,7 +4688,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.title.codec)}`;
             }
           });
         }
@@ -4682,7 +4711,7 @@ export const plans = {
             type: "attribute",
             attribute: "show_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.show_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.show_id.codec)}`;
             }
           });
         }
@@ -4855,7 +4884,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.code.codec)}`;
             }
           });
         }
@@ -4878,7 +4907,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.title.codec)}`;
             }
           });
         }
@@ -4901,7 +4930,7 @@ export const plans = {
             type: "attribute",
             attribute: "studio_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.studio_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.studio_id.codec)}`;
             }
           });
         }
@@ -5235,7 +5264,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.id.codec)}`;
             }
           });
         }
@@ -5258,7 +5287,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.body.codec)}`;
             }
           });
         }
@@ -5281,7 +5310,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.author_id.codec)}`;
             }
           });
         }
@@ -5376,7 +5405,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), renamed_tableAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_renamed_table.attributes.col1.codec)}`;
             }
           });
         }
@@ -5531,7 +5560,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_films.attributes.code.codec)}`;
             }
           });
         }
@@ -5554,7 +5583,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_films.attributes.title.codec)}`;
             }
           });
         }
@@ -5709,7 +5738,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_studios.attributes.id.codec)}`;
             }
           });
         }
@@ -5732,7 +5761,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_studios.attributes.name.codec)}`;
             }
           });
         }
@@ -6057,7 +6086,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.id.codec)}`;
             }
           });
         }
@@ -6080,7 +6109,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.first_name.codec)}`;
             }
           });
         }
@@ -6103,7 +6132,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_name.codec)}`;
             }
           });
         }
@@ -6126,7 +6155,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_create.codec)}`;
             }
           });
         }
@@ -6149,7 +6178,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_update.codec)}`;
             }
           });
         }
@@ -6172,7 +6201,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_order",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_order.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_order.codec)}`;
             }
           });
         }
@@ -6195,7 +6224,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_create_update.codec)}`;
             }
           });
         }
@@ -6821,6 +6850,9 @@ export const plans = {
     }
   },
   RenamedTableInput: {
+    "__inputPlan": function RenamedTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     colA: {
       applyPlan($insert, val) {
         $insert.set("col1", val.get());
@@ -6888,6 +6920,9 @@ export const plans = {
     }
   },
   FilmInput: {
+    "__inputPlan": function FilmInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -6962,6 +6997,9 @@ export const plans = {
     }
   },
   StudioInput: {
+    "__inputPlan": function StudioInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7041,6 +7079,9 @@ export const plans = {
     }
   },
   PostInput: {
+    "__inputPlan": function PostInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7127,6 +7168,9 @@ export const plans = {
     }
   },
   TvEpisodeInput: {
+    "__inputPlan": function TvEpisodeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7213,6 +7257,9 @@ export const plans = {
     }
   },
   TvShowInput: {
+    "__inputPlan": function TvShowInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7294,6 +7341,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7395,6 +7445,9 @@ export const plans = {
     }
   },
   FilmPatch: {
+    "__inputPlan": function FilmPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7482,6 +7535,9 @@ export const plans = {
     }
   },
   StudioPatch: {
+    "__inputPlan": function StudioPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7574,6 +7630,9 @@ export const plans = {
     }
   },
   PostPatch: {
+    "__inputPlan": function PostPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7673,6 +7732,9 @@ export const plans = {
     }
   },
   TvEpisodePatch: {
+    "__inputPlan": function TvEpisodePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7772,6 +7834,9 @@ export const plans = {
     }
   },
   TvShowPatch: {
+    "__inputPlan": function TvShowPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7866,6 +7931,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-loads.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-loads.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, makeRegistry, pgClassExpression, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectSingleFromRecord, pgUpdateSingle, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
+import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -84,25 +101,24 @@ const flambleCodec = recordCodec({
       name: "flamble"
     })
   },
-  executor
+  executor: executor
 });
-const renamed_tableAttributes = Object.assign(Object.create(null), {
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "colA"
-      }
-    }
-  }
-});
-const renamed_tableCodec = recordCodec({
+const spec_renamed_table = {
   name: "renamed_table",
   identifier: sql.identifier("d", "original_table"),
-  attributes: renamed_tableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "colA"
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -115,21 +131,10 @@ const renamed_tableCodec = recordCodec({
       name: "renamed_table"
     })
   },
-  executor
-});
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "films"
-  },
-  tags: Object.assign(Object.create(null), {
-    omit: "read,all,update,create,delete,many",
-    behavior: ["-select -node -query:resource:list -query:resource:connection -update -insert -delete -singularRelation:resource:list -singularRelation:resource:connection -manyRelation:resource:list -manyRelation:resource:connection"]
-  })
+  executor: executor
 };
-const filmsCodec = recordCodec({
+const renamed_tableCodec = recordCodec(spec_renamed_table);
+const spec_films = {
   name: "films",
   identifier: sql.identifier("d", "films"),
   attributes: Object.assign(Object.create(null), {
@@ -153,33 +158,44 @@ const filmsCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions: extensions3,
-  executor
-});
-const studiosAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "films"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: "read,all,update,create,delete,many",
+      behavior: ["-select -node -query:resource:list -query:resource:connection -update -insert -delete -singularRelation:resource:list -singularRelation:resource:connection -manyRelation:resource:list -manyRelation:resource:connection"]
+    })
   },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const studiosCodec = recordCodec({
+  executor: executor
+};
+const filmsCodec = recordCodec(spec_films);
+const spec_studios = {
   name: "studios",
   identifier: sql.identifier("d", "studios"),
-  attributes: studiosAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -190,41 +206,41 @@ const studiosCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const postAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  body: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const postCodec = recordCodec({
+  executor: executor
+};
+const studiosCodec = recordCodec(spec_studios);
+const spec_post = {
   name: "post",
   identifier: sql.identifier("d", "post"),
-  attributes: postAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    body: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -235,41 +251,41 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const tvEpisodesAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  show_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const tvEpisodesCodec = recordCodec({
+  executor: executor
+};
+const postCodec = recordCodec(spec_post);
+const spec_tvEpisodes = {
   name: "tvEpisodes",
   identifier: sql.identifier("d", "tv_episodes"),
-  attributes: tvEpisodesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    show_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -280,41 +296,41 @@ const tvEpisodesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const tvShowsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  studio_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const tvShowsCodec = recordCodec({
+  executor: executor
+};
+const tvEpisodesCodec = recordCodec(spec_tvEpisodes);
+const spec_tvShows = {
   name: "tvShows",
   identifier: sql.identifier("d", "tv_shows"),
-  attributes: tvShowsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    studio_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -325,8 +341,9 @@ const tvShowsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const tvShowsCodec = recordCodec(spec_tvShows);
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
   identifier: sql.identifier("d", "jwt_token"),
@@ -369,125 +386,124 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const personAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  first_name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col_no_create: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create",
-        behavior: ["-insert"]
-      }
-    }
-  },
-  col_no_update: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "update",
-        behavior: ["-update"]
-      }
-    }
-  },
-  col_no_order: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "order",
-        behavior: ["-order -orderBy"]
-      }
-    }
-  },
-  col_no_filter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "filter",
-        behavior: ["-filter -filterBy"]
-      }
-    }
-  },
-  col_no_create_update: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create,update",
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  col_no_create_update_order_filter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create,update,order,filter",
-        behavior: ["-insert -update -order -orderBy -filter -filterBy"]
-      }
-    }
-  },
-  col_no_anything: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: true,
-        behavior: ["-*"]
-      }
-    }
-  }
-});
-const personCodec = recordCodec({
+const spec_person = {
   name: "person",
   identifier: sql.identifier("d", "person"),
-  attributes: personAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    first_name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col_no_create: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create",
+          behavior: ["-insert"]
+        }
+      }
+    },
+    col_no_update: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "update",
+          behavior: ["-update"]
+        }
+      }
+    },
+    col_no_order: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "order",
+          behavior: ["-order -orderBy"]
+        }
+      }
+    },
+    col_no_filter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "filter",
+          behavior: ["-filter -filterBy"]
+        }
+      }
+    },
+    col_no_create_update: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create,update",
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    col_no_create_update_order_filter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create,update,order,filter",
+          behavior: ["-insert -update -order -orderBy -filter -filterBy"]
+        }
+      }
+    },
+    col_no_anything: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: true,
+          behavior: ["-*"]
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -498,8 +514,9 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const personCodec = recordCodec(spec_person);
 const original_functionFunctionIdentifer = sql.identifier("d", "original_function");
 const getflambleFunctionIdentifer = sql.identifier("d", "getflamble");
 const studiosUniques = [{
@@ -773,7 +790,7 @@ const registry = makeRegistry({
         },
         tags: {
           omit: "read,all,update,create,delete,many",
-          behavior: extensions3.tags.behavior
+          behavior: spec_films.extensions.tags.behavior
         }
       }
     },
@@ -1343,6 +1360,9 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
+function CursorSerialize(value) {
+  return "" + value;
+}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -4124,6 +4144,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: CursorSerialize,
+    parseValue: CursorSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -4294,7 +4324,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.code.codec)}`;
             }
           });
         }
@@ -4317,7 +4347,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.title.codec)}`;
             }
           });
         }
@@ -4340,7 +4370,7 @@ export const plans = {
             type: "attribute",
             attribute: "show_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.show_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.show_id.codec)}`;
             }
           });
         }
@@ -4513,7 +4543,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.code.codec)}`;
             }
           });
         }
@@ -4536,7 +4566,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.title.codec)}`;
             }
           });
         }
@@ -4559,7 +4589,7 @@ export const plans = {
             type: "attribute",
             attribute: "studio_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.studio_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.studio_id.codec)}`;
             }
           });
         }
@@ -4893,7 +4923,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.id.codec)}`;
             }
           });
         }
@@ -4916,7 +4946,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.body.codec)}`;
             }
           });
         }
@@ -4939,7 +4969,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.author_id.codec)}`;
             }
           });
         }
@@ -5034,7 +5064,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), renamed_tableAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_renamed_table.attributes.col1.codec)}`;
             }
           });
         }
@@ -5189,7 +5219,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_studios.attributes.id.codec)}`;
             }
           });
         }
@@ -5212,7 +5242,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_studios.attributes.name.codec)}`;
             }
           });
         }
@@ -5537,7 +5567,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.id.codec)}`;
             }
           });
         }
@@ -5560,7 +5590,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.first_name.codec)}`;
             }
           });
         }
@@ -5583,7 +5613,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_name.codec)}`;
             }
           });
         }
@@ -5606,7 +5636,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_create.codec)}`;
             }
           });
         }
@@ -5629,7 +5659,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_update.codec)}`;
             }
           });
         }
@@ -5652,7 +5682,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_order",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_order.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_order.codec)}`;
             }
           });
         }
@@ -5675,7 +5705,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_create_update.codec)}`;
             }
           });
         }
@@ -6250,6 +6280,9 @@ export const plans = {
     }
   },
   RenamedTableInput: {
+    "__inputPlan": function RenamedTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     colA: {
       applyPlan($insert, val) {
         $insert.set("col1", val.get());
@@ -6317,6 +6350,9 @@ export const plans = {
     }
   },
   StudioInput: {
+    "__inputPlan": function StudioInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -6396,6 +6432,9 @@ export const plans = {
     }
   },
   PostInput: {
+    "__inputPlan": function PostInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -6482,6 +6521,9 @@ export const plans = {
     }
   },
   TvEpisodeInput: {
+    "__inputPlan": function TvEpisodeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -6568,6 +6610,9 @@ export const plans = {
     }
   },
   TvShowInput: {
+    "__inputPlan": function TvShowInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -6649,6 +6694,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -6750,6 +6798,9 @@ export const plans = {
     }
   },
   StudioPatch: {
+    "__inputPlan": function StudioPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -6842,6 +6893,9 @@ export const plans = {
     }
   },
   PostPatch: {
+    "__inputPlan": function PostPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -6941,6 +6995,9 @@ export const plans = {
     }
   },
   TvEpisodePatch: {
+    "__inputPlan": function TvEpisodePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7040,6 +7097,9 @@ export const plans = {
     }
   },
   TvShowPatch: {
+    "__inputPlan": function TvShowPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7134,6 +7194,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-update.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-update.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, makeRegistry, pgClassExpression, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectSingleFromRecord, pgUpdateSingle, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
+import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -84,25 +101,24 @@ const flambleCodec = recordCodec({
       name: "flamble"
     })
   },
-  executor
+  executor: executor
 });
-const renamed_tableAttributes = Object.assign(Object.create(null), {
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "colA"
-      }
-    }
-  }
-});
-const renamed_tableCodec = recordCodec({
+const spec_renamed_table = {
   name: "renamed_table",
   identifier: sql.identifier("d", "original_table"),
-  attributes: renamed_tableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "colA"
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -115,72 +131,71 @@ const renamed_tableCodec = recordCodec({
       name: "renamed_table"
     })
   },
-  executor
-});
-const filmsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "films"
-  },
-  tags: Object.assign(Object.create(null), {
-    omit: "update",
-    behavior: ["-update"]
-  })
+  executor: executor
 };
-const filmsCodec = recordCodec({
+const renamed_tableCodec = recordCodec(spec_renamed_table);
+const spec_films = {
   name: "films",
   identifier: sql.identifier("d", "films"),
-  attributes: filmsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions3,
-  executor
-});
-const studiosAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "films"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: "update",
+      behavior: ["-update"]
+    })
   },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const studiosCodec = recordCodec({
+  executor: executor
+};
+const filmsCodec = recordCodec(spec_films);
+const spec_studios = {
   name: "studios",
   identifier: sql.identifier("d", "studios"),
-  attributes: studiosAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -191,41 +206,41 @@ const studiosCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const postAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  body: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const postCodec = recordCodec({
+  executor: executor
+};
+const studiosCodec = recordCodec(spec_studios);
+const spec_post = {
   name: "post",
   identifier: sql.identifier("d", "post"),
-  attributes: postAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    body: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -236,41 +251,41 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const tvEpisodesAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  show_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const tvEpisodesCodec = recordCodec({
+  executor: executor
+};
+const postCodec = recordCodec(spec_post);
+const spec_tvEpisodes = {
   name: "tvEpisodes",
   identifier: sql.identifier("d", "tv_episodes"),
-  attributes: tvEpisodesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    show_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -281,41 +296,41 @@ const tvEpisodesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const tvShowsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  studio_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const tvShowsCodec = recordCodec({
+  executor: executor
+};
+const tvEpisodesCodec = recordCodec(spec_tvEpisodes);
+const spec_tvShows = {
   name: "tvShows",
   identifier: sql.identifier("d", "tv_shows"),
-  attributes: tvShowsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    studio_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -326,8 +341,9 @@ const tvShowsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const tvShowsCodec = recordCodec(spec_tvShows);
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
   identifier: sql.identifier("d", "jwt_token"),
@@ -370,125 +386,124 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const personAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  first_name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col_no_create: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create",
-        behavior: ["-insert"]
-      }
-    }
-  },
-  col_no_update: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "update",
-        behavior: ["-update"]
-      }
-    }
-  },
-  col_no_order: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "order",
-        behavior: ["-order -orderBy"]
-      }
-    }
-  },
-  col_no_filter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "filter",
-        behavior: ["-filter -filterBy"]
-      }
-    }
-  },
-  col_no_create_update: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create,update",
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  col_no_create_update_order_filter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create,update,order,filter",
-        behavior: ["-insert -update -order -orderBy -filter -filterBy"]
-      }
-    }
-  },
-  col_no_anything: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: true,
-        behavior: ["-*"]
-      }
-    }
-  }
-});
-const personCodec = recordCodec({
+const spec_person = {
   name: "person",
   identifier: sql.identifier("d", "person"),
-  attributes: personAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    first_name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col_no_create: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create",
+          behavior: ["-insert"]
+        }
+      }
+    },
+    col_no_update: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "update",
+          behavior: ["-update"]
+        }
+      }
+    },
+    col_no_order: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "order",
+          behavior: ["-order -orderBy"]
+        }
+      }
+    },
+    col_no_filter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "filter",
+          behavior: ["-filter -filterBy"]
+        }
+      }
+    },
+    col_no_create_update: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create,update",
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    col_no_create_update_order_filter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create,update,order,filter",
+          behavior: ["-insert -update -order -orderBy -filter -filterBy"]
+        }
+      }
+    },
+    col_no_anything: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: true,
+          behavior: ["-*"]
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -499,8 +514,9 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const personCodec = recordCodec(spec_person);
 const original_functionFunctionIdentifer = sql.identifier("d", "original_function");
 const getflambleFunctionIdentifer = sql.identifier("d", "getflamble");
 const filmsUniques = [{
@@ -775,7 +791,7 @@ const registry = makeRegistry({
         },
         tags: {
           omit: "update",
-          behavior: extensions3.tags.behavior
+          behavior: spec_films.extensions.tags.behavior
         }
       }
     },
@@ -1373,6 +1389,9 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
+function CursorSerialize(value) {
+  return "" + value;
+}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -4451,6 +4470,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: CursorSerialize,
+    parseValue: CursorSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -4621,7 +4650,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.code.codec)}`;
             }
           });
         }
@@ -4644,7 +4673,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.title.codec)}`;
             }
           });
         }
@@ -4667,7 +4696,7 @@ export const plans = {
             type: "attribute",
             attribute: "show_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.show_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.show_id.codec)}`;
             }
           });
         }
@@ -4840,7 +4869,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.code.codec)}`;
             }
           });
         }
@@ -4863,7 +4892,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.title.codec)}`;
             }
           });
         }
@@ -4886,7 +4915,7 @@ export const plans = {
             type: "attribute",
             attribute: "studio_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.studio_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.studio_id.codec)}`;
             }
           });
         }
@@ -5220,7 +5249,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.id.codec)}`;
             }
           });
         }
@@ -5243,7 +5272,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.body.codec)}`;
             }
           });
         }
@@ -5266,7 +5295,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.author_id.codec)}`;
             }
           });
         }
@@ -5361,7 +5390,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), renamed_tableAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_renamed_table.attributes.col1.codec)}`;
             }
           });
         }
@@ -5516,7 +5545,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_films.attributes.code.codec)}`;
             }
           });
         }
@@ -5539,7 +5568,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_films.attributes.title.codec)}`;
             }
           });
         }
@@ -5694,7 +5723,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_studios.attributes.id.codec)}`;
             }
           });
         }
@@ -5717,7 +5746,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_studios.attributes.name.codec)}`;
             }
           });
         }
@@ -6042,7 +6071,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.id.codec)}`;
             }
           });
         }
@@ -6065,7 +6094,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.first_name.codec)}`;
             }
           });
         }
@@ -6088,7 +6117,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_name.codec)}`;
             }
           });
         }
@@ -6111,7 +6140,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_create.codec)}`;
             }
           });
         }
@@ -6134,7 +6163,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_update.codec)}`;
             }
           });
         }
@@ -6157,7 +6186,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_order",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_order.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_order.codec)}`;
             }
           });
         }
@@ -6180,7 +6209,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_create_update.codec)}`;
             }
           });
         }
@@ -6806,6 +6835,9 @@ export const plans = {
     }
   },
   RenamedTableInput: {
+    "__inputPlan": function RenamedTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     colA: {
       applyPlan($insert, val) {
         $insert.set("col1", val.get());
@@ -6873,6 +6905,9 @@ export const plans = {
     }
   },
   FilmInput: {
+    "__inputPlan": function FilmInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -6947,6 +6982,9 @@ export const plans = {
     }
   },
   StudioInput: {
+    "__inputPlan": function StudioInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7026,6 +7064,9 @@ export const plans = {
     }
   },
   PostInput: {
+    "__inputPlan": function PostInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7112,6 +7153,9 @@ export const plans = {
     }
   },
   TvEpisodeInput: {
+    "__inputPlan": function TvEpisodeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7198,6 +7242,9 @@ export const plans = {
     }
   },
   TvShowInput: {
+    "__inputPlan": function TvShowInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7279,6 +7326,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7380,6 +7430,9 @@ export const plans = {
     }
   },
   StudioPatch: {
+    "__inputPlan": function StudioPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7472,6 +7525,9 @@ export const plans = {
     }
   },
   PostPatch: {
+    "__inputPlan": function PostPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7571,6 +7627,9 @@ export const plans = {
     }
   },
   TvEpisodePatch: {
+    "__inputPlan": function TvEpisodePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7670,6 +7729,9 @@ export const plans = {
     }
   },
   TvShowPatch: {
+    "__inputPlan": function TvShowPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7764,6 +7826,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.shows-order.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.shows-order.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, makeRegistry, pgClassExpression, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectSingleFromRecord, pgUpdateSingle, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
+import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -84,25 +101,24 @@ const flambleCodec = recordCodec({
       name: "flamble"
     })
   },
-  executor
+  executor: executor
 });
-const renamed_tableAttributes = Object.assign(Object.create(null), {
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "colA"
-      }
-    }
-  }
-});
-const renamed_tableCodec = recordCodec({
+const spec_renamed_table = {
   name: "renamed_table",
   identifier: sql.identifier("d", "original_table"),
-  attributes: renamed_tableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "colA"
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -115,32 +131,32 @@ const renamed_tableCodec = recordCodec({
       name: "renamed_table"
     })
   },
-  executor
-});
-const filmsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const filmsCodec = recordCodec({
+  executor: executor
+};
+const renamed_tableCodec = recordCodec(spec_renamed_table);
+const spec_films = {
   name: "films",
   identifier: sql.identifier("d", "films"),
-  attributes: filmsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -151,32 +167,32 @@ const filmsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const studiosAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const studiosCodec = recordCodec({
+  executor: executor
+};
+const filmsCodec = recordCodec(spec_films);
+const spec_studios = {
   name: "studios",
   identifier: sql.identifier("d", "studios"),
-  attributes: studiosAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -187,41 +203,41 @@ const studiosCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const postAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  body: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const postCodec = recordCodec({
+  executor: executor
+};
+const studiosCodec = recordCodec(spec_studios);
+const spec_post = {
   name: "post",
   identifier: sql.identifier("d", "post"),
-  attributes: postAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    body: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -232,41 +248,41 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const tvEpisodesAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  show_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const tvEpisodesCodec = recordCodec({
+  executor: executor
+};
+const postCodec = recordCodec(spec_post);
+const spec_tvEpisodes = {
   name: "tvEpisodes",
   identifier: sql.identifier("d", "tv_episodes"),
-  attributes: tvEpisodesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    show_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -277,57 +293,57 @@ const tvEpisodesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const tvShowsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  studio_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "d",
-    name: "tv_shows"
-  },
-  tags: Object.assign(Object.create(null), {
-    omit: "order",
-    behavior: ["-order -orderBy"]
-  })
+  executor: executor
 };
-const tvShowsCodec = recordCodec({
+const tvEpisodesCodec = recordCodec(spec_tvEpisodes);
+const spec_tvShows = {
   name: "tvShows",
   identifier: sql.identifier("d", "tv_shows"),
-  attributes: tvShowsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    studio_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions7,
-  executor
-});
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "d",
+      name: "tv_shows"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: "order",
+      behavior: ["-order -orderBy"]
+    })
+  },
+  executor: executor
+};
+const tvShowsCodec = recordCodec(spec_tvShows);
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
   identifier: sql.identifier("d", "jwt_token"),
@@ -370,125 +386,124 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const personAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  first_name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col_no_create: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create",
-        behavior: ["-insert"]
-      }
-    }
-  },
-  col_no_update: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "update",
-        behavior: ["-update"]
-      }
-    }
-  },
-  col_no_order: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "order",
-        behavior: ["-order -orderBy"]
-      }
-    }
-  },
-  col_no_filter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "filter",
-        behavior: ["-filter -filterBy"]
-      }
-    }
-  },
-  col_no_create_update: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create,update",
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  col_no_create_update_order_filter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create,update,order,filter",
-        behavior: ["-insert -update -order -orderBy -filter -filterBy"]
-      }
-    }
-  },
-  col_no_anything: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: true,
-        behavior: ["-*"]
-      }
-    }
-  }
-});
-const personCodec = recordCodec({
+const spec_person = {
   name: "person",
   identifier: sql.identifier("d", "person"),
-  attributes: personAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    first_name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col_no_create: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create",
+          behavior: ["-insert"]
+        }
+      }
+    },
+    col_no_update: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "update",
+          behavior: ["-update"]
+        }
+      }
+    },
+    col_no_order: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "order",
+          behavior: ["-order -orderBy"]
+        }
+      }
+    },
+    col_no_filter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "filter",
+          behavior: ["-filter -filterBy"]
+        }
+      }
+    },
+    col_no_create_update: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create,update",
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    col_no_create_update_order_filter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create,update,order,filter",
+          behavior: ["-insert -update -order -orderBy -filter -filterBy"]
+        }
+      }
+    },
+    col_no_anything: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: true,
+          behavior: ["-*"]
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -499,8 +514,9 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const personCodec = recordCodec(spec_person);
 const original_functionFunctionIdentifer = sql.identifier("d", "original_function");
 const getflambleFunctionIdentifer = sql.identifier("d", "getflamble");
 const filmsUniques = [{
@@ -617,7 +633,7 @@ const registryConfig_pgResources_tv_shows_tv_shows = {
     },
     tags: {
       omit: "order",
-      behavior: extensions7.tags.behavior
+      behavior: spec_tvShows.extensions.tags.behavior
     }
   }
 };
@@ -1372,6 +1388,9 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
+function CursorSerialize(value) {
+  return "" + value;
+}
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";
 }
@@ -4478,6 +4497,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: CursorSerialize,
+    parseValue: CursorSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -4648,7 +4677,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.code.codec)}`;
             }
           });
         }
@@ -4671,7 +4700,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.title.codec)}`;
             }
           });
         }
@@ -4694,7 +4723,7 @@ export const plans = {
             type: "attribute",
             attribute: "show_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.show_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.show_id.codec)}`;
             }
           });
         }
@@ -4728,7 +4757,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.code.codec)}`;
             }
           });
         }
@@ -4751,7 +4780,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.title.codec)}`;
             }
           });
         }
@@ -4774,7 +4803,7 @@ export const plans = {
             type: "attribute",
             attribute: "studio_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.studio_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.studio_id.codec)}`;
             }
           });
         }
@@ -5108,7 +5137,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.id.codec)}`;
             }
           });
         }
@@ -5131,7 +5160,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.body.codec)}`;
             }
           });
         }
@@ -5154,7 +5183,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.author_id.codec)}`;
             }
           });
         }
@@ -5249,7 +5278,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), renamed_tableAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_renamed_table.attributes.col1.codec)}`;
             }
           });
         }
@@ -5404,7 +5433,7 @@ export const plans = {
             type: "attribute",
             attribute: "code",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.code.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_films.attributes.code.codec)}`;
             }
           });
         }
@@ -5427,7 +5456,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_films.attributes.title.codec)}`;
             }
           });
         }
@@ -5582,7 +5611,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_studios.attributes.id.codec)}`;
             }
           });
         }
@@ -5605,7 +5634,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_studios.attributes.name.codec)}`;
             }
           });
         }
@@ -5930,7 +5959,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.id.codec)}`;
             }
           });
         }
@@ -5953,7 +5982,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.first_name.codec)}`;
             }
           });
         }
@@ -5976,7 +6005,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_name.codec)}`;
             }
           });
         }
@@ -5999,7 +6028,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_create.codec)}`;
             }
           });
         }
@@ -6022,7 +6051,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_update.codec)}`;
             }
           });
         }
@@ -6045,7 +6074,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_order",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_order.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_order.codec)}`;
             }
           });
         }
@@ -6068,7 +6097,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_create_update.codec)}`;
             }
           });
         }
@@ -6728,6 +6757,9 @@ export const plans = {
     }
   },
   RenamedTableInput: {
+    "__inputPlan": function RenamedTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     colA: {
       applyPlan($insert, val) {
         $insert.set("col1", val.get());
@@ -6795,6 +6827,9 @@ export const plans = {
     }
   },
   FilmInput: {
+    "__inputPlan": function FilmInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -6869,6 +6904,9 @@ export const plans = {
     }
   },
   StudioInput: {
+    "__inputPlan": function StudioInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -6948,6 +6986,9 @@ export const plans = {
     }
   },
   PostInput: {
+    "__inputPlan": function PostInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7034,6 +7075,9 @@ export const plans = {
     }
   },
   TvEpisodeInput: {
+    "__inputPlan": function TvEpisodeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7089,6 +7133,9 @@ export const plans = {
     }
   },
   TvShowInput: {
+    "__inputPlan": function TvShowInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7170,6 +7217,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7271,6 +7321,9 @@ export const plans = {
     }
   },
   FilmPatch: {
+    "__inputPlan": function FilmPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7358,6 +7411,9 @@ export const plans = {
     }
   },
   StudioPatch: {
+    "__inputPlan": function StudioPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7450,6 +7506,9 @@ export const plans = {
     }
   },
   PostPatch: {
+    "__inputPlan": function PostPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7549,6 +7608,9 @@ export const plans = {
     }
   },
   TvEpisodePatch: {
+    "__inputPlan": function TvEpisodePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7617,6 +7679,9 @@ export const plans = {
     }
   },
   TvShowPatch: {
+    "__inputPlan": function TvShowPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -7711,6 +7776,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/pg11.custom.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/pg11.custom.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, domainOfCodec, enumCodec, listOfCodec, makeRegistry, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectSingleFromRecord, pgUpdateSingle, recordCodec } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId } from "grafast";
+import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,46 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
-  }
-});
-const alwaysAsIdentityAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        behavior: ["-attribute:insert -attribute:update"]
-      }
-    }
-  },
-  t: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -80,10 +75,31 @@ const executor = new PgExecutor({
     });
   }
 });
-const alwaysAsIdentityCodec = recordCodec({
+const spec_alwaysAsIdentity = {
   name: "alwaysAsIdentity",
   identifier: sql.identifier("pg11", "always_as_identity"),
-  attributes: alwaysAsIdentityAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          behavior: ["-attribute:insert -attribute:update"]
+        }
+      }
+    },
+    t: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -94,32 +110,32 @@ const alwaysAsIdentityCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const byDefaultAsIdentityAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  t: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const byDefaultAsIdentityCodec = recordCodec({
+  executor: executor
+};
+const alwaysAsIdentityCodec = recordCodec(spec_alwaysAsIdentity);
+const spec_byDefaultAsIdentity = {
   name: "byDefaultAsIdentity",
   identifier: sql.identifier("pg11", "by_default_as_identity"),
-  attributes: byDefaultAsIdentityAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    t: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -130,59 +146,59 @@ const byDefaultAsIdentityCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const networkAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  inet: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  cidr: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  macaddr: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  macaddr8: {
-    description: undefined,
-    codec: TYPES.macaddr8,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const networkCodec = recordCodec({
+  executor: executor
+};
+const byDefaultAsIdentityCodec = recordCodec(spec_byDefaultAsIdentity);
+const spec_network = {
   name: "network",
   identifier: sql.identifier("pg11", "network"),
-  attributes: networkAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    inet: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    cidr: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    macaddr: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    macaddr8: {
+      description: undefined,
+      codec: TYPES.macaddr8,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -193,8 +209,9 @@ const networkCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const networkCodec = recordCodec(spec_network);
 const bigintDomainCodec = domainOfCodec(TYPES.bigint, "bigintDomain", sql.identifier("c", "bigint_domain"), {
   description: undefined,
   extensions: {
@@ -361,7 +378,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const domainConstrainedCompoundTypeCodec = domainOfCodec(compoundTypeCodec, "domainConstrainedCompoundType", sql.identifier("pg11", "domain_constrained_compound_type"), {
   description: undefined,
@@ -375,57 +392,56 @@ const domainConstrainedCompoundTypeCodec = domainOfCodec(compoundTypeCodec, "dom
   },
   notNull: false
 });
-const typesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  regrole: {
-    description: undefined,
-    codec: TYPES.regrole,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regnamespace: {
-    description: undefined,
-    codec: TYPES.regnamespace,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bigint_domain_array_domain: {
-    description: undefined,
-    codec: bigintDomainArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain_constrained_compound_type: {
-    description: undefined,
-    codec: domainConstrainedCompoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const typesCodec = recordCodec({
+const spec_types = {
   name: "types",
   identifier: sql.identifier("pg11", "types"),
-  attributes: typesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    regrole: {
+      description: undefined,
+      codec: TYPES.regrole,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regnamespace: {
+      description: undefined,
+      codec: TYPES.regnamespace,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bigint_domain_array_domain: {
+      description: undefined,
+      codec: bigintDomainArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain_constrained_compound_type: {
+      description: undefined,
+      codec: domainConstrainedCompoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -436,8 +452,9 @@ const typesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const typesCodec = recordCodec(spec_types);
 const always_as_identityUniques = [{
   isPrimary: true,
   attributes: ["id"],
@@ -729,7 +746,16 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
+function InternetAddressSerialize(value) {
+  return "" + value;
+}
 const resource_frmcdc_domainConstrainedCompoundTypePgResource = registry.pgResources["frmcdc_domainConstrainedCompoundType"];
+const coerce = string => {
+  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
+    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
+  }
+  return string;
+};
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.AlwaysAsIdentity, $nodeId);
@@ -2504,6 +2530,46 @@ export const plans = {
       return $record.get("macaddr8");
     }
   },
+  InternetAddress: {
+    serialize: InternetAddressSerialize,
+    parseValue: InternetAddressSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"InternetAddress" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  CidrAddress: {
+    serialize: InternetAddressSerialize,
+    parseValue: InternetAddressSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"CidrAddress" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  MacAddress: {
+    serialize: InternetAddressSerialize,
+    parseValue: InternetAddressSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"MacAddress" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  MacAddress8: {
+    serialize: InternetAddressSerialize,
+    parseValue: InternetAddressSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"MacAddress8" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   Type: {
     __assertStep: assertPgClassSingleStep,
     nodeId($parent) {
@@ -2530,6 +2596,36 @@ export const plans = {
       }
       $select.getClassStep().setTrusted();
       return $select;
+    }
+  },
+  RegRole: {
+    serialize: InternetAddressSerialize,
+    parseValue: InternetAddressSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegRole" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegNamespace: {
+    serialize: InternetAddressSerialize,
+    parseValue: InternetAddressSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegNamespace" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  BigintDomain: {
+    serialize: InternetAddressSerialize,
+    parseValue: InternetAddressSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigInt" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   DomainConstrainedCompoundType: {
@@ -2568,6 +2664,19 @@ export const plans = {
     },
     BLUE: {
       value: "blue"
+    }
+  },
+  UUID: {
+    serialize: InternetAddressSerialize,
+    parseValue(value) {
+      return coerce("" + value);
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // ERRORS: add name to this error
+        throw new GraphQLError(`${"UUID" ?? "This scalar"} can only parse string values (kind = '${ast.kind}')`);
+      }
+      return coerce(ast.value);
     }
   },
   EnumCaps: {
@@ -2630,6 +2739,16 @@ export const plans = {
     },
     node($edge) {
       return $edge.node();
+    }
+  },
+  Cursor: {
+    serialize: InternetAddressSerialize,
+    parseValue: InternetAddressSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   PageInfo: {
@@ -2768,7 +2887,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), alwaysAsIdentityAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_alwaysAsIdentity.attributes.id.codec)}`;
             }
           });
         }
@@ -2791,7 +2910,7 @@ export const plans = {
             type: "attribute",
             attribute: "t",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), alwaysAsIdentityAttributes.t.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_alwaysAsIdentity.attributes.t.codec)}`;
             }
           });
         }
@@ -2946,7 +3065,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), byDefaultAsIdentityAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_byDefaultAsIdentity.attributes.id.codec)}`;
             }
           });
         }
@@ -2969,7 +3088,7 @@ export const plans = {
             type: "attribute",
             attribute: "t",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), byDefaultAsIdentityAttributes.t.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_byDefaultAsIdentity.attributes.t.codec)}`;
             }
           });
         }
@@ -3226,7 +3345,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), networkAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_network.attributes.id.codec)}`;
             }
           });
         }
@@ -3249,7 +3368,7 @@ export const plans = {
             type: "attribute",
             attribute: "inet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), networkAttributes.inet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_network.attributes.inet.codec)}`;
             }
           });
         }
@@ -3272,7 +3391,7 @@ export const plans = {
             type: "attribute",
             attribute: "cidr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), networkAttributes.cidr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_network.attributes.cidr.codec)}`;
             }
           });
         }
@@ -3295,7 +3414,7 @@ export const plans = {
             type: "attribute",
             attribute: "macaddr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), networkAttributes.macaddr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_network.attributes.macaddr.codec)}`;
             }
           });
         }
@@ -3318,7 +3437,7 @@ export const plans = {
             type: "attribute",
             attribute: "macaddr8",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), networkAttributes.macaddr8.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_network.attributes.macaddr8.codec)}`;
             }
           });
         }
@@ -3541,7 +3660,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.id.codec)}`;
             }
           });
         }
@@ -3564,7 +3683,7 @@ export const plans = {
             type: "attribute",
             attribute: "regrole",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regrole.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regrole.codec)}`;
             }
           });
         }
@@ -3587,7 +3706,7 @@ export const plans = {
             type: "attribute",
             attribute: "regnamespace",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regnamespace.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regnamespace.codec)}`;
             }
           });
         }
@@ -3610,7 +3729,7 @@ export const plans = {
             type: "attribute",
             attribute: "bigint_domain_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.bigint_domain_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.bigint_domain_array_domain.codec)}`;
             }
           });
         }
@@ -3633,7 +3752,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain_constrained_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain_constrained_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.domain_constrained_compound_type.codec)}`;
             }
           });
         }
@@ -3643,6 +3762,9 @@ export const plans = {
     }
   },
   DomainConstrainedCompoundTypeInput: {
+    "__inputPlan": function DomainConstrainedCompoundTypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     a: {
       applyPlan($insert, val) {
         $insert.set("a", val.get());
@@ -4110,6 +4232,9 @@ export const plans = {
     }
   },
   AlwaysAsIdentityInput: {
+    "__inputPlan": function AlwaysAsIdentityInput_inputPlan() {
+      return object(Object.create(null));
+    },
     t: {
       applyPlan($insert, val) {
         $insert.set("t", val.get());
@@ -4177,6 +4302,9 @@ export const plans = {
     }
   },
   ByDefaultAsIdentityInput: {
+    "__inputPlan": function ByDefaultAsIdentityInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -4251,6 +4379,9 @@ export const plans = {
     }
   },
   NetworkInput: {
+    "__inputPlan": function NetworkInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -4346,6 +4477,9 @@ export const plans = {
     }
   },
   TypeInput: {
+    "__inputPlan": function TypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -4440,6 +4574,9 @@ export const plans = {
     }
   },
   AlwaysAsIdentityPatch: {
+    "__inputPlan": function AlwaysAsIdentityPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     t: {
       applyPlan($insert, val) {
         $insert.set("t", val.get());
@@ -4520,6 +4657,9 @@ export const plans = {
     }
   },
   ByDefaultAsIdentityPatch: {
+    "__inputPlan": function ByDefaultAsIdentityPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -4607,6 +4747,9 @@ export const plans = {
     }
   },
   NetworkPatch: {
+    "__inputPlan": function NetworkPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -4715,6 +4858,9 @@ export const plans = {
     }
   },
   TypePatch: {
+    "__inputPlan": function TypePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/polymorphic.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/polymorphic.1.export.mjs
@@ -1,15 +1,24 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, enumCodec, makeRegistry, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgUnionAll, pgUpdateSingle, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeDecodeNodeId, makeGrafastSchema, node, object, rootValue, specFromNodeId } from "grafast";
+import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler_codec_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const executor = new PgExecutor({
   name: "main",
@@ -21,19 +30,7 @@ const executor = new PgExecutor({
     });
   }
 });
-const extensions = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "aws_application_first_party_vulnerabilities"
-  },
-  tags: Object.assign(Object.create(null), {
-    omit: true,
-    behavior: ["-*"]
-  })
-};
-const awsApplicationFirstPartyVulnerabilitiesCodec = recordCodec({
+const spec_awsApplicationFirstPartyVulnerabilities = {
   name: "awsApplicationFirstPartyVulnerabilities",
   identifier: sql.identifier("polymorphic", "aws_application_first_party_vulnerabilities"),
   attributes: Object.assign(Object.create(null), {
@@ -57,22 +54,22 @@ const awsApplicationFirstPartyVulnerabilitiesCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions,
-  executor
-});
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "aws_application_third_party_vulnerabilities"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "aws_application_first_party_vulnerabilities"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: true,
+      behavior: ["-*"]
+    })
   },
-  tags: Object.assign(Object.create(null), {
-    omit: true,
-    behavior: ["-*"]
-  })
+  executor: executor
 };
-const awsApplicationThirdPartyVulnerabilitiesCodec = recordCodec({
+const awsApplicationFirstPartyVulnerabilitiesCodec = recordCodec(spec_awsApplicationFirstPartyVulnerabilities);
+const spec_awsApplicationThirdPartyVulnerabilities = {
   name: "awsApplicationThirdPartyVulnerabilities",
   identifier: sql.identifier("polymorphic", "aws_application_third_party_vulnerabilities"),
   attributes: Object.assign(Object.create(null), {
@@ -96,22 +93,22 @@ const awsApplicationThirdPartyVulnerabilitiesCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions: extensions2,
-  executor
-});
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "gcp_application_first_party_vulnerabilities"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "aws_application_third_party_vulnerabilities"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: true,
+      behavior: ["-*"]
+    })
   },
-  tags: Object.assign(Object.create(null), {
-    omit: true,
-    behavior: ["-*"]
-  })
+  executor: executor
 };
-const gcpApplicationFirstPartyVulnerabilitiesCodec = recordCodec({
+const awsApplicationThirdPartyVulnerabilitiesCodec = recordCodec(spec_awsApplicationThirdPartyVulnerabilities);
+const spec_gcpApplicationFirstPartyVulnerabilities = {
   name: "gcpApplicationFirstPartyVulnerabilities",
   identifier: sql.identifier("polymorphic", "gcp_application_first_party_vulnerabilities"),
   attributes: Object.assign(Object.create(null), {
@@ -135,22 +132,22 @@ const gcpApplicationFirstPartyVulnerabilitiesCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions: extensions3,
-  executor
-});
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "gcp_application_third_party_vulnerabilities"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "gcp_application_first_party_vulnerabilities"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: true,
+      behavior: ["-*"]
+    })
   },
-  tags: Object.assign(Object.create(null), {
-    omit: true,
-    behavior: ["-*"]
-  })
+  executor: executor
 };
-const gcpApplicationThirdPartyVulnerabilitiesCodec = recordCodec({
+const gcpApplicationFirstPartyVulnerabilitiesCodec = recordCodec(spec_gcpApplicationFirstPartyVulnerabilities);
+const spec_gcpApplicationThirdPartyVulnerabilities = {
   name: "gcpApplicationThirdPartyVulnerabilities",
   identifier: sql.identifier("polymorphic", "gcp_application_third_party_vulnerabilities"),
   attributes: Object.assign(Object.create(null), {
@@ -174,33 +171,44 @@ const gcpApplicationThirdPartyVulnerabilitiesCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions: extensions4,
-  executor
-});
-const organizationsAttributes = Object.assign(Object.create(null), {
-  organization_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "gcp_application_third_party_vulnerabilities"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: true,
+      behavior: ["-*"]
+    })
   },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const organizationsCodec = recordCodec({
+  executor: executor
+};
+const gcpApplicationThirdPartyVulnerabilitiesCodec = recordCodec(spec_gcpApplicationThirdPartyVulnerabilities);
+const spec_organizations = {
   name: "organizations",
   identifier: sql.identifier("polymorphic", "organizations"),
-  attributes: organizationsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    organization_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -213,75 +221,63 @@ const organizationsCodec = recordCodec({
       unionMember: "PersonOrOrganization"
     })
   },
-  executor
-});
-const peopleAttributes = Object.assign(Object.create(null), {
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  username: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "people"
-  },
-  tags: Object.assign(Object.create(null), {
-    unionMember: "PersonOrOrganization",
-    ref: "applications to:Application",
-    refVia: ["applications via:aws_applications", "applications via:gcp_applications"]
-  }),
-  refDefinitions: Object.assign(Object.create(null), {
-    applications: {
-      singular: false,
-      graphqlType: "Application",
-      sourceGraphqlType: undefined,
-      extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
-      }
-    }
-  })
+  executor: executor
 };
-const peopleCodec = recordCodec({
+const organizationsCodec = recordCodec(spec_organizations);
+const spec_people = {
   name: "people",
   identifier: sql.identifier("polymorphic", "people"),
-  attributes: peopleAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    username: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions6,
-  executor
-});
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "priorities"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "people"
+    },
+    tags: Object.assign(Object.create(null), {
+      unionMember: "PersonOrOrganization",
+      ref: "applications to:Application",
+      refVia: ["applications via:aws_applications", "applications via:gcp_applications"]
+    }),
+    refDefinitions: Object.assign(Object.create(null), {
+      applications: {
+        singular: false,
+        graphqlType: "Application",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      }
+    })
   },
-  tags: Object.assign(Object.create(null), {
-    omit: "create,update,delete,filter,order",
-    behavior: ["-insert -update -delete -filter -filterBy -order -orderBy"]
-  })
+  executor: executor
 };
-const prioritiesCodec = recordCodec({
+const peopleCodec = recordCodec(spec_people);
+const spec_priorities = {
   name: "priorities",
   identifier: sql.identifier("polymorphic", "priorities"),
   attributes: Object.assign(Object.create(null), {
@@ -305,9 +301,21 @@ const prioritiesCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions: extensions7,
-  executor
-});
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "priorities"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: "create,update,delete,filter,order",
+      behavior: ["-insert -update -delete -filter -filterBy -order -orderBy"]
+    })
+  },
+  executor: executor
+};
+const prioritiesCodec = recordCodec(spec_priorities);
 const itemTypeCodec = enumCodec({
   name: "itemType",
   identifier: sql.identifier("polymorphic", "item_type"),
@@ -322,140 +330,139 @@ const itemTypeCodec = enumCodec({
     tags: Object.create(null)
   }
 });
-const relationalChecklistsAttributes = Object.assign(Object.create(null), {
-  checklist_item_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  id: {
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  },
-  type: {
-    codec: itemTypeCodec,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  },
-  parent_id: {
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyChecklistItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  },
-  root_topic_id: {
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyChecklistItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    via: "relationalItemsByMyChecklistItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  },
-  position: {
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  },
-  created_at: {
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  },
-  updated_at: {
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  },
-  is_explicitly_archived: {
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  },
-  archived_at: {
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyChecklistItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const relationalChecklistsCodec = recordCodec({
+const spec_relationalChecklists = {
   name: "relationalChecklists",
   identifier: sql.identifier("polymorphic", "relational_checklists"),
-  attributes: relationalChecklistsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    checklist_item_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    id: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    },
+    type: {
+      codec: itemTypeCodec,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    },
+    parent_id: {
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyChecklistItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    },
+    root_topic_id: {
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyChecklistItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      via: "relationalItemsByMyChecklistItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    },
+    position: {
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    },
+    created_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    },
+    updated_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    },
+    is_explicitly_archived: {
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    },
+    archived_at: {
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyChecklistItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -467,32 +474,32 @@ const relationalChecklistsCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor
-});
-const relationalItemRelationCompositePksAttributes = Object.assign(Object.create(null), {
-  parent_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  child_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const relationalItemRelationCompositePksCodec = recordCodec({
+  executor: executor
+};
+const relationalChecklistsCodec = recordCodec(spec_relationalChecklists);
+const spec_relationalItemRelationCompositePks = {
   name: "relationalItemRelationCompositePks",
   identifier: sql.identifier("polymorphic", "relational_item_relation_composite_pks"),
-  attributes: relationalItemRelationCompositePksAttributes,
+  attributes: Object.assign(Object.create(null), {
+    parent_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    child_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -503,142 +510,142 @@ const relationalItemRelationCompositePksCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const relationalTopicsAttributes = Object.assign(Object.create(null), {
-  topic_item_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  id: {
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyTopicItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.id.extensions.tags
-    }
-  },
-  type: {
-    codec: itemTypeCodec,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyTopicItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.type.extensions.tags
-    }
-  },
-  parent_id: {
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyTopicItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.parent_id.extensions.tags
-    }
-  },
-  root_topic_id: {
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyTopicItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.root_topic_id.extensions.tags
-    }
-  },
-  author_id: {
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    via: "relationalItemsByMyTopicItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.author_id.extensions.tags
-    }
-  },
-  position: {
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyTopicItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.position.extensions.tags
-    }
-  },
-  created_at: {
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyTopicItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.created_at.extensions.tags
-    }
-  },
-  updated_at: {
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyTopicItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.updated_at.extensions.tags
-    }
-  },
-  is_explicitly_archived: {
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyTopicItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.is_explicitly_archived.extensions.tags
-    }
-  },
-  archived_at: {
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyTopicItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.archived_at.extensions.tags
-    }
-  }
-});
-const relationalTopicsCodec = recordCodec({
+  executor: executor
+};
+const relationalItemRelationCompositePksCodec = recordCodec(spec_relationalItemRelationCompositePks);
+const spec_relationalTopics = {
   name: "relationalTopics",
   identifier: sql.identifier("polymorphic", "relational_topics"),
-  attributes: relationalTopicsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    topic_item_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    id: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyTopicItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.id.extensions.tags
+      }
+    },
+    type: {
+      codec: itemTypeCodec,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyTopicItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.type.extensions.tags
+      }
+    },
+    parent_id: {
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyTopicItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.parent_id.extensions.tags
+      }
+    },
+    root_topic_id: {
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyTopicItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.root_topic_id.extensions.tags
+      }
+    },
+    author_id: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      via: "relationalItemsByMyTopicItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.author_id.extensions.tags
+      }
+    },
+    position: {
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyTopicItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.position.extensions.tags
+      }
+    },
+    created_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyTopicItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.created_at.extensions.tags
+      }
+    },
+    updated_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyTopicItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.updated_at.extensions.tags
+      }
+    },
+    is_explicitly_archived: {
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyTopicItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.is_explicitly_archived.extensions.tags
+      }
+    },
+    archived_at: {
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyTopicItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.archived_at.extensions.tags
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -650,32 +657,32 @@ const relationalTopicsCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor
-});
-const singleTableItemRelationCompositePksAttributes = Object.assign(Object.create(null), {
-  parent_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  child_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const singleTableItemRelationCompositePksCodec = recordCodec({
+  executor: executor
+};
+const relationalTopicsCodec = recordCodec(spec_relationalTopics);
+const spec_singleTableItemRelationCompositePks = {
   name: "singleTableItemRelationCompositePks",
   identifier: sql.identifier("polymorphic", "single_table_item_relation_composite_pks"),
-  attributes: singleTableItemRelationCompositePksAttributes,
+  attributes: Object.assign(Object.create(null), {
+    parent_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    child_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -686,151 +693,151 @@ const singleTableItemRelationCompositePksCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const relationalChecklistItemsAttributes = Object.assign(Object.create(null), {
-  checklist_item_item_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  description: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  note: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  id: {
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.id.extensions.tags
-    }
-  },
-  type: {
-    codec: itemTypeCodec,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.type.extensions.tags
-    }
-  },
-  parent_id: {
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyChecklistItemItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.parent_id.extensions.tags
-    }
-  },
-  root_topic_id: {
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyChecklistItemItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.root_topic_id.extensions.tags
-    }
-  },
-  author_id: {
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    via: "relationalItemsByMyChecklistItemItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.author_id.extensions.tags
-    }
-  },
-  position: {
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.position.extensions.tags
-    }
-  },
-  created_at: {
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.created_at.extensions.tags
-    }
-  },
-  updated_at: {
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.updated_at.extensions.tags
-    }
-  },
-  is_explicitly_archived: {
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.is_explicitly_archived.extensions.tags
-    }
-  },
-  archived_at: {
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyChecklistItemItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.archived_at.extensions.tags
-    }
-  }
-});
-const relationalChecklistItemsCodec = recordCodec({
+  executor: executor
+};
+const singleTableItemRelationCompositePksCodec = recordCodec(spec_singleTableItemRelationCompositePks);
+const spec_relationalChecklistItems = {
   name: "relationalChecklistItems",
   identifier: sql.identifier("polymorphic", "relational_checklist_items"),
-  attributes: relationalChecklistItemsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    checklist_item_item_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    description: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    note: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    id: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.id.extensions.tags
+      }
+    },
+    type: {
+      codec: itemTypeCodec,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.type.extensions.tags
+      }
+    },
+    parent_id: {
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyChecklistItemItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.parent_id.extensions.tags
+      }
+    },
+    root_topic_id: {
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyChecklistItemItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.root_topic_id.extensions.tags
+      }
+    },
+    author_id: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      via: "relationalItemsByMyChecklistItemItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.author_id.extensions.tags
+      }
+    },
+    position: {
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.position.extensions.tags
+      }
+    },
+    created_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.created_at.extensions.tags
+      }
+    },
+    updated_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.updated_at.extensions.tags
+      }
+    },
+    is_explicitly_archived: {
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.is_explicitly_archived.extensions.tags
+      }
+    },
+    archived_at: {
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyChecklistItemItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.archived_at.extensions.tags
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -842,151 +849,151 @@ const relationalChecklistItemsCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor
-});
-const relationalDividersAttributes = Object.assign(Object.create(null), {
-  divider_item_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  color: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  id: {
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyDividerItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.id.extensions.tags
-    }
-  },
-  type: {
-    codec: itemTypeCodec,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyDividerItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.type.extensions.tags
-    }
-  },
-  parent_id: {
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyDividerItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.parent_id.extensions.tags
-    }
-  },
-  root_topic_id: {
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyDividerItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.root_topic_id.extensions.tags
-    }
-  },
-  author_id: {
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    via: "relationalItemsByMyDividerItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.author_id.extensions.tags
-    }
-  },
-  position: {
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyDividerItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.position.extensions.tags
-    }
-  },
-  created_at: {
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyDividerItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.created_at.extensions.tags
-    }
-  },
-  updated_at: {
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyDividerItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.updated_at.extensions.tags
-    }
-  },
-  is_explicitly_archived: {
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyDividerItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.is_explicitly_archived.extensions.tags
-    }
-  },
-  archived_at: {
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyDividerItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.archived_at.extensions.tags
-    }
-  }
-});
-const relationalDividersCodec = recordCodec({
+  executor: executor
+};
+const relationalChecklistItemsCodec = recordCodec(spec_relationalChecklistItems);
+const spec_relationalDividers = {
   name: "relationalDividers",
   identifier: sql.identifier("polymorphic", "relational_dividers"),
-  attributes: relationalDividersAttributes,
+  attributes: Object.assign(Object.create(null), {
+    divider_item_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    color: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    id: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyDividerItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.id.extensions.tags
+      }
+    },
+    type: {
+      codec: itemTypeCodec,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyDividerItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.type.extensions.tags
+      }
+    },
+    parent_id: {
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyDividerItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.parent_id.extensions.tags
+      }
+    },
+    root_topic_id: {
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyDividerItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.root_topic_id.extensions.tags
+      }
+    },
+    author_id: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      via: "relationalItemsByMyDividerItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.author_id.extensions.tags
+      }
+    },
+    position: {
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyDividerItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.position.extensions.tags
+      }
+    },
+    created_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyDividerItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.created_at.extensions.tags
+      }
+    },
+    updated_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyDividerItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.updated_at.extensions.tags
+      }
+    },
+    is_explicitly_archived: {
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyDividerItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.is_explicitly_archived.extensions.tags
+      }
+    },
+    archived_at: {
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyDividerItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.archived_at.extensions.tags
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -998,41 +1005,41 @@ const relationalDividersCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor
-});
-const relationalItemRelationsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  parent_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  child_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const relationalItemRelationsCodec = recordCodec({
+  executor: executor
+};
+const relationalDividersCodec = recordCodec(spec_relationalDividers);
+const spec_relationalItemRelations = {
   name: "relationalItemRelations",
   identifier: sql.identifier("polymorphic", "relational_item_relations"),
-  attributes: relationalItemRelationsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    parent_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    child_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1043,41 +1050,41 @@ const relationalItemRelationsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const singleTableItemRelationsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  parent_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  child_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const singleTableItemRelationsCodec = recordCodec({
+  executor: executor
+};
+const relationalItemRelationsCodec = recordCodec(spec_relationalItemRelations);
+const spec_singleTableItemRelations = {
   name: "singleTableItemRelations",
   identifier: sql.identifier("polymorphic", "single_table_item_relations"),
-  attributes: singleTableItemRelationsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    parent_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    child_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1088,231 +1095,230 @@ const singleTableItemRelationsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const logEntriesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  organization_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions17 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "log_entries"
-  },
-  tags: Object.assign(Object.create(null), {
-    ref: "author to:PersonOrOrganization singular",
-    refVia: ["author via:people", "author via:organizations"]
-  }),
-  refDefinitions: Object.assign(Object.create(null), {
-    author: {
-      singular: true,
-      graphqlType: "PersonOrOrganization",
-      sourceGraphqlType: undefined,
-      extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
-      }
-    }
-  })
+  executor: executor
 };
-const logEntriesCodec = recordCodec({
+const singleTableItemRelationsCodec = recordCodec(spec_singleTableItemRelations);
+const spec_logEntries = {
   name: "logEntries",
   identifier: sql.identifier("polymorphic", "log_entries"),
-  attributes: logEntriesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    organization_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions17,
-  executor
-});
-const relationalPostsAttributes = Object.assign(Object.create(null), {
-  post_item_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "log_entries"
+    },
+    tags: Object.assign(Object.create(null), {
+      ref: "author to:PersonOrOrganization singular",
+      refVia: ["author via:people", "author via:organizations"]
+    }),
+    refDefinitions: Object.assign(Object.create(null), {
+      author: {
+        singular: true,
+        graphqlType: "PersonOrOrganization",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      }
+    })
   },
-  title: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  description: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  note: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  id: {
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyPostItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.id.extensions.tags
-    }
-  },
-  type: {
-    codec: itemTypeCodec,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyPostItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.type.extensions.tags
-    }
-  },
-  parent_id: {
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyPostItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.parent_id.extensions.tags
-    }
-  },
-  root_topic_id: {
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyPostItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.root_topic_id.extensions.tags
-    }
-  },
-  author_id: {
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    via: "relationalItemsByMyPostItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.author_id.extensions.tags
-    }
-  },
-  position: {
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyPostItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.position.extensions.tags
-    }
-  },
-  created_at: {
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyPostItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.created_at.extensions.tags
-    }
-  },
-  updated_at: {
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyPostItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.updated_at.extensions.tags
-    }
-  },
-  is_explicitly_archived: {
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyPostItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.is_explicitly_archived.extensions.tags
-    }
-  },
-  archived_at: {
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyPostItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.archived_at.extensions.tags
-    }
-  }
-});
-const relationalPostsCodec = recordCodec({
+  executor: executor
+};
+const logEntriesCodec = recordCodec(spec_logEntries);
+const spec_relationalPosts = {
   name: "relationalPosts",
   identifier: sql.identifier("polymorphic", "relational_posts"),
-  attributes: relationalPostsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    post_item_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    description: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    note: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    id: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyPostItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.id.extensions.tags
+      }
+    },
+    type: {
+      codec: itemTypeCodec,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyPostItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.type.extensions.tags
+      }
+    },
+    parent_id: {
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyPostItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.parent_id.extensions.tags
+      }
+    },
+    root_topic_id: {
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyPostItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.root_topic_id.extensions.tags
+      }
+    },
+    author_id: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      via: "relationalItemsByMyPostItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.author_id.extensions.tags
+      }
+    },
+    position: {
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyPostItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.position.extensions.tags
+      }
+    },
+    created_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyPostItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.created_at.extensions.tags
+      }
+    },
+    updated_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyPostItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.updated_at.extensions.tags
+      }
+    },
+    is_explicitly_archived: {
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyPostItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.is_explicitly_archived.extensions.tags
+      }
+    },
+    archived_at: {
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyPostItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.archived_at.extensions.tags
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1324,758 +1330,971 @@ const relationalPostsCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor
-});
-const firstPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  cvss_score: {
-    description: undefined,
-    codec: TYPES.float,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  team_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions19 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "first_party_vulnerabilities"
-  },
-  tags: Object.assign(Object.create(null), {
-    implements: "Vulnerability",
-    ref: ["applications to:Application plural", "owners to:PersonOrOrganization plural"],
-    refVia: ["applications via:aws_application_first_party_vulnerabilities;aws_applications", "applications via:gcp_application_first_party_vulnerabilities;gcp_applications", "owners via:aws_application_first_party_vulnerabilities;aws_applications;people", "owners via:aws_application_first_party_vulnerabilities;aws_applications;organizations", "owners via:gcp_application_first_party_vulnerabilities;gcp_applications;people", "owners via:gcp_application_first_party_vulnerabilities;gcp_applications;organizations"]
-  }),
-  refDefinitions: Object.assign(Object.create(null), {
-    applications: {
-      singular: false,
-      graphqlType: "Application",
-      sourceGraphqlType: undefined,
-      extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
-      }
-    },
-    owners: {
-      singular: false,
-      graphqlType: "PersonOrOrganization",
-      sourceGraphqlType: undefined,
-      extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
-      }
-    }
-  })
+  executor: executor
 };
-const firstPartyVulnerabilitiesCodec = recordCodec({
+const relationalPostsCodec = recordCodec(spec_relationalPosts);
+const spec_firstPartyVulnerabilities = {
   name: "firstPartyVulnerabilities",
   identifier: sql.identifier("polymorphic", "first_party_vulnerabilities"),
-  attributes: firstPartyVulnerabilitiesAttributes,
-  description: undefined,
-  extensions: extensions19,
-  executor
-});
-const thirdPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  cvss_score: {
-    description: undefined,
-    codec: TYPES.float,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  vendor_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions20 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "third_party_vulnerabilities"
-  },
-  tags: Object.assign(Object.create(null), {
-    implements: "Vulnerability",
-    ref: ["applications to:Application plural", "owners to:PersonOrOrganization plural"],
-    refVia: ["applications via:aws_application_third_party_vulnerabilities;aws_applications", "applications via:gcp_application_third_party_vulnerabilities;gcp_applications", "owners via:aws_application_third_party_vulnerabilities;aws_applications;people", "owners via:aws_application_third_party_vulnerabilities;aws_applications;organizations", "owners via:gcp_application_third_party_vulnerabilities;gcp_applications;people", "owners via:gcp_application_third_party_vulnerabilities;gcp_applications;organizations"]
-  }),
-  refDefinitions: Object.assign(Object.create(null), {
-    applications: {
-      singular: false,
-      graphqlType: "Application",
-      sourceGraphqlType: undefined,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
       extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
+        tags: {}
       }
     },
-    owners: {
-      singular: false,
-      graphqlType: "PersonOrOrganization",
-      sourceGraphqlType: undefined,
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
       extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
+        tags: {}
+      }
+    },
+    cvss_score: {
+      description: undefined,
+      codec: TYPES.float,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    team_name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
       }
     }
-  })
+  }),
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "first_party_vulnerabilities"
+    },
+    tags: Object.assign(Object.create(null), {
+      implements: "Vulnerability",
+      ref: ["applications to:Application plural", "owners to:PersonOrOrganization plural"],
+      refVia: ["applications via:aws_application_first_party_vulnerabilities;aws_applications", "applications via:gcp_application_first_party_vulnerabilities;gcp_applications", "owners via:aws_application_first_party_vulnerabilities;aws_applications;people", "owners via:aws_application_first_party_vulnerabilities;aws_applications;organizations", "owners via:gcp_application_first_party_vulnerabilities;gcp_applications;people", "owners via:gcp_application_first_party_vulnerabilities;gcp_applications;organizations"]
+    }),
+    refDefinitions: Object.assign(Object.create(null), {
+      applications: {
+        singular: false,
+        graphqlType: "Application",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      },
+      owners: {
+        singular: false,
+        graphqlType: "PersonOrOrganization",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      }
+    })
+  },
+  executor: executor
 };
-const thirdPartyVulnerabilitiesCodec = recordCodec({
+const firstPartyVulnerabilitiesCodec = recordCodec(spec_firstPartyVulnerabilities);
+const spec_thirdPartyVulnerabilities = {
   name: "thirdPartyVulnerabilities",
   identifier: sql.identifier("polymorphic", "third_party_vulnerabilities"),
-  attributes: thirdPartyVulnerabilitiesAttributes,
-  description: undefined,
-  extensions: extensions20,
-  executor
-});
-const awsApplicationsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_deployed: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  organization_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  aws_id: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions21 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "aws_applications"
-  },
-  tags: Object.assign(Object.create(null), {
-    implements: "Application",
-    ref: ["vulnerabilities to:Vulnerability plural", "owner to:PersonOrOrganization singular"],
-    refVia: ["vulnerabilities via:(id)->aws_application_first_party_vulnerabilities(aws_application_id);(first_party_vulnerability_id)->first_party_vulnerabilities(id)", "vulnerabilities via:(id)->aws_application_third_party_vulnerabilities(aws_application_id);(third_party_vulnerability_id)->third_party_vulnerabilities(id)", "owner via:people", "owner via:organizations"]
-  }),
-  refDefinitions: Object.assign(Object.create(null), {
-    vulnerabilities: {
-      singular: false,
-      graphqlType: "Vulnerability",
-      sourceGraphqlType: undefined,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
       extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
+        tags: {}
       }
     },
-    owner: {
-      singular: true,
-      graphqlType: "PersonOrOrganization",
-      sourceGraphqlType: undefined,
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
       extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
+        tags: {}
+      }
+    },
+    cvss_score: {
+      description: undefined,
+      codec: TYPES.float,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    vendor_name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
       }
     }
-  })
+  }),
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "third_party_vulnerabilities"
+    },
+    tags: Object.assign(Object.create(null), {
+      implements: "Vulnerability",
+      ref: ["applications to:Application plural", "owners to:PersonOrOrganization plural"],
+      refVia: ["applications via:aws_application_third_party_vulnerabilities;aws_applications", "applications via:gcp_application_third_party_vulnerabilities;gcp_applications", "owners via:aws_application_third_party_vulnerabilities;aws_applications;people", "owners via:aws_application_third_party_vulnerabilities;aws_applications;organizations", "owners via:gcp_application_third_party_vulnerabilities;gcp_applications;people", "owners via:gcp_application_third_party_vulnerabilities;gcp_applications;organizations"]
+    }),
+    refDefinitions: Object.assign(Object.create(null), {
+      applications: {
+        singular: false,
+        graphqlType: "Application",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      },
+      owners: {
+        singular: false,
+        graphqlType: "PersonOrOrganization",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      }
+    })
+  },
+  executor: executor
 };
-const awsApplicationsCodec = recordCodec({
+const thirdPartyVulnerabilitiesCodec = recordCodec(spec_thirdPartyVulnerabilities);
+const spec_awsApplications = {
   name: "awsApplications",
   identifier: sql.identifier("polymorphic", "aws_applications"),
-  attributes: awsApplicationsAttributes,
-  description: undefined,
-  extensions: extensions21,
-  executor
-});
-const gcpApplicationsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_deployed: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  organization_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  gcp_id: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions22 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "gcp_applications"
-  },
-  tags: Object.assign(Object.create(null), {
-    implements: "Application",
-    ref: ["vulnerabilities to:Vulnerability plural", "owner to:PersonOrOrganization singular"],
-    refVia: ["vulnerabilities via:(id)->gcp_application_first_party_vulnerabilities(gcp_application_id);(first_party_vulnerability_id)->first_party_vulnerabilities(id)", "vulnerabilities via:(id)->gcp_application_third_party_vulnerabilities(gcp_application_id);(third_party_vulnerability_id)->third_party_vulnerabilities(id)", "owner via:people", "owner via:organizations"]
-  }),
-  refDefinitions: Object.assign(Object.create(null), {
-    vulnerabilities: {
-      singular: false,
-      graphqlType: "Vulnerability",
-      sourceGraphqlType: undefined,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
       extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
+        tags: {}
       }
     },
-    owner: {
-      singular: true,
-      graphqlType: "PersonOrOrganization",
-      sourceGraphqlType: undefined,
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
       extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
+        tags: {}
+      }
+    },
+    last_deployed: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    organization_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    aws_id: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
       }
     }
-  })
+  }),
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "aws_applications"
+    },
+    tags: Object.assign(Object.create(null), {
+      implements: "Application",
+      ref: ["vulnerabilities to:Vulnerability plural", "owner to:PersonOrOrganization singular"],
+      refVia: ["vulnerabilities via:(id)->aws_application_first_party_vulnerabilities(aws_application_id);(first_party_vulnerability_id)->first_party_vulnerabilities(id)", "vulnerabilities via:(id)->aws_application_third_party_vulnerabilities(aws_application_id);(third_party_vulnerability_id)->third_party_vulnerabilities(id)", "owner via:people", "owner via:organizations"]
+    }),
+    refDefinitions: Object.assign(Object.create(null), {
+      vulnerabilities: {
+        singular: false,
+        graphqlType: "Vulnerability",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      },
+      owner: {
+        singular: true,
+        graphqlType: "PersonOrOrganization",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      }
+    })
+  },
+  executor: executor
 };
-const gcpApplicationsCodec = recordCodec({
+const awsApplicationsCodec = recordCodec(spec_awsApplications);
+const spec_gcpApplications = {
   name: "gcpApplications",
   identifier: sql.identifier("polymorphic", "gcp_applications"),
-  attributes: gcpApplicationsAttributes,
-  description: undefined,
-  extensions: extensions22,
-  executor
-});
-const singleTableItemsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  type: {
-    description: undefined,
-    codec: itemTypeCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  parent_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  root_topic_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  position: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  created_at: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  updated_at: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  is_explicitly_archived: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  archived_at: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  description: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  note: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  color: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  priority_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions23 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "single_table_items"
-  },
-  tags: Object.assign(Object.create(null), {
-    interface: "mode:single type:type",
-    type: ["TOPIC name:SingleTableTopic attributes:title!", "POST name:SingleTablePost attributes:title>subject,description,note,priority_id", "DIVIDER name:SingleTableDivider attributes:title,color", "CHECKLIST name:SingleTableChecklist attributes:title", "CHECKLIST_ITEM name:SingleTableChecklistItem attributes:description,note,priority_id"],
-    ref: ["rootTopic to:SingleTableTopic singular via:(root_topic_id)->polymorphic.single_table_items(id)", "rootChecklistTopic from:SingleTableChecklist to:SingleTableTopic singular via:(root_topic_id)->polymorphic.single_table_items(id)"]
-  }),
-  refDefinitions: Object.assign(Object.create(null), {
-    rootTopic: {
-      singular: true,
-      graphqlType: "SingleTableTopic",
-      sourceGraphqlType: undefined,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
       extensions: {
-        via: "(root_topic_id)->polymorphic.single_table_items(id)",
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_deployed: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    organization_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    gcp_id: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "gcp_applications"
+    },
+    tags: Object.assign(Object.create(null), {
+      implements: "Application",
+      ref: ["vulnerabilities to:Vulnerability plural", "owner to:PersonOrOrganization singular"],
+      refVia: ["vulnerabilities via:(id)->gcp_application_first_party_vulnerabilities(gcp_application_id);(first_party_vulnerability_id)->first_party_vulnerabilities(id)", "vulnerabilities via:(id)->gcp_application_third_party_vulnerabilities(gcp_application_id);(third_party_vulnerability_id)->third_party_vulnerabilities(id)", "owner via:people", "owner via:organizations"]
+    }),
+    refDefinitions: Object.assign(Object.create(null), {
+      vulnerabilities: {
+        singular: false,
+        graphqlType: "Vulnerability",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      },
+      owner: {
+        singular: true,
+        graphqlType: "PersonOrOrganization",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      }
+    })
+  },
+  executor: executor
+};
+const gcpApplicationsCodec = recordCodec(spec_gcpApplications);
+const spec_singleTableItems = {
+  name: "singleTableItems",
+  identifier: sql.identifier("polymorphic", "single_table_items"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    type: {
+      description: undefined,
+      codec: itemTypeCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    parent_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    root_topic_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    position: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    created_at: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    updated_at: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    is_explicitly_archived: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    archived_at: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    description: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    note: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    color: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    priority_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "single_table_items"
+    },
+    tags: Object.assign(Object.create(null), {
+      interface: "mode:single type:type",
+      type: ["TOPIC name:SingleTableTopic attributes:title!", "POST name:SingleTablePost attributes:title>subject,description,note,priority_id", "DIVIDER name:SingleTableDivider attributes:title,color", "CHECKLIST name:SingleTableChecklist attributes:title", "CHECKLIST_ITEM name:SingleTableChecklistItem attributes:description,note,priority_id"],
+      ref: ["rootTopic to:SingleTableTopic singular via:(root_topic_id)->polymorphic.single_table_items(id)", "rootChecklistTopic from:SingleTableChecklist to:SingleTableTopic singular via:(root_topic_id)->polymorphic.single_table_items(id)"]
+    }),
+    refDefinitions: Object.assign(Object.create(null), {
+      rootTopic: {
+        singular: true,
+        graphqlType: "SingleTableTopic",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: "(root_topic_id)->polymorphic.single_table_items(id)",
+          tags: {
+            behavior: undefined
+          }
+        }
+      },
+      rootChecklistTopic: {
+        singular: true,
+        graphqlType: "SingleTableTopic",
+        sourceGraphqlType: "SingleTableChecklist",
+        extensions: {
+          via: "(root_topic_id)->polymorphic.single_table_items(id)",
+          tags: {
+            behavior: undefined
+          }
+        }
+      }
+    })
+  },
+  executor: executor,
+  polymorphism: {
+    mode: "single",
+    commonAttributes: ["id", "type", "parent_id", "root_topic_id", "author_id", "position", "created_at", "updated_at", "is_explicitly_archived", "archived_at"],
+    typeAttributes: ["type"],
+    types: Object.assign(Object.create(null), {
+      TOPIC: {
+        name: "SingleTableTopic",
+        attributes: [{
+          attribute: "title",
+          isNotNull: true,
+          rename: undefined
+        }]
+      },
+      POST: {
+        name: "SingleTablePost",
+        attributes: [{
+          attribute: "title",
+          isNotNull: false,
+          rename: "subject"
+        }, {
+          attribute: "description",
+          isNotNull: false,
+          rename: undefined
+        }, {
+          attribute: "note",
+          isNotNull: false,
+          rename: undefined
+        }, {
+          attribute: "priority_id",
+          isNotNull: false,
+          rename: undefined
+        }]
+      },
+      DIVIDER: {
+        name: "SingleTableDivider",
+        attributes: [{
+          attribute: "title",
+          isNotNull: false,
+          rename: undefined
+        }, {
+          attribute: "color",
+          isNotNull: false,
+          rename: undefined
+        }]
+      },
+      CHECKLIST: {
+        name: "SingleTableChecklist",
+        attributes: [{
+          attribute: "title",
+          isNotNull: false,
+          rename: undefined
+        }]
+      },
+      CHECKLIST_ITEM: {
+        name: "SingleTableChecklistItem",
+        attributes: [{
+          attribute: "description",
+          isNotNull: false,
+          rename: undefined
+        }, {
+          attribute: "note",
+          isNotNull: false,
+          rename: undefined
+        }, {
+          attribute: "priority_id",
+          isNotNull: false,
+          rename: undefined
+        }]
+      }
+    })
+  }
+};
+const singleTableItemsCodec = recordCodec(spec_singleTableItems);
+const spec_relationalItems = {
+  name: "relationalItems",
+  identifier: sql.identifier("polymorphic", "relational_items"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.id.extensions.tags
+      }
+    },
+    type: {
+      description: undefined,
+      codec: itemTypeCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.type.extensions.tags
+      }
+    },
+    parent_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.parent_id.extensions.tags
+      }
+    },
+    root_topic_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.root_topic_id.extensions.tags
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.author_id.extensions.tags
+      }
+    },
+    position: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.position.extensions.tags
+      }
+    },
+    created_at: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.created_at.extensions.tags
+      }
+    },
+    updated_at: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.updated_at.extensions.tags
+      }
+    },
+    is_explicitly_archived: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.is_explicitly_archived.extensions.tags
+      }
+    },
+    archived_at: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.archived_at.extensions.tags
+      }
+    }
+  }),
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_items"
+    },
+    tags: Object.assign(Object.create(null), {
+      interface: "mode:relational",
+      type: ["TOPIC references:relational_topics", "POST references:relational_posts", "DIVIDER references:relational_dividers", "CHECKLIST references:relational_checklists", "CHECKLIST_ITEM references:relational_checklist_items"]
+    })
+  },
+  executor: executor,
+  polymorphism: {
+    mode: "relational",
+    typeAttributes: ["type"],
+    types: Object.assign(Object.create(null), {
+      TOPIC: {
+        name: "RelationalTopic",
+        references: "relational_topics",
+        relationName: "relationalTopicsByTheirTopicItemId"
+      },
+      POST: {
+        name: "RelationalPost",
+        references: "relational_posts",
+        relationName: "relationalPostsByTheirPostItemId"
+      },
+      DIVIDER: {
+        name: "RelationalDivider",
+        references: "relational_dividers",
+        relationName: "relationalDividersByTheirDividerItemId"
+      },
+      CHECKLIST: {
+        name: "RelationalChecklist",
+        references: "relational_checklists",
+        relationName: "relationalChecklistsByTheirChecklistItemId"
+      },
+      CHECKLIST_ITEM: {
+        name: "RelationalChecklistItem",
+        references: "relational_checklist_items",
+        relationName: "relationalChecklistItemsByTheirChecklistItemItemId"
+      }
+    })
+  }
+};
+const relationalItemsCodec = recordCodec(spec_relationalItems);
+const spec_Application = {
+  name: "Application",
+  identifier: sql.identifier("polymorphic", "applications"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
         tags: {
-          behavior: undefined
+          notNull: true
         }
       }
     },
-    rootChecklistTopic: {
-      singular: true,
-      graphqlType: "SingleTableTopic",
-      sourceGraphqlType: "SingleTableChecklist",
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
       extensions: {
-        via: "(root_topic_id)->polymorphic.single_table_items(id)",
         tags: {
-          behavior: undefined
+          notNull: true
+        }
+      }
+    },
+    last_deployed: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
+  description: undefined,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "applications"
+    },
+    tags: Object.assign(Object.create(null), {
+      interface: "mode:union",
+      name: "Application",
+      behavior: "node",
+      ref: ["vulnerabilities to:Vulnerability plural", "owner to:PersonOrOrganization singular"]
+    }),
+    refDefinitions: Object.assign(Object.create(null), {
+      vulnerabilities: {
+        singular: false,
+        graphqlType: "Vulnerability",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      },
+      owner: {
+        singular: true,
+        graphqlType: "PersonOrOrganization",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      }
+    })
+  },
+  executor: executor,
+  polymorphism: {
+    mode: "union"
+  }
+};
+const spec_Vulnerability = {
+  name: "Vulnerability",
+  identifier: sql.identifier("polymorphic", "vulnerabilities"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          notNull: true
+        }
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          notNull: true
+        }
+      }
+    },
+    cvss_score: {
+      description: undefined,
+      codec: TYPES.float,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          notNull: true
         }
       }
     }
-  })
-};
-const singleTableItemsCodec = recordCodec({
-  name: "singleTableItems",
-  identifier: sql.identifier("polymorphic", "single_table_items"),
-  attributes: singleTableItemsAttributes,
+  }),
   description: undefined,
-  extensions: extensions23,
-  executor
-});
-const relationalItemsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: relationalChecklistsAttributes.id.extensions.tags
-    }
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "vulnerabilities"
+    },
+    tags: Object.assign(Object.create(null), {
+      interface: "mode:union",
+      name: "Vulnerability",
+      behavior: "node",
+      ref: ["applications to:Application plural", "owners to:PersonOrOrganization plural"]
+    }),
+    refDefinitions: Object.assign(Object.create(null), {
+      applications: {
+        singular: false,
+        graphqlType: "Application",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      },
+      owners: {
+        singular: false,
+        graphqlType: "PersonOrOrganization",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      }
+    })
   },
-  type: {
-    description: undefined,
-    codec: itemTypeCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: relationalChecklistsAttributes.type.extensions.tags
-    }
-  },
-  parent_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: relationalChecklistsAttributes.parent_id.extensions.tags
-    }
-  },
-  root_topic_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: relationalChecklistsAttributes.root_topic_id.extensions.tags
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: relationalChecklistsAttributes.author_id.extensions.tags
-    }
-  },
-  position: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: relationalChecklistsAttributes.position.extensions.tags
-    }
-  },
-  created_at: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: relationalChecklistsAttributes.created_at.extensions.tags
-    }
-  },
-  updated_at: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: relationalChecklistsAttributes.updated_at.extensions.tags
-    }
-  },
-  is_explicitly_archived: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: relationalChecklistsAttributes.is_explicitly_archived.extensions.tags
-    }
-  },
-  archived_at: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: relationalChecklistsAttributes.archived_at.extensions.tags
-    }
+  executor: executor,
+  polymorphism: {
+    mode: "union"
   }
-});
-const extensions24 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_items"
-  },
-  tags: Object.assign(Object.create(null), {
-    interface: "mode:relational",
-    type: ["TOPIC references:relational_topics", "POST references:relational_posts", "DIVIDER references:relational_dividers", "CHECKLIST references:relational_checklists", "CHECKLIST_ITEM references:relational_checklist_items"]
-  })
 };
-const relationalItemsCodec = recordCodec({
-  name: "relationalItems",
-  identifier: sql.identifier("polymorphic", "relational_items"),
-  attributes: relationalItemsAttributes,
+const spec_ZeroImplementation = {
+  name: "ZeroImplementation",
+  identifier: sql.identifier("polymorphic", "zero_implementation"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions24,
-  executor
-});
-const ApplicationAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        notNull: true
-      }
-    }
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "zero_implementation"
+    },
+    tags: Object.assign(Object.create(null), {
+      interface: "mode:union",
+      name: "ZeroImplementation",
+      behavior: "node"
+    })
   },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        notNull: true
-      }
-    }
-  },
-  last_deployed: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  executor: executor,
+  polymorphism: {
+    mode: "union"
   }
-});
-const VulnerabilityAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        notNull: true
-      }
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        notNull: true
-      }
-    }
-  },
-  cvss_score: {
-    description: undefined,
-    codec: TYPES.float,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        notNull: true
-      }
-    }
-  }
-});
-const ZeroImplementationAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
+};
 const registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws_application_first_party_vulnerabilities = {
   executor,
   name: "aws_application_first_party_vulnerabilities",
@@ -2101,7 +2320,7 @@ const registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws
     },
     tags: {
       omit: true,
-      behavior: extensions.tags.behavior
+      behavior: spec_awsApplicationFirstPartyVulnerabilities.extensions.tags.behavior
     }
   }
 };
@@ -2130,7 +2349,7 @@ const registryConfig_pgResources_aws_application_third_party_vulnerabilities_aws
     },
     tags: {
       omit: true,
-      behavior: extensions2.tags.behavior
+      behavior: spec_awsApplicationThirdPartyVulnerabilities.extensions.tags.behavior
     }
   }
 };
@@ -2159,7 +2378,7 @@ const registryConfig_pgResources_gcp_application_first_party_vulnerabilities_gcp
     },
     tags: {
       omit: true,
-      behavior: extensions3.tags.behavior
+      behavior: spec_gcpApplicationFirstPartyVulnerabilities.extensions.tags.behavior
     }
   }
 };
@@ -2188,7 +2407,7 @@ const registryConfig_pgResources_gcp_application_third_party_vulnerabilities_gcp
     },
     tags: {
       omit: true,
-      behavior: extensions4.tags.behavior
+      behavior: spec_gcpApplicationThirdPartyVulnerabilities.extensions.tags.behavior
     }
   }
 };
@@ -2262,7 +2481,7 @@ const registryConfig_pgResources_people_people = {
     tags: {
       unionMember: "PersonOrOrganization",
       ref: "applications to:Application",
-      refVia: extensions6.tags.refVia
+      refVia: spec_people.extensions.tags.refVia
     }
   }
 };
@@ -2291,7 +2510,7 @@ const registryConfig_pgResources_priorities_priorities = {
     },
     tags: {
       omit: "create,update,delete,filter,order",
-      behavior: extensions7.tags.behavior
+      behavior: spec_priorities.extensions.tags.behavior
     }
   }
 };
@@ -2551,7 +2770,7 @@ const registryConfig_pgResources_log_entries_log_entries = {
     },
     tags: {
       ref: "author to:PersonOrOrganization singular",
-      refVia: extensions17.tags.refVia
+      refVia: spec_logEntries.extensions.tags.refVia
     }
   }
 };
@@ -2608,8 +2827,8 @@ const registryConfig_pgResources_first_party_vulnerabilities_first_party_vulnera
     },
     tags: {
       implements: "Vulnerability",
-      ref: extensions19.tags.ref,
-      refVia: extensions19.tags.refVia
+      ref: spec_firstPartyVulnerabilities.extensions.tags.ref,
+      refVia: spec_firstPartyVulnerabilities.extensions.tags.refVia
     }
   }
 };
@@ -2639,8 +2858,8 @@ const registryConfig_pgResources_third_party_vulnerabilities_third_party_vulnera
     },
     tags: {
       implements: "Vulnerability",
-      ref: extensions20.tags.ref,
-      refVia: extensions20.tags.refVia
+      ref: spec_thirdPartyVulnerabilities.extensions.tags.ref,
+      refVia: spec_thirdPartyVulnerabilities.extensions.tags.refVia
     }
   }
 };
@@ -2670,8 +2889,8 @@ const registryConfig_pgResources_aws_applications_aws_applications = {
     },
     tags: {
       implements: "Application",
-      ref: extensions21.tags.ref,
-      refVia: extensions21.tags.refVia
+      ref: spec_awsApplications.extensions.tags.ref,
+      refVia: spec_awsApplications.extensions.tags.refVia
     }
   }
 };
@@ -2701,8 +2920,8 @@ const registryConfig_pgResources_gcp_applications_gcp_applications = {
     },
     tags: {
       implements: "Application",
-      ref: extensions22.tags.ref,
-      refVia: extensions22.tags.refVia
+      ref: spec_gcpApplications.extensions.tags.ref,
+      refVia: spec_gcpApplications.extensions.tags.refVia
     }
   }
 };
@@ -2733,8 +2952,8 @@ const registryConfig_pgResources_single_table_items_single_table_items = {
     },
     tags: {
       interface: "mode:single type:type",
-      type: extensions23.tags.type,
-      ref: extensions23.tags.ref
+      type: spec_singleTableItems.extensions.tags.type,
+      ref: spec_singleTableItems.extensions.tags.ref
     }
   }
 };
@@ -2766,7 +2985,7 @@ const registryConfig_pgResources_relational_items_relational_items = {
     },
     tags: {
       interface: "mode:relational",
-      type: extensions24.tags.type
+      type: spec_relationalItems.extensions.tags.type
     }
   }
 };
@@ -2804,116 +3023,9 @@ const registryConfig = {
     relationalItems: relationalItemsCodec,
     varchar: TYPES.varchar,
     bpchar: TYPES.bpchar,
-    Application: recordCodec({
-      name: "Application",
-      identifier: sql.identifier("polymorphic", "applications"),
-      attributes: ApplicationAttributes,
-      description: undefined,
-      extensions: {
-        isTableLike: false,
-        pg: {
-          serviceName: "main",
-          schemaName: "polymorphic",
-          name: "applications"
-        },
-        tags: Object.assign(Object.create(null), {
-          interface: "mode:union",
-          name: "Application",
-          behavior: "node",
-          ref: ["vulnerabilities to:Vulnerability plural", "owner to:PersonOrOrganization singular"]
-        }),
-        refDefinitions: Object.assign(Object.create(null), {
-          vulnerabilities: {
-            singular: false,
-            graphqlType: "Vulnerability",
-            sourceGraphqlType: undefined,
-            extensions: {
-              via: undefined,
-              tags: {
-                behavior: undefined
-              }
-            }
-          },
-          owner: {
-            singular: true,
-            graphqlType: "PersonOrOrganization",
-            sourceGraphqlType: undefined,
-            extensions: {
-              via: undefined,
-              tags: {
-                behavior: undefined
-              }
-            }
-          }
-        })
-      },
-      executor
-    }),
-    Vulnerability: recordCodec({
-      name: "Vulnerability",
-      identifier: sql.identifier("polymorphic", "vulnerabilities"),
-      attributes: VulnerabilityAttributes,
-      description: undefined,
-      extensions: {
-        isTableLike: false,
-        pg: {
-          serviceName: "main",
-          schemaName: "polymorphic",
-          name: "vulnerabilities"
-        },
-        tags: Object.assign(Object.create(null), {
-          interface: "mode:union",
-          name: "Vulnerability",
-          behavior: "node",
-          ref: ["applications to:Application plural", "owners to:PersonOrOrganization plural"]
-        }),
-        refDefinitions: Object.assign(Object.create(null), {
-          applications: {
-            singular: false,
-            graphqlType: "Application",
-            sourceGraphqlType: undefined,
-            extensions: {
-              via: undefined,
-              tags: {
-                behavior: undefined
-              }
-            }
-          },
-          owners: {
-            singular: false,
-            graphqlType: "PersonOrOrganization",
-            sourceGraphqlType: undefined,
-            extensions: {
-              via: undefined,
-              tags: {
-                behavior: undefined
-              }
-            }
-          }
-        })
-      },
-      executor
-    }),
-    ZeroImplementation: recordCodec({
-      name: "ZeroImplementation",
-      identifier: sql.identifier("polymorphic", "zero_implementation"),
-      attributes: ZeroImplementationAttributes,
-      description: undefined,
-      extensions: {
-        isTableLike: false,
-        pg: {
-          serviceName: "main",
-          schemaName: "polymorphic",
-          name: "zero_implementation"
-        },
-        tags: Object.assign(Object.create(null), {
-          interface: "mode:union",
-          name: "ZeroImplementation",
-          behavior: "node"
-        })
-      },
-      executor
-    })
+    Application: recordCodec(spec_Application),
+    Vulnerability: recordCodec(spec_Vulnerability),
+    ZeroImplementation: recordCodec(spec_ZeroImplementation)
   }),
   pgResources: Object.assign(Object.create(null), {
     aws_application_first_party_vulnerabilities: registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws_application_first_party_vulnerabilities,
@@ -4116,22 +4228,30 @@ const handler = {
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   base64JSON: handler_codec_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const otherSource_peoplePgResource = registry.pgResources["people"];
@@ -4155,6 +4275,9 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
 };
 const otherSource_single_table_item_relationsPgResource = registry.pgResources["single_table_item_relations"];
 const otherSource_single_table_item_relation_composite_pksPgResource = registry.pgResources["single_table_item_relation_composite_pks"];
+function BigIntSerialize(value) {
+  return "" + value;
+}
 const handler2 = {
   typeName: "Person",
   codec: handler_codec_base64JSON,
@@ -14255,6 +14378,26 @@ export const plans = {
       });
     }
   },
+  BigInt: {
+    serialize: BigIntSerialize,
+    parseValue: BigIntSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigInt" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  Datetime: {
+    serialize: BigIntSerialize,
+    parseValue: BigIntSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   Person: {
     __assertStep: assertPgClassSingleStep,
     nodeId($parent) {
@@ -14562,7 +14705,7 @@ export const plans = {
           }, Object.create(null));
         }
         const $list = pgUnionAll({
-          attributes: ApplicationAttributes,
+          attributes: spec_Application.attributes,
           resourceByTypeName,
           members,
           name: "applications"
@@ -14885,6 +15028,16 @@ export const plans = {
       }
     }
   },
+  Cursor: {
+    serialize: BigIntSerialize,
+    parseValue: BigIntSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   LogEntriesOrderBy: {
     NATURAL: {
       applyPlan() {}
@@ -15074,7 +15227,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), logEntriesAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_logEntries.attributes.id.codec)}`;
             }
           });
         }
@@ -15097,7 +15250,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), logEntriesAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_logEntries.attributes.person_id.codec)}`;
             }
           });
         }
@@ -15120,7 +15273,7 @@ export const plans = {
             type: "attribute",
             attribute: "organization_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), logEntriesAttributes.organization_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_logEntries.attributes.organization_id.codec)}`;
             }
           });
         }
@@ -15143,7 +15296,7 @@ export const plans = {
             type: "attribute",
             attribute: "text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), logEntriesAttributes.text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_logEntries.attributes.text.codec)}`;
             }
           });
         }
@@ -15217,7 +15370,7 @@ export const plans = {
           }, Object.create(null));
         }
         const $list = pgUnionAll({
-          attributes: VulnerabilityAttributes,
+          attributes: spec_Vulnerability.attributes,
           resourceByTypeName: resourceByTypeName3,
           members: members3,
           name: "vulnerabilities"
@@ -15524,7 +15677,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), VulnerabilityAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_Vulnerability.attributes.id.codec)}`;
             }
           });
         }
@@ -15547,7 +15700,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), VulnerabilityAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_Vulnerability.attributes.name.codec)}`;
             }
           });
         }
@@ -15570,7 +15723,7 @@ export const plans = {
             type: "attribute",
             attribute: "cvss_score",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), VulnerabilityAttributes.cvss_score.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_Vulnerability.attributes.cvss_score.codec)}`;
             }
           });
         }
@@ -15845,7 +15998,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_awsApplications.attributes.id.codec)}`;
             }
           });
         }
@@ -15868,7 +16021,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_awsApplications.attributes.name.codec)}`;
             }
           });
         }
@@ -15891,7 +16044,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_deployed",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.last_deployed.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_awsApplications.attributes.last_deployed.codec)}`;
             }
           });
         }
@@ -15914,7 +16067,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_awsApplications.attributes.person_id.codec)}`;
             }
           });
         }
@@ -15937,7 +16090,7 @@ export const plans = {
             type: "attribute",
             attribute: "organization_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.organization_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_awsApplications.attributes.organization_id.codec)}`;
             }
           });
         }
@@ -15960,7 +16113,7 @@ export const plans = {
             type: "attribute",
             attribute: "aws_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.aws_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_awsApplications.attributes.aws_id.codec)}`;
             }
           });
         }
@@ -16034,7 +16187,7 @@ export const plans = {
           }, Object.create(null));
         }
         const $list = pgUnionAll({
-          attributes: VulnerabilityAttributes,
+          attributes: spec_Vulnerability.attributes,
           resourceByTypeName: resourceByTypeName5,
           members: members5,
           name: "vulnerabilities"
@@ -16397,7 +16550,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_gcpApplications.attributes.id.codec)}`;
             }
           });
         }
@@ -16420,7 +16573,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_gcpApplications.attributes.name.codec)}`;
             }
           });
         }
@@ -16443,7 +16596,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_deployed",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.last_deployed.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_gcpApplications.attributes.last_deployed.codec)}`;
             }
           });
         }
@@ -16466,7 +16619,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_gcpApplications.attributes.person_id.codec)}`;
             }
           });
         }
@@ -16489,7 +16642,7 @@ export const plans = {
             type: "attribute",
             attribute: "organization_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.organization_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_gcpApplications.attributes.organization_id.codec)}`;
             }
           });
         }
@@ -16512,7 +16665,7 @@ export const plans = {
             type: "attribute",
             attribute: "gcp_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.gcp_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_gcpApplications.attributes.gcp_id.codec)}`;
             }
           });
         }
@@ -16948,7 +17101,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItems.attributes.id.codec)}`;
             }
           });
         }
@@ -16971,7 +17124,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItems.attributes.type.codec)}`;
             }
           });
         }
@@ -16994,7 +17147,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItems.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -17017,7 +17170,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItems.attributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -17040,7 +17193,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItems.attributes.author_id.codec)}`;
             }
           });
         }
@@ -17063,7 +17216,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItems.attributes.position.codec)}`;
             }
           });
         }
@@ -17086,7 +17239,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItems.attributes.created_at.codec)}`;
             }
           });
         }
@@ -17109,7 +17262,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItems.attributes.updated_at.codec)}`;
             }
           });
         }
@@ -17132,7 +17285,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItems.attributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -17155,7 +17308,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItems.attributes.archived_at.codec)}`;
             }
           });
         }
@@ -17681,7 +17834,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.id.codec)}`;
             }
           });
         }
@@ -17704,7 +17857,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.type.codec)}`;
             }
           });
         }
@@ -17727,7 +17880,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -17750,7 +17903,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -17773,7 +17926,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.author_id.codec)}`;
             }
           });
         }
@@ -17796,7 +17949,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.position.codec)}`;
             }
           });
         }
@@ -17819,7 +17972,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.created_at.codec)}`;
             }
           });
         }
@@ -17842,7 +17995,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.updated_at.codec)}`;
             }
           });
         }
@@ -17865,7 +18018,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -17888,7 +18041,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.archived_at.codec)}`;
             }
           });
         }
@@ -18020,7 +18173,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), ApplicationAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_Application.attributes.id.codec)}`;
             }
           });
         }
@@ -18043,7 +18196,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), ApplicationAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_Application.attributes.name.codec)}`;
             }
           });
         }
@@ -18066,7 +18219,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_deployed",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), ApplicationAttributes.last_deployed.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_Application.attributes.last_deployed.codec)}`;
             }
           });
         }
@@ -18329,7 +18482,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemRelationsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItemRelations.attributes.id.codec)}`;
             }
           });
         }
@@ -18352,7 +18505,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemRelationsAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItemRelations.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -18375,7 +18528,7 @@ export const plans = {
             type: "attribute",
             attribute: "child_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemRelationsAttributes.child_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItemRelations.attributes.child_id.codec)}`;
             }
           });
         }
@@ -18505,7 +18658,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemRelationCompositePksAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItemRelationCompositePks.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -18528,7 +18681,7 @@ export const plans = {
             type: "attribute",
             attribute: "child_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemRelationCompositePksAttributes.child_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItemRelationCompositePks.attributes.child_id.codec)}`;
             }
           });
         }
@@ -20662,7 +20815,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemRelationsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItemRelations.attributes.id.codec)}`;
             }
           });
         }
@@ -20685,7 +20838,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemRelationsAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItemRelations.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -20708,7 +20861,7 @@ export const plans = {
             type: "attribute",
             attribute: "child_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemRelationsAttributes.child_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItemRelations.attributes.child_id.codec)}`;
             }
           });
         }
@@ -20838,7 +20991,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemRelationCompositePksAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItemRelationCompositePks.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -20861,7 +21014,7 @@ export const plans = {
             type: "attribute",
             attribute: "child_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemRelationCompositePksAttributes.child_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItemRelationCompositePks.attributes.child_id.codec)}`;
             }
           });
         }
@@ -23260,7 +23413,7 @@ export const plans = {
     allVulnerabilities: {
       plan() {
         const $list = pgUnionAll({
-          attributes: VulnerabilityAttributes,
+          attributes: spec_Vulnerability.attributes,
           resourceByTypeName: resourceByTypeName7,
           members: members7,
           name: "Vulnerability"
@@ -23326,7 +23479,7 @@ export const plans = {
     allApplications: {
       plan() {
         const $list = pgUnionAll({
-          attributes: ApplicationAttributes,
+          attributes: spec_Application.attributes,
           resourceByTypeName: resourceByTypeName8,
           members: members8,
           name: "Application"
@@ -23392,7 +23545,7 @@ export const plans = {
     allZeroImplementations: {
       plan() {
         const $list = pgUnionAll({
-          attributes: ZeroImplementationAttributes,
+          attributes: spec_ZeroImplementation.attributes,
           resourceByTypeName: resourceByTypeName9,
           members: members9,
           name: "ZeroImplementation"
@@ -24473,7 +24626,7 @@ export const plans = {
           }, Object.create(null));
         }
         const $list = pgUnionAll({
-          attributes: ApplicationAttributes,
+          attributes: spec_Application.attributes,
           resourceByTypeName: resourceByTypeName10,
           members: members10,
           name: "applications"
@@ -24603,7 +24756,7 @@ export const plans = {
           }, Object.create(null));
         }
         const $list = pgUnionAll({
-          attributes: ApplicationAttributes,
+          attributes: spec_Application.attributes,
           resourceByTypeName: resourceByTypeName12,
           members: members12,
           name: "applications"
@@ -24814,7 +24967,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), ZeroImplementationAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_ZeroImplementation.attributes.id.codec)}`;
             }
           });
         }
@@ -24837,7 +24990,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), ZeroImplementationAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_ZeroImplementation.attributes.name.codec)}`;
             }
           });
         }
@@ -24992,7 +25145,7 @@ export const plans = {
             type: "attribute",
             attribute: "organization_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), organizationsAttributes.organization_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_organizations.attributes.organization_id.codec)}`;
             }
           });
         }
@@ -25015,7 +25168,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), organizationsAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_organizations.attributes.name.codec)}`;
             }
           });
         }
@@ -25170,7 +25323,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), peopleAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_people.attributes.person_id.codec)}`;
             }
           });
         }
@@ -25193,7 +25346,7 @@ export const plans = {
             type: "attribute",
             attribute: "username",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), peopleAttributes.username.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_people.attributes.username.codec)}`;
             }
           });
         }
@@ -25679,7 +25832,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.title.codec)}`;
             }
           });
         }
@@ -25702,7 +25855,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.id.codec)}`;
             }
           });
         }
@@ -25725,7 +25878,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.type.codec)}`;
             }
           });
         }
@@ -25748,7 +25901,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -25771,7 +25924,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -25794,7 +25947,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.author_id.codec)}`;
             }
           });
         }
@@ -25817,7 +25970,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.position.codec)}`;
             }
           });
         }
@@ -25840,7 +25993,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.created_at.codec)}`;
             }
           });
         }
@@ -25863,7 +26016,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.updated_at.codec)}`;
             }
           });
         }
@@ -25886,7 +26039,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -25909,7 +26062,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.archived_at.codec)}`;
             }
           });
         }
@@ -26370,7 +26523,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.title.codec)}`;
             }
           });
         }
@@ -26393,7 +26546,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.id.codec)}`;
             }
           });
         }
@@ -26416,7 +26569,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.type.codec)}`;
             }
           });
         }
@@ -26439,7 +26592,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -26462,7 +26615,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -26485,7 +26638,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.author_id.codec)}`;
             }
           });
         }
@@ -26508,7 +26661,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.position.codec)}`;
             }
           });
         }
@@ -26531,7 +26684,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.created_at.codec)}`;
             }
           });
         }
@@ -26554,7 +26707,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.updated_at.codec)}`;
             }
           });
         }
@@ -26577,7 +26730,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -26600,7 +26753,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.archived_at.codec)}`;
             }
           });
         }
@@ -27095,7 +27248,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.description.codec)}`;
             }
           });
         }
@@ -27118,7 +27271,7 @@ export const plans = {
             type: "attribute",
             attribute: "note",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.note.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.note.codec)}`;
             }
           });
         }
@@ -27141,7 +27294,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.id.codec)}`;
             }
           });
         }
@@ -27164,7 +27317,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.type.codec)}`;
             }
           });
         }
@@ -27187,7 +27340,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -27210,7 +27363,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -27233,7 +27386,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.author_id.codec)}`;
             }
           });
         }
@@ -27256,7 +27409,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.position.codec)}`;
             }
           });
         }
@@ -27279,7 +27432,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.created_at.codec)}`;
             }
           });
         }
@@ -27302,7 +27455,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.updated_at.codec)}`;
             }
           });
         }
@@ -27325,7 +27478,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -27348,7 +27501,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.archived_at.codec)}`;
             }
           });
         }
@@ -27843,7 +27996,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.title.codec)}`;
             }
           });
         }
@@ -27866,7 +28019,7 @@ export const plans = {
             type: "attribute",
             attribute: "color",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.color.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.color.codec)}`;
             }
           });
         }
@@ -27889,7 +28042,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.id.codec)}`;
             }
           });
         }
@@ -27912,7 +28065,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.type.codec)}`;
             }
           });
         }
@@ -27935,7 +28088,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -27958,7 +28111,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -27981,7 +28134,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.author_id.codec)}`;
             }
           });
         }
@@ -28004,7 +28157,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.position.codec)}`;
             }
           });
         }
@@ -28027,7 +28180,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.created_at.codec)}`;
             }
           });
         }
@@ -28050,7 +28203,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.updated_at.codec)}`;
             }
           });
         }
@@ -28073,7 +28226,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -28096,7 +28249,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.archived_at.codec)}`;
             }
           });
         }
@@ -28625,7 +28778,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.title.codec)}`;
             }
           });
         }
@@ -28648,7 +28801,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.description.codec)}`;
             }
           });
         }
@@ -28671,7 +28824,7 @@ export const plans = {
             type: "attribute",
             attribute: "note",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.note.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.note.codec)}`;
             }
           });
         }
@@ -28694,7 +28847,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.id.codec)}`;
             }
           });
         }
@@ -28717,7 +28870,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.type.codec)}`;
             }
           });
         }
@@ -28740,7 +28893,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -28763,7 +28916,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -28786,7 +28939,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.author_id.codec)}`;
             }
           });
         }
@@ -28809,7 +28962,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.position.codec)}`;
             }
           });
         }
@@ -28832,7 +28985,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.created_at.codec)}`;
             }
           });
         }
@@ -28855,7 +29008,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.updated_at.codec)}`;
             }
           });
         }
@@ -28878,7 +29031,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -28901,7 +29054,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.archived_at.codec)}`;
             }
           });
         }
@@ -29124,7 +29277,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), firstPartyVulnerabilitiesAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_firstPartyVulnerabilities.attributes.id.codec)}`;
             }
           });
         }
@@ -29147,7 +29300,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), firstPartyVulnerabilitiesAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_firstPartyVulnerabilities.attributes.name.codec)}`;
             }
           });
         }
@@ -29170,7 +29323,7 @@ export const plans = {
             type: "attribute",
             attribute: "cvss_score",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), firstPartyVulnerabilitiesAttributes.cvss_score.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_firstPartyVulnerabilities.attributes.cvss_score.codec)}`;
             }
           });
         }
@@ -29193,7 +29346,7 @@ export const plans = {
             type: "attribute",
             attribute: "team_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), firstPartyVulnerabilitiesAttributes.team_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_firstPartyVulnerabilities.attributes.team_name.codec)}`;
             }
           });
         }
@@ -29416,7 +29569,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), thirdPartyVulnerabilitiesAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_thirdPartyVulnerabilities.attributes.id.codec)}`;
             }
           });
         }
@@ -29439,7 +29592,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), thirdPartyVulnerabilitiesAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_thirdPartyVulnerabilities.attributes.name.codec)}`;
             }
           });
         }
@@ -29462,7 +29615,7 @@ export const plans = {
             type: "attribute",
             attribute: "cvss_score",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), thirdPartyVulnerabilitiesAttributes.cvss_score.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_thirdPartyVulnerabilities.attributes.cvss_score.codec)}`;
             }
           });
         }
@@ -29485,7 +29638,7 @@ export const plans = {
             type: "attribute",
             attribute: "vendor_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), thirdPartyVulnerabilitiesAttributes.vendor_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_thirdPartyVulnerabilities.attributes.vendor_name.codec)}`;
             }
           });
         }
@@ -30681,6 +30834,9 @@ export const plans = {
     }
   },
   OrganizationInput: {
+    "__inputPlan": function OrganizationInput_inputPlan() {
+      return object(Object.create(null));
+    },
     organizationId: {
       applyPlan($insert, val) {
         $insert.set("organization_id", val.get());
@@ -30755,6 +30911,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -30839,6 +30998,9 @@ export const plans = {
     }
   },
   RelationalItemRelationCompositePkInput: {
+    "__inputPlan": function RelationalItemRelationCompositePkInput_inputPlan() {
+      return object(Object.create(null));
+    },
     parentId: {
       applyPlan($insert, val) {
         $insert.set("parent_id", val.get());
@@ -30923,6 +31085,9 @@ export const plans = {
     }
   },
   SingleTableItemRelationCompositePkInput: {
+    "__inputPlan": function SingleTableItemRelationCompositePkInput_inputPlan() {
+      return object(Object.create(null));
+    },
     parentId: {
       applyPlan($insert, val) {
         $insert.set("parent_id", val.get());
@@ -31007,6 +31172,9 @@ export const plans = {
     }
   },
   RelationalItemRelationInput: {
+    "__inputPlan": function RelationalItemRelationInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -31098,6 +31266,9 @@ export const plans = {
     }
   },
   SingleTableItemRelationInput: {
+    "__inputPlan": function SingleTableItemRelationInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -31189,6 +31360,9 @@ export const plans = {
     }
   },
   LogEntryInput: {
+    "__inputPlan": function LogEntryInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -31277,6 +31451,9 @@ export const plans = {
     }
   },
   FirstPartyVulnerabilityInput: {
+    "__inputPlan": function FirstPartyVulnerabilityInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -31365,6 +31542,9 @@ export const plans = {
     }
   },
   ThirdPartyVulnerabilityInput: {
+    "__inputPlan": function ThirdPartyVulnerabilityInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -31463,6 +31643,9 @@ export const plans = {
     }
   },
   AwsApplicationInput: {
+    "__inputPlan": function AwsApplicationInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -31575,6 +31758,9 @@ export const plans = {
     }
   },
   GcpApplicationInput: {
+    "__inputPlan": function GcpApplicationInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -31676,6 +31862,9 @@ export const plans = {
     }
   },
   OrganizationPatch: {
+    "__inputPlan": function OrganizationPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     organizationId: {
       applyPlan($insert, val) {
         $insert.set("organization_id", val.get());
@@ -31777,6 +31966,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -31888,6 +32080,9 @@ export const plans = {
     }
   },
   RelationalItemRelationCompositePkPatch: {
+    "__inputPlan": function RelationalItemRelationCompositePkPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     parentId: {
       applyPlan($insert, val) {
         $insert.set("parent_id", val.get());
@@ -31986,6 +32181,9 @@ export const plans = {
     }
   },
   SingleTableItemRelationCompositePkPatch: {
+    "__inputPlan": function SingleTableItemRelationCompositePkPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     parentId: {
       applyPlan($insert, val) {
         $insert.set("parent_id", val.get());
@@ -32084,6 +32282,9 @@ export const plans = {
     }
   },
   RelationalItemRelationPatch: {
+    "__inputPlan": function RelationalItemRelationPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -32203,6 +32404,9 @@ export const plans = {
     }
   },
   SingleTableItemRelationPatch: {
+    "__inputPlan": function SingleTableItemRelationPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -32322,6 +32526,9 @@ export const plans = {
     }
   },
   LogEntryPatch: {
+    "__inputPlan": function LogEntryPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -32423,6 +32630,9 @@ export const plans = {
     }
   },
   FirstPartyVulnerabilityPatch: {
+    "__inputPlan": function FirstPartyVulnerabilityPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -32524,6 +32734,9 @@ export const plans = {
     }
   },
   ThirdPartyVulnerabilityPatch: {
+    "__inputPlan": function ThirdPartyVulnerabilityPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -32635,6 +32848,9 @@ export const plans = {
     }
   },
   AwsApplicationPatch: {
+    "__inputPlan": function AwsApplicationPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -32760,6 +32976,9 @@ export const plans = {
     }
   },
   GcpApplicationPatch: {
+    "__inputPlan": function GcpApplicationPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, domainOfCodec, enumCodec, listOfCodec, makeRegistry, pgClassExpression, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectFromRecords, pgSelectSingleFromRecord, pgUpdateSingle, rangeOfCodec, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
+import { GraphQLError, GraphQLInt, GraphQLString, Kind, valueFromASTUntyped } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -442,21 +459,20 @@ const textArrayCodec = listOfCodec(TYPES.text, {
   description: undefined,
   name: "textArray"
 });
-const nonUpdatableViewAttributes = Object.assign(Object.create(null), {
-  "?column?": {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const nonUpdatableViewCodec = recordCodec({
+const spec_nonUpdatableView = {
   name: "nonUpdatableView",
   identifier: sql.identifier("a", "non_updatable_view"),
-  attributes: nonUpdatableViewAttributes,
+  attributes: Object.assign(Object.create(null), {
+    "?column?": {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -467,23 +483,23 @@ const nonUpdatableViewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const inputsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const inputsCodec = recordCodec({
+  executor: executor
+};
+const nonUpdatableViewCodec = recordCodec(spec_nonUpdatableView);
+const spec_inputs = {
   name: "inputs",
   identifier: sql.identifier("a", "inputs"),
-  attributes: inputsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Should output as Input",
   extensions: {
     isTableLike: true,
@@ -494,23 +510,23 @@ const inputsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const patchsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const patchsCodec = recordCodec({
+  executor: executor
+};
+const inputsCodec = recordCodec(spec_inputs);
+const spec_patchs = {
   name: "patchs",
   identifier: sql.identifier("a", "patchs"),
-  attributes: patchsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Should output as Patch",
   extensions: {
     isTableLike: true,
@@ -521,23 +537,23 @@ const patchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const reservedAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const reservedCodec = recordCodec({
+  executor: executor
+};
+const patchsCodec = recordCodec(spec_patchs);
+const spec_reserved = {
   name: "reserved",
   identifier: sql.identifier("a", "reserved"),
-  attributes: reservedAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -548,23 +564,23 @@ const reservedCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const reservedPatchsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const reservedPatchsCodec = recordCodec({
+  executor: executor
+};
+const reservedCodec = recordCodec(spec_reserved);
+const spec_reservedPatchs = {
   name: "reservedPatchs",
   identifier: sql.identifier("a", "reservedPatchs"),
-  attributes: reservedPatchsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   extensions: {
     isTableLike: true,
@@ -575,23 +591,23 @@ const reservedPatchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const reservedInputAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const reservedInputCodec = recordCodec({
+  executor: executor
+};
+const reservedPatchsCodec = recordCodec(spec_reservedPatchs);
+const spec_reservedInput = {
   name: "reservedInput",
   identifier: sql.identifier("a", "reserved_input"),
-  attributes: reservedInputAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
   extensions: {
     isTableLike: true,
@@ -602,32 +618,32 @@ const reservedInputCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const defaultValueAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  null_value: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const defaultValueCodec = recordCodec({
+  executor: executor
+};
+const reservedInputCodec = recordCodec(spec_reservedInput);
+const spec_defaultValue = {
   name: "defaultValue",
   identifier: sql.identifier("a", "default_value"),
-  attributes: defaultValueAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    null_value: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -638,41 +654,41 @@ const defaultValueCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const foreignKeyAttributes = Object.assign(Object.create(null), {
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_key_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_key_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const foreignKeyCodec = recordCodec({
+  executor: executor
+};
+const defaultValueCodec = recordCodec(spec_defaultValue);
+const spec_foreignKey = {
   name: "foreignKey",
   identifier: sql.identifier("a", "foreign_key"),
-  attributes: foreignKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_key_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_key_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -683,32 +699,32 @@ const foreignKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  str: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const noPrimaryKeyCodec = recordCodec({
+  executor: executor
+};
+const foreignKeyCodec = recordCodec(spec_foreignKey);
+const spec_noPrimaryKey = {
   name: "noPrimaryKey",
   identifier: sql.identifier("a", "no_primary_key"),
-  attributes: noPrimaryKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    str: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -719,41 +735,41 @@ const noPrimaryKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const testviewAttributes = Object.assign(Object.create(null), {
-  testviewid: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const testviewCodec = recordCodec({
+  executor: executor
+};
+const noPrimaryKeyCodec = recordCodec(spec_noPrimaryKey);
+const spec_testview = {
   name: "testview",
   identifier: sql.identifier("a", "testview"),
-  attributes: testviewAttributes,
+  attributes: Object.assign(Object.create(null), {
+    testviewid: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -764,21 +780,10 @@ const testviewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const extensions12 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "unique_foreign_key"
-  },
-  tags: Object.assign(Object.create(null), {
-    omit: "create,update,delete,all,order,filter",
-    behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy"]
-  })
+  executor: executor
 };
-const uniqueForeignKeyCodec = recordCodec({
+const testviewCodec = recordCodec(spec_testview);
+const spec_uniqueForeignKey = {
   name: "uniqueForeignKey",
   identifier: sql.identifier("a", "unique_foreign_key"),
   attributes: Object.assign(Object.create(null), {
@@ -802,33 +807,44 @@ const uniqueForeignKeyCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions: extensions12,
-  executor
-});
-const myTableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "unique_foreign_key"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: "create,update,delete,all,order,filter",
+      behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy"]
+    })
   },
-  json_data: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const myTableCodec = recordCodec({
+  executor: executor
+};
+const uniqueForeignKeyCodec = recordCodec(spec_uniqueForeignKey);
+const spec_myTable = {
   name: "myTable",
   identifier: sql.identifier("c", "my_table"),
-  attributes: myTableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    json_data: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -839,34 +855,34 @@ const myTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const personSecretAttributes = Object.assign(Object.create(null), {
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  sekrit: {
-    description: "A secret held by the associated Person",
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "secret"
-      }
-    }
-  }
-});
-const personSecretCodec = recordCodec({
+  executor: executor
+};
+const myTableCodec = recordCodec(spec_myTable);
+const spec_personSecret = {
   name: "personSecret",
   identifier: sql.identifier("c", "person_secret"),
-  attributes: personSecretAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    sekrit: {
+      description: "A secret held by the associated Person",
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "secret"
+        }
+      }
+    }
+  }),
   description: "Tracks the person's secret",
   extensions: {
     isTableLike: true,
@@ -879,41 +895,41 @@ const personSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor
-});
-const viewTableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const viewTableCodec = recordCodec({
+  executor: executor
+};
+const personSecretCodec = recordCodec(spec_personSecret);
+const spec_viewTable = {
   name: "viewTable",
   identifier: sql.identifier("a", "view_table"),
-  attributes: viewTableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -924,41 +940,41 @@ const viewTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const compoundKeyAttributes = Object.assign(Object.create(null), {
-  person_id_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  extra: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const compoundKeyCodec = recordCodec({
+  executor: executor
+};
+const viewTableCodec = recordCodec(spec_viewTable);
+const spec_compoundKey = {
   name: "compoundKey",
   identifier: sql.identifier("c", "compound_key"),
-  attributes: compoundKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    extra: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -969,50 +985,50 @@ const compoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const similarTable1Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col3: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const similarTable1Codec = recordCodec({
+  executor: executor
+};
+const compoundKeyCodec = recordCodec(spec_compoundKey);
+const spec_similarTable1 = {
   name: "similarTable1",
   identifier: sql.identifier("a", "similar_table_1"),
-  attributes: similarTable1Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col3: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1023,50 +1039,50 @@ const similarTable1Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const similarTable2Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  col3: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col4: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col5: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const similarTable2Codec = recordCodec({
+  executor: executor
+};
+const similarTable1Codec = recordCodec(spec_similarTable1);
+const spec_similarTable2 = {
   name: "similarTable2",
   identifier: sql.identifier("a", "similar_table_2"),
-  attributes: similarTable2Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    col3: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col4: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col5: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1077,50 +1093,50 @@ const similarTable2Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const updatableViewAttributes = Object.assign(Object.create(null), {
-  x: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  description: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  constant: {
-    description: "This is constantly 2",
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const updatableViewCodec = recordCodec({
+  executor: executor
+};
+const similarTable2Codec = recordCodec(spec_similarTable2);
+const spec_updatableView = {
   name: "updatableView",
   identifier: sql.identifier("b", "updatable_view"),
-  attributes: updatableViewAttributes,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    description: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    constant: {
+      description: "This is constantly 2",
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "YOYOYO!!",
   extensions: {
     isTableLike: true,
@@ -1134,50 +1150,50 @@ const updatableViewCodec = recordCodec({
       unique: "x|@behavior -single -update -delete"
     })
   },
-  executor
-});
-const nullTestRecordAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_int: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  non_null_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const nullTestRecordCodec = recordCodec({
+  executor: executor
+};
+const updatableViewCodec = recordCodec(spec_updatableView);
+const spec_nullTestRecord = {
   name: "nullTestRecord",
   identifier: sql.identifier("c", "null_test_record"),
-  attributes: nullTestRecordAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_int: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    non_null_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1188,8 +1204,9 @@ const nullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const nullTestRecordCodec = recordCodec(spec_nullTestRecord);
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   extensions: {
     pg: {
@@ -1203,39 +1220,38 @@ const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   description: undefined,
   name: "uuidArray"
 });
-const edgeCaseAttributes = Object.assign(Object.create(null), {
-  not_null_has_default: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  wont_cast_easy: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  row_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const edgeCaseCodec = recordCodec({
+const spec_edgeCase = {
   name: "edgeCase",
   identifier: sql.identifier("c", "edge_case"),
-  attributes: edgeCaseAttributes,
+  attributes: Object.assign(Object.create(null), {
+    not_null_has_default: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    wont_cast_easy: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    row_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1246,50 +1262,50 @@ const edgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const leftArmAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  length_in_metres: {
-    description: undefined,
-    codec: TYPES.float,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  mood: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const leftArmCodec = recordCodec({
+  executor: executor
+};
+const edgeCaseCodec = recordCodec(spec_edgeCase);
+const spec_leftArm = {
   name: "leftArm",
   identifier: sql.identifier("c", "left_arm"),
-  attributes: leftArmAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    length_in_metres: {
+      description: undefined,
+      codec: TYPES.float,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    mood: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Tracks metadata about the left arms of various people",
   extensions: {
     isTableLike: true,
@@ -1300,8 +1316,9 @@ const leftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const leftArmCodec = recordCodec(spec_leftArm);
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
   identifier: sql.identifier("b", "jwt_token"),
@@ -1362,7 +1379,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
@@ -1376,30 +1393,29 @@ const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp
   },
   notNull: true
 });
-const issue756Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  ts: {
-    description: undefined,
-    codec: notNullTimestampCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const issue756Codec = recordCodec({
+const spec_issue756 = {
   name: "issue756",
   identifier: sql.identifier("c", "issue756"),
-  attributes: issue756Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    ts: {
+      description: undefined,
+      codec: notNullTimestampCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1410,8 +1426,9 @@ const issue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const issue756Codec = recordCodec(spec_issue756);
 const authPayloadCodec = recordCodec({
   name: "authPayload",
   identifier: sql.identifier("b", "auth_payload"),
@@ -1456,7 +1473,7 @@ const authPayloadCodec = recordCodec({
       foreignKey: "(id) references c.person"
     })
   },
-  executor
+  executor: executor
 });
 const colorCodec = enumCodec({
   name: "color",
@@ -1587,7 +1604,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
@@ -1709,7 +1726,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1724,66 +1741,65 @@ const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   description: undefined,
   name: "comptypeArray"
 });
-const postAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  headline: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  body: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  enums: {
-    description: undefined,
-    codec: anEnumArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  comptypes: {
-    description: undefined,
-    codec: comptypeArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const postCodec = recordCodec({
+const spec_post = {
   name: "post",
   identifier: sql.identifier("a", "post"),
-  attributes: postAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    headline: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    body: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    enums: {
+      description: undefined,
+      codec: anEnumArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    comptypes: {
+      description: undefined,
+      codec: comptypeArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1794,8 +1810,9 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const postCodec = recordCodec(spec_post);
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
@@ -1942,117 +1959,116 @@ const wrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const personAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: "The primary unique identifier for the person",
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_full_name: {
-    description: "The person\u2019s name",
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "name"
-      }
-    }
-  },
-  aliases: {
-    description: undefined,
-    codec: textArrayCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  about: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  email: {
-    description: undefined,
-    codec: emailCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  site: {
-    description: undefined,
-    codec: wrappedUrlCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        deprecated: "Don\u2019t use me"
-      }
-    }
-  },
-  config: {
-    description: undefined,
-    codec: TYPES.hstore,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_login_from_ip: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_login_from_subnet: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  user_mac: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  created_at: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const personCodec = recordCodec({
+const spec_person = {
   name: "person",
   identifier: sql.identifier("c", "person"),
-  attributes: personAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: "The primary unique identifier for the person",
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_full_name: {
+      description: "The person\u2019s name",
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "name"
+        }
+      }
+    },
+    aliases: {
+      description: undefined,
+      codec: textArrayCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    about: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    email: {
+      description: undefined,
+      codec: emailCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    site: {
+      description: undefined,
+      codec: wrappedUrlCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          deprecated: "Don\u2019t use me"
+        }
+      }
+    },
+    config: {
+      description: undefined,
+      codec: TYPES.hstore,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_login_from_ip: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_login_from_subnet: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    user_mac: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    created_at: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Person test comment",
   extensions: {
     isTableLike: true,
@@ -2063,8 +2079,9 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const personCodec = recordCodec(spec_person);
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
@@ -2397,7 +2414,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -2449,7 +2466,7 @@ const byteaArrayCodec = listOfCodec(TYPES.bytea, {
   description: undefined,
   name: "byteaArray"
 });
-const typesAttributes_ltree_codec_ltree = {
+const spec_types_attributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -2461,469 +2478,468 @@ const typesAttributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
-const typesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  smallint: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bigint: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numeric: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  decimal: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  boolean: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  varchar: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum_array: {
-    description: undefined,
-    codec: colorArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain: {
-    description: undefined,
-    codec: anIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain2: {
-    description: undefined,
-    codec: anotherIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array: {
-    description: undefined,
-    codec: textArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  json: {
-    description: undefined,
-    codec: TYPES.json,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  jsonb: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_range: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numrange: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  daterange: {
-    description: undefined,
-    codec: daterangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  an_int_range: {
-    description: undefined,
-    codec: anIntRangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamp: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamptz: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  date: {
-    description: undefined,
-    codec: TYPES.date,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  time: {
-    description: undefined,
-    codec: TYPES.time,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timetz: {
-    description: undefined,
-    codec: TYPES.timetz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval_array: {
-    description: undefined,
-    codec: intervalArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  money: {
-    description: undefined,
-    codec: TYPES.money,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  point: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullablePoint: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  inet: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  cidr: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  macaddr: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regproc: {
-    description: undefined,
-    codec: TYPES.regproc,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regprocedure: {
-    description: undefined,
-    codec: TYPES.regprocedure,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoper: {
-    description: undefined,
-    codec: TYPES.regoper,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoperator: {
-    description: undefined,
-    codec: TYPES.regoperator,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regclass: {
-    description: undefined,
-    codec: TYPES.regclass,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regtype: {
-    description: undefined,
-    codec: TYPES.regtype,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regconfig: {
-    description: undefined,
-    codec: TYPES.regconfig,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regdictionary: {
-    description: undefined,
-    codec: TYPES.regdictionary,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array_domain: {
-    description: undefined,
-    codec: textArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  int8_array_domain: {
-    description: undefined,
-    codec: int8ArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea: {
-    description: undefined,
-    codec: TYPES.bytea,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea_array: {
-    description: undefined,
-    codec: byteaArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree: {
-    description: undefined,
-    codec: typesAttributes_ltree_codec_ltree,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree_array: {
-    description: undefined,
-    codec: typesAttributes_ltree_array_codec_ltree_,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions46 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "types"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: ["(smallint) references a.post", "(id) references a.post"]
-  })
-};
-const typesCodec = recordCodec({
+const spec_types_attributes_ltree_array_codec_ltree_ = listOfCodec(spec_types_attributes_ltree_codec_ltree);
+const spec_types = {
   name: "types",
   identifier: sql.identifier("b", "types"),
-  attributes: typesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    smallint: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bigint: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numeric: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    decimal: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    boolean: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    varchar: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum_array: {
+      description: undefined,
+      codec: colorArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain: {
+      description: undefined,
+      codec: anIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain2: {
+      description: undefined,
+      codec: anotherIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array: {
+      description: undefined,
+      codec: textArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    json: {
+      description: undefined,
+      codec: TYPES.json,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    jsonb: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_range: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numrange: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    daterange: {
+      description: undefined,
+      codec: daterangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    an_int_range: {
+      description: undefined,
+      codec: anIntRangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamp: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamptz: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    date: {
+      description: undefined,
+      codec: TYPES.date,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    time: {
+      description: undefined,
+      codec: TYPES.time,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timetz: {
+      description: undefined,
+      codec: TYPES.timetz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval_array: {
+      description: undefined,
+      codec: intervalArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    money: {
+      description: undefined,
+      codec: TYPES.money,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    point: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullablePoint: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    inet: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    cidr: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    macaddr: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regproc: {
+      description: undefined,
+      codec: TYPES.regproc,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regprocedure: {
+      description: undefined,
+      codec: TYPES.regprocedure,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoper: {
+      description: undefined,
+      codec: TYPES.regoper,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoperator: {
+      description: undefined,
+      codec: TYPES.regoperator,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regclass: {
+      description: undefined,
+      codec: TYPES.regclass,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regtype: {
+      description: undefined,
+      codec: TYPES.regtype,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regconfig: {
+      description: undefined,
+      codec: TYPES.regconfig,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regdictionary: {
+      description: undefined,
+      codec: TYPES.regdictionary,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array_domain: {
+      description: undefined,
+      codec: textArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    int8_array_domain: {
+      description: undefined,
+      codec: int8ArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea: {
+      description: undefined,
+      codec: TYPES.bytea,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea_array: {
+      description: undefined,
+      codec: byteaArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree: {
+      description: undefined,
+      codec: spec_types_attributes_ltree_codec_ltree,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree_array: {
+      description: undefined,
+      codec: spec_types_attributes_ltree_array_codec_ltree_,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions46,
-  executor
-});
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "types"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: ["(smallint) references a.post", "(id) references a.post"]
+    })
+  },
+  executor: executor
+};
+const typesCodec = recordCodec(spec_types);
 const int4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
     pg: {
@@ -3116,7 +3132,7 @@ const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
     },
     tags: {
       omit: "create,update,delete,all,order,filter",
-      behavior: extensions12.tags.behavior
+      behavior: spec_uniqueForeignKey.extensions.tags.behavior
     }
   }
 };
@@ -3465,7 +3481,7 @@ const registryConfig_pgResources_types_types = {
       name: "types"
     },
     tags: {
-      foreignKey: extensions46.tags.foreignKey
+      foreignKey: spec_types.extensions.tags.foreignKey
     }
   }
 };
@@ -3588,8 +3604,8 @@ const registry = makeRegistry({
     int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
     byteaArray: byteaArrayCodec,
-    ltree: typesAttributes_ltree_codec_ltree,
-    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
+    ltree: spec_types_attributes_ltree_codec_ltree,
+    "ltree[]": spec_types_attributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     compoundTypeArray: listOfCodec(compoundTypeCodec, {
       extensions: {
@@ -3676,7 +3692,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor
+      executor: executor
     }),
     tablefuncCrosstab3: recordCodec({
       name: "tablefuncCrosstab3",
@@ -3729,7 +3745,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor
+      executor: executor
     }),
     tablefuncCrosstab4: recordCodec({
       name: "tablefuncCrosstab4",
@@ -3791,7 +3807,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor
+      executor: executor
     })
   }),
   pgResources: Object.assign(Object.create(null), {
@@ -12373,6 +12389,15 @@ const makeArgs64 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
+function UUIDSerialize(value) {
+  return "" + value;
+}
+const coerce = string => {
+  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
+    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
+  }
+  return string;
+};
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -12877,6 +12902,60 @@ const makeArgs73 = (args, path = []) => {
 const resource_post_computed_compound_type_arrayPgResource = registry.pgResources["post_computed_compound_type_array"];
 const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
+function LTreeParseValue(value) {
+  return value;
+}
+const isValidHstoreObject = obj => {
+  if (obj === null) {
+    // Null is okay
+    return true;
+  } else if (typeof obj === "object") {
+    // A hash with string/null values is also okay
+    const keys = Object.keys(obj);
+    for (const key of keys) {
+      const val = obj[key];
+      if (val === null) {
+        // Null is okay
+      } else if (typeof val === "string") {
+        // String is okay
+      } else {
+        // Everything else is invalid.
+        return false;
+      }
+    }
+    return true;
+  } else {
+    // Everything else is invalid.
+    return false;
+  }
+};
+const parseValueLiteral = (ast, variables) => {
+  switch (ast.kind) {
+    case Kind.INT:
+    case Kind.FLOAT:
+      // Number isn't really okay, but we'll coerce it to a string anyway.
+      return String(parseFloat(ast.value));
+    case Kind.STRING:
+      // String is okay.
+      return String(ast.value);
+    case Kind.NULL:
+      // Null is okay.
+      return null;
+    case Kind.VARIABLE:
+      {
+        // Variable is okay if that variable is either a string or null.
+        const name = ast.name.value;
+        const value = variables ? variables[name] : undefined;
+        if (value === null || typeof value === "string") {
+          return value;
+        }
+        return undefined;
+      }
+    default:
+      // Everything else is invalid.
+      return undefined;
+  }
+};
 const argDetailsSimple74 = [];
 const makeArgs74 = (args, path = []) => {
   const selectArgs = [];
@@ -29725,6 +29804,11 @@ export const plans = {
       return $record.get("o");
     }
   },
+  Email: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
   PersonComputedFirstArgInoutOutRecord: {
     __assertStep: assertPgClassSingleStep,
     person($record) {
@@ -29834,6 +29918,19 @@ export const plans = {
     },
     BLUE: {
       value: "blue"
+    }
+  },
+  UUID: {
+    serialize: UUIDSerialize,
+    parseValue(value) {
+      return coerce("" + value);
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // ERRORS: add name to this error
+        throw new GraphQLError(`${"UUID" ?? "This scalar"} can only parse string values (kind = '${ast.kind}')`);
+      }
+      return coerce(ast.value);
     }
   },
   EnumCaps: {
@@ -30340,6 +30437,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -30356,6 +30463,9 @@ export const plans = {
     }
   },
   CompoundTypeInput: {
+    "__inputPlan": function CompoundTypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     a: {
       applyPlan($insert, val) {
         $insert.set("a", val.get());
@@ -30484,6 +30594,16 @@ export const plans = {
     },
     isOptimised($record) {
       return $record.get("is_optimised");
+    }
+  },
+  Datetime: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   TypesConnection: {
@@ -30690,12 +30810,77 @@ export const plans = {
       });
     }
   },
+  BigInt: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigInt" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  BigFloat: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigFloat" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  AnInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
+  AnotherInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
+  JSON: {
+    serialize(value) {
+      return JSON.stringify(value);
+    },
+    parseValue(value) {
+      return JSON.parse(value);
+    },
+    parseLiteral(ast, _variables) {
+      if (ast.kind === Kind.STRING) {
+        return JSON.parse(ast.value);
+      } else {
+        return undefined;
+      }
+    }
+  },
   BigFloatRange: {},
   BigFloatRangeBound: {},
   DateRange: {},
   DateRangeBound: {},
+  Date: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Date" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   AnIntRange: {},
   AnIntRangeBound: {},
+  Time: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Time" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   NestedCompoundType: {
     __assertStep: assertPgClassSingleStep,
     a($record) {
@@ -30721,6 +30906,128 @@ export const plans = {
     }
   },
   Point: {},
+  InternetAddress: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"InternetAddress" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProc: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProc" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProcedure: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProcedure" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOper: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOper" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOperator: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOperator" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegClass: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegClass" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegType: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegType" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegConfig: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegConfig" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegDictionary: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegDictionary" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  Base64EncodedBinary: {
+    serialize(data) {
+      if (Buffer.isBuffer(data)) {
+        return data.toString("base64");
+      } else {
+        throw new Error(`Base64EncodeBinary can only be used with Node.js buffers.`);
+      }
+    },
+    parseValue(data) {
+      if (typeof data === "string") {
+        return Buffer.from(data, "base64");
+      } else {
+        throw new GraphQLError("Base64EncodedBinary can only parse string values.");
+      }
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // TODO: add name to this error
+        throw new GraphQLError("Base64EncodedBinary can only parse string values");
+      }
+      return Buffer.from(ast.value, "base64");
+    }
+  },
+  LTree: {
+    serialize(x) {
+      return x;
+    },
+    parseValue: LTreeParseValue,
+    parseLiteral(node, variables) {
+      return LTreeParseValue(valueFromASTUntyped(node, variables));
+    }
+  },
   TypesEdge: {
     __assertStep: assertEdgeCapableStep,
     cursor($edge) {
@@ -32041,7 +32348,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.id.codec)}`;
             }
           });
         }
@@ -32064,7 +32371,7 @@ export const plans = {
             type: "attribute",
             attribute: "smallint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.smallint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.smallint.codec)}`;
             }
           });
         }
@@ -32087,7 +32394,7 @@ export const plans = {
             type: "attribute",
             attribute: "bigint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.bigint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.bigint.codec)}`;
             }
           });
         }
@@ -32110,7 +32417,7 @@ export const plans = {
             type: "attribute",
             attribute: "numeric",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numeric.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.numeric.codec)}`;
             }
           });
         }
@@ -32133,7 +32440,7 @@ export const plans = {
             type: "attribute",
             attribute: "decimal",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.decimal.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.decimal.codec)}`;
             }
           });
         }
@@ -32156,7 +32463,7 @@ export const plans = {
             type: "attribute",
             attribute: "boolean",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.boolean.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.boolean.codec)}`;
             }
           });
         }
@@ -32179,7 +32486,7 @@ export const plans = {
             type: "attribute",
             attribute: "varchar",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.varchar.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.varchar.codec)}`;
             }
           });
         }
@@ -32202,7 +32509,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.enum.codec)}`;
             }
           });
         }
@@ -32225,7 +32532,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.enum_array.codec)}`;
             }
           });
         }
@@ -32248,7 +32555,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.domain.codec)}`;
             }
           });
         }
@@ -32271,7 +32578,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.domain2.codec)}`;
             }
           });
         }
@@ -32294,7 +32601,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.text_array.codec)}`;
             }
           });
         }
@@ -32317,7 +32624,7 @@ export const plans = {
             type: "attribute",
             attribute: "json",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.json.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.json.codec)}`;
             }
           });
         }
@@ -32340,7 +32647,7 @@ export const plans = {
             type: "attribute",
             attribute: "jsonb",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.jsonb.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.jsonb.codec)}`;
             }
           });
         }
@@ -32363,7 +32670,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullable_range.codec)}`;
             }
           });
         }
@@ -32386,7 +32693,7 @@ export const plans = {
             type: "attribute",
             attribute: "numrange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numrange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.numrange.codec)}`;
             }
           });
         }
@@ -32409,7 +32716,7 @@ export const plans = {
             type: "attribute",
             attribute: "daterange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.daterange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.daterange.codec)}`;
             }
           });
         }
@@ -32432,7 +32739,7 @@ export const plans = {
             type: "attribute",
             attribute: "an_int_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.an_int_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.an_int_range.codec)}`;
             }
           });
         }
@@ -32455,7 +32762,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamp",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamp.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.timestamp.codec)}`;
             }
           });
         }
@@ -32478,7 +32785,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamptz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamptz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.timestamptz.codec)}`;
             }
           });
         }
@@ -32501,7 +32808,7 @@ export const plans = {
             type: "attribute",
             attribute: "date",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.date.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.date.codec)}`;
             }
           });
         }
@@ -32524,7 +32831,7 @@ export const plans = {
             type: "attribute",
             attribute: "time",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.time.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.time.codec)}`;
             }
           });
         }
@@ -32547,7 +32854,7 @@ export const plans = {
             type: "attribute",
             attribute: "timetz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timetz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.timetz.codec)}`;
             }
           });
         }
@@ -32570,7 +32877,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.interval.codec)}`;
             }
           });
         }
@@ -32593,7 +32900,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.interval_array.codec)}`;
             }
           });
         }
@@ -32616,7 +32923,7 @@ export const plans = {
             type: "attribute",
             attribute: "money",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.money.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.money.codec)}`;
             }
           });
         }
@@ -32639,7 +32946,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.compound_type.codec)}`;
             }
           });
         }
@@ -32662,7 +32969,7 @@ export const plans = {
             type: "attribute",
             attribute: "nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nested_compound_type.codec)}`;
             }
           });
         }
@@ -32685,7 +32992,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullable_compound_type.codec)}`;
             }
           });
         }
@@ -32708,7 +33015,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullable_nested_compound_type.codec)}`;
             }
           });
         }
@@ -32731,7 +33038,7 @@ export const plans = {
             type: "attribute",
             attribute: "point",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.point.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.point.codec)}`;
             }
           });
         }
@@ -32754,7 +33061,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullablePoint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullablePoint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullablePoint.codec)}`;
             }
           });
         }
@@ -32777,7 +33084,7 @@ export const plans = {
             type: "attribute",
             attribute: "inet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.inet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.inet.codec)}`;
             }
           });
         }
@@ -32800,7 +33107,7 @@ export const plans = {
             type: "attribute",
             attribute: "cidr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.cidr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.cidr.codec)}`;
             }
           });
         }
@@ -32823,7 +33130,7 @@ export const plans = {
             type: "attribute",
             attribute: "macaddr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.macaddr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.macaddr.codec)}`;
             }
           });
         }
@@ -32846,7 +33153,7 @@ export const plans = {
             type: "attribute",
             attribute: "regproc",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regproc.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regproc.codec)}`;
             }
           });
         }
@@ -32869,7 +33176,7 @@ export const plans = {
             type: "attribute",
             attribute: "regprocedure",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regprocedure.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regprocedure.codec)}`;
             }
           });
         }
@@ -32892,7 +33199,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoper",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoper.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regoper.codec)}`;
             }
           });
         }
@@ -32915,7 +33222,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoperator",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoperator.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regoperator.codec)}`;
             }
           });
         }
@@ -32938,7 +33245,7 @@ export const plans = {
             type: "attribute",
             attribute: "regclass",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regclass.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regclass.codec)}`;
             }
           });
         }
@@ -32961,7 +33268,7 @@ export const plans = {
             type: "attribute",
             attribute: "regtype",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regtype.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regtype.codec)}`;
             }
           });
         }
@@ -32984,7 +33291,7 @@ export const plans = {
             type: "attribute",
             attribute: "regconfig",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regconfig.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regconfig.codec)}`;
             }
           });
         }
@@ -33007,7 +33314,7 @@ export const plans = {
             type: "attribute",
             attribute: "regdictionary",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regdictionary.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regdictionary.codec)}`;
             }
           });
         }
@@ -33030,7 +33337,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.text_array_domain.codec)}`;
             }
           });
         }
@@ -33053,7 +33360,7 @@ export const plans = {
             type: "attribute",
             attribute: "int8_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.int8_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.int8_array_domain.codec)}`;
             }
           });
         }
@@ -33076,7 +33383,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.ltree.codec)}`;
             }
           });
         }
@@ -33099,7 +33406,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.ltree_array.codec)}`;
             }
           });
         }
@@ -33133,6 +33440,9 @@ export const plans = {
     inclusive: undefined
   },
   NestedCompoundTypeInput: {
+    "__inputPlan": function NestedCompoundTypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     a: {
       applyPlan($insert, val) {
         $insert.set("a", val.get());
@@ -33627,6 +33937,50 @@ export const plans = {
       return $record.get("url");
     }
   },
+  NotNullUrl: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
+  KeyValueHash: {
+    serialize(value) {
+      return value;
+    },
+    parseValue(obj) {
+      if (isValidHstoreObject(obj)) {
+        return obj;
+      }
+      throw new GraphQLError(`This is not a valid ${"KeyValueHash"} object, it must be a key/value hash where keys and values are both strings (or null).`);
+    },
+    parseLiteral(ast, variables) {
+      switch (ast.kind) {
+        case Kind.OBJECT:
+          {
+            const value = ast.fields.reduce((memo, field) => {
+              memo[field.name.value] = parseValueLiteral(field.value, variables);
+              return memo;
+            }, Object.create(null));
+            if (!isValidHstoreObject(value)) {
+              return undefined;
+            }
+            return value;
+          }
+        case Kind.NULL:
+          return null;
+        case Kind.VARIABLE:
+          {
+            const name = ast.name.value;
+            const value = variables ? variables[name] : undefined;
+            if (!isValidHstoreObject(value)) {
+              return undefined;
+            }
+            return value;
+          }
+        default:
+          return undefined;
+      }
+    }
+  },
   PostsConnection: {
     __assertStep: ConnectionStep,
     nodes($connection) {
@@ -33871,7 +34225,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.id.codec)}`;
             }
           });
         }
@@ -33894,7 +34248,7 @@ export const plans = {
             type: "attribute",
             attribute: "headline",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.headline.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.headline.codec)}`;
             }
           });
         }
@@ -33917,7 +34271,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.body.codec)}`;
             }
           });
         }
@@ -33940,7 +34294,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.author_id.codec)}`;
             }
           });
         }
@@ -33963,7 +34317,7 @@ export const plans = {
             type: "attribute",
             attribute: "enums",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.enums.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.enums.codec)}`;
             }
           });
         }
@@ -33986,7 +34340,7 @@ export const plans = {
             type: "attribute",
             attribute: "comptypes",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.comptypes.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.comptypes.codec)}`;
             }
           });
         }
@@ -34011,6 +34365,9 @@ export const plans = {
     }
   },
   ComptypeInput: {
+    "__inputPlan": function ComptypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     schedule: {
       applyPlan($insert, val) {
         $insert.set("schedule", val.get());
@@ -34197,7 +34554,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_foreignKey.attributes.person_id.codec)}`;
             }
           });
         }
@@ -34220,7 +34577,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_foreignKey.attributes.compound_key_1.codec)}`;
             }
           });
         }
@@ -34243,7 +34600,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_foreignKey.attributes.compound_key_2.codec)}`;
             }
           });
         }
@@ -34474,7 +34831,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.person_id_2.codec)}`;
             }
           });
         }
@@ -34497,7 +34854,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.person_id_1.codec)}`;
             }
           });
         }
@@ -34520,7 +34877,7 @@ export const plans = {
             type: "attribute",
             attribute: "extra",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.extra.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.extra.codec)}`;
             }
           });
         }
@@ -34626,6 +34983,16 @@ export const plans = {
     },
     ts($record) {
       return $record.get("ts");
+    }
+  },
+  NotNullTimestamp: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   FuncOutSetofConnection: {
@@ -35021,7 +35388,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.id.codec)}`;
             }
           });
         }
@@ -35044,7 +35411,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_full_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.person_full_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.person_full_name.codec)}`;
             }
           });
         }
@@ -35067,7 +35434,7 @@ export const plans = {
             type: "attribute",
             attribute: "aliases",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.aliases.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.aliases.codec)}`;
             }
           });
         }
@@ -35090,7 +35457,7 @@ export const plans = {
             type: "attribute",
             attribute: "about",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.about.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.about.codec)}`;
             }
           });
         }
@@ -35113,7 +35480,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.email.codec)}`;
             }
           });
         }
@@ -35136,7 +35503,7 @@ export const plans = {
             type: "attribute",
             attribute: "site",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.site.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.site.codec)}`;
             }
           });
         }
@@ -35159,7 +35526,7 @@ export const plans = {
             type: "attribute",
             attribute: "config",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.config.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.config.codec)}`;
             }
           });
         }
@@ -35182,7 +35549,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_ip",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_ip.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_login_from_ip.codec)}`;
             }
           });
         }
@@ -35205,7 +35572,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_subnet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_subnet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_login_from_subnet.codec)}`;
             }
           });
         }
@@ -35228,7 +35595,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_mac",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.user_mac.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.user_mac.codec)}`;
             }
           });
         }
@@ -35251,7 +35618,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.created_at.codec)}`;
             }
           });
         }
@@ -35276,6 +35643,9 @@ export const plans = {
     }
   },
   WrappedUrlInput: {
+    "__inputPlan": function WrappedUrlInput_inputPlan() {
+      return object(Object.create(null));
+    },
     url: {
       applyPlan($insert, val) {
         $insert.set("url", val.get());
@@ -35370,7 +35740,7 @@ export const plans = {
             type: "attribute",
             attribute: "?column?",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nonUpdatableViewAttributes["?column?"].codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nonUpdatableView.attributes["?column?"].codec)}`;
             }
           });
         }
@@ -35491,7 +35861,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), inputsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_inputs.attributes.id.codec)}`;
             }
           });
         }
@@ -35612,7 +35982,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), patchsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_patchs.attributes.id.codec)}`;
             }
           });
         }
@@ -35733,7 +36103,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reserved.attributes.id.codec)}`;
             }
           });
         }
@@ -35854,7 +36224,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedPatchsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reservedPatchs.attributes.id.codec)}`;
             }
           });
         }
@@ -35975,7 +36345,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedInputAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reservedInput.attributes.id.codec)}`;
             }
           });
         }
@@ -36130,7 +36500,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_defaultValue.attributes.id.codec)}`;
             }
           });
         }
@@ -36153,7 +36523,7 @@ export const plans = {
             type: "attribute",
             attribute: "null_value",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.null_value.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_defaultValue.attributes.null_value.codec)}`;
             }
           });
         }
@@ -36276,7 +36646,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_noPrimaryKey.attributes.id.codec)}`;
             }
           });
         }
@@ -36299,7 +36669,7 @@ export const plans = {
             type: "attribute",
             attribute: "str",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.str.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_noPrimaryKey.attributes.str.codec)}`;
             }
           });
         }
@@ -36468,7 +36838,7 @@ export const plans = {
             type: "attribute",
             attribute: "testviewid",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.testviewid.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_testview.attributes.testviewid.codec)}`;
             }
           });
         }
@@ -36491,7 +36861,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_testview.attributes.col1.codec)}`;
             }
           });
         }
@@ -36514,7 +36884,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_testview.attributes.col2.codec)}`;
             }
           });
         }
@@ -36669,7 +37039,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_myTable.attributes.id.codec)}`;
             }
           });
         }
@@ -36692,7 +37062,7 @@ export const plans = {
             type: "attribute",
             attribute: "json_data",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.json_data.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_myTable.attributes.json_data.codec)}`;
             }
           });
         }
@@ -36847,7 +37217,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_personSecret.attributes.person_id.codec)}`;
             }
           });
         }
@@ -36870,7 +37240,7 @@ export const plans = {
             type: "attribute",
             attribute: "sekrit",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.sekrit.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_personSecret.attributes.sekrit.codec)}`;
             }
           });
         }
@@ -37059,7 +37429,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_viewTable.attributes.id.codec)}`;
             }
           });
         }
@@ -37082,7 +37452,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_viewTable.attributes.col1.codec)}`;
             }
           });
         }
@@ -37105,7 +37475,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_viewTable.attributes.col2.codec)}`;
             }
           });
         }
@@ -37328,7 +37698,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.id.codec)}`;
             }
           });
         }
@@ -37351,7 +37721,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.col1.codec)}`;
             }
           });
         }
@@ -37374,7 +37744,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.col2.codec)}`;
             }
           });
         }
@@ -37397,7 +37767,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.col3.codec)}`;
             }
           });
         }
@@ -37620,7 +37990,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.id.codec)}`;
             }
           });
         }
@@ -37643,7 +38013,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.col3.codec)}`;
             }
           });
         }
@@ -37666,7 +38036,7 @@ export const plans = {
             type: "attribute",
             attribute: "col4",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col4.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.col4.codec)}`;
             }
           });
         }
@@ -37689,7 +38059,7 @@ export const plans = {
             type: "attribute",
             attribute: "col5",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col5.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.col5.codec)}`;
             }
           });
         }
@@ -37895,7 +38265,7 @@ export const plans = {
             type: "attribute",
             attribute: "x",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.x.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.x.codec)}`;
             }
           });
         }
@@ -37918,7 +38288,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.name.codec)}`;
             }
           });
         }
@@ -37941,7 +38311,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.description.codec)}`;
             }
           });
         }
@@ -37964,7 +38334,7 @@ export const plans = {
             type: "attribute",
             attribute: "constant",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.constant.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.constant.codec)}`;
             }
           });
         }
@@ -38187,7 +38557,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.id.codec)}`;
             }
           });
         }
@@ -38210,7 +38580,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.nullable_text.codec)}`;
             }
           });
         }
@@ -38233,7 +38603,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_int",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_int.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.nullable_int.codec)}`;
             }
           });
         }
@@ -38256,7 +38626,7 @@ export const plans = {
             type: "attribute",
             attribute: "non_null_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.non_null_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.non_null_text.codec)}`;
             }
           });
         }
@@ -38459,7 +38829,7 @@ export const plans = {
             type: "attribute",
             attribute: "not_null_has_default",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.not_null_has_default.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.not_null_has_default.codec)}`;
             }
           });
         }
@@ -38482,7 +38852,7 @@ export const plans = {
             type: "attribute",
             attribute: "wont_cast_easy",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.wont_cast_easy.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.wont_cast_easy.codec)}`;
             }
           });
         }
@@ -38505,7 +38875,7 @@ export const plans = {
             type: "attribute",
             attribute: "row_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.row_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.row_id.codec)}`;
             }
           });
         }
@@ -38728,7 +39098,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.id.codec)}`;
             }
           });
         }
@@ -38751,7 +39121,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.person_id.codec)}`;
             }
           });
         }
@@ -38774,7 +39144,7 @@ export const plans = {
             type: "attribute",
             attribute: "length_in_metres",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.length_in_metres.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.length_in_metres.codec)}`;
             }
           });
         }
@@ -38797,7 +39167,7 @@ export const plans = {
             type: "attribute",
             attribute: "mood",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.mood.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.mood.codec)}`;
             }
           });
         }
@@ -38952,7 +39322,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_issue756.attributes.id.codec)}`;
             }
           });
         }
@@ -38975,7 +39345,7 @@ export const plans = {
             type: "attribute",
             attribute: "ts",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.ts.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_issue756.attributes.ts.codec)}`;
             }
           });
         }
@@ -42311,6 +42681,11 @@ export const plans = {
       return rootValue();
     }
   },
+  Guid: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
   GuidFnInput: {
     clientMutationId: {
       applyPlan($input, val) {
@@ -42502,6 +42877,9 @@ export const plans = {
     leftArm: undefined
   },
   LeftArmBaseInput: {
+    "__inputPlan": function LeftArmBaseInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -42896,6 +43274,9 @@ export const plans = {
     suffix: undefined
   },
   PostInput: {
+    "__inputPlan": function PostInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43346,6 +43727,9 @@ export const plans = {
     }
   },
   InputInput: {
+    "__inputPlan": function InputInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43413,6 +43797,9 @@ export const plans = {
     }
   },
   PatchInput: {
+    "__inputPlan": function PatchInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43480,6 +43867,9 @@ export const plans = {
     }
   },
   ReservedInput: {
+    "__inputPlan": function ReservedInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43547,6 +43937,9 @@ export const plans = {
     }
   },
   ReservedPatchRecordInput: {
+    "__inputPlan": function ReservedPatchRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43614,6 +44007,9 @@ export const plans = {
     }
   },
   ReservedInputRecordInput: {
+    "__inputPlan": function ReservedInputRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43681,6 +44077,9 @@ export const plans = {
     }
   },
   DefaultValueInput: {
+    "__inputPlan": function DefaultValueInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43735,6 +44134,9 @@ export const plans = {
     }
   },
   ForeignKeyInput: {
+    "__inputPlan": function ForeignKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -43785,6 +44187,9 @@ export const plans = {
     }
   },
   NoPrimaryKeyInput: {
+    "__inputPlan": function NoPrimaryKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43828,6 +44233,9 @@ export const plans = {
     }
   },
   TestviewInput: {
+    "__inputPlan": function TestviewInput_inputPlan() {
+      return object(Object.create(null));
+    },
     testviewid: {
       applyPlan($insert, val) {
         $insert.set("testviewid", val.get());
@@ -43909,6 +44317,9 @@ export const plans = {
     }
   },
   MyTableInput: {
+    "__inputPlan": function MyTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43988,6 +44399,9 @@ export const plans = {
     }
   },
   PersonSecretInput: {
+    "__inputPlan": function PersonSecretInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -44062,6 +44476,9 @@ export const plans = {
     }
   },
   ViewTableInput: {
+    "__inputPlan": function ViewTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44153,6 +44570,9 @@ export const plans = {
     }
   },
   CompoundKeyInput: {
+    "__inputPlan": function CompoundKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId2: {
       applyPlan($insert, val) {
         $insert.set("person_id_2", val.get());
@@ -44234,6 +44654,9 @@ export const plans = {
     }
   },
   SimilarTable1Input: {
+    "__inputPlan": function SimilarTable1Input_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44322,6 +44745,9 @@ export const plans = {
     }
   },
   SimilarTable2Input: {
+    "__inputPlan": function SimilarTable2Input_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44379,6 +44805,9 @@ export const plans = {
     }
   },
   UpdatableViewInput: {
+    "__inputPlan": function UpdatableViewInput_inputPlan() {
+      return object(Object.create(null));
+    },
     x: {
       applyPlan($insert, val) {
         $insert.set("x", val.get());
@@ -44467,6 +44896,9 @@ export const plans = {
     }
   },
   NullTestRecordInput: {
+    "__inputPlan": function NullTestRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44524,6 +44956,9 @@ export const plans = {
     }
   },
   EdgeCaseInput: {
+    "__inputPlan": function EdgeCaseInput_inputPlan() {
+      return object(Object.create(null));
+    },
     notNullHasDefault: {
       applyPlan($insert, val) {
         $insert.set("not_null_has_default", val.get());
@@ -44610,6 +45045,9 @@ export const plans = {
     }
   },
   LeftArmInput: {
+    "__inputPlan": function LeftArmInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44698,6 +45136,9 @@ export const plans = {
     }
   },
   Issue756Input: {
+    "__inputPlan": function Issue756Input_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44835,6 +45276,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44982,6 +45426,9 @@ export const plans = {
     }
   },
   TypeInput: {
+    "__inputPlan": function TypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45384,6 +45831,9 @@ export const plans = {
     }
   },
   InputPatch: {
+    "__inputPlan": function InputPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45464,6 +45914,9 @@ export const plans = {
     }
   },
   PatchPatch: {
+    "__inputPlan": function PatchPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45544,6 +45997,9 @@ export const plans = {
     }
   },
   ReservedPatch: {
+    "__inputPlan": function ReservedPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45624,6 +46080,9 @@ export const plans = {
     }
   },
   ReservedPatchRecordPatch: {
+    "__inputPlan": function ReservedPatchRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45704,6 +46163,9 @@ export const plans = {
     }
   },
   ReservedInputRecordPatch: {
+    "__inputPlan": function ReservedInputRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45784,6 +46246,9 @@ export const plans = {
     }
   },
   DefaultValuePatch: {
+    "__inputPlan": function DefaultValuePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45840,6 +46305,9 @@ export const plans = {
     }
   },
   NoPrimaryKeyPatch: {
+    "__inputPlan": function NoPrimaryKeyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45913,6 +46381,9 @@ export const plans = {
     }
   },
   MyTablePatch: {
+    "__inputPlan": function MyTablePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46005,6 +46476,9 @@ export const plans = {
     }
   },
   PersonSecretPatch: {
+    "__inputPlan": function PersonSecretPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -46092,6 +46566,9 @@ export const plans = {
     }
   },
   ViewTablePatch: {
+    "__inputPlan": function ViewTablePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46196,6 +46673,9 @@ export const plans = {
     }
   },
   CompoundKeyPatch: {
+    "__inputPlan": function CompoundKeyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     personId2: {
       applyPlan($insert, val) {
         $insert.set("person_id_2", val.get());
@@ -46291,6 +46771,9 @@ export const plans = {
     }
   },
   SimilarTable1Patch: {
+    "__inputPlan": function SimilarTable1Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46392,6 +46875,9 @@ export const plans = {
     }
   },
   SimilarTable2Patch: {
+    "__inputPlan": function SimilarTable2Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46493,6 +46979,9 @@ export const plans = {
     }
   },
   NullTestRecordPatch: {
+    "__inputPlan": function NullTestRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46599,6 +47088,9 @@ export const plans = {
     }
   },
   LeftArmPatch: {
+    "__inputPlan": function LeftArmPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46714,6 +47206,9 @@ export const plans = {
     }
   },
   Issue756Patch: {
+    "__inputPlan": function Issue756Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46806,6 +47301,9 @@ export const plans = {
     }
   },
   PostPatch: {
+    "__inputPlan": function PostPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46921,6 +47419,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -47095,6 +47596,9 @@ export const plans = {
     }
   },
   TypePatch: {
+    "__inputPlan": function TypePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/relay.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/relay.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, makeRegistry, pgClassExpression, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectSingleFromRecord, pgUpdateSingle, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertNotNull, assertPageInfoCapableStep, condition, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB, trap } from "grafast";
+import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -84,25 +101,24 @@ const flambleCodec = recordCodec({
       name: "flamble"
     })
   },
-  executor
+  executor: executor
 });
-const renamed_tableAttributes = Object.assign(Object.create(null), {
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "colA"
-      }
-    }
-  }
-});
-const renamed_tableCodec = recordCodec({
+const spec_renamed_table = {
   name: "renamed_table",
   identifier: sql.identifier("d", "original_table"),
-  attributes: renamed_tableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "colA"
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -115,32 +131,32 @@ const renamed_tableCodec = recordCodec({
       name: "renamed_table"
     })
   },
-  executor
-});
-const filmsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const filmsCodec = recordCodec({
+  executor: executor
+};
+const renamed_tableCodec = recordCodec(spec_renamed_table);
+const spec_films = {
   name: "films",
   identifier: sql.identifier("d", "films"),
-  attributes: filmsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -151,32 +167,32 @@ const filmsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const studiosAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const studiosCodec = recordCodec({
+  executor: executor
+};
+const filmsCodec = recordCodec(spec_films);
+const spec_studios = {
   name: "studios",
   identifier: sql.identifier("d", "studios"),
-  attributes: studiosAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -187,41 +203,41 @@ const studiosCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const postAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  body: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const postCodec = recordCodec({
+  executor: executor
+};
+const studiosCodec = recordCodec(spec_studios);
+const spec_post = {
   name: "post",
   identifier: sql.identifier("d", "post"),
-  attributes: postAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    body: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -232,41 +248,41 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const tvEpisodesAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  show_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const tvEpisodesCodec = recordCodec({
+  executor: executor
+};
+const postCodec = recordCodec(spec_post);
+const spec_tvEpisodes = {
   name: "tvEpisodes",
   identifier: sql.identifier("d", "tv_episodes"),
-  attributes: tvEpisodesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    show_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -277,41 +293,41 @@ const tvEpisodesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const tvShowsAttributes = Object.assign(Object.create(null), {
-  code: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  studio_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const tvShowsCodec = recordCodec({
+  executor: executor
+};
+const tvEpisodesCodec = recordCodec(spec_tvEpisodes);
+const spec_tvShows = {
   name: "tvShows",
   identifier: sql.identifier("d", "tv_shows"),
-  attributes: tvShowsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    code: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    studio_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -322,8 +338,9 @@ const tvShowsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const tvShowsCodec = recordCodec(spec_tvShows);
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
   identifier: sql.identifier("d", "jwt_token"),
@@ -366,125 +383,124 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const personAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  first_name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col_no_create: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create",
-        behavior: ["-insert"]
-      }
-    }
-  },
-  col_no_update: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "update",
-        behavior: ["-update"]
-      }
-    }
-  },
-  col_no_order: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "order",
-        behavior: ["-order -orderBy"]
-      }
-    }
-  },
-  col_no_filter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "filter",
-        behavior: ["-filter -filterBy"]
-      }
-    }
-  },
-  col_no_create_update: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create,update",
-        behavior: ["-insert -update"]
-      }
-    }
-  },
-  col_no_create_update_order_filter: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: "create,update,order,filter",
-        behavior: ["-insert -update -order -orderBy -filter -filterBy"]
-      }
-    }
-  },
-  col_no_anything: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {
-        omit: true,
-        behavior: ["-*"]
-      }
-    }
-  }
-});
-const personCodec = recordCodec({
+const spec_person = {
   name: "person",
   identifier: sql.identifier("d", "person"),
-  attributes: personAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    first_name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col_no_create: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create",
+          behavior: ["-insert"]
+        }
+      }
+    },
+    col_no_update: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "update",
+          behavior: ["-update"]
+        }
+      }
+    },
+    col_no_order: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "order",
+          behavior: ["-order -orderBy"]
+        }
+      }
+    },
+    col_no_filter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "filter",
+          behavior: ["-filter -filterBy"]
+        }
+      }
+    },
+    col_no_create_update: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create,update",
+          behavior: ["-insert -update"]
+        }
+      }
+    },
+    col_no_create_update_order_filter: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: "create,update,order,filter",
+          behavior: ["-insert -update -order -orderBy -filter -filterBy"]
+        }
+      }
+    },
+    col_no_anything: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {
+          omit: true,
+          behavior: ["-*"]
+        }
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -495,8 +511,9 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const personCodec = recordCodec(spec_person);
 const original_functionFunctionIdentifer = sql.identifier("d", "original_function");
 const getflambleFunctionIdentifer = sql.identifier("d", "getflamble");
 const filmsUniques = [{
@@ -1415,6 +1432,9 @@ const makeArgs4 = (args, path = []) => {
   }
   return selectArgs;
 };
+function CursorSerialize(value) {
+  return "" + value;
+}
 const getSpec2 = $nodeId => {
   // TODO: should change this to a common method like
   // `const $decoded = getDecodedNodeIdForHandler(handler, $nodeId)`
@@ -4108,6 +4128,16 @@ export const plans = {
       }
     }
   },
+  Cursor: {
+    serialize: CursorSerialize,
+    parseValue: CursorSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PostsOrderBy: {
     NATURAL: {
       applyPlan() {}
@@ -4195,7 +4225,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.body.codec)}`;
             }
           });
         }
@@ -4544,7 +4574,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvEpisodesAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvEpisodes.attributes.title.codec)}`;
             }
           });
         }
@@ -4675,7 +4705,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), tvShowsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_tvShows.attributes.title.codec)}`;
             }
           });
         }
@@ -4796,7 +4826,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), renamed_tableAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_renamed_table.attributes.col1.codec)}`;
             }
           });
         }
@@ -4917,7 +4947,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), filmsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_films.attributes.title.codec)}`;
             }
           });
         }
@@ -5038,7 +5068,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), studiosAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_studios.attributes.name.codec)}`;
             }
           });
         }
@@ -5329,7 +5359,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.first_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.first_name.codec)}`;
             }
           });
         }
@@ -5352,7 +5382,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_name.codec)}`;
             }
           });
         }
@@ -5375,7 +5405,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_create.codec)}`;
             }
           });
         }
@@ -5398,7 +5428,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_update.codec)}`;
             }
           });
         }
@@ -5421,7 +5451,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_order",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_order.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_order.codec)}`;
             }
           });
         }
@@ -5444,7 +5474,7 @@ export const plans = {
             type: "attribute",
             attribute: "col_no_create_update",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.col_no_create_update.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.col_no_create_update.codec)}`;
             }
           });
         }
@@ -5888,6 +5918,9 @@ export const plans = {
     }
   },
   RenamedTableInput: {
+    "__inputPlan": function RenamedTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     colA: {
       applyPlan($insert, val) {
         $insert.set("col1", val.get());
@@ -5955,6 +5988,9 @@ export const plans = {
     }
   },
   FilmInput: {
+    "__inputPlan": function FilmInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -6029,6 +6065,9 @@ export const plans = {
     }
   },
   StudioInput: {
+    "__inputPlan": function StudioInput_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -6103,6 +6142,9 @@ export const plans = {
     }
   },
   PostInput: {
+    "__inputPlan": function PostInput_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -6190,6 +6232,9 @@ export const plans = {
     }
   },
   TvEpisodeInput: {
+    "__inputPlan": function TvEpisodeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -6277,6 +6322,9 @@ export const plans = {
     }
   },
   TvShowInput: {
+    "__inputPlan": function TvShowInput_inputPlan() {
+      return object(Object.create(null));
+    },
     code: {
       applyPlan($insert, val) {
         $insert.set("code", val.get());
@@ -6364,6 +6412,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -6465,6 +6516,9 @@ export const plans = {
     }
   },
   FilmPatch: {
+    "__inputPlan": function FilmPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     title: {
       applyPlan($insert, val) {
         $insert.set("title", val.get());
@@ -6531,6 +6585,9 @@ export const plans = {
     }
   },
   StudioPatch: {
+    "__inputPlan": function StudioPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     name: {
       applyPlan($insert, val) {
         $insert.set("name", val.get());
@@ -6597,6 +6654,9 @@ export const plans = {
     }
   },
   PostPatch: {
+    "__inputPlan": function PostPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     body: {
       applyPlan($insert, val) {
         $insert.set("body", val.get());
@@ -6676,6 +6736,9 @@ export const plans = {
     }
   },
   TvEpisodePatch: {
+    "__inputPlan": function TvEpisodePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     title: {
       applyPlan($insert, val) {
         $insert.set("title", val.get());
@@ -6755,6 +6818,9 @@ export const plans = {
     }
   },
   TvShowPatch: {
+    "__inputPlan": function TvShowPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     title: {
       applyPlan($insert, val) {
         $insert.set("title", val.get());
@@ -6834,6 +6900,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     firstName: {
       applyPlan($insert, val) {
         $insert.set("first_name", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, domainOfCodec, enumCodec, listOfCodec, makeRegistry, pgClassExpression, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectFromRecords, pgSelectSingleFromRecord, pgUpdateSingle, rangeOfCodec, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
+import { GraphQLError, GraphQLInt, GraphQLString, Kind, valueFromASTUntyped } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -404,30 +421,29 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
   executor,
   isAnonymous: true
 });
-const myTableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  json_data: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const myTableCodec = recordCodec({
+const spec_myTable = {
   name: "myTable",
   identifier: sql.identifier("c", "my_table"),
-  attributes: myTableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    json_data: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -438,34 +454,34 @@ const myTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const personSecretAttributes = Object.assign(Object.create(null), {
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  sekrit: {
-    description: "A secret held by the associated Person",
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "secret"
-      }
-    }
-  }
-});
-const personSecretCodec = recordCodec({
+  executor: executor
+};
+const myTableCodec = recordCodec(spec_myTable);
+const spec_personSecret = {
   name: "personSecret",
   identifier: sql.identifier("c", "person_secret"),
-  attributes: personSecretAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    sekrit: {
+      description: "A secret held by the associated Person",
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "secret"
+        }
+      }
+    }
+  }),
   description: "Tracks the person's secret",
   extensions: {
     isTableLike: true,
@@ -478,41 +494,41 @@ const personSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor
-});
-const compoundKeyAttributes = Object.assign(Object.create(null), {
-  person_id_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  extra: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const compoundKeyCodec = recordCodec({
+  executor: executor
+};
+const personSecretCodec = recordCodec(spec_personSecret);
+const spec_compoundKey = {
   name: "compoundKey",
   identifier: sql.identifier("c", "compound_key"),
-  attributes: compoundKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    extra: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -523,50 +539,50 @@ const compoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const nullTestRecordAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_int: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  non_null_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const nullTestRecordCodec = recordCodec({
+  executor: executor
+};
+const compoundKeyCodec = recordCodec(spec_compoundKey);
+const spec_nullTestRecord = {
   name: "nullTestRecord",
   identifier: sql.identifier("c", "null_test_record"),
-  attributes: nullTestRecordAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_int: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    non_null_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -577,41 +593,41 @@ const nullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const edgeCaseAttributes = Object.assign(Object.create(null), {
-  not_null_has_default: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  wont_cast_easy: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  row_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const edgeCaseCodec = recordCodec({
+  executor: executor
+};
+const nullTestRecordCodec = recordCodec(spec_nullTestRecord);
+const spec_edgeCase = {
   name: "edgeCase",
   identifier: sql.identifier("c", "edge_case"),
-  attributes: edgeCaseAttributes,
+  attributes: Object.assign(Object.create(null), {
+    not_null_has_default: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    wont_cast_easy: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    row_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -622,50 +638,50 @@ const edgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const leftArmAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  length_in_metres: {
-    description: undefined,
-    codec: TYPES.float,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  mood: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const leftArmCodec = recordCodec({
+  executor: executor
+};
+const edgeCaseCodec = recordCodec(spec_edgeCase);
+const spec_leftArm = {
   name: "leftArm",
   identifier: sql.identifier("c", "left_arm"),
-  attributes: leftArmAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    length_in_metres: {
+      description: undefined,
+      codec: TYPES.float,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    mood: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Tracks metadata about the left arms of various people",
   extensions: {
     isTableLike: true,
@@ -676,8 +692,9 @@ const leftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const leftArmCodec = recordCodec(spec_leftArm);
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
   extensions: {
@@ -690,30 +707,29 @@ const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp
   },
   notNull: true
 });
-const issue756Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  ts: {
-    description: undefined,
-    codec: notNullTimestampCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const issue756Codec = recordCodec({
+const spec_issue756 = {
   name: "issue756",
   identifier: sql.identifier("c", "issue756"),
-  attributes: issue756Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    ts: {
+      description: undefined,
+      codec: notNullTimestampCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -724,8 +740,9 @@ const issue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const issue756Codec = recordCodec(spec_issue756);
 const colorCodec = enumCodec({
   name: "color",
   identifier: sql.identifier("b", "color"),
@@ -855,7 +872,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
@@ -977,7 +994,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1061,7 +1078,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
@@ -1222,117 +1239,116 @@ const wrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const personAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: "The primary unique identifier for the person",
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_full_name: {
-    description: "The person\u2019s name",
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "name"
-      }
-    }
-  },
-  aliases: {
-    description: undefined,
-    codec: textArrayCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  about: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  email: {
-    description: undefined,
-    codec: emailCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  site: {
-    description: undefined,
-    codec: wrappedUrlCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        deprecated: "Don\u2019t use me"
-      }
-    }
-  },
-  config: {
-    description: undefined,
-    codec: TYPES.hstore,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_login_from_ip: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_login_from_subnet: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  user_mac: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  created_at: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const personCodec = recordCodec({
+const spec_person = {
   name: "person",
   identifier: sql.identifier("c", "person"),
-  attributes: personAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: "The primary unique identifier for the person",
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_full_name: {
+      description: "The person\u2019s name",
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "name"
+        }
+      }
+    },
+    aliases: {
+      description: undefined,
+      codec: textArrayCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    about: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    email: {
+      description: undefined,
+      codec: emailCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    site: {
+      description: undefined,
+      codec: wrappedUrlCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          deprecated: "Don\u2019t use me"
+        }
+      }
+    },
+    config: {
+      description: undefined,
+      codec: TYPES.hstore,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_login_from_ip: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_login_from_subnet: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    user_mac: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    created_at: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Person test comment",
   extensions: {
     isTableLike: true,
@@ -1343,8 +1359,9 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const personCodec = recordCodec(spec_person);
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
@@ -1690,7 +1707,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -1742,7 +1759,7 @@ const byteaArrayCodec = listOfCodec(TYPES.bytea, {
   description: undefined,
   name: "byteaArray"
 });
-const typesAttributes_ltree_codec_ltree = {
+const spec_types_attributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -1754,7 +1771,7 @@ const typesAttributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
+const spec_types_attributes_ltree_array_codec_ltree_ = listOfCodec(spec_types_attributes_ltree_codec_ltree);
 const typesCodec = recordCodec({
   name: "types",
   identifier: sql.identifier("b", "types"),
@@ -2184,7 +2201,7 @@ const typesCodec = recordCodec({
     },
     ltree: {
       description: undefined,
-      codec: typesAttributes_ltree_codec_ltree,
+      codec: spec_types_attributes_ltree_codec_ltree,
       notNull: false,
       hasDefault: false,
       extensions: {
@@ -2193,7 +2210,7 @@ const typesCodec = recordCodec({
     },
     ltree_array: {
       description: undefined,
-      codec: typesAttributes_ltree_array_codec_ltree_,
+      codec: spec_types_attributes_ltree_array_codec_ltree_,
       notNull: false,
       hasDefault: false,
       extensions: {
@@ -2213,7 +2230,7 @@ const typesCodec = recordCodec({
       foreignKey: ["(smallint) references a.post", "(id) references a.post"]
     })
   },
-  executor
+  executor: executor
 });
 const int4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
@@ -2570,8 +2587,8 @@ const registry = makeRegistry({
     int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
     byteaArray: byteaArrayCodec,
-    ltree: typesAttributes_ltree_codec_ltree,
-    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
+    ltree: spec_types_attributes_ltree_codec_ltree,
+    "ltree[]": spec_types_attributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     typesArray: listOfCodec(typesCodec, {
       extensions: {
@@ -7559,8 +7576,71 @@ const makeArgs45 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
+function UUIDSerialize(value) {
+  return "" + value;
+}
+const coerce = string => {
+  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
+    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
+  }
+  return string;
+};
 const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
+function LTreeParseValue(value) {
+  return value;
+}
+const isValidHstoreObject = obj => {
+  if (obj === null) {
+    // Null is okay
+    return true;
+  } else if (typeof obj === "object") {
+    // A hash with string/null values is also okay
+    const keys = Object.keys(obj);
+    for (const key of keys) {
+      const val = obj[key];
+      if (val === null) {
+        // Null is okay
+      } else if (typeof val === "string") {
+        // String is okay
+      } else {
+        // Everything else is invalid.
+        return false;
+      }
+    }
+    return true;
+  } else {
+    // Everything else is invalid.
+    return false;
+  }
+};
+const parseValueLiteral = (ast, variables) => {
+  switch (ast.kind) {
+    case Kind.INT:
+    case Kind.FLOAT:
+      // Number isn't really okay, but we'll coerce it to a string anyway.
+      return String(parseFloat(ast.value));
+    case Kind.STRING:
+      // String is okay.
+      return String(ast.value);
+    case Kind.NULL:
+      // Null is okay.
+      return null;
+    case Kind.VARIABLE:
+      {
+        // Variable is okay if that variable is either a string or null.
+        const name = ast.name.value;
+        const value = variables ? variables[name] : undefined;
+        if (value === null || typeof value === "string") {
+          return value;
+        }
+        return undefined;
+      }
+    default:
+      // Everything else is invalid.
+      return undefined;
+  }
+};
 const resource_frmcdc_postPgResource = registry.pgResources["frmcdc_post"];
 const argDetailsSimple46 = [];
 const makeArgs46 = (args, path = []) => {
@@ -14823,6 +14903,21 @@ export const plans = {
       return $record.get("json_data");
     }
   },
+  JSON: {
+    serialize(value) {
+      return JSON.stringify(value);
+    },
+    parseValue(value) {
+      return JSON.parse(value);
+    },
+    parseLiteral(ast, _variables) {
+      if (ast.kind === Kind.STRING) {
+        return JSON.parse(ast.value);
+      } else {
+        return undefined;
+      }
+    }
+  },
   PersonSecret: {
     __assertStep: assertPgClassSingleStep,
     id($parent) {
@@ -15556,6 +15651,11 @@ export const plans = {
       return $record.get("o");
     }
   },
+  Email: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
   PersonComputedFirstArgInoutOutRecord: {
     __assertStep: assertPgClassSingleStep,
     person($record) {
@@ -15665,6 +15765,19 @@ export const plans = {
     },
     BLUE: {
       value: "blue"
+    }
+  },
+  UUID: {
+    serialize: UUIDSerialize,
+    parseValue(value) {
+      return coerce("" + value);
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // ERRORS: add name to this error
+        throw new GraphQLError(`${"UUID" ?? "This scalar"} can only parse string values (kind = '${ast.kind}')`);
+      }
+      return coerce(ast.value);
     }
   },
   EnumCaps: {
@@ -15793,6 +15906,16 @@ export const plans = {
       return $record.get("is_optimised");
     }
   },
+  Datetime: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PeopleConnection: {
     __assertStep: ConnectionStep,
     nodes($connection) {
@@ -15816,6 +15939,16 @@ export const plans = {
     },
     node($edge) {
       return $edge.node();
+    }
+  },
+  Cursor: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   PageInfo: {
@@ -16460,12 +16593,62 @@ export const plans = {
       return $record.get("ltree_array");
     }
   },
+  BigInt: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigInt" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  BigFloat: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigFloat" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  AnInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
+  AnotherInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
   BigFloatRange: {},
   BigFloatRangeBound: {},
   DateRange: {},
   DateRangeBound: {},
+  Date: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Date" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   AnIntRange: {},
   AnIntRangeBound: {},
+  Time: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Time" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   NestedCompoundType: {
     __assertStep: assertPgClassSingleStep,
     a($record) {
@@ -16491,6 +16674,128 @@ export const plans = {
     }
   },
   Point: {},
+  InternetAddress: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"InternetAddress" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProc: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProc" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProcedure: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProcedure" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOper: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOper" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOperator: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOperator" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegClass: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegClass" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegType: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegType" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegConfig: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegConfig" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegDictionary: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegDictionary" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  Base64EncodedBinary: {
+    serialize(data) {
+      if (Buffer.isBuffer(data)) {
+        return data.toString("base64");
+      } else {
+        throw new Error(`Base64EncodeBinary can only be used with Node.js buffers.`);
+      }
+    },
+    parseValue(data) {
+      if (typeof data === "string") {
+        return Buffer.from(data, "base64");
+      } else {
+        throw new GraphQLError("Base64EncodedBinary can only parse string values.");
+      }
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // TODO: add name to this error
+        throw new GraphQLError("Base64EncodedBinary can only parse string values");
+      }
+      return Buffer.from(ast.value, "base64");
+    }
+  },
+  LTree: {
+    serialize(x) {
+      return x;
+    },
+    parseValue: LTreeParseValue,
+    parseLiteral(node, variables) {
+      return LTreeParseValue(valueFromASTUntyped(node, variables));
+    }
+  },
   TypesEdge: {
     __assertStep: assertEdgeCapableStep,
     cursor($edge) {
@@ -16504,6 +16809,50 @@ export const plans = {
     __assertStep: assertPgClassSingleStep,
     url($record) {
       return $record.get("url");
+    }
+  },
+  NotNullUrl: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
+  KeyValueHash: {
+    serialize(value) {
+      return value;
+    },
+    parseValue(obj) {
+      if (isValidHstoreObject(obj)) {
+        return obj;
+      }
+      throw new GraphQLError(`This is not a valid ${"KeyValueHash"} object, it must be a key/value hash where keys and values are both strings (or null).`);
+    },
+    parseLiteral(ast, variables) {
+      switch (ast.kind) {
+        case Kind.OBJECT:
+          {
+            const value = ast.fields.reduce((memo, field) => {
+              memo[field.name.value] = parseValueLiteral(field.value, variables);
+              return memo;
+            }, Object.create(null));
+            if (!isValidHstoreObject(value)) {
+              return undefined;
+            }
+            return value;
+          }
+        case Kind.NULL:
+          return null;
+        case Kind.VARIABLE:
+          {
+            const name = ast.name.value;
+            const value = variables ? variables[name] : undefined;
+            if (!isValidHstoreObject(value)) {
+              return undefined;
+            }
+            return value;
+          }
+        default:
+          return undefined;
+      }
     }
   },
   LeftArm: {
@@ -16736,7 +17085,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.person_id_2.codec)}`;
             }
           });
         }
@@ -16759,7 +17108,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.person_id_1.codec)}`;
             }
           });
         }
@@ -16782,7 +17131,7 @@ export const plans = {
             type: "attribute",
             attribute: "extra",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.extra.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.extra.codec)}`;
             }
           });
         }
@@ -16821,6 +17170,16 @@ export const plans = {
     },
     ts($record) {
       return $record.get("ts");
+    }
+  },
+  NotNullTimestamp: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   FuncOutSetofConnection: {
@@ -17166,7 +17525,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.id.codec)}`;
             }
           });
         }
@@ -17189,7 +17548,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_full_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.person_full_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.person_full_name.codec)}`;
             }
           });
         }
@@ -17212,7 +17571,7 @@ export const plans = {
             type: "attribute",
             attribute: "aliases",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.aliases.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.aliases.codec)}`;
             }
           });
         }
@@ -17235,7 +17594,7 @@ export const plans = {
             type: "attribute",
             attribute: "about",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.about.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.about.codec)}`;
             }
           });
         }
@@ -17258,7 +17617,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.email.codec)}`;
             }
           });
         }
@@ -17281,7 +17640,7 @@ export const plans = {
             type: "attribute",
             attribute: "site",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.site.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.site.codec)}`;
             }
           });
         }
@@ -17304,7 +17663,7 @@ export const plans = {
             type: "attribute",
             attribute: "config",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.config.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.config.codec)}`;
             }
           });
         }
@@ -17327,7 +17686,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_ip",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_ip.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_login_from_ip.codec)}`;
             }
           });
         }
@@ -17350,7 +17709,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_subnet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_subnet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_login_from_subnet.codec)}`;
             }
           });
         }
@@ -17373,7 +17732,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_mac",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.user_mac.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.user_mac.codec)}`;
             }
           });
         }
@@ -17396,7 +17755,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.created_at.codec)}`;
             }
           });
         }
@@ -17421,6 +17780,9 @@ export const plans = {
     }
   },
   WrappedUrlInput: {
+    "__inputPlan": function WrappedUrlInput_inputPlan() {
+      return object(Object.create(null));
+    },
     url: {
       applyPlan($insert, val) {
         $insert.set("url", val.get());
@@ -17575,7 +17937,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_myTable.attributes.id.codec)}`;
             }
           });
         }
@@ -17598,7 +17960,7 @@ export const plans = {
             type: "attribute",
             attribute: "json_data",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.json_data.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_myTable.attributes.json_data.codec)}`;
             }
           });
         }
@@ -17753,7 +18115,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_personSecret.attributes.person_id.codec)}`;
             }
           });
         }
@@ -17776,7 +18138,7 @@ export const plans = {
             type: "attribute",
             attribute: "sekrit",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.sekrit.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_personSecret.attributes.sekrit.codec)}`;
             }
           });
         }
@@ -17999,7 +18361,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.id.codec)}`;
             }
           });
         }
@@ -18022,7 +18384,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.nullable_text.codec)}`;
             }
           });
         }
@@ -18045,7 +18407,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_int",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_int.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.nullable_int.codec)}`;
             }
           });
         }
@@ -18068,7 +18430,7 @@ export const plans = {
             type: "attribute",
             attribute: "non_null_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.non_null_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.non_null_text.codec)}`;
             }
           });
         }
@@ -18271,7 +18633,7 @@ export const plans = {
             type: "attribute",
             attribute: "not_null_has_default",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.not_null_has_default.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.not_null_has_default.codec)}`;
             }
           });
         }
@@ -18294,7 +18656,7 @@ export const plans = {
             type: "attribute",
             attribute: "wont_cast_easy",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.wont_cast_easy.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.wont_cast_easy.codec)}`;
             }
           });
         }
@@ -18317,7 +18679,7 @@ export const plans = {
             type: "attribute",
             attribute: "row_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.row_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.row_id.codec)}`;
             }
           });
         }
@@ -18540,7 +18902,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.id.codec)}`;
             }
           });
         }
@@ -18563,7 +18925,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.person_id.codec)}`;
             }
           });
         }
@@ -18586,7 +18948,7 @@ export const plans = {
             type: "attribute",
             attribute: "length_in_metres",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.length_in_metres.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.length_in_metres.codec)}`;
             }
           });
         }
@@ -18609,7 +18971,7 @@ export const plans = {
             type: "attribute",
             attribute: "mood",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.mood.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.mood.codec)}`;
             }
           });
         }
@@ -18764,7 +19126,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_issue756.attributes.id.codec)}`;
             }
           });
         }
@@ -18787,7 +19149,7 @@ export const plans = {
             type: "attribute",
             attribute: "ts",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.ts.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_issue756.attributes.ts.codec)}`;
             }
           });
         }
@@ -20419,6 +20781,9 @@ export const plans = {
     leftArm: undefined
   },
   LeftArmBaseInput: {
+    "__inputPlan": function LeftArmBaseInput_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -20844,6 +21209,9 @@ export const plans = {
     }
   },
   MyTableInput: {
+    "__inputPlan": function MyTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -20923,6 +21291,9 @@ export const plans = {
     }
   },
   PersonSecretInput: {
+    "__inputPlan": function PersonSecretInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -21007,6 +21378,9 @@ export const plans = {
     }
   },
   CompoundKeyInput: {
+    "__inputPlan": function CompoundKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId2: {
       applyPlan($insert, val) {
         $insert.set("person_id_2", val.get());
@@ -21088,6 +21462,9 @@ export const plans = {
     }
   },
   NullTestRecordInput: {
+    "__inputPlan": function NullTestRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -21145,6 +21522,9 @@ export const plans = {
     }
   },
   EdgeCaseInput: {
+    "__inputPlan": function EdgeCaseInput_inputPlan() {
+      return object(Object.create(null));
+    },
     notNullHasDefault: {
       applyPlan($insert, val) {
         $insert.set("not_null_has_default", val.get());
@@ -21231,6 +21611,9 @@ export const plans = {
     }
   },
   LeftArmInput: {
+    "__inputPlan": function LeftArmInput_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -21319,6 +21702,9 @@ export const plans = {
     }
   },
   Issue756Input: {
+    "__inputPlan": function Issue756Input_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -21393,6 +21779,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -21529,6 +21918,9 @@ export const plans = {
     }
   },
   MyTablePatch: {
+    "__inputPlan": function MyTablePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -21621,6 +22013,9 @@ export const plans = {
     }
   },
   PersonSecretPatch: {
+    "__inputPlan": function PersonSecretPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -21718,6 +22113,9 @@ export const plans = {
     }
   },
   CompoundKeyPatch: {
+    "__inputPlan": function CompoundKeyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     personId2: {
       applyPlan($insert, val) {
         $insert.set("person_id_2", val.get());
@@ -21813,6 +22211,9 @@ export const plans = {
     }
   },
   NullTestRecordPatch: {
+    "__inputPlan": function NullTestRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -21919,6 +22320,9 @@ export const plans = {
     }
   },
   LeftArmPatch: {
+    "__inputPlan": function LeftArmPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -22034,6 +22438,9 @@ export const plans = {
     }
   },
   Issue756Patch: {
+    "__inputPlan": function Issue756Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -22121,6 +22528,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, domainOfCodec, enumCodec, listOfCodec, makeRegistry, pgClassExpression, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectFromRecords, pgSelectSingleFromRecord, pgUpdateSingle, rangeOfCodec, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
+import { GraphQLError, GraphQLInt, GraphQLString, Kind, valueFromASTUntyped } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -404,30 +421,29 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
   executor,
   isAnonymous: true
 });
-const myTableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  json_data: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const myTableCodec = recordCodec({
+const spec_myTable = {
   name: "myTable",
   identifier: sql.identifier("c", "my_table"),
-  attributes: myTableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    json_data: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -438,34 +454,34 @@ const myTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const personSecretAttributes = Object.assign(Object.create(null), {
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  sekrit: {
-    description: "A secret held by the associated Person",
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "secret"
-      }
-    }
-  }
-});
-const personSecretCodec = recordCodec({
+  executor: executor
+};
+const myTableCodec = recordCodec(spec_myTable);
+const spec_personSecret = {
   name: "personSecret",
   identifier: sql.identifier("c", "person_secret"),
-  attributes: personSecretAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    sekrit: {
+      description: "A secret held by the associated Person",
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "secret"
+        }
+      }
+    }
+  }),
   description: "Tracks the person's secret",
   extensions: {
     isTableLike: true,
@@ -478,41 +494,41 @@ const personSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor
-});
-const compoundKeyAttributes = Object.assign(Object.create(null), {
-  person_id_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  extra: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const compoundKeyCodec = recordCodec({
+  executor: executor
+};
+const personSecretCodec = recordCodec(spec_personSecret);
+const spec_compoundKey = {
   name: "compoundKey",
   identifier: sql.identifier("c", "compound_key"),
-  attributes: compoundKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    extra: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -523,50 +539,50 @@ const compoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const nullTestRecordAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_int: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  non_null_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const nullTestRecordCodec = recordCodec({
+  executor: executor
+};
+const compoundKeyCodec = recordCodec(spec_compoundKey);
+const spec_nullTestRecord = {
   name: "nullTestRecord",
   identifier: sql.identifier("c", "null_test_record"),
-  attributes: nullTestRecordAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_int: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    non_null_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -577,41 +593,41 @@ const nullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const edgeCaseAttributes = Object.assign(Object.create(null), {
-  not_null_has_default: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  wont_cast_easy: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  row_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const edgeCaseCodec = recordCodec({
+  executor: executor
+};
+const nullTestRecordCodec = recordCodec(spec_nullTestRecord);
+const spec_edgeCase = {
   name: "edgeCase",
   identifier: sql.identifier("c", "edge_case"),
-  attributes: edgeCaseAttributes,
+  attributes: Object.assign(Object.create(null), {
+    not_null_has_default: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    wont_cast_easy: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    row_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -622,50 +638,50 @@ const edgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const leftArmAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  length_in_metres: {
-    description: undefined,
-    codec: TYPES.float,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  mood: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const leftArmCodec = recordCodec({
+  executor: executor
+};
+const edgeCaseCodec = recordCodec(spec_edgeCase);
+const spec_leftArm = {
   name: "leftArm",
   identifier: sql.identifier("c", "left_arm"),
-  attributes: leftArmAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    length_in_metres: {
+      description: undefined,
+      codec: TYPES.float,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    mood: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Tracks metadata about the left arms of various people",
   extensions: {
     isTableLike: true,
@@ -676,8 +692,9 @@ const leftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const leftArmCodec = recordCodec(spec_leftArm);
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
   extensions: {
@@ -690,30 +707,29 @@ const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp
   },
   notNull: true
 });
-const issue756Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  ts: {
-    description: undefined,
-    codec: notNullTimestampCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const issue756Codec = recordCodec({
+const spec_issue756 = {
   name: "issue756",
   identifier: sql.identifier("c", "issue756"),
-  attributes: issue756Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    ts: {
+      description: undefined,
+      codec: notNullTimestampCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -724,8 +740,9 @@ const issue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const issue756Codec = recordCodec(spec_issue756);
 const colorCodec = enumCodec({
   name: "color",
   identifier: sql.identifier("b", "color"),
@@ -855,7 +872,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
@@ -977,7 +994,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1061,7 +1078,7 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
@@ -1222,117 +1239,116 @@ const wrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const personAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: "The primary unique identifier for the person",
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_full_name: {
-    description: "The person\u2019s name",
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "name"
-      }
-    }
-  },
-  aliases: {
-    description: undefined,
-    codec: textArrayCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  about: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  email: {
-    description: undefined,
-    codec: emailCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  site: {
-    description: undefined,
-    codec: wrappedUrlCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        deprecated: "Don\u2019t use me"
-      }
-    }
-  },
-  config: {
-    description: undefined,
-    codec: TYPES.hstore,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_login_from_ip: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_login_from_subnet: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  user_mac: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  created_at: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const personCodec = recordCodec({
+const spec_person = {
   name: "person",
   identifier: sql.identifier("c", "person"),
-  attributes: personAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: "The primary unique identifier for the person",
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_full_name: {
+      description: "The person\u2019s name",
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "name"
+        }
+      }
+    },
+    aliases: {
+      description: undefined,
+      codec: textArrayCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    about: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    email: {
+      description: undefined,
+      codec: emailCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    site: {
+      description: undefined,
+      codec: wrappedUrlCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          deprecated: "Don\u2019t use me"
+        }
+      }
+    },
+    config: {
+      description: undefined,
+      codec: TYPES.hstore,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_login_from_ip: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_login_from_subnet: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    user_mac: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    created_at: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Person test comment",
   extensions: {
     isTableLike: true,
@@ -1343,8 +1359,9 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const personCodec = recordCodec(spec_person);
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
@@ -1690,7 +1707,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -1742,7 +1759,7 @@ const byteaArrayCodec = listOfCodec(TYPES.bytea, {
   description: undefined,
   name: "byteaArray"
 });
-const typesAttributes_ltree_codec_ltree = {
+const spec_types_attributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -1754,7 +1771,7 @@ const typesAttributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
+const spec_types_attributes_ltree_array_codec_ltree_ = listOfCodec(spec_types_attributes_ltree_codec_ltree);
 const typesCodec = recordCodec({
   name: "types",
   identifier: sql.identifier("b", "types"),
@@ -2184,7 +2201,7 @@ const typesCodec = recordCodec({
     },
     ltree: {
       description: undefined,
-      codec: typesAttributes_ltree_codec_ltree,
+      codec: spec_types_attributes_ltree_codec_ltree,
       notNull: false,
       hasDefault: false,
       extensions: {
@@ -2193,7 +2210,7 @@ const typesCodec = recordCodec({
     },
     ltree_array: {
       description: undefined,
-      codec: typesAttributes_ltree_array_codec_ltree_,
+      codec: spec_types_attributes_ltree_array_codec_ltree_,
       notNull: false,
       hasDefault: false,
       extensions: {
@@ -2213,7 +2230,7 @@ const typesCodec = recordCodec({
       foreignKey: ["(smallint) references a.post", "(id) references a.post"]
     })
   },
-  executor
+  executor: executor
 });
 const int4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
@@ -2570,8 +2587,8 @@ const registry = makeRegistry({
     int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
     byteaArray: byteaArrayCodec,
-    ltree: typesAttributes_ltree_codec_ltree,
-    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
+    ltree: spec_types_attributes_ltree_codec_ltree,
+    "ltree[]": spec_types_attributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     typesArray: listOfCodec(typesCodec, {
       extensions: {
@@ -7559,8 +7576,71 @@ const makeArgs45 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
+function UUIDSerialize(value) {
+  return "" + value;
+}
+const coerce = string => {
+  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
+    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
+  }
+  return string;
+};
 const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
+function LTreeParseValue(value) {
+  return value;
+}
+const isValidHstoreObject = obj => {
+  if (obj === null) {
+    // Null is okay
+    return true;
+  } else if (typeof obj === "object") {
+    // A hash with string/null values is also okay
+    const keys = Object.keys(obj);
+    for (const key of keys) {
+      const val = obj[key];
+      if (val === null) {
+        // Null is okay
+      } else if (typeof val === "string") {
+        // String is okay
+      } else {
+        // Everything else is invalid.
+        return false;
+      }
+    }
+    return true;
+  } else {
+    // Everything else is invalid.
+    return false;
+  }
+};
+const parseValueLiteral = (ast, variables) => {
+  switch (ast.kind) {
+    case Kind.INT:
+    case Kind.FLOAT:
+      // Number isn't really okay, but we'll coerce it to a string anyway.
+      return String(parseFloat(ast.value));
+    case Kind.STRING:
+      // String is okay.
+      return String(ast.value);
+    case Kind.NULL:
+      // Null is okay.
+      return null;
+    case Kind.VARIABLE:
+      {
+        // Variable is okay if that variable is either a string or null.
+        const name = ast.name.value;
+        const value = variables ? variables[name] : undefined;
+        if (value === null || typeof value === "string") {
+          return value;
+        }
+        return undefined;
+      }
+    default:
+      // Everything else is invalid.
+      return undefined;
+  }
+};
 const resource_frmcdc_postPgResource = registry.pgResources["frmcdc_post"];
 const argDetailsSimple46 = [];
 const makeArgs46 = (args, path = []) => {
@@ -15578,6 +15658,21 @@ export const plans = {
       return $record.get("json_data");
     }
   },
+  JSON: {
+    serialize(value) {
+      return JSON.stringify(value);
+    },
+    parseValue(value) {
+      return JSON.parse(value);
+    },
+    parseLiteral(ast, _variables) {
+      if (ast.kind === Kind.STRING) {
+        return JSON.parse(ast.value);
+      } else {
+        return undefined;
+      }
+    }
+  },
   PersonSecret: {
     __assertStep: assertPgClassSingleStep,
     nodeId($parent) {
@@ -16423,6 +16518,11 @@ export const plans = {
       return $record.get("o");
     }
   },
+  Email: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
   PersonComputedFirstArgInoutOutRecord: {
     __assertStep: assertPgClassSingleStep,
     person($record) {
@@ -16532,6 +16632,19 @@ export const plans = {
     },
     BLUE: {
       value: "blue"
+    }
+  },
+  UUID: {
+    serialize: UUIDSerialize,
+    parseValue(value) {
+      return coerce("" + value);
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // ERRORS: add name to this error
+        throw new GraphQLError(`${"UUID" ?? "This scalar"} can only parse string values (kind = '${ast.kind}')`);
+      }
+      return coerce(ast.value);
     }
   },
   EnumCaps: {
@@ -16660,6 +16773,16 @@ export const plans = {
       return $record.get("is_optimised");
     }
   },
+  Datetime: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PeopleConnection: {
     __assertStep: ConnectionStep,
     nodes($connection) {
@@ -16683,6 +16806,16 @@ export const plans = {
     },
     node($edge) {
       return $edge.node();
+    }
+  },
+  Cursor: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   PageInfo: {
@@ -17327,12 +17460,62 @@ export const plans = {
       return $record.get("ltree_array");
     }
   },
+  BigInt: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigInt" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  BigFloat: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigFloat" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  AnInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
+  AnotherInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
   BigFloatRange: {},
   BigFloatRangeBound: {},
   DateRange: {},
   DateRangeBound: {},
+  Date: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Date" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   AnIntRange: {},
   AnIntRangeBound: {},
+  Time: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Time" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   NestedCompoundType: {
     __assertStep: assertPgClassSingleStep,
     a($record) {
@@ -17358,6 +17541,128 @@ export const plans = {
     }
   },
   Point: {},
+  InternetAddress: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"InternetAddress" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProc: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProc" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProcedure: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProcedure" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOper: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOper" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOperator: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOperator" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegClass: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegClass" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegType: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegType" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegConfig: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegConfig" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegDictionary: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegDictionary" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  Base64EncodedBinary: {
+    serialize(data) {
+      if (Buffer.isBuffer(data)) {
+        return data.toString("base64");
+      } else {
+        throw new Error(`Base64EncodeBinary can only be used with Node.js buffers.`);
+      }
+    },
+    parseValue(data) {
+      if (typeof data === "string") {
+        return Buffer.from(data, "base64");
+      } else {
+        throw new GraphQLError("Base64EncodedBinary can only parse string values.");
+      }
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // TODO: add name to this error
+        throw new GraphQLError("Base64EncodedBinary can only parse string values");
+      }
+      return Buffer.from(ast.value, "base64");
+    }
+  },
+  LTree: {
+    serialize(x) {
+      return x;
+    },
+    parseValue: LTreeParseValue,
+    parseLiteral(node, variables) {
+      return LTreeParseValue(valueFromASTUntyped(node, variables));
+    }
+  },
   TypesEdge: {
     __assertStep: assertEdgeCapableStep,
     cursor($edge) {
@@ -17371,6 +17676,50 @@ export const plans = {
     __assertStep: assertPgClassSingleStep,
     url($record) {
       return $record.get("url");
+    }
+  },
+  NotNullUrl: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
+  KeyValueHash: {
+    serialize(value) {
+      return value;
+    },
+    parseValue(obj) {
+      if (isValidHstoreObject(obj)) {
+        return obj;
+      }
+      throw new GraphQLError(`This is not a valid ${"KeyValueHash"} object, it must be a key/value hash where keys and values are both strings (or null).`);
+    },
+    parseLiteral(ast, variables) {
+      switch (ast.kind) {
+        case Kind.OBJECT:
+          {
+            const value = ast.fields.reduce((memo, field) => {
+              memo[field.name.value] = parseValueLiteral(field.value, variables);
+              return memo;
+            }, Object.create(null));
+            if (!isValidHstoreObject(value)) {
+              return undefined;
+            }
+            return value;
+          }
+        case Kind.NULL:
+          return null;
+        case Kind.VARIABLE:
+          {
+            const name = ast.name.value;
+            const value = variables ? variables[name] : undefined;
+            if (!isValidHstoreObject(value)) {
+              return undefined;
+            }
+            return value;
+          }
+        default:
+          return undefined;
+      }
     }
   },
   LeftArm: {
@@ -17603,7 +17952,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.person_id_2.codec)}`;
             }
           });
         }
@@ -17626,7 +17975,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.person_id_1.codec)}`;
             }
           });
         }
@@ -17649,7 +17998,7 @@ export const plans = {
             type: "attribute",
             attribute: "extra",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.extra.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.extra.codec)}`;
             }
           });
         }
@@ -17688,6 +18037,16 @@ export const plans = {
     },
     ts($record) {
       return $record.get("ts");
+    }
+  },
+  NotNullTimestamp: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   FuncOutSetofConnection: {
@@ -18033,7 +18392,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.id.codec)}`;
             }
           });
         }
@@ -18056,7 +18415,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_full_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.person_full_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.person_full_name.codec)}`;
             }
           });
         }
@@ -18079,7 +18438,7 @@ export const plans = {
             type: "attribute",
             attribute: "aliases",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.aliases.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.aliases.codec)}`;
             }
           });
         }
@@ -18102,7 +18461,7 @@ export const plans = {
             type: "attribute",
             attribute: "about",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.about.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.about.codec)}`;
             }
           });
         }
@@ -18125,7 +18484,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.email.codec)}`;
             }
           });
         }
@@ -18148,7 +18507,7 @@ export const plans = {
             type: "attribute",
             attribute: "site",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.site.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.site.codec)}`;
             }
           });
         }
@@ -18171,7 +18530,7 @@ export const plans = {
             type: "attribute",
             attribute: "config",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.config.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.config.codec)}`;
             }
           });
         }
@@ -18194,7 +18553,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_ip",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_ip.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_login_from_ip.codec)}`;
             }
           });
         }
@@ -18217,7 +18576,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_subnet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_subnet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_login_from_subnet.codec)}`;
             }
           });
         }
@@ -18240,7 +18599,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_mac",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.user_mac.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.user_mac.codec)}`;
             }
           });
         }
@@ -18263,7 +18622,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.created_at.codec)}`;
             }
           });
         }
@@ -18288,6 +18647,9 @@ export const plans = {
     }
   },
   WrappedUrlInput: {
+    "__inputPlan": function WrappedUrlInput_inputPlan() {
+      return object(Object.create(null));
+    },
     url: {
       applyPlan($insert, val) {
         $insert.set("url", val.get());
@@ -18417,7 +18779,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_myTable.attributes.id.codec)}`;
             }
           });
         }
@@ -18440,7 +18802,7 @@ export const plans = {
             type: "attribute",
             attribute: "json_data",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.json_data.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_myTable.attributes.json_data.codec)}`;
             }
           });
         }
@@ -18595,7 +18957,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_personSecret.attributes.person_id.codec)}`;
             }
           });
         }
@@ -18618,7 +18980,7 @@ export const plans = {
             type: "attribute",
             attribute: "sekrit",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.sekrit.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_personSecret.attributes.sekrit.codec)}`;
             }
           });
         }
@@ -18841,7 +19203,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.id.codec)}`;
             }
           });
         }
@@ -18864,7 +19226,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.nullable_text.codec)}`;
             }
           });
         }
@@ -18887,7 +19249,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_int",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_int.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.nullable_int.codec)}`;
             }
           });
         }
@@ -18910,7 +19272,7 @@ export const plans = {
             type: "attribute",
             attribute: "non_null_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.non_null_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.non_null_text.codec)}`;
             }
           });
         }
@@ -19113,7 +19475,7 @@ export const plans = {
             type: "attribute",
             attribute: "not_null_has_default",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.not_null_has_default.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.not_null_has_default.codec)}`;
             }
           });
         }
@@ -19136,7 +19498,7 @@ export const plans = {
             type: "attribute",
             attribute: "wont_cast_easy",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.wont_cast_easy.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.wont_cast_easy.codec)}`;
             }
           });
         }
@@ -19159,7 +19521,7 @@ export const plans = {
             type: "attribute",
             attribute: "row_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.row_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.row_id.codec)}`;
             }
           });
         }
@@ -19382,7 +19744,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.id.codec)}`;
             }
           });
         }
@@ -19405,7 +19767,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.person_id.codec)}`;
             }
           });
         }
@@ -19428,7 +19790,7 @@ export const plans = {
             type: "attribute",
             attribute: "length_in_metres",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.length_in_metres.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.length_in_metres.codec)}`;
             }
           });
         }
@@ -19451,7 +19813,7 @@ export const plans = {
             type: "attribute",
             attribute: "mood",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.mood.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.mood.codec)}`;
             }
           });
         }
@@ -19606,7 +19968,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_issue756.attributes.id.codec)}`;
             }
           });
         }
@@ -19629,7 +19991,7 @@ export const plans = {
             type: "attribute",
             attribute: "ts",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.ts.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_issue756.attributes.ts.codec)}`;
             }
           });
         }
@@ -21286,6 +21648,9 @@ export const plans = {
     leftArm: undefined
   },
   LeftArmBaseInput: {
+    "__inputPlan": function LeftArmBaseInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -21711,6 +22076,9 @@ export const plans = {
     }
   },
   MyTableInput: {
+    "__inputPlan": function MyTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -21790,6 +22158,9 @@ export const plans = {
     }
   },
   PersonSecretInput: {
+    "__inputPlan": function PersonSecretInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -21874,6 +22245,9 @@ export const plans = {
     }
   },
   CompoundKeyInput: {
+    "__inputPlan": function CompoundKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId2: {
       applyPlan($insert, val) {
         $insert.set("person_id_2", val.get());
@@ -21955,6 +22329,9 @@ export const plans = {
     }
   },
   NullTestRecordInput: {
+    "__inputPlan": function NullTestRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -22012,6 +22389,9 @@ export const plans = {
     }
   },
   EdgeCaseInput: {
+    "__inputPlan": function EdgeCaseInput_inputPlan() {
+      return object(Object.create(null));
+    },
     notNullHasDefault: {
       applyPlan($insert, val) {
         $insert.set("not_null_has_default", val.get());
@@ -22098,6 +22478,9 @@ export const plans = {
     }
   },
   LeftArmInput: {
+    "__inputPlan": function LeftArmInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -22186,6 +22569,9 @@ export const plans = {
     }
   },
   Issue756Input: {
+    "__inputPlan": function Issue756Input_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -22260,6 +22646,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -22396,6 +22785,9 @@ export const plans = {
     }
   },
   MyTablePatch: {
+    "__inputPlan": function MyTablePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -22488,6 +22880,9 @@ export const plans = {
     }
   },
   PersonSecretPatch: {
+    "__inputPlan": function PersonSecretPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -22585,6 +22980,9 @@ export const plans = {
     }
   },
   CompoundKeyPatch: {
+    "__inputPlan": function CompoundKeyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     personId2: {
       applyPlan($insert, val) {
         $insert.set("person_id_2", val.get());
@@ -22680,6 +23078,9 @@ export const plans = {
     }
   },
   NullTestRecordPatch: {
+    "__inputPlan": function NullTestRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -22786,6 +23187,9 @@ export const plans = {
     }
   },
   LeftArmPatch: {
+    "__inputPlan": function LeftArmPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -22901,6 +23305,9 @@ export const plans = {
     }
   },
   Issue756Patch: {
+    "__inputPlan": function Issue756Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -22988,6 +23395,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.omit-pets-simple.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.omit-pets-simple.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, makeRegistry, pgClassExpression, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectSingleFromRecord, pgUpdateSingle, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
+import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,44 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
-  }
-});
-const peopleAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -78,10 +75,29 @@ const executor = new PgExecutor({
     });
   }
 });
-const peopleCodec = recordCodec({
+const spec_people = {
   name: "people",
   identifier: sql.identifier("simple_collections", "people"),
-  attributes: peopleAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -92,41 +108,41 @@ const peopleCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const petsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  owner_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const petsCodec = recordCodec({
+  executor: executor
+};
+const peopleCodec = recordCodec(spec_people);
+const spec_pets = {
   name: "pets",
   identifier: sql.identifier("simple_collections", "pets"),
-  attributes: petsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    owner_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -137,8 +153,9 @@ const petsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const petsCodec = recordCodec(spec_pets);
 const peopleUniques = [{
   isPrimary: true,
   attributes: ["id"],
@@ -416,6 +433,9 @@ const makeArgs = (args, path = []) => {
   return selectArgs;
 };
 const resource_people_odd_petsPgResource = registry.pgResources["people_odd_pets"];
+function CursorSerialize(value) {
+  return "" + value;
+}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
@@ -1444,6 +1464,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: CursorSerialize,
+    parseValue: CursorSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -1614,7 +1644,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), petsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_pets.attributes.id.codec)}`;
             }
           });
         }
@@ -1637,7 +1667,7 @@ export const plans = {
             type: "attribute",
             attribute: "owner_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), petsAttributes.owner_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_pets.attributes.owner_id.codec)}`;
             }
           });
         }
@@ -1660,7 +1690,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), petsAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_pets.attributes.name.codec)}`;
             }
           });
         }
@@ -1815,7 +1845,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), peopleAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_people.attributes.id.codec)}`;
             }
           });
         }
@@ -1838,7 +1868,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), peopleAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_people.attributes.name.codec)}`;
             }
           });
         }
@@ -2079,6 +2109,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -2158,6 +2191,9 @@ export const plans = {
     }
   },
   PetInput: {
+    "__inputPlan": function PetInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -2238,6 +2274,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -2330,6 +2369,9 @@ export const plans = {
     }
   },
   PetPatch: {
+    "__inputPlan": function PetPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.pets-simple.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.pets-simple.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, makeRegistry, pgClassExpression, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectSingleFromRecord, pgUpdateSingle, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
+import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,44 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
-  }
-});
-const peopleAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -78,10 +75,29 @@ const executor = new PgExecutor({
     });
   }
 });
-const peopleCodec = recordCodec({
+const spec_people = {
   name: "people",
   identifier: sql.identifier("simple_collections", "people"),
-  attributes: peopleAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -92,41 +108,41 @@ const peopleCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const petsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  owner_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const petsCodec = recordCodec({
+  executor: executor
+};
+const peopleCodec = recordCodec(spec_people);
+const spec_pets = {
   name: "pets",
   identifier: sql.identifier("simple_collections", "pets"),
-  attributes: petsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    owner_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -137,8 +153,9 @@ const petsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const petsCodec = recordCodec(spec_pets);
 const peopleUniques = [{
   isPrimary: true,
   attributes: ["id"],
@@ -451,6 +468,9 @@ const getSelectPlanFromParentAndArgs = ($in, args, _info) => {
   // PERF: or here, if scalar add select to `$row`?
   return resource_people_odd_petsPgResource.execute(selectArgs);
 };
+function CursorSerialize(value) {
+  return "" + value;
+}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Person, $nodeId);
@@ -1453,6 +1473,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: CursorSerialize,
+    parseValue: CursorSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -1623,7 +1653,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), petsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_pets.attributes.id.codec)}`;
             }
           });
         }
@@ -1646,7 +1676,7 @@ export const plans = {
             type: "attribute",
             attribute: "owner_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), petsAttributes.owner_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_pets.attributes.owner_id.codec)}`;
             }
           });
         }
@@ -1669,7 +1699,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), petsAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_pets.attributes.name.codec)}`;
             }
           });
         }
@@ -1824,7 +1854,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), peopleAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_people.attributes.id.codec)}`;
             }
           });
         }
@@ -1847,7 +1877,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), peopleAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_people.attributes.name.codec)}`;
             }
           });
         }
@@ -2088,6 +2118,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -2167,6 +2200,9 @@ export const plans = {
     }
   },
   PetInput: {
+    "__inputPlan": function PetInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -2247,6 +2283,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -2339,6 +2378,9 @@ export const plans = {
     }
   },
   PetPatch: {
+    "__inputPlan": function PetPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, domainOfCodec, enumCodec, listOfCodec, makeRegistry, pgClassExpression, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectFromRecords, pgSelectSingleFromRecord, pgUpdateSingle, rangeOfCodec, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId, stepAMayDependOnStepB } from "grafast";
+import { GraphQLError, GraphQLInt, GraphQLString, Kind, valueFromASTUntyped } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -442,21 +459,20 @@ const textArrayCodec = listOfCodec(TYPES.text, {
   description: undefined,
   name: "textArray"
 });
-const nonUpdatableViewAttributes = Object.assign(Object.create(null), {
-  "?column?": {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const nonUpdatableViewCodec = recordCodec({
+const spec_nonUpdatableView = {
   name: "nonUpdatableView",
   identifier: sql.identifier("a", "non_updatable_view"),
-  attributes: nonUpdatableViewAttributes,
+  attributes: Object.assign(Object.create(null), {
+    "?column?": {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -467,23 +483,23 @@ const nonUpdatableViewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const inputsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const inputsCodec = recordCodec({
+  executor: executor
+};
+const nonUpdatableViewCodec = recordCodec(spec_nonUpdatableView);
+const spec_inputs = {
   name: "inputs",
   identifier: sql.identifier("a", "inputs"),
-  attributes: inputsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Should output as Input",
   extensions: {
     isTableLike: true,
@@ -494,23 +510,23 @@ const inputsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const patchsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const patchsCodec = recordCodec({
+  executor: executor
+};
+const inputsCodec = recordCodec(spec_inputs);
+const spec_patchs = {
   name: "patchs",
   identifier: sql.identifier("a", "patchs"),
-  attributes: patchsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Should output as Patch",
   extensions: {
     isTableLike: true,
@@ -521,23 +537,23 @@ const patchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const reservedAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const reservedCodec = recordCodec({
+  executor: executor
+};
+const patchsCodec = recordCodec(spec_patchs);
+const spec_reserved = {
   name: "reserved",
   identifier: sql.identifier("a", "reserved"),
-  attributes: reservedAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -548,23 +564,23 @@ const reservedCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const reservedPatchsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const reservedPatchsCodec = recordCodec({
+  executor: executor
+};
+const reservedCodec = recordCodec(spec_reserved);
+const spec_reservedPatchs = {
   name: "reservedPatchs",
   identifier: sql.identifier("a", "reservedPatchs"),
-  attributes: reservedPatchsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   extensions: {
     isTableLike: true,
@@ -575,23 +591,23 @@ const reservedPatchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const reservedInputAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const reservedInputCodec = recordCodec({
+  executor: executor
+};
+const reservedPatchsCodec = recordCodec(spec_reservedPatchs);
+const spec_reservedInput = {
   name: "reservedInput",
   identifier: sql.identifier("a", "reserved_input"),
-  attributes: reservedInputAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
   extensions: {
     isTableLike: true,
@@ -602,32 +618,32 @@ const reservedInputCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const defaultValueAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  null_value: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const defaultValueCodec = recordCodec({
+  executor: executor
+};
+const reservedInputCodec = recordCodec(spec_reservedInput);
+const spec_defaultValue = {
   name: "defaultValue",
   identifier: sql.identifier("a", "default_value"),
-  attributes: defaultValueAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    null_value: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -638,41 +654,41 @@ const defaultValueCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const foreignKeyAttributes = Object.assign(Object.create(null), {
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_key_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_key_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const foreignKeyCodec = recordCodec({
+  executor: executor
+};
+const defaultValueCodec = recordCodec(spec_defaultValue);
+const spec_foreignKey = {
   name: "foreignKey",
   identifier: sql.identifier("a", "foreign_key"),
-  attributes: foreignKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_key_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_key_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -683,32 +699,32 @@ const foreignKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  str: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const noPrimaryKeyCodec = recordCodec({
+  executor: executor
+};
+const foreignKeyCodec = recordCodec(spec_foreignKey);
+const spec_noPrimaryKey = {
   name: "noPrimaryKey",
   identifier: sql.identifier("a", "no_primary_key"),
-  attributes: noPrimaryKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    str: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -719,41 +735,41 @@ const noPrimaryKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const testviewAttributes = Object.assign(Object.create(null), {
-  testviewid: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const testviewCodec = recordCodec({
+  executor: executor
+};
+const noPrimaryKeyCodec = recordCodec(spec_noPrimaryKey);
+const spec_testview = {
   name: "testview",
   identifier: sql.identifier("a", "testview"),
-  attributes: testviewAttributes,
+  attributes: Object.assign(Object.create(null), {
+    testviewid: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -764,21 +780,10 @@ const testviewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const extensions12 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "unique_foreign_key"
-  },
-  tags: Object.assign(Object.create(null), {
-    omit: "create,update,delete,all,order,filter",
-    behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy"]
-  })
+  executor: executor
 };
-const uniqueForeignKeyCodec = recordCodec({
+const testviewCodec = recordCodec(spec_testview);
+const spec_uniqueForeignKey = {
   name: "uniqueForeignKey",
   identifier: sql.identifier("a", "unique_foreign_key"),
   attributes: Object.assign(Object.create(null), {
@@ -802,33 +807,44 @@ const uniqueForeignKeyCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions: extensions12,
-  executor
-});
-const myTableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "unique_foreign_key"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: "create,update,delete,all,order,filter",
+      behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy"]
+    })
   },
-  json_data: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const myTableCodec = recordCodec({
+  executor: executor
+};
+const uniqueForeignKeyCodec = recordCodec(spec_uniqueForeignKey);
+const spec_myTable = {
   name: "myTable",
   identifier: sql.identifier("c", "my_table"),
-  attributes: myTableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    json_data: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -839,34 +855,34 @@ const myTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const personSecretAttributes = Object.assign(Object.create(null), {
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  sekrit: {
-    description: "A secret held by the associated Person",
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "secret"
-      }
-    }
-  }
-});
-const personSecretCodec = recordCodec({
+  executor: executor
+};
+const myTableCodec = recordCodec(spec_myTable);
+const spec_personSecret = {
   name: "personSecret",
   identifier: sql.identifier("c", "person_secret"),
-  attributes: personSecretAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    sekrit: {
+      description: "A secret held by the associated Person",
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "secret"
+        }
+      }
+    }
+  }),
   description: "Tracks the person's secret",
   extensions: {
     isTableLike: true,
@@ -879,41 +895,41 @@ const personSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor
-});
-const viewTableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const viewTableCodec = recordCodec({
+  executor: executor
+};
+const personSecretCodec = recordCodec(spec_personSecret);
+const spec_viewTable = {
   name: "viewTable",
   identifier: sql.identifier("a", "view_table"),
-  attributes: viewTableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -924,41 +940,41 @@ const viewTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const compoundKeyAttributes = Object.assign(Object.create(null), {
-  person_id_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  extra: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const compoundKeyCodec = recordCodec({
+  executor: executor
+};
+const viewTableCodec = recordCodec(spec_viewTable);
+const spec_compoundKey = {
   name: "compoundKey",
   identifier: sql.identifier("c", "compound_key"),
-  attributes: compoundKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    extra: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -969,50 +985,50 @@ const compoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const similarTable1Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col3: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const similarTable1Codec = recordCodec({
+  executor: executor
+};
+const compoundKeyCodec = recordCodec(spec_compoundKey);
+const spec_similarTable1 = {
   name: "similarTable1",
   identifier: sql.identifier("a", "similar_table_1"),
-  attributes: similarTable1Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col3: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1023,50 +1039,50 @@ const similarTable1Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const similarTable2Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  col3: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col4: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col5: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const similarTable2Codec = recordCodec({
+  executor: executor
+};
+const similarTable1Codec = recordCodec(spec_similarTable1);
+const spec_similarTable2 = {
   name: "similarTable2",
   identifier: sql.identifier("a", "similar_table_2"),
-  attributes: similarTable2Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    col3: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col4: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col5: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1077,50 +1093,50 @@ const similarTable2Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const updatableViewAttributes = Object.assign(Object.create(null), {
-  x: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  description: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  constant: {
-    description: "This is constantly 2",
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const updatableViewCodec = recordCodec({
+  executor: executor
+};
+const similarTable2Codec = recordCodec(spec_similarTable2);
+const spec_updatableView = {
   name: "updatableView",
   identifier: sql.identifier("b", "updatable_view"),
-  attributes: updatableViewAttributes,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    description: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    constant: {
+      description: "This is constantly 2",
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "YOYOYO!!",
   extensions: {
     isTableLike: true,
@@ -1134,50 +1150,50 @@ const updatableViewCodec = recordCodec({
       unique: "x|@behavior -single -update -delete"
     })
   },
-  executor
-});
-const nullTestRecordAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_int: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  non_null_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const nullTestRecordCodec = recordCodec({
+  executor: executor
+};
+const updatableViewCodec = recordCodec(spec_updatableView);
+const spec_nullTestRecord = {
   name: "nullTestRecord",
   identifier: sql.identifier("c", "null_test_record"),
-  attributes: nullTestRecordAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_int: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    non_null_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1188,8 +1204,9 @@ const nullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const nullTestRecordCodec = recordCodec(spec_nullTestRecord);
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   extensions: {
     pg: {
@@ -1203,39 +1220,38 @@ const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   description: undefined,
   name: "uuidArray"
 });
-const edgeCaseAttributes = Object.assign(Object.create(null), {
-  not_null_has_default: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  wont_cast_easy: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  row_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const edgeCaseCodec = recordCodec({
+const spec_edgeCase = {
   name: "edgeCase",
   identifier: sql.identifier("c", "edge_case"),
-  attributes: edgeCaseAttributes,
+  attributes: Object.assign(Object.create(null), {
+    not_null_has_default: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    wont_cast_easy: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    row_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1246,50 +1262,50 @@ const edgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const leftArmAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  length_in_metres: {
-    description: undefined,
-    codec: TYPES.float,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  mood: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const leftArmCodec = recordCodec({
+  executor: executor
+};
+const edgeCaseCodec = recordCodec(spec_edgeCase);
+const spec_leftArm = {
   name: "leftArm",
   identifier: sql.identifier("c", "left_arm"),
-  attributes: leftArmAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    length_in_metres: {
+      description: undefined,
+      codec: TYPES.float,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    mood: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Tracks metadata about the left arms of various people",
   extensions: {
     isTableLike: true,
@@ -1300,8 +1316,9 @@ const leftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const leftArmCodec = recordCodec(spec_leftArm);
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
   identifier: sql.identifier("b", "jwt_token"),
@@ -1362,7 +1379,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
@@ -1376,30 +1393,29 @@ const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp
   },
   notNull: true
 });
-const issue756Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  ts: {
-    description: undefined,
-    codec: notNullTimestampCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const issue756Codec = recordCodec({
+const spec_issue756 = {
   name: "issue756",
   identifier: sql.identifier("c", "issue756"),
-  attributes: issue756Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    ts: {
+      description: undefined,
+      codec: notNullTimestampCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1410,8 +1426,9 @@ const issue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const issue756Codec = recordCodec(spec_issue756);
 const authPayloadCodec = recordCodec({
   name: "authPayload",
   identifier: sql.identifier("b", "auth_payload"),
@@ -1456,7 +1473,7 @@ const authPayloadCodec = recordCodec({
       foreignKey: "(id) references c.person"
     })
   },
-  executor
+  executor: executor
 });
 const colorCodec = enumCodec({
   name: "color",
@@ -1587,7 +1604,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
@@ -1709,7 +1726,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1724,66 +1741,65 @@ const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   description: undefined,
   name: "comptypeArray"
 });
-const postAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  headline: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  body: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  enums: {
-    description: undefined,
-    codec: anEnumArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  comptypes: {
-    description: undefined,
-    codec: comptypeArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const postCodec = recordCodec({
+const spec_post = {
   name: "post",
   identifier: sql.identifier("a", "post"),
-  attributes: postAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    headline: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    body: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    enums: {
+      description: undefined,
+      codec: anEnumArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    comptypes: {
+      description: undefined,
+      codec: comptypeArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1794,8 +1810,9 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const postCodec = recordCodec(spec_post);
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
@@ -1942,117 +1959,116 @@ const wrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const personAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: "The primary unique identifier for the person",
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_full_name: {
-    description: "The person\u2019s name",
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "name"
-      }
-    }
-  },
-  aliases: {
-    description: undefined,
-    codec: textArrayCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  about: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  email: {
-    description: undefined,
-    codec: emailCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  site: {
-    description: undefined,
-    codec: wrappedUrlCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        deprecated: "Don\u2019t use me"
-      }
-    }
-  },
-  config: {
-    description: undefined,
-    codec: TYPES.hstore,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_login_from_ip: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_login_from_subnet: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  user_mac: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  created_at: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const personCodec = recordCodec({
+const spec_person = {
   name: "person",
   identifier: sql.identifier("c", "person"),
-  attributes: personAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: "The primary unique identifier for the person",
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_full_name: {
+      description: "The person\u2019s name",
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "name"
+        }
+      }
+    },
+    aliases: {
+      description: undefined,
+      codec: textArrayCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    about: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    email: {
+      description: undefined,
+      codec: emailCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    site: {
+      description: undefined,
+      codec: wrappedUrlCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          deprecated: "Don\u2019t use me"
+        }
+      }
+    },
+    config: {
+      description: undefined,
+      codec: TYPES.hstore,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_login_from_ip: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_login_from_subnet: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    user_mac: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    created_at: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Person test comment",
   extensions: {
     isTableLike: true,
@@ -2063,8 +2079,9 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const personCodec = recordCodec(spec_person);
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
@@ -2397,7 +2414,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -2449,7 +2466,7 @@ const byteaArrayCodec = listOfCodec(TYPES.bytea, {
   description: undefined,
   name: "byteaArray"
 });
-const typesAttributes_ltree_codec_ltree = {
+const spec_types_attributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -2461,469 +2478,468 @@ const typesAttributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
-const typesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  smallint: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bigint: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numeric: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  decimal: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  boolean: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  varchar: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum_array: {
-    description: undefined,
-    codec: colorArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain: {
-    description: undefined,
-    codec: anIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain2: {
-    description: undefined,
-    codec: anotherIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array: {
-    description: undefined,
-    codec: textArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  json: {
-    description: undefined,
-    codec: TYPES.json,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  jsonb: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_range: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numrange: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  daterange: {
-    description: undefined,
-    codec: daterangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  an_int_range: {
-    description: undefined,
-    codec: anIntRangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamp: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamptz: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  date: {
-    description: undefined,
-    codec: TYPES.date,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  time: {
-    description: undefined,
-    codec: TYPES.time,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timetz: {
-    description: undefined,
-    codec: TYPES.timetz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval_array: {
-    description: undefined,
-    codec: intervalArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  money: {
-    description: undefined,
-    codec: TYPES.money,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  point: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullablePoint: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  inet: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  cidr: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  macaddr: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regproc: {
-    description: undefined,
-    codec: TYPES.regproc,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regprocedure: {
-    description: undefined,
-    codec: TYPES.regprocedure,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoper: {
-    description: undefined,
-    codec: TYPES.regoper,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoperator: {
-    description: undefined,
-    codec: TYPES.regoperator,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regclass: {
-    description: undefined,
-    codec: TYPES.regclass,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regtype: {
-    description: undefined,
-    codec: TYPES.regtype,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regconfig: {
-    description: undefined,
-    codec: TYPES.regconfig,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regdictionary: {
-    description: undefined,
-    codec: TYPES.regdictionary,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array_domain: {
-    description: undefined,
-    codec: textArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  int8_array_domain: {
-    description: undefined,
-    codec: int8ArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea: {
-    description: undefined,
-    codec: TYPES.bytea,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea_array: {
-    description: undefined,
-    codec: byteaArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree: {
-    description: undefined,
-    codec: typesAttributes_ltree_codec_ltree,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree_array: {
-    description: undefined,
-    codec: typesAttributes_ltree_array_codec_ltree_,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions46 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "types"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: ["(smallint) references a.post", "(id) references a.post"]
-  })
-};
-const typesCodec = recordCodec({
+const spec_types_attributes_ltree_array_codec_ltree_ = listOfCodec(spec_types_attributes_ltree_codec_ltree);
+const spec_types = {
   name: "types",
   identifier: sql.identifier("b", "types"),
-  attributes: typesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    smallint: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bigint: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numeric: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    decimal: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    boolean: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    varchar: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum_array: {
+      description: undefined,
+      codec: colorArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain: {
+      description: undefined,
+      codec: anIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain2: {
+      description: undefined,
+      codec: anotherIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array: {
+      description: undefined,
+      codec: textArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    json: {
+      description: undefined,
+      codec: TYPES.json,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    jsonb: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_range: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numrange: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    daterange: {
+      description: undefined,
+      codec: daterangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    an_int_range: {
+      description: undefined,
+      codec: anIntRangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamp: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamptz: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    date: {
+      description: undefined,
+      codec: TYPES.date,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    time: {
+      description: undefined,
+      codec: TYPES.time,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timetz: {
+      description: undefined,
+      codec: TYPES.timetz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval_array: {
+      description: undefined,
+      codec: intervalArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    money: {
+      description: undefined,
+      codec: TYPES.money,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    point: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullablePoint: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    inet: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    cidr: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    macaddr: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regproc: {
+      description: undefined,
+      codec: TYPES.regproc,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regprocedure: {
+      description: undefined,
+      codec: TYPES.regprocedure,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoper: {
+      description: undefined,
+      codec: TYPES.regoper,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoperator: {
+      description: undefined,
+      codec: TYPES.regoperator,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regclass: {
+      description: undefined,
+      codec: TYPES.regclass,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regtype: {
+      description: undefined,
+      codec: TYPES.regtype,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regconfig: {
+      description: undefined,
+      codec: TYPES.regconfig,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regdictionary: {
+      description: undefined,
+      codec: TYPES.regdictionary,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array_domain: {
+      description: undefined,
+      codec: textArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    int8_array_domain: {
+      description: undefined,
+      codec: int8ArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea: {
+      description: undefined,
+      codec: TYPES.bytea,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea_array: {
+      description: undefined,
+      codec: byteaArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree: {
+      description: undefined,
+      codec: spec_types_attributes_ltree_codec_ltree,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree_array: {
+      description: undefined,
+      codec: spec_types_attributes_ltree_array_codec_ltree_,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions46,
-  executor
-});
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "types"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: ["(smallint) references a.post", "(id) references a.post"]
+    })
+  },
+  executor: executor
+};
+const typesCodec = recordCodec(spec_types);
 const int4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
     pg: {
@@ -3116,7 +3132,7 @@ const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
     },
     tags: {
       omit: "create,update,delete,all,order,filter",
-      behavior: extensions12.tags.behavior
+      behavior: spec_uniqueForeignKey.extensions.tags.behavior
     }
   }
 };
@@ -3465,7 +3481,7 @@ const registryConfig_pgResources_types_types = {
       name: "types"
     },
     tags: {
-      foreignKey: extensions46.tags.foreignKey
+      foreignKey: spec_types.extensions.tags.foreignKey
     }
   }
 };
@@ -3588,8 +3604,8 @@ const registry = makeRegistry({
     int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
     byteaArray: byteaArrayCodec,
-    ltree: typesAttributes_ltree_codec_ltree,
-    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
+    ltree: spec_types_attributes_ltree_codec_ltree,
+    "ltree[]": spec_types_attributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     compoundTypeArray: listOfCodec(compoundTypeCodec, {
       extensions: {
@@ -3676,7 +3692,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor
+      executor: executor
     }),
     tablefuncCrosstab3: recordCodec({
       name: "tablefuncCrosstab3",
@@ -3729,7 +3745,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor
+      executor: executor
     }),
     tablefuncCrosstab4: recordCodec({
       name: "tablefuncCrosstab4",
@@ -3791,7 +3807,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor
+      executor: executor
     })
   }),
   pgResources: Object.assign(Object.create(null), {
@@ -12373,6 +12389,15 @@ const makeArgs64 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
+function UUIDSerialize(value) {
+  return "" + value;
+}
+const coerce = string => {
+  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
+    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
+  }
+  return string;
+};
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -12877,6 +12902,60 @@ const makeArgs73 = (args, path = []) => {
 const resource_post_computed_compound_type_arrayPgResource = registry.pgResources["post_computed_compound_type_array"];
 const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
+function LTreeParseValue(value) {
+  return value;
+}
+const isValidHstoreObject = obj => {
+  if (obj === null) {
+    // Null is okay
+    return true;
+  } else if (typeof obj === "object") {
+    // A hash with string/null values is also okay
+    const keys = Object.keys(obj);
+    for (const key of keys) {
+      const val = obj[key];
+      if (val === null) {
+        // Null is okay
+      } else if (typeof val === "string") {
+        // String is okay
+      } else {
+        // Everything else is invalid.
+        return false;
+      }
+    }
+    return true;
+  } else {
+    // Everything else is invalid.
+    return false;
+  }
+};
+const parseValueLiteral = (ast, variables) => {
+  switch (ast.kind) {
+    case Kind.INT:
+    case Kind.FLOAT:
+      // Number isn't really okay, but we'll coerce it to a string anyway.
+      return String(parseFloat(ast.value));
+    case Kind.STRING:
+      // String is okay.
+      return String(ast.value);
+    case Kind.NULL:
+      // Null is okay.
+      return null;
+    case Kind.VARIABLE:
+      {
+        // Variable is okay if that variable is either a string or null.
+        const name = ast.name.value;
+        const value = variables ? variables[name] : undefined;
+        if (value === null || typeof value === "string") {
+          return value;
+        }
+        return undefined;
+      }
+    default:
+      // Everything else is invalid.
+      return undefined;
+  }
+};
 const argDetailsSimple74 = [];
 const makeArgs74 = (args, path = []) => {
   const selectArgs = [];
@@ -29725,6 +29804,11 @@ export const plans = {
       return $record.get("o");
     }
   },
+  Email: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
   PersonComputedFirstArgInoutOutRecord: {
     __assertStep: assertPgClassSingleStep,
     person($record) {
@@ -29834,6 +29918,19 @@ export const plans = {
     },
     BLUE: {
       value: "blue"
+    }
+  },
+  UUID: {
+    serialize: UUIDSerialize,
+    parseValue(value) {
+      return coerce("" + value);
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // ERRORS: add name to this error
+        throw new GraphQLError(`${"UUID" ?? "This scalar"} can only parse string values (kind = '${ast.kind}')`);
+      }
+      return coerce(ast.value);
     }
   },
   EnumCaps: {
@@ -30340,6 +30437,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -30356,6 +30463,9 @@ export const plans = {
     }
   },
   CompoundTypeInput: {
+    "__inputPlan": function CompoundTypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     a: {
       applyPlan($insert, val) {
         $insert.set("a", val.get());
@@ -30484,6 +30594,16 @@ export const plans = {
     },
     isOptimised($record) {
       return $record.get("is_optimised");
+    }
+  },
+  Datetime: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   TypesConnection: {
@@ -30690,12 +30810,77 @@ export const plans = {
       });
     }
   },
+  BigInt: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigInt" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  BigFloat: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigFloat" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  AnInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
+  AnotherInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
+  JSON: {
+    serialize(value) {
+      return JSON.stringify(value);
+    },
+    parseValue(value) {
+      return JSON.parse(value);
+    },
+    parseLiteral(ast, _variables) {
+      if (ast.kind === Kind.STRING) {
+        return JSON.parse(ast.value);
+      } else {
+        return undefined;
+      }
+    }
+  },
   BigFloatRange: {},
   BigFloatRangeBound: {},
   DateRange: {},
   DateRangeBound: {},
+  Date: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Date" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   AnIntRange: {},
   AnIntRangeBound: {},
+  Time: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Time" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   NestedCompoundType: {
     __assertStep: assertPgClassSingleStep,
     a($record) {
@@ -30721,6 +30906,128 @@ export const plans = {
     }
   },
   Point: {},
+  InternetAddress: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"InternetAddress" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProc: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProc" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProcedure: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProcedure" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOper: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOper" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOperator: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOperator" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegClass: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegClass" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegType: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegType" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegConfig: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegConfig" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegDictionary: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegDictionary" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  Base64EncodedBinary: {
+    serialize(data) {
+      if (Buffer.isBuffer(data)) {
+        return data.toString("base64");
+      } else {
+        throw new Error(`Base64EncodeBinary can only be used with Node.js buffers.`);
+      }
+    },
+    parseValue(data) {
+      if (typeof data === "string") {
+        return Buffer.from(data, "base64");
+      } else {
+        throw new GraphQLError("Base64EncodedBinary can only parse string values.");
+      }
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // TODO: add name to this error
+        throw new GraphQLError("Base64EncodedBinary can only parse string values");
+      }
+      return Buffer.from(ast.value, "base64");
+    }
+  },
+  LTree: {
+    serialize(x) {
+      return x;
+    },
+    parseValue: LTreeParseValue,
+    parseLiteral(node, variables) {
+      return LTreeParseValue(valueFromASTUntyped(node, variables));
+    }
+  },
   TypesEdge: {
     __assertStep: assertEdgeCapableStep,
     cursor($edge) {
@@ -32041,7 +32348,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.id.codec)}`;
             }
           });
         }
@@ -32064,7 +32371,7 @@ export const plans = {
             type: "attribute",
             attribute: "smallint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.smallint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.smallint.codec)}`;
             }
           });
         }
@@ -32087,7 +32394,7 @@ export const plans = {
             type: "attribute",
             attribute: "bigint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.bigint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.bigint.codec)}`;
             }
           });
         }
@@ -32110,7 +32417,7 @@ export const plans = {
             type: "attribute",
             attribute: "numeric",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numeric.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.numeric.codec)}`;
             }
           });
         }
@@ -32133,7 +32440,7 @@ export const plans = {
             type: "attribute",
             attribute: "decimal",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.decimal.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.decimal.codec)}`;
             }
           });
         }
@@ -32156,7 +32463,7 @@ export const plans = {
             type: "attribute",
             attribute: "boolean",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.boolean.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.boolean.codec)}`;
             }
           });
         }
@@ -32179,7 +32486,7 @@ export const plans = {
             type: "attribute",
             attribute: "varchar",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.varchar.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.varchar.codec)}`;
             }
           });
         }
@@ -32202,7 +32509,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.enum.codec)}`;
             }
           });
         }
@@ -32225,7 +32532,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.enum_array.codec)}`;
             }
           });
         }
@@ -32248,7 +32555,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.domain.codec)}`;
             }
           });
         }
@@ -32271,7 +32578,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.domain2.codec)}`;
             }
           });
         }
@@ -32294,7 +32601,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.text_array.codec)}`;
             }
           });
         }
@@ -32317,7 +32624,7 @@ export const plans = {
             type: "attribute",
             attribute: "json",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.json.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.json.codec)}`;
             }
           });
         }
@@ -32340,7 +32647,7 @@ export const plans = {
             type: "attribute",
             attribute: "jsonb",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.jsonb.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.jsonb.codec)}`;
             }
           });
         }
@@ -32363,7 +32670,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullable_range.codec)}`;
             }
           });
         }
@@ -32386,7 +32693,7 @@ export const plans = {
             type: "attribute",
             attribute: "numrange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numrange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.numrange.codec)}`;
             }
           });
         }
@@ -32409,7 +32716,7 @@ export const plans = {
             type: "attribute",
             attribute: "daterange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.daterange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.daterange.codec)}`;
             }
           });
         }
@@ -32432,7 +32739,7 @@ export const plans = {
             type: "attribute",
             attribute: "an_int_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.an_int_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.an_int_range.codec)}`;
             }
           });
         }
@@ -32455,7 +32762,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamp",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamp.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.timestamp.codec)}`;
             }
           });
         }
@@ -32478,7 +32785,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamptz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamptz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.timestamptz.codec)}`;
             }
           });
         }
@@ -32501,7 +32808,7 @@ export const plans = {
             type: "attribute",
             attribute: "date",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.date.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.date.codec)}`;
             }
           });
         }
@@ -32524,7 +32831,7 @@ export const plans = {
             type: "attribute",
             attribute: "time",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.time.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.time.codec)}`;
             }
           });
         }
@@ -32547,7 +32854,7 @@ export const plans = {
             type: "attribute",
             attribute: "timetz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timetz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.timetz.codec)}`;
             }
           });
         }
@@ -32570,7 +32877,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.interval.codec)}`;
             }
           });
         }
@@ -32593,7 +32900,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.interval_array.codec)}`;
             }
           });
         }
@@ -32616,7 +32923,7 @@ export const plans = {
             type: "attribute",
             attribute: "money",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.money.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.money.codec)}`;
             }
           });
         }
@@ -32639,7 +32946,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.compound_type.codec)}`;
             }
           });
         }
@@ -32662,7 +32969,7 @@ export const plans = {
             type: "attribute",
             attribute: "nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nested_compound_type.codec)}`;
             }
           });
         }
@@ -32685,7 +32992,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullable_compound_type.codec)}`;
             }
           });
         }
@@ -32708,7 +33015,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullable_nested_compound_type.codec)}`;
             }
           });
         }
@@ -32731,7 +33038,7 @@ export const plans = {
             type: "attribute",
             attribute: "point",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.point.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.point.codec)}`;
             }
           });
         }
@@ -32754,7 +33061,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullablePoint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullablePoint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullablePoint.codec)}`;
             }
           });
         }
@@ -32777,7 +33084,7 @@ export const plans = {
             type: "attribute",
             attribute: "inet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.inet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.inet.codec)}`;
             }
           });
         }
@@ -32800,7 +33107,7 @@ export const plans = {
             type: "attribute",
             attribute: "cidr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.cidr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.cidr.codec)}`;
             }
           });
         }
@@ -32823,7 +33130,7 @@ export const plans = {
             type: "attribute",
             attribute: "macaddr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.macaddr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.macaddr.codec)}`;
             }
           });
         }
@@ -32846,7 +33153,7 @@ export const plans = {
             type: "attribute",
             attribute: "regproc",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regproc.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regproc.codec)}`;
             }
           });
         }
@@ -32869,7 +33176,7 @@ export const plans = {
             type: "attribute",
             attribute: "regprocedure",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regprocedure.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regprocedure.codec)}`;
             }
           });
         }
@@ -32892,7 +33199,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoper",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoper.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regoper.codec)}`;
             }
           });
         }
@@ -32915,7 +33222,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoperator",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoperator.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regoperator.codec)}`;
             }
           });
         }
@@ -32938,7 +33245,7 @@ export const plans = {
             type: "attribute",
             attribute: "regclass",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regclass.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regclass.codec)}`;
             }
           });
         }
@@ -32961,7 +33268,7 @@ export const plans = {
             type: "attribute",
             attribute: "regtype",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regtype.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regtype.codec)}`;
             }
           });
         }
@@ -32984,7 +33291,7 @@ export const plans = {
             type: "attribute",
             attribute: "regconfig",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regconfig.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regconfig.codec)}`;
             }
           });
         }
@@ -33007,7 +33314,7 @@ export const plans = {
             type: "attribute",
             attribute: "regdictionary",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regdictionary.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regdictionary.codec)}`;
             }
           });
         }
@@ -33030,7 +33337,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.text_array_domain.codec)}`;
             }
           });
         }
@@ -33053,7 +33360,7 @@ export const plans = {
             type: "attribute",
             attribute: "int8_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.int8_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.int8_array_domain.codec)}`;
             }
           });
         }
@@ -33076,7 +33383,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.ltree.codec)}`;
             }
           });
         }
@@ -33099,7 +33406,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.ltree_array.codec)}`;
             }
           });
         }
@@ -33133,6 +33440,9 @@ export const plans = {
     inclusive: undefined
   },
   NestedCompoundTypeInput: {
+    "__inputPlan": function NestedCompoundTypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     a: {
       applyPlan($insert, val) {
         $insert.set("a", val.get());
@@ -33627,6 +33937,50 @@ export const plans = {
       return $record.get("url");
     }
   },
+  NotNullUrl: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
+  KeyValueHash: {
+    serialize(value) {
+      return value;
+    },
+    parseValue(obj) {
+      if (isValidHstoreObject(obj)) {
+        return obj;
+      }
+      throw new GraphQLError(`This is not a valid ${"KeyValueHash"} object, it must be a key/value hash where keys and values are both strings (or null).`);
+    },
+    parseLiteral(ast, variables) {
+      switch (ast.kind) {
+        case Kind.OBJECT:
+          {
+            const value = ast.fields.reduce((memo, field) => {
+              memo[field.name.value] = parseValueLiteral(field.value, variables);
+              return memo;
+            }, Object.create(null));
+            if (!isValidHstoreObject(value)) {
+              return undefined;
+            }
+            return value;
+          }
+        case Kind.NULL:
+          return null;
+        case Kind.VARIABLE:
+          {
+            const name = ast.name.value;
+            const value = variables ? variables[name] : undefined;
+            if (!isValidHstoreObject(value)) {
+              return undefined;
+            }
+            return value;
+          }
+        default:
+          return undefined;
+      }
+    }
+  },
   PostsConnection: {
     __assertStep: ConnectionStep,
     nodes($connection) {
@@ -33871,7 +34225,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.id.codec)}`;
             }
           });
         }
@@ -33894,7 +34248,7 @@ export const plans = {
             type: "attribute",
             attribute: "headline",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.headline.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.headline.codec)}`;
             }
           });
         }
@@ -33917,7 +34271,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.body.codec)}`;
             }
           });
         }
@@ -33940,7 +34294,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.author_id.codec)}`;
             }
           });
         }
@@ -33963,7 +34317,7 @@ export const plans = {
             type: "attribute",
             attribute: "enums",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.enums.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.enums.codec)}`;
             }
           });
         }
@@ -33986,7 +34340,7 @@ export const plans = {
             type: "attribute",
             attribute: "comptypes",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.comptypes.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.comptypes.codec)}`;
             }
           });
         }
@@ -34011,6 +34365,9 @@ export const plans = {
     }
   },
   ComptypeInput: {
+    "__inputPlan": function ComptypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     schedule: {
       applyPlan($insert, val) {
         $insert.set("schedule", val.get());
@@ -34197,7 +34554,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_foreignKey.attributes.person_id.codec)}`;
             }
           });
         }
@@ -34220,7 +34577,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_foreignKey.attributes.compound_key_1.codec)}`;
             }
           });
         }
@@ -34243,7 +34600,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_foreignKey.attributes.compound_key_2.codec)}`;
             }
           });
         }
@@ -34474,7 +34831,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.person_id_2.codec)}`;
             }
           });
         }
@@ -34497,7 +34854,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.person_id_1.codec)}`;
             }
           });
         }
@@ -34520,7 +34877,7 @@ export const plans = {
             type: "attribute",
             attribute: "extra",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.extra.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.extra.codec)}`;
             }
           });
         }
@@ -34626,6 +34983,16 @@ export const plans = {
     },
     ts($record) {
       return $record.get("ts");
+    }
+  },
+  NotNullTimestamp: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   FuncOutSetofConnection: {
@@ -35021,7 +35388,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.id.codec)}`;
             }
           });
         }
@@ -35044,7 +35411,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_full_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.person_full_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.person_full_name.codec)}`;
             }
           });
         }
@@ -35067,7 +35434,7 @@ export const plans = {
             type: "attribute",
             attribute: "aliases",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.aliases.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.aliases.codec)}`;
             }
           });
         }
@@ -35090,7 +35457,7 @@ export const plans = {
             type: "attribute",
             attribute: "about",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.about.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.about.codec)}`;
             }
           });
         }
@@ -35113,7 +35480,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.email.codec)}`;
             }
           });
         }
@@ -35136,7 +35503,7 @@ export const plans = {
             type: "attribute",
             attribute: "site",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.site.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.site.codec)}`;
             }
           });
         }
@@ -35159,7 +35526,7 @@ export const plans = {
             type: "attribute",
             attribute: "config",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.config.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.config.codec)}`;
             }
           });
         }
@@ -35182,7 +35549,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_ip",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_ip.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_login_from_ip.codec)}`;
             }
           });
         }
@@ -35205,7 +35572,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_subnet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_subnet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_login_from_subnet.codec)}`;
             }
           });
         }
@@ -35228,7 +35595,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_mac",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.user_mac.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.user_mac.codec)}`;
             }
           });
         }
@@ -35251,7 +35618,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.created_at.codec)}`;
             }
           });
         }
@@ -35276,6 +35643,9 @@ export const plans = {
     }
   },
   WrappedUrlInput: {
+    "__inputPlan": function WrappedUrlInput_inputPlan() {
+      return object(Object.create(null));
+    },
     url: {
       applyPlan($insert, val) {
         $insert.set("url", val.get());
@@ -35370,7 +35740,7 @@ export const plans = {
             type: "attribute",
             attribute: "?column?",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nonUpdatableViewAttributes["?column?"].codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nonUpdatableView.attributes["?column?"].codec)}`;
             }
           });
         }
@@ -35491,7 +35861,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), inputsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_inputs.attributes.id.codec)}`;
             }
           });
         }
@@ -35612,7 +35982,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), patchsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_patchs.attributes.id.codec)}`;
             }
           });
         }
@@ -35733,7 +36103,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reserved.attributes.id.codec)}`;
             }
           });
         }
@@ -35854,7 +36224,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedPatchsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reservedPatchs.attributes.id.codec)}`;
             }
           });
         }
@@ -35975,7 +36345,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedInputAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reservedInput.attributes.id.codec)}`;
             }
           });
         }
@@ -36130,7 +36500,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_defaultValue.attributes.id.codec)}`;
             }
           });
         }
@@ -36153,7 +36523,7 @@ export const plans = {
             type: "attribute",
             attribute: "null_value",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.null_value.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_defaultValue.attributes.null_value.codec)}`;
             }
           });
         }
@@ -36276,7 +36646,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_noPrimaryKey.attributes.id.codec)}`;
             }
           });
         }
@@ -36299,7 +36669,7 @@ export const plans = {
             type: "attribute",
             attribute: "str",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.str.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_noPrimaryKey.attributes.str.codec)}`;
             }
           });
         }
@@ -36468,7 +36838,7 @@ export const plans = {
             type: "attribute",
             attribute: "testviewid",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.testviewid.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_testview.attributes.testviewid.codec)}`;
             }
           });
         }
@@ -36491,7 +36861,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_testview.attributes.col1.codec)}`;
             }
           });
         }
@@ -36514,7 +36884,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_testview.attributes.col2.codec)}`;
             }
           });
         }
@@ -36669,7 +37039,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_myTable.attributes.id.codec)}`;
             }
           });
         }
@@ -36692,7 +37062,7 @@ export const plans = {
             type: "attribute",
             attribute: "json_data",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.json_data.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_myTable.attributes.json_data.codec)}`;
             }
           });
         }
@@ -36847,7 +37217,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_personSecret.attributes.person_id.codec)}`;
             }
           });
         }
@@ -36870,7 +37240,7 @@ export const plans = {
             type: "attribute",
             attribute: "sekrit",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.sekrit.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_personSecret.attributes.sekrit.codec)}`;
             }
           });
         }
@@ -37059,7 +37429,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_viewTable.attributes.id.codec)}`;
             }
           });
         }
@@ -37082,7 +37452,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_viewTable.attributes.col1.codec)}`;
             }
           });
         }
@@ -37105,7 +37475,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_viewTable.attributes.col2.codec)}`;
             }
           });
         }
@@ -37328,7 +37698,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.id.codec)}`;
             }
           });
         }
@@ -37351,7 +37721,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.col1.codec)}`;
             }
           });
         }
@@ -37374,7 +37744,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.col2.codec)}`;
             }
           });
         }
@@ -37397,7 +37767,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.col3.codec)}`;
             }
           });
         }
@@ -37620,7 +37990,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.id.codec)}`;
             }
           });
         }
@@ -37643,7 +38013,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.col3.codec)}`;
             }
           });
         }
@@ -37666,7 +38036,7 @@ export const plans = {
             type: "attribute",
             attribute: "col4",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col4.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.col4.codec)}`;
             }
           });
         }
@@ -37689,7 +38059,7 @@ export const plans = {
             type: "attribute",
             attribute: "col5",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col5.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.col5.codec)}`;
             }
           });
         }
@@ -37895,7 +38265,7 @@ export const plans = {
             type: "attribute",
             attribute: "x",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.x.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.x.codec)}`;
             }
           });
         }
@@ -37918,7 +38288,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.name.codec)}`;
             }
           });
         }
@@ -37941,7 +38311,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.description.codec)}`;
             }
           });
         }
@@ -37964,7 +38334,7 @@ export const plans = {
             type: "attribute",
             attribute: "constant",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.constant.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.constant.codec)}`;
             }
           });
         }
@@ -38187,7 +38557,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.id.codec)}`;
             }
           });
         }
@@ -38210,7 +38580,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.nullable_text.codec)}`;
             }
           });
         }
@@ -38233,7 +38603,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_int",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_int.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.nullable_int.codec)}`;
             }
           });
         }
@@ -38256,7 +38626,7 @@ export const plans = {
             type: "attribute",
             attribute: "non_null_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.non_null_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.non_null_text.codec)}`;
             }
           });
         }
@@ -38459,7 +38829,7 @@ export const plans = {
             type: "attribute",
             attribute: "not_null_has_default",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.not_null_has_default.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.not_null_has_default.codec)}`;
             }
           });
         }
@@ -38482,7 +38852,7 @@ export const plans = {
             type: "attribute",
             attribute: "wont_cast_easy",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.wont_cast_easy.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.wont_cast_easy.codec)}`;
             }
           });
         }
@@ -38505,7 +38875,7 @@ export const plans = {
             type: "attribute",
             attribute: "row_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.row_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.row_id.codec)}`;
             }
           });
         }
@@ -38728,7 +39098,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.id.codec)}`;
             }
           });
         }
@@ -38751,7 +39121,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.person_id.codec)}`;
             }
           });
         }
@@ -38774,7 +39144,7 @@ export const plans = {
             type: "attribute",
             attribute: "length_in_metres",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.length_in_metres.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.length_in_metres.codec)}`;
             }
           });
         }
@@ -38797,7 +39167,7 @@ export const plans = {
             type: "attribute",
             attribute: "mood",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.mood.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.mood.codec)}`;
             }
           });
         }
@@ -38952,7 +39322,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_issue756.attributes.id.codec)}`;
             }
           });
         }
@@ -38975,7 +39345,7 @@ export const plans = {
             type: "attribute",
             attribute: "ts",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.ts.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_issue756.attributes.ts.codec)}`;
             }
           });
         }
@@ -42311,6 +42681,11 @@ export const plans = {
       return rootValue();
     }
   },
+  Guid: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
   GuidFnInput: {
     clientMutationId: {
       applyPlan($input, val) {
@@ -42502,6 +42877,9 @@ export const plans = {
     leftArm: undefined
   },
   LeftArmBaseInput: {
+    "__inputPlan": function LeftArmBaseInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -42896,6 +43274,9 @@ export const plans = {
     suffix: undefined
   },
   PostInput: {
+    "__inputPlan": function PostInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43346,6 +43727,9 @@ export const plans = {
     }
   },
   InputInput: {
+    "__inputPlan": function InputInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43413,6 +43797,9 @@ export const plans = {
     }
   },
   PatchInput: {
+    "__inputPlan": function PatchInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43480,6 +43867,9 @@ export const plans = {
     }
   },
   ReservedInput: {
+    "__inputPlan": function ReservedInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43547,6 +43937,9 @@ export const plans = {
     }
   },
   ReservedPatchRecordInput: {
+    "__inputPlan": function ReservedPatchRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43614,6 +44007,9 @@ export const plans = {
     }
   },
   ReservedInputRecordInput: {
+    "__inputPlan": function ReservedInputRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43681,6 +44077,9 @@ export const plans = {
     }
   },
   DefaultValueInput: {
+    "__inputPlan": function DefaultValueInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43735,6 +44134,9 @@ export const plans = {
     }
   },
   ForeignKeyInput: {
+    "__inputPlan": function ForeignKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -43785,6 +44187,9 @@ export const plans = {
     }
   },
   NoPrimaryKeyInput: {
+    "__inputPlan": function NoPrimaryKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43828,6 +44233,9 @@ export const plans = {
     }
   },
   TestviewInput: {
+    "__inputPlan": function TestviewInput_inputPlan() {
+      return object(Object.create(null));
+    },
     testviewid: {
       applyPlan($insert, val) {
         $insert.set("testviewid", val.get());
@@ -43909,6 +44317,9 @@ export const plans = {
     }
   },
   MyTableInput: {
+    "__inputPlan": function MyTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43988,6 +44399,9 @@ export const plans = {
     }
   },
   PersonSecretInput: {
+    "__inputPlan": function PersonSecretInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -44062,6 +44476,9 @@ export const plans = {
     }
   },
   ViewTableInput: {
+    "__inputPlan": function ViewTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44153,6 +44570,9 @@ export const plans = {
     }
   },
   CompoundKeyInput: {
+    "__inputPlan": function CompoundKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId2: {
       applyPlan($insert, val) {
         $insert.set("person_id_2", val.get());
@@ -44234,6 +44654,9 @@ export const plans = {
     }
   },
   SimilarTable1Input: {
+    "__inputPlan": function SimilarTable1Input_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44322,6 +44745,9 @@ export const plans = {
     }
   },
   SimilarTable2Input: {
+    "__inputPlan": function SimilarTable2Input_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44379,6 +44805,9 @@ export const plans = {
     }
   },
   UpdatableViewInput: {
+    "__inputPlan": function UpdatableViewInput_inputPlan() {
+      return object(Object.create(null));
+    },
     x: {
       applyPlan($insert, val) {
         $insert.set("x", val.get());
@@ -44467,6 +44896,9 @@ export const plans = {
     }
   },
   NullTestRecordInput: {
+    "__inputPlan": function NullTestRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44524,6 +44956,9 @@ export const plans = {
     }
   },
   EdgeCaseInput: {
+    "__inputPlan": function EdgeCaseInput_inputPlan() {
+      return object(Object.create(null));
+    },
     notNullHasDefault: {
       applyPlan($insert, val) {
         $insert.set("not_null_has_default", val.get());
@@ -44610,6 +45045,9 @@ export const plans = {
     }
   },
   LeftArmInput: {
+    "__inputPlan": function LeftArmInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44698,6 +45136,9 @@ export const plans = {
     }
   },
   Issue756Input: {
+    "__inputPlan": function Issue756Input_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44835,6 +45276,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44982,6 +45426,9 @@ export const plans = {
     }
   },
   TypeInput: {
+    "__inputPlan": function TypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45384,6 +45831,9 @@ export const plans = {
     }
   },
   InputPatch: {
+    "__inputPlan": function InputPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45464,6 +45914,9 @@ export const plans = {
     }
   },
   PatchPatch: {
+    "__inputPlan": function PatchPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45544,6 +45997,9 @@ export const plans = {
     }
   },
   ReservedPatch: {
+    "__inputPlan": function ReservedPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45624,6 +46080,9 @@ export const plans = {
     }
   },
   ReservedPatchRecordPatch: {
+    "__inputPlan": function ReservedPatchRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45704,6 +46163,9 @@ export const plans = {
     }
   },
   ReservedInputRecordPatch: {
+    "__inputPlan": function ReservedInputRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45784,6 +46246,9 @@ export const plans = {
     }
   },
   DefaultValuePatch: {
+    "__inputPlan": function DefaultValuePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45840,6 +46305,9 @@ export const plans = {
     }
   },
   NoPrimaryKeyPatch: {
+    "__inputPlan": function NoPrimaryKeyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -45913,6 +46381,9 @@ export const plans = {
     }
   },
   MyTablePatch: {
+    "__inputPlan": function MyTablePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46005,6 +46476,9 @@ export const plans = {
     }
   },
   PersonSecretPatch: {
+    "__inputPlan": function PersonSecretPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -46092,6 +46566,9 @@ export const plans = {
     }
   },
   ViewTablePatch: {
+    "__inputPlan": function ViewTablePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46196,6 +46673,9 @@ export const plans = {
     }
   },
   CompoundKeyPatch: {
+    "__inputPlan": function CompoundKeyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     personId2: {
       applyPlan($insert, val) {
         $insert.set("person_id_2", val.get());
@@ -46291,6 +46771,9 @@ export const plans = {
     }
   },
   SimilarTable1Patch: {
+    "__inputPlan": function SimilarTable1Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46392,6 +46875,9 @@ export const plans = {
     }
   },
   SimilarTable2Patch: {
+    "__inputPlan": function SimilarTable2Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46493,6 +46979,9 @@ export const plans = {
     }
   },
   NullTestRecordPatch: {
+    "__inputPlan": function NullTestRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46599,6 +47088,9 @@ export const plans = {
     }
   },
   LeftArmPatch: {
+    "__inputPlan": function LeftArmPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46714,6 +47206,9 @@ export const plans = {
     }
   },
   Issue756Patch: {
+    "__inputPlan": function Issue756Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46806,6 +47301,9 @@ export const plans = {
     }
   },
   PostPatch: {
+    "__inputPlan": function PostPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -46921,6 +47419,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -47095,6 +47596,9 @@ export const plans = {
     }
   },
   TypePatch: {
+    "__inputPlan": function TypePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.1.export.mjs
@@ -1,5 +1,6 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, domainOfCodec, enumCodec, listOfCodec, makeRegistry, pgClassExpression, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectFromRecords, pgSelectSingleFromRecord, pgUpdateSingle, rangeOfCodec, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, makeGrafastSchema, object, rootValue, stepAMayDependOnStepB } from "grafast";
+import { GraphQLError, GraphQLInt, GraphQLString, Kind, valueFromASTUntyped } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const executor = new PgExecutor({
@@ -396,21 +397,20 @@ const textArrayCodec = listOfCodec(TYPES.text, {
   description: undefined,
   name: "textArray"
 });
-const nonUpdatableViewAttributes = Object.assign(Object.create(null), {
-  "?column?": {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const nonUpdatableViewCodec = recordCodec({
+const spec_nonUpdatableView = {
   name: "nonUpdatableView",
   identifier: sql.identifier("a", "non_updatable_view"),
-  attributes: nonUpdatableViewAttributes,
+  attributes: Object.assign(Object.create(null), {
+    "?column?": {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -421,23 +421,23 @@ const nonUpdatableViewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const inputsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const inputsCodec = recordCodec({
+  executor: executor
+};
+const nonUpdatableViewCodec = recordCodec(spec_nonUpdatableView);
+const spec_inputs = {
   name: "inputs",
   identifier: sql.identifier("a", "inputs"),
-  attributes: inputsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Should output as Input",
   extensions: {
     isTableLike: true,
@@ -448,23 +448,23 @@ const inputsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const patchsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const patchsCodec = recordCodec({
+  executor: executor
+};
+const inputsCodec = recordCodec(spec_inputs);
+const spec_patchs = {
   name: "patchs",
   identifier: sql.identifier("a", "patchs"),
-  attributes: patchsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Should output as Patch",
   extensions: {
     isTableLike: true,
@@ -475,23 +475,23 @@ const patchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const reservedAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const reservedCodec = recordCodec({
+  executor: executor
+};
+const patchsCodec = recordCodec(spec_patchs);
+const spec_reserved = {
   name: "reserved",
   identifier: sql.identifier("a", "reserved"),
-  attributes: reservedAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -502,23 +502,23 @@ const reservedCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const reservedPatchsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const reservedPatchsCodec = recordCodec({
+  executor: executor
+};
+const reservedCodec = recordCodec(spec_reserved);
+const spec_reservedPatchs = {
   name: "reservedPatchs",
   identifier: sql.identifier("a", "reservedPatchs"),
-  attributes: reservedPatchsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   extensions: {
     isTableLike: true,
@@ -529,23 +529,23 @@ const reservedPatchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const reservedInputAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const reservedInputCodec = recordCodec({
+  executor: executor
+};
+const reservedPatchsCodec = recordCodec(spec_reservedPatchs);
+const spec_reservedInput = {
   name: "reservedInput",
   identifier: sql.identifier("a", "reserved_input"),
-  attributes: reservedInputAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
   extensions: {
     isTableLike: true,
@@ -556,32 +556,32 @@ const reservedInputCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const defaultValueAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  null_value: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const defaultValueCodec = recordCodec({
+  executor: executor
+};
+const reservedInputCodec = recordCodec(spec_reservedInput);
+const spec_defaultValue = {
   name: "defaultValue",
   identifier: sql.identifier("a", "default_value"),
-  attributes: defaultValueAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    null_value: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -592,41 +592,41 @@ const defaultValueCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const foreignKeyAttributes = Object.assign(Object.create(null), {
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_key_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_key_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const foreignKeyCodec = recordCodec({
+  executor: executor
+};
+const defaultValueCodec = recordCodec(spec_defaultValue);
+const spec_foreignKey = {
   name: "foreignKey",
   identifier: sql.identifier("a", "foreign_key"),
-  attributes: foreignKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_key_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_key_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -637,32 +637,32 @@ const foreignKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  str: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const noPrimaryKeyCodec = recordCodec({
+  executor: executor
+};
+const foreignKeyCodec = recordCodec(spec_foreignKey);
+const spec_noPrimaryKey = {
   name: "noPrimaryKey",
   identifier: sql.identifier("a", "no_primary_key"),
-  attributes: noPrimaryKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    str: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -673,41 +673,41 @@ const noPrimaryKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const testviewAttributes = Object.assign(Object.create(null), {
-  testviewid: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const testviewCodec = recordCodec({
+  executor: executor
+};
+const noPrimaryKeyCodec = recordCodec(spec_noPrimaryKey);
+const spec_testview = {
   name: "testview",
   identifier: sql.identifier("a", "testview"),
-  attributes: testviewAttributes,
+  attributes: Object.assign(Object.create(null), {
+    testviewid: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -718,21 +718,10 @@ const testviewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const extensions12 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "a",
-    name: "unique_foreign_key"
-  },
-  tags: Object.assign(Object.create(null), {
-    omit: "create,update,delete,all,order,filter",
-    behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy"]
-  })
+  executor: executor
 };
-const uniqueForeignKeyCodec = recordCodec({
+const testviewCodec = recordCodec(spec_testview);
+const spec_uniqueForeignKey = {
   name: "uniqueForeignKey",
   identifier: sql.identifier("a", "unique_foreign_key"),
   attributes: Object.assign(Object.create(null), {
@@ -756,33 +745,44 @@ const uniqueForeignKeyCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions: extensions12,
-  executor
-});
-const myTableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "a",
+      name: "unique_foreign_key"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: "create,update,delete,all,order,filter",
+      behavior: ["-insert -update -delete -query:resource:list -query:resource:connection -order -orderBy -filter -filterBy"]
+    })
   },
-  json_data: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const myTableCodec = recordCodec({
+  executor: executor
+};
+const uniqueForeignKeyCodec = recordCodec(spec_uniqueForeignKey);
+const spec_myTable = {
   name: "myTable",
   identifier: sql.identifier("c", "my_table"),
-  attributes: myTableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    json_data: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -793,34 +793,34 @@ const myTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const personSecretAttributes = Object.assign(Object.create(null), {
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  sekrit: {
-    description: "A secret held by the associated Person",
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "secret"
-      }
-    }
-  }
-});
-const personSecretCodec = recordCodec({
+  executor: executor
+};
+const myTableCodec = recordCodec(spec_myTable);
+const spec_personSecret = {
   name: "personSecret",
   identifier: sql.identifier("c", "person_secret"),
-  attributes: personSecretAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    sekrit: {
+      description: "A secret held by the associated Person",
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "secret"
+        }
+      }
+    }
+  }),
   description: "Tracks the person's secret",
   extensions: {
     isTableLike: true,
@@ -833,41 +833,41 @@ const personSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor
-});
-const viewTableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const viewTableCodec = recordCodec({
+  executor: executor
+};
+const personSecretCodec = recordCodec(spec_personSecret);
+const spec_viewTable = {
   name: "viewTable",
   identifier: sql.identifier("a", "view_table"),
-  attributes: viewTableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -878,41 +878,41 @@ const viewTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const compoundKeyAttributes = Object.assign(Object.create(null), {
-  person_id_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  extra: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const compoundKeyCodec = recordCodec({
+  executor: executor
+};
+const viewTableCodec = recordCodec(spec_viewTable);
+const spec_compoundKey = {
   name: "compoundKey",
   identifier: sql.identifier("c", "compound_key"),
-  attributes: compoundKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    extra: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -923,50 +923,50 @@ const compoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const similarTable1Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col3: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const similarTable1Codec = recordCodec({
+  executor: executor
+};
+const compoundKeyCodec = recordCodec(spec_compoundKey);
+const spec_similarTable1 = {
   name: "similarTable1",
   identifier: sql.identifier("a", "similar_table_1"),
-  attributes: similarTable1Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col3: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -977,50 +977,50 @@ const similarTable1Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const similarTable2Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  col3: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col4: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col5: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const similarTable2Codec = recordCodec({
+  executor: executor
+};
+const similarTable1Codec = recordCodec(spec_similarTable1);
+const spec_similarTable2 = {
   name: "similarTable2",
   identifier: sql.identifier("a", "similar_table_2"),
-  attributes: similarTable2Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    col3: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col4: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col5: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1031,50 +1031,50 @@ const similarTable2Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const updatableViewAttributes = Object.assign(Object.create(null), {
-  x: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  description: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  constant: {
-    description: "This is constantly 2",
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const updatableViewCodec = recordCodec({
+  executor: executor
+};
+const similarTable2Codec = recordCodec(spec_similarTable2);
+const spec_updatableView = {
   name: "updatableView",
   identifier: sql.identifier("b", "updatable_view"),
-  attributes: updatableViewAttributes,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    description: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    constant: {
+      description: "This is constantly 2",
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "YOYOYO!!",
   extensions: {
     isTableLike: true,
@@ -1088,50 +1088,50 @@ const updatableViewCodec = recordCodec({
       unique: "x|@behavior -single -update -delete"
     })
   },
-  executor
-});
-const nullTestRecordAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_int: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  non_null_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const nullTestRecordCodec = recordCodec({
+  executor: executor
+};
+const updatableViewCodec = recordCodec(spec_updatableView);
+const spec_nullTestRecord = {
   name: "nullTestRecord",
   identifier: sql.identifier("c", "null_test_record"),
-  attributes: nullTestRecordAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_int: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    non_null_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1142,8 +1142,9 @@ const nullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const nullTestRecordCodec = recordCodec(spec_nullTestRecord);
 const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   extensions: {
     pg: {
@@ -1157,39 +1158,38 @@ const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   description: undefined,
   name: "uuidArray"
 });
-const edgeCaseAttributes = Object.assign(Object.create(null), {
-  not_null_has_default: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  wont_cast_easy: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  row_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const edgeCaseCodec = recordCodec({
+const spec_edgeCase = {
   name: "edgeCase",
   identifier: sql.identifier("c", "edge_case"),
-  attributes: edgeCaseAttributes,
+  attributes: Object.assign(Object.create(null), {
+    not_null_has_default: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    wont_cast_easy: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    row_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1200,50 +1200,50 @@ const edgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const leftArmAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  length_in_metres: {
-    description: undefined,
-    codec: TYPES.float,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  mood: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const leftArmCodec = recordCodec({
+  executor: executor
+};
+const edgeCaseCodec = recordCodec(spec_edgeCase);
+const spec_leftArm = {
   name: "leftArm",
   identifier: sql.identifier("c", "left_arm"),
-  attributes: leftArmAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    length_in_metres: {
+      description: undefined,
+      codec: TYPES.float,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    mood: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Tracks metadata about the left arms of various people",
   extensions: {
     isTableLike: true,
@@ -1254,8 +1254,9 @@ const leftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const leftArmCodec = recordCodec(spec_leftArm);
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
   identifier: sql.identifier("b", "jwt_token"),
@@ -1316,7 +1317,7 @@ const jwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
@@ -1330,30 +1331,29 @@ const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp
   },
   notNull: true
 });
-const issue756Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  ts: {
-    description: undefined,
-    codec: notNullTimestampCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const issue756Codec = recordCodec({
+const spec_issue756 = {
   name: "issue756",
   identifier: sql.identifier("c", "issue756"),
-  attributes: issue756Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    ts: {
+      description: undefined,
+      codec: notNullTimestampCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1364,8 +1364,9 @@ const issue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const issue756Codec = recordCodec(spec_issue756);
 const authPayloadCodec = recordCodec({
   name: "authPayload",
   identifier: sql.identifier("b", "auth_payload"),
@@ -1410,7 +1411,7 @@ const authPayloadCodec = recordCodec({
       foreignKey: "(id) references c.person"
     })
   },
-  executor
+  executor: executor
 });
 const colorCodec = enumCodec({
   name: "color",
@@ -1541,7 +1542,7 @@ const compoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const registryConfig_pgCodecs_FuncOutOutCompoundTypeRecord_FuncOutOutCompoundTypeRecord = recordCodec({
   name: "FuncOutOutCompoundTypeRecord",
@@ -1663,7 +1664,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1678,66 +1679,65 @@ const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   description: undefined,
   name: "comptypeArray"
 });
-const postAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  headline: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  body: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  enums: {
-    description: undefined,
-    codec: anEnumArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  comptypes: {
-    description: undefined,
-    codec: comptypeArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const postCodec = recordCodec({
+const spec_post = {
   name: "post",
   identifier: sql.identifier("a", "post"),
-  attributes: postAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    headline: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    body: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    enums: {
+      description: undefined,
+      codec: anEnumArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    comptypes: {
+      description: undefined,
+      codec: comptypeArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1748,8 +1748,9 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const postCodec = recordCodec(spec_post);
 const registryConfig_pgCodecs_QueryOutputTwoRowsRecord_QueryOutputTwoRowsRecord = recordCodec({
   name: "QueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
@@ -1896,117 +1897,116 @@ const wrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const personAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: "The primary unique identifier for the person",
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_full_name: {
-    description: "The person\u2019s name",
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "name"
-      }
-    }
-  },
-  aliases: {
-    description: undefined,
-    codec: textArrayCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  about: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  email: {
-    description: undefined,
-    codec: emailCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  site: {
-    description: undefined,
-    codec: wrappedUrlCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        deprecated: "Don\u2019t use me"
-      }
-    }
-  },
-  config: {
-    description: undefined,
-    codec: TYPES.hstore,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_login_from_ip: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_login_from_subnet: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  user_mac: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  created_at: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const personCodec = recordCodec({
+const spec_person = {
   name: "person",
   identifier: sql.identifier("c", "person"),
-  attributes: personAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: "The primary unique identifier for the person",
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_full_name: {
+      description: "The person\u2019s name",
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "name"
+        }
+      }
+    },
+    aliases: {
+      description: undefined,
+      codec: textArrayCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    about: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    email: {
+      description: undefined,
+      codec: emailCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    site: {
+      description: undefined,
+      codec: wrappedUrlCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          deprecated: "Don\u2019t use me"
+        }
+      }
+    },
+    config: {
+      description: undefined,
+      codec: TYPES.hstore,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_login_from_ip: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_login_from_subnet: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    user_mac: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    created_at: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Person test comment",
   extensions: {
     isTableLike: true,
@@ -2017,8 +2017,9 @@ const personCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const personCodec = recordCodec(spec_person);
 const registryConfig_pgCodecs_PersonComputedFirstArgInoutOutRecord_PersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "PersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
@@ -2351,7 +2352,7 @@ const nestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const textArrayDomainCodec = domainOfCodec(textArrayCodec, "textArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -2403,7 +2404,7 @@ const byteaArrayCodec = listOfCodec(TYPES.bytea, {
   description: undefined,
   name: "byteaArray"
 });
-const typesAttributes_ltree_codec_ltree = {
+const spec_types_attributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -2415,469 +2416,468 @@ const typesAttributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const typesAttributes_ltree_array_codec_ltree_ = listOfCodec(typesAttributes_ltree_codec_ltree);
-const typesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  smallint: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bigint: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numeric: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  decimal: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  boolean: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  varchar: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum: {
-    description: undefined,
-    codec: colorCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum_array: {
-    description: undefined,
-    codec: colorArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain: {
-    description: undefined,
-    codec: anIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain2: {
-    description: undefined,
-    codec: anotherIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array: {
-    description: undefined,
-    codec: textArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  json: {
-    description: undefined,
-    codec: TYPES.json,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  jsonb: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_range: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numrange: {
-    description: undefined,
-    codec: numrangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  daterange: {
-    description: undefined,
-    codec: daterangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  an_int_range: {
-    description: undefined,
-    codec: anIntRangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamp: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamptz: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  date: {
-    description: undefined,
-    codec: TYPES.date,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  time: {
-    description: undefined,
-    codec: TYPES.time,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timetz: {
-    description: undefined,
-    codec: TYPES.timetz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval_array: {
-    description: undefined,
-    codec: intervalArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  money: {
-    description: undefined,
-    codec: TYPES.money,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_compound_type: {
-    description: undefined,
-    codec: compoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_nested_compound_type: {
-    description: undefined,
-    codec: nestedCompoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  point: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullablePoint: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  inet: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  cidr: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  macaddr: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regproc: {
-    description: undefined,
-    codec: TYPES.regproc,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regprocedure: {
-    description: undefined,
-    codec: TYPES.regprocedure,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoper: {
-    description: undefined,
-    codec: TYPES.regoper,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoperator: {
-    description: undefined,
-    codec: TYPES.regoperator,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regclass: {
-    description: undefined,
-    codec: TYPES.regclass,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regtype: {
-    description: undefined,
-    codec: TYPES.regtype,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regconfig: {
-    description: undefined,
-    codec: TYPES.regconfig,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regdictionary: {
-    description: undefined,
-    codec: TYPES.regdictionary,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array_domain: {
-    description: undefined,
-    codec: textArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  int8_array_domain: {
-    description: undefined,
-    codec: int8ArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea: {
-    description: undefined,
-    codec: TYPES.bytea,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea_array: {
-    description: undefined,
-    codec: byteaArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree: {
-    description: undefined,
-    codec: typesAttributes_ltree_codec_ltree,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree_array: {
-    description: undefined,
-    codec: typesAttributes_ltree_array_codec_ltree_,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions46 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "types"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: ["(smallint) references a.post", "(id) references a.post"]
-  })
-};
-const typesCodec = recordCodec({
+const spec_types_attributes_ltree_array_codec_ltree_ = listOfCodec(spec_types_attributes_ltree_codec_ltree);
+const spec_types = {
   name: "types",
   identifier: sql.identifier("b", "types"),
-  attributes: typesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    smallint: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bigint: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numeric: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    decimal: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    boolean: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    varchar: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum: {
+      description: undefined,
+      codec: colorCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum_array: {
+      description: undefined,
+      codec: colorArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain: {
+      description: undefined,
+      codec: anIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain2: {
+      description: undefined,
+      codec: anotherIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array: {
+      description: undefined,
+      codec: textArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    json: {
+      description: undefined,
+      codec: TYPES.json,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    jsonb: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_range: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numrange: {
+      description: undefined,
+      codec: numrangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    daterange: {
+      description: undefined,
+      codec: daterangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    an_int_range: {
+      description: undefined,
+      codec: anIntRangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamp: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamptz: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    date: {
+      description: undefined,
+      codec: TYPES.date,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    time: {
+      description: undefined,
+      codec: TYPES.time,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timetz: {
+      description: undefined,
+      codec: TYPES.timetz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval_array: {
+      description: undefined,
+      codec: intervalArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    money: {
+      description: undefined,
+      codec: TYPES.money,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_compound_type: {
+      description: undefined,
+      codec: compoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_nested_compound_type: {
+      description: undefined,
+      codec: nestedCompoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    point: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullablePoint: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    inet: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    cidr: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    macaddr: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regproc: {
+      description: undefined,
+      codec: TYPES.regproc,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regprocedure: {
+      description: undefined,
+      codec: TYPES.regprocedure,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoper: {
+      description: undefined,
+      codec: TYPES.regoper,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoperator: {
+      description: undefined,
+      codec: TYPES.regoperator,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regclass: {
+      description: undefined,
+      codec: TYPES.regclass,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regtype: {
+      description: undefined,
+      codec: TYPES.regtype,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regconfig: {
+      description: undefined,
+      codec: TYPES.regconfig,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regdictionary: {
+      description: undefined,
+      codec: TYPES.regdictionary,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array_domain: {
+      description: undefined,
+      codec: textArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    int8_array_domain: {
+      description: undefined,
+      codec: int8ArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea: {
+      description: undefined,
+      codec: TYPES.bytea,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea_array: {
+      description: undefined,
+      codec: byteaArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree: {
+      description: undefined,
+      codec: spec_types_attributes_ltree_codec_ltree,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree_array: {
+      description: undefined,
+      codec: spec_types_attributes_ltree_array_codec_ltree_,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions46,
-  executor
-});
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "types"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: ["(smallint) references a.post", "(id) references a.post"]
+    })
+  },
+  executor: executor
+};
+const typesCodec = recordCodec(spec_types);
 const int4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
     pg: {
@@ -3070,7 +3070,7 @@ const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
     },
     tags: {
       omit: "create,update,delete,all,order,filter",
-      behavior: extensions12.tags.behavior
+      behavior: spec_uniqueForeignKey.extensions.tags.behavior
     }
   }
 };
@@ -3419,7 +3419,7 @@ const registryConfig_pgResources_types_types = {
       name: "types"
     },
     tags: {
-      foreignKey: extensions46.tags.foreignKey
+      foreignKey: spec_types.extensions.tags.foreignKey
     }
   }
 };
@@ -3542,8 +3542,8 @@ const registry = makeRegistry({
     int8ArrayDomain: int8ArrayDomainCodec,
     bytea: TYPES.bytea,
     byteaArray: byteaArrayCodec,
-    ltree: typesAttributes_ltree_codec_ltree,
-    "ltree[]": typesAttributes_ltree_array_codec_ltree_,
+    ltree: spec_types_attributes_ltree_codec_ltree,
+    "ltree[]": spec_types_attributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     compoundTypeArray: listOfCodec(compoundTypeCodec, {
       extensions: {
@@ -3630,7 +3630,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor
+      executor: executor
     }),
     tablefuncCrosstab3: recordCodec({
       name: "tablefuncCrosstab3",
@@ -3683,7 +3683,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor
+      executor: executor
     }),
     tablefuncCrosstab4: recordCodec({
       name: "tablefuncCrosstab4",
@@ -3745,7 +3745,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor
+      executor: executor
     })
   }),
   pgResources: Object.assign(Object.create(null), {
@@ -11819,6 +11819,15 @@ const makeArgs64 = (args, path = []) => {
   return selectArgs;
 };
 const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
+function UUIDSerialize(value) {
+  return "" + value;
+}
+const coerce = string => {
+  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
+    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
+  }
+  return string;
+};
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -12323,6 +12332,60 @@ const makeArgs73 = (args, path = []) => {
 const resource_post_computed_compound_type_arrayPgResource = registry.pgResources["post_computed_compound_type_array"];
 const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];
+function LTreeParseValue(value) {
+  return value;
+}
+const isValidHstoreObject = obj => {
+  if (obj === null) {
+    // Null is okay
+    return true;
+  } else if (typeof obj === "object") {
+    // A hash with string/null values is also okay
+    const keys = Object.keys(obj);
+    for (const key of keys) {
+      const val = obj[key];
+      if (val === null) {
+        // Null is okay
+      } else if (typeof val === "string") {
+        // String is okay
+      } else {
+        // Everything else is invalid.
+        return false;
+      }
+    }
+    return true;
+  } else {
+    // Everything else is invalid.
+    return false;
+  }
+};
+const parseValueLiteral = (ast, variables) => {
+  switch (ast.kind) {
+    case Kind.INT:
+    case Kind.FLOAT:
+      // Number isn't really okay, but we'll coerce it to a string anyway.
+      return String(parseFloat(ast.value));
+    case Kind.STRING:
+      // String is okay.
+      return String(ast.value);
+    case Kind.NULL:
+      // Null is okay.
+      return null;
+    case Kind.VARIABLE:
+      {
+        // Variable is okay if that variable is either a string or null.
+        const name = ast.name.value;
+        const value = variables ? variables[name] : undefined;
+        if (value === null || typeof value === "string") {
+          return value;
+        }
+        return undefined;
+      }
+    default:
+      // Everything else is invalid.
+      return undefined;
+  }
+};
 const argDetailsSimple74 = [];
 const makeArgs74 = (args, path = []) => {
   const selectArgs = [];
@@ -27689,6 +27752,11 @@ export const plans = {
       return $record.get("o");
     }
   },
+  Email: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
   PersonComputedFirstArgInoutOutRecord: {
     __assertStep: assertPgClassSingleStep,
     person($record) {
@@ -27798,6 +27866,19 @@ export const plans = {
     },
     BLUE: {
       value: "blue"
+    }
+  },
+  UUID: {
+    serialize: UUIDSerialize,
+    parseValue(value) {
+      return coerce("" + value);
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // ERRORS: add name to this error
+        throw new GraphQLError(`${"UUID" ?? "This scalar"} can only parse string values (kind = '${ast.kind}')`);
+      }
+      return coerce(ast.value);
     }
   },
   EnumCaps: {
@@ -28300,6 +28381,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -28316,6 +28407,9 @@ export const plans = {
     }
   },
   CompoundTypeInput: {
+    "__inputPlan": function CompoundTypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     a: {
       applyPlan($insert, val) {
         $insert.set("a", val.get());
@@ -28444,6 +28538,16 @@ export const plans = {
     },
     isOptimised($record) {
       return $record.get("is_optimised");
+    }
+  },
+  Datetime: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   TypesConnection: {
@@ -28646,12 +28750,77 @@ export const plans = {
       });
     }
   },
+  BigInt: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigInt" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  BigFloat: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigFloat" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  AnInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
+  AnotherInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
+  JSON: {
+    serialize(value) {
+      return JSON.stringify(value);
+    },
+    parseValue(value) {
+      return JSON.parse(value);
+    },
+    parseLiteral(ast, _variables) {
+      if (ast.kind === Kind.STRING) {
+        return JSON.parse(ast.value);
+      } else {
+        return undefined;
+      }
+    }
+  },
   BigFloatRange: {},
   BigFloatRangeBound: {},
   DateRange: {},
   DateRangeBound: {},
+  Date: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Date" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   AnIntRange: {},
   AnIntRangeBound: {},
+  Time: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Time" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   NestedCompoundType: {
     __assertStep: assertPgClassSingleStep,
     a($record) {
@@ -28677,6 +28846,128 @@ export const plans = {
     }
   },
   Point: {},
+  InternetAddress: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"InternetAddress" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProc: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProc" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProcedure: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProcedure" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOper: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOper" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOperator: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOperator" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegClass: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegClass" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegType: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegType" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegConfig: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegConfig" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegDictionary: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegDictionary" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  Base64EncodedBinary: {
+    serialize(data) {
+      if (Buffer.isBuffer(data)) {
+        return data.toString("base64");
+      } else {
+        throw new Error(`Base64EncodeBinary can only be used with Node.js buffers.`);
+      }
+    },
+    parseValue(data) {
+      if (typeof data === "string") {
+        return Buffer.from(data, "base64");
+      } else {
+        throw new GraphQLError("Base64EncodedBinary can only parse string values.");
+      }
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // TODO: add name to this error
+        throw new GraphQLError("Base64EncodedBinary can only parse string values");
+      }
+      return Buffer.from(ast.value, "base64");
+    }
+  },
+  LTree: {
+    serialize(x) {
+      return x;
+    },
+    parseValue: LTreeParseValue,
+    parseLiteral(node, variables) {
+      return LTreeParseValue(valueFromASTUntyped(node, variables));
+    }
+  },
   TypesEdge: {
     __assertStep: assertEdgeCapableStep,
     cursor($edge) {
@@ -29997,7 +30288,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.id.codec)}`;
             }
           });
         }
@@ -30020,7 +30311,7 @@ export const plans = {
             type: "attribute",
             attribute: "smallint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.smallint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.smallint.codec)}`;
             }
           });
         }
@@ -30043,7 +30334,7 @@ export const plans = {
             type: "attribute",
             attribute: "bigint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.bigint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.bigint.codec)}`;
             }
           });
         }
@@ -30066,7 +30357,7 @@ export const plans = {
             type: "attribute",
             attribute: "numeric",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numeric.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.numeric.codec)}`;
             }
           });
         }
@@ -30089,7 +30380,7 @@ export const plans = {
             type: "attribute",
             attribute: "decimal",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.decimal.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.decimal.codec)}`;
             }
           });
         }
@@ -30112,7 +30403,7 @@ export const plans = {
             type: "attribute",
             attribute: "boolean",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.boolean.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.boolean.codec)}`;
             }
           });
         }
@@ -30135,7 +30426,7 @@ export const plans = {
             type: "attribute",
             attribute: "varchar",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.varchar.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.varchar.codec)}`;
             }
           });
         }
@@ -30158,7 +30449,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.enum.codec)}`;
             }
           });
         }
@@ -30181,7 +30472,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.enum_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.enum_array.codec)}`;
             }
           });
         }
@@ -30204,7 +30495,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.domain.codec)}`;
             }
           });
         }
@@ -30227,7 +30518,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.domain2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.domain2.codec)}`;
             }
           });
         }
@@ -30250,7 +30541,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.text_array.codec)}`;
             }
           });
         }
@@ -30273,7 +30564,7 @@ export const plans = {
             type: "attribute",
             attribute: "json",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.json.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.json.codec)}`;
             }
           });
         }
@@ -30296,7 +30587,7 @@ export const plans = {
             type: "attribute",
             attribute: "jsonb",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.jsonb.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.jsonb.codec)}`;
             }
           });
         }
@@ -30319,7 +30610,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullable_range.codec)}`;
             }
           });
         }
@@ -30342,7 +30633,7 @@ export const plans = {
             type: "attribute",
             attribute: "numrange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.numrange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.numrange.codec)}`;
             }
           });
         }
@@ -30365,7 +30656,7 @@ export const plans = {
             type: "attribute",
             attribute: "daterange",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.daterange.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.daterange.codec)}`;
             }
           });
         }
@@ -30388,7 +30679,7 @@ export const plans = {
             type: "attribute",
             attribute: "an_int_range",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.an_int_range.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.an_int_range.codec)}`;
             }
           });
         }
@@ -30411,7 +30702,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamp",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamp.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.timestamp.codec)}`;
             }
           });
         }
@@ -30434,7 +30725,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamptz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timestamptz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.timestamptz.codec)}`;
             }
           });
         }
@@ -30457,7 +30748,7 @@ export const plans = {
             type: "attribute",
             attribute: "date",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.date.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.date.codec)}`;
             }
           });
         }
@@ -30480,7 +30771,7 @@ export const plans = {
             type: "attribute",
             attribute: "time",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.time.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.time.codec)}`;
             }
           });
         }
@@ -30503,7 +30794,7 @@ export const plans = {
             type: "attribute",
             attribute: "timetz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.timetz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.timetz.codec)}`;
             }
           });
         }
@@ -30526,7 +30817,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.interval.codec)}`;
             }
           });
         }
@@ -30549,7 +30840,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.interval_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.interval_array.codec)}`;
             }
           });
         }
@@ -30572,7 +30863,7 @@ export const plans = {
             type: "attribute",
             attribute: "money",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.money.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.money.codec)}`;
             }
           });
         }
@@ -30595,7 +30886,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.compound_type.codec)}`;
             }
           });
         }
@@ -30618,7 +30909,7 @@ export const plans = {
             type: "attribute",
             attribute: "nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nested_compound_type.codec)}`;
             }
           });
         }
@@ -30641,7 +30932,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullable_compound_type.codec)}`;
             }
           });
         }
@@ -30664,7 +30955,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_nested_compound_type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullable_nested_compound_type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullable_nested_compound_type.codec)}`;
             }
           });
         }
@@ -30687,7 +30978,7 @@ export const plans = {
             type: "attribute",
             attribute: "point",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.point.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.point.codec)}`;
             }
           });
         }
@@ -30710,7 +31001,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullablePoint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.nullablePoint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.nullablePoint.codec)}`;
             }
           });
         }
@@ -30733,7 +31024,7 @@ export const plans = {
             type: "attribute",
             attribute: "inet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.inet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.inet.codec)}`;
             }
           });
         }
@@ -30756,7 +31047,7 @@ export const plans = {
             type: "attribute",
             attribute: "cidr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.cidr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.cidr.codec)}`;
             }
           });
         }
@@ -30779,7 +31070,7 @@ export const plans = {
             type: "attribute",
             attribute: "macaddr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.macaddr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.macaddr.codec)}`;
             }
           });
         }
@@ -30802,7 +31093,7 @@ export const plans = {
             type: "attribute",
             attribute: "regproc",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regproc.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regproc.codec)}`;
             }
           });
         }
@@ -30825,7 +31116,7 @@ export const plans = {
             type: "attribute",
             attribute: "regprocedure",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regprocedure.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regprocedure.codec)}`;
             }
           });
         }
@@ -30848,7 +31139,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoper",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoper.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regoper.codec)}`;
             }
           });
         }
@@ -30871,7 +31162,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoperator",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regoperator.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regoperator.codec)}`;
             }
           });
         }
@@ -30894,7 +31185,7 @@ export const plans = {
             type: "attribute",
             attribute: "regclass",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regclass.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regclass.codec)}`;
             }
           });
         }
@@ -30917,7 +31208,7 @@ export const plans = {
             type: "attribute",
             attribute: "regtype",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regtype.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regtype.codec)}`;
             }
           });
         }
@@ -30940,7 +31231,7 @@ export const plans = {
             type: "attribute",
             attribute: "regconfig",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regconfig.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regconfig.codec)}`;
             }
           });
         }
@@ -30963,7 +31254,7 @@ export const plans = {
             type: "attribute",
             attribute: "regdictionary",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.regdictionary.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.regdictionary.codec)}`;
             }
           });
         }
@@ -30986,7 +31277,7 @@ export const plans = {
             type: "attribute",
             attribute: "text_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.text_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.text_array_domain.codec)}`;
             }
           });
         }
@@ -31009,7 +31300,7 @@ export const plans = {
             type: "attribute",
             attribute: "int8_array_domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.int8_array_domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.int8_array_domain.codec)}`;
             }
           });
         }
@@ -31032,7 +31323,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.ltree.codec)}`;
             }
           });
         }
@@ -31055,7 +31346,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree_array",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), typesAttributes.ltree_array.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_types.attributes.ltree_array.codec)}`;
             }
           });
         }
@@ -31089,6 +31380,9 @@ export const plans = {
     inclusive: undefined
   },
   NestedCompoundTypeInput: {
+    "__inputPlan": function NestedCompoundTypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     a: {
       applyPlan($insert, val) {
         $insert.set("a", val.get());
@@ -31583,6 +31877,50 @@ export const plans = {
       return $record.get("url");
     }
   },
+  NotNullUrl: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
+  KeyValueHash: {
+    serialize(value) {
+      return value;
+    },
+    parseValue(obj) {
+      if (isValidHstoreObject(obj)) {
+        return obj;
+      }
+      throw new GraphQLError(`This is not a valid ${"KeyValueHash"} object, it must be a key/value hash where keys and values are both strings (or null).`);
+    },
+    parseLiteral(ast, variables) {
+      switch (ast.kind) {
+        case Kind.OBJECT:
+          {
+            const value = ast.fields.reduce((memo, field) => {
+              memo[field.name.value] = parseValueLiteral(field.value, variables);
+              return memo;
+            }, Object.create(null));
+            if (!isValidHstoreObject(value)) {
+              return undefined;
+            }
+            return value;
+          }
+        case Kind.NULL:
+          return null;
+        case Kind.VARIABLE:
+          {
+            const name = ast.name.value;
+            const value = variables ? variables[name] : undefined;
+            if (!isValidHstoreObject(value)) {
+              return undefined;
+            }
+            return value;
+          }
+        default:
+          return undefined;
+      }
+    }
+  },
   PostsConnection: {
     __assertStep: ConnectionStep,
     nodes($connection) {
@@ -31827,7 +32165,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.id.codec)}`;
             }
           });
         }
@@ -31850,7 +32188,7 @@ export const plans = {
             type: "attribute",
             attribute: "headline",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.headline.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.headline.codec)}`;
             }
           });
         }
@@ -31873,7 +32211,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.body.codec)}`;
             }
           });
         }
@@ -31896,7 +32234,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.author_id.codec)}`;
             }
           });
         }
@@ -31919,7 +32257,7 @@ export const plans = {
             type: "attribute",
             attribute: "enums",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.enums.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.enums.codec)}`;
             }
           });
         }
@@ -31942,7 +32280,7 @@ export const plans = {
             type: "attribute",
             attribute: "comptypes",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.comptypes.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.comptypes.codec)}`;
             }
           });
         }
@@ -31967,6 +32305,9 @@ export const plans = {
     }
   },
   ComptypeInput: {
+    "__inputPlan": function ComptypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     schedule: {
       applyPlan($insert, val) {
         $insert.set("schedule", val.get());
@@ -32153,7 +32494,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_foreignKey.attributes.person_id.codec)}`;
             }
           });
         }
@@ -32176,7 +32517,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_foreignKey.attributes.compound_key_1.codec)}`;
             }
           });
         }
@@ -32199,7 +32540,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_foreignKey.attributes.compound_key_2.codec)}`;
             }
           });
         }
@@ -32422,7 +32763,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.person_id_2.codec)}`;
             }
           });
         }
@@ -32445,7 +32786,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.person_id_1.codec)}`;
             }
           });
         }
@@ -32468,7 +32809,7 @@ export const plans = {
             type: "attribute",
             attribute: "extra",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), compoundKeyAttributes.extra.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_compoundKey.attributes.extra.codec)}`;
             }
           });
         }
@@ -32550,6 +32891,16 @@ export const plans = {
     },
     ts($record) {
       return $record.get("ts");
+    }
+  },
+  NotNullTimestamp: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   FuncOutSetofConnection: {
@@ -32945,7 +33296,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.id.codec)}`;
             }
           });
         }
@@ -32968,7 +33319,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_full_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.person_full_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.person_full_name.codec)}`;
             }
           });
         }
@@ -32991,7 +33342,7 @@ export const plans = {
             type: "attribute",
             attribute: "aliases",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.aliases.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.aliases.codec)}`;
             }
           });
         }
@@ -33014,7 +33365,7 @@ export const plans = {
             type: "attribute",
             attribute: "about",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.about.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.about.codec)}`;
             }
           });
         }
@@ -33037,7 +33388,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.email.codec)}`;
             }
           });
         }
@@ -33060,7 +33411,7 @@ export const plans = {
             type: "attribute",
             attribute: "site",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.site.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.site.codec)}`;
             }
           });
         }
@@ -33083,7 +33434,7 @@ export const plans = {
             type: "attribute",
             attribute: "config",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.config.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.config.codec)}`;
             }
           });
         }
@@ -33106,7 +33457,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_ip",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_ip.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_login_from_ip.codec)}`;
             }
           });
         }
@@ -33129,7 +33480,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_subnet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.last_login_from_subnet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.last_login_from_subnet.codec)}`;
             }
           });
         }
@@ -33152,7 +33503,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_mac",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.user_mac.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.user_mac.codec)}`;
             }
           });
         }
@@ -33175,7 +33526,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_person.attributes.created_at.codec)}`;
             }
           });
         }
@@ -33200,6 +33551,9 @@ export const plans = {
     }
   },
   WrappedUrlInput: {
+    "__inputPlan": function WrappedUrlInput_inputPlan() {
+      return object(Object.create(null));
+    },
     url: {
       applyPlan($insert, val) {
         $insert.set("url", val.get());
@@ -33294,7 +33648,7 @@ export const plans = {
             type: "attribute",
             attribute: "?column?",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nonUpdatableViewAttributes["?column?"].codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nonUpdatableView.attributes["?column?"].codec)}`;
             }
           });
         }
@@ -33415,7 +33769,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), inputsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_inputs.attributes.id.codec)}`;
             }
           });
         }
@@ -33536,7 +33890,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), patchsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_patchs.attributes.id.codec)}`;
             }
           });
         }
@@ -33657,7 +34011,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reserved.attributes.id.codec)}`;
             }
           });
         }
@@ -33778,7 +34132,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedPatchsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reservedPatchs.attributes.id.codec)}`;
             }
           });
         }
@@ -33899,7 +34253,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedInputAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reservedInput.attributes.id.codec)}`;
             }
           });
         }
@@ -34054,7 +34408,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_defaultValue.attributes.id.codec)}`;
             }
           });
         }
@@ -34077,7 +34431,7 @@ export const plans = {
             type: "attribute",
             attribute: "null_value",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.null_value.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_defaultValue.attributes.null_value.codec)}`;
             }
           });
         }
@@ -34200,7 +34554,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_noPrimaryKey.attributes.id.codec)}`;
             }
           });
         }
@@ -34223,7 +34577,7 @@ export const plans = {
             type: "attribute",
             attribute: "str",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.str.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_noPrimaryKey.attributes.str.codec)}`;
             }
           });
         }
@@ -34392,7 +34746,7 @@ export const plans = {
             type: "attribute",
             attribute: "testviewid",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.testviewid.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_testview.attributes.testviewid.codec)}`;
             }
           });
         }
@@ -34415,7 +34769,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_testview.attributes.col1.codec)}`;
             }
           });
         }
@@ -34438,7 +34792,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_testview.attributes.col2.codec)}`;
             }
           });
         }
@@ -34593,7 +34947,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_myTable.attributes.id.codec)}`;
             }
           });
         }
@@ -34616,7 +34970,7 @@ export const plans = {
             type: "attribute",
             attribute: "json_data",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), myTableAttributes.json_data.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_myTable.attributes.json_data.codec)}`;
             }
           });
         }
@@ -34771,7 +35125,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_personSecret.attributes.person_id.codec)}`;
             }
           });
         }
@@ -34794,7 +35148,7 @@ export const plans = {
             type: "attribute",
             attribute: "sekrit",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), personSecretAttributes.sekrit.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_personSecret.attributes.sekrit.codec)}`;
             }
           });
         }
@@ -34983,7 +35337,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_viewTable.attributes.id.codec)}`;
             }
           });
         }
@@ -35006,7 +35360,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_viewTable.attributes.col1.codec)}`;
             }
           });
         }
@@ -35029,7 +35383,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_viewTable.attributes.col2.codec)}`;
             }
           });
         }
@@ -35252,7 +35606,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.id.codec)}`;
             }
           });
         }
@@ -35275,7 +35629,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.col1.codec)}`;
             }
           });
         }
@@ -35298,7 +35652,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.col2.codec)}`;
             }
           });
         }
@@ -35321,7 +35675,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.col3.codec)}`;
             }
           });
         }
@@ -35544,7 +35898,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.id.codec)}`;
             }
           });
         }
@@ -35567,7 +35921,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.col3.codec)}`;
             }
           });
         }
@@ -35590,7 +35944,7 @@ export const plans = {
             type: "attribute",
             attribute: "col4",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col4.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.col4.codec)}`;
             }
           });
         }
@@ -35613,7 +35967,7 @@ export const plans = {
             type: "attribute",
             attribute: "col5",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col5.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.col5.codec)}`;
             }
           });
         }
@@ -35819,7 +36173,7 @@ export const plans = {
             type: "attribute",
             attribute: "x",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.x.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.x.codec)}`;
             }
           });
         }
@@ -35842,7 +36196,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.name.codec)}`;
             }
           });
         }
@@ -35865,7 +36219,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.description.codec)}`;
             }
           });
         }
@@ -35888,7 +36242,7 @@ export const plans = {
             type: "attribute",
             attribute: "constant",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), updatableViewAttributes.constant.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_updatableView.attributes.constant.codec)}`;
             }
           });
         }
@@ -36111,7 +36465,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.id.codec)}`;
             }
           });
         }
@@ -36134,7 +36488,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.nullable_text.codec)}`;
             }
           });
         }
@@ -36157,7 +36511,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_int",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.nullable_int.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.nullable_int.codec)}`;
             }
           });
         }
@@ -36180,7 +36534,7 @@ export const plans = {
             type: "attribute",
             attribute: "non_null_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nullTestRecordAttributes.non_null_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nullTestRecord.attributes.non_null_text.codec)}`;
             }
           });
         }
@@ -36383,7 +36737,7 @@ export const plans = {
             type: "attribute",
             attribute: "not_null_has_default",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.not_null_has_default.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.not_null_has_default.codec)}`;
             }
           });
         }
@@ -36406,7 +36760,7 @@ export const plans = {
             type: "attribute",
             attribute: "wont_cast_easy",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.wont_cast_easy.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.wont_cast_easy.codec)}`;
             }
           });
         }
@@ -36429,7 +36783,7 @@ export const plans = {
             type: "attribute",
             attribute: "row_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), edgeCaseAttributes.row_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_edgeCase.attributes.row_id.codec)}`;
             }
           });
         }
@@ -36652,7 +37006,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.id.codec)}`;
             }
           });
         }
@@ -36675,7 +37029,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.person_id.codec)}`;
             }
           });
         }
@@ -36698,7 +37052,7 @@ export const plans = {
             type: "attribute",
             attribute: "length_in_metres",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.length_in_metres.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.length_in_metres.codec)}`;
             }
           });
         }
@@ -36721,7 +37075,7 @@ export const plans = {
             type: "attribute",
             attribute: "mood",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), leftArmAttributes.mood.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_leftArm.attributes.mood.codec)}`;
             }
           });
         }
@@ -36876,7 +37230,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_issue756.attributes.id.codec)}`;
             }
           });
         }
@@ -36899,7 +37253,7 @@ export const plans = {
             type: "attribute",
             attribute: "ts",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), issue756Attributes.ts.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_issue756.attributes.ts.codec)}`;
             }
           });
         }
@@ -39659,6 +40013,11 @@ export const plans = {
       return rootValue();
     }
   },
+  Guid: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
   GuidFnInput: {
     clientMutationId: {
       applyPlan($input, val) {
@@ -39850,6 +40209,9 @@ export const plans = {
     leftArm: undefined
   },
   LeftArmBaseInput: {
+    "__inputPlan": function LeftArmBaseInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -40244,6 +40606,9 @@ export const plans = {
     suffix: undefined
   },
   PostInput: {
+    "__inputPlan": function PostInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -40694,6 +41059,9 @@ export const plans = {
     }
   },
   InputInput: {
+    "__inputPlan": function InputInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -40761,6 +41129,9 @@ export const plans = {
     }
   },
   PatchInput: {
+    "__inputPlan": function PatchInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -40828,6 +41199,9 @@ export const plans = {
     }
   },
   ReservedInput: {
+    "__inputPlan": function ReservedInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -40895,6 +41269,9 @@ export const plans = {
     }
   },
   ReservedPatchRecordInput: {
+    "__inputPlan": function ReservedPatchRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -40962,6 +41339,9 @@ export const plans = {
     }
   },
   ReservedInputRecordInput: {
+    "__inputPlan": function ReservedInputRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -41029,6 +41409,9 @@ export const plans = {
     }
   },
   DefaultValueInput: {
+    "__inputPlan": function DefaultValueInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -41083,6 +41466,9 @@ export const plans = {
     }
   },
   ForeignKeyInput: {
+    "__inputPlan": function ForeignKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -41133,6 +41519,9 @@ export const plans = {
     }
   },
   NoPrimaryKeyInput: {
+    "__inputPlan": function NoPrimaryKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -41176,6 +41565,9 @@ export const plans = {
     }
   },
   TestviewInput: {
+    "__inputPlan": function TestviewInput_inputPlan() {
+      return object(Object.create(null));
+    },
     testviewid: {
       applyPlan($insert, val) {
         $insert.set("testviewid", val.get());
@@ -41257,6 +41649,9 @@ export const plans = {
     }
   },
   MyTableInput: {
+    "__inputPlan": function MyTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -41336,6 +41731,9 @@ export const plans = {
     }
   },
   PersonSecretInput: {
+    "__inputPlan": function PersonSecretInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -41410,6 +41808,9 @@ export const plans = {
     }
   },
   ViewTableInput: {
+    "__inputPlan": function ViewTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -41501,6 +41902,9 @@ export const plans = {
     }
   },
   CompoundKeyInput: {
+    "__inputPlan": function CompoundKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId2: {
       applyPlan($insert, val) {
         $insert.set("person_id_2", val.get());
@@ -41582,6 +41986,9 @@ export const plans = {
     }
   },
   SimilarTable1Input: {
+    "__inputPlan": function SimilarTable1Input_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -41670,6 +42077,9 @@ export const plans = {
     }
   },
   SimilarTable2Input: {
+    "__inputPlan": function SimilarTable2Input_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -41727,6 +42137,9 @@ export const plans = {
     }
   },
   UpdatableViewInput: {
+    "__inputPlan": function UpdatableViewInput_inputPlan() {
+      return object(Object.create(null));
+    },
     x: {
       applyPlan($insert, val) {
         $insert.set("x", val.get());
@@ -41815,6 +42228,9 @@ export const plans = {
     }
   },
   NullTestRecordInput: {
+    "__inputPlan": function NullTestRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -41872,6 +42288,9 @@ export const plans = {
     }
   },
   EdgeCaseInput: {
+    "__inputPlan": function EdgeCaseInput_inputPlan() {
+      return object(Object.create(null));
+    },
     notNullHasDefault: {
       applyPlan($insert, val) {
         $insert.set("not_null_has_default", val.get());
@@ -41958,6 +42377,9 @@ export const plans = {
     }
   },
   LeftArmInput: {
+    "__inputPlan": function LeftArmInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -42046,6 +42468,9 @@ export const plans = {
     }
   },
   Issue756Input: {
+    "__inputPlan": function Issue756Input_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -42183,6 +42608,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -42330,6 +42758,9 @@ export const plans = {
     }
   },
   TypeInput: {
+    "__inputPlan": function TypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -42732,6 +43163,9 @@ export const plans = {
     }
   },
   InputPatch: {
+    "__inputPlan": function InputPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -42798,6 +43232,9 @@ export const plans = {
     }
   },
   PatchPatch: {
+    "__inputPlan": function PatchPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -42864,6 +43301,9 @@ export const plans = {
     }
   },
   ReservedPatch: {
+    "__inputPlan": function ReservedPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -42930,6 +43370,9 @@ export const plans = {
     }
   },
   ReservedPatchRecordPatch: {
+    "__inputPlan": function ReservedPatchRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -42996,6 +43439,9 @@ export const plans = {
     }
   },
   ReservedInputRecordPatch: {
+    "__inputPlan": function ReservedInputRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43062,6 +43508,9 @@ export const plans = {
     }
   },
   DefaultValuePatch: {
+    "__inputPlan": function DefaultValuePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43104,6 +43553,9 @@ export const plans = {
     }
   },
   NoPrimaryKeyPatch: {
+    "__inputPlan": function NoPrimaryKeyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43177,6 +43629,9 @@ export const plans = {
     }
   },
   MyTablePatch: {
+    "__inputPlan": function MyTablePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43255,6 +43710,9 @@ export const plans = {
     }
   },
   PersonSecretPatch: {
+    "__inputPlan": function PersonSecretPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -43328,6 +43786,9 @@ export const plans = {
     }
   },
   ViewTablePatch: {
+    "__inputPlan": function ViewTablePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43419,6 +43880,9 @@ export const plans = {
     }
   },
   CompoundKeyPatch: {
+    "__inputPlan": function CompoundKeyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     personId2: {
       applyPlan($insert, val) {
         $insert.set("person_id_2", val.get());
@@ -43499,6 +43963,9 @@ export const plans = {
     }
   },
   SimilarTable1Patch: {
+    "__inputPlan": function SimilarTable1Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43586,6 +44053,9 @@ export const plans = {
     }
   },
   SimilarTable2Patch: {
+    "__inputPlan": function SimilarTable2Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43673,6 +44143,9 @@ export const plans = {
     }
   },
   NullTestRecordPatch: {
+    "__inputPlan": function NullTestRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43765,6 +44238,9 @@ export const plans = {
     }
   },
   LeftArmPatch: {
+    "__inputPlan": function LeftArmPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43866,6 +44342,9 @@ export const plans = {
     }
   },
   Issue756Patch: {
+    "__inputPlan": function Issue756Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43944,6 +44423,9 @@ export const plans = {
     }
   },
   PostPatch: {
+    "__inputPlan": function PostPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44045,6 +44527,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44205,6 +44690,9 @@ export const plans = {
     }
   },
   TypePatch: {
+    "__inputPlan": function TypePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.polymorphic.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.polymorphic.1.export.mjs
@@ -1,5 +1,6 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, enumCodec, makeRegistry, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgUnionAll, pgUpdateSingle, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, makeGrafastSchema, object, rootValue } from "grafast";
+import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const executor = new PgExecutor({
@@ -12,19 +13,7 @@ const executor = new PgExecutor({
     });
   }
 });
-const extensions = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "aws_application_first_party_vulnerabilities"
-  },
-  tags: Object.assign(Object.create(null), {
-    omit: true,
-    behavior: ["-*"]
-  })
-};
-const awsApplicationFirstPartyVulnerabilitiesCodec = recordCodec({
+const spec_awsApplicationFirstPartyVulnerabilities = {
   name: "awsApplicationFirstPartyVulnerabilities",
   identifier: sql.identifier("polymorphic", "aws_application_first_party_vulnerabilities"),
   attributes: Object.assign(Object.create(null), {
@@ -48,22 +37,22 @@ const awsApplicationFirstPartyVulnerabilitiesCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions,
-  executor
-});
-const extensions2 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "aws_application_third_party_vulnerabilities"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "aws_application_first_party_vulnerabilities"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: true,
+      behavior: ["-*"]
+    })
   },
-  tags: Object.assign(Object.create(null), {
-    omit: true,
-    behavior: ["-*"]
-  })
+  executor: executor
 };
-const awsApplicationThirdPartyVulnerabilitiesCodec = recordCodec({
+const awsApplicationFirstPartyVulnerabilitiesCodec = recordCodec(spec_awsApplicationFirstPartyVulnerabilities);
+const spec_awsApplicationThirdPartyVulnerabilities = {
   name: "awsApplicationThirdPartyVulnerabilities",
   identifier: sql.identifier("polymorphic", "aws_application_third_party_vulnerabilities"),
   attributes: Object.assign(Object.create(null), {
@@ -87,22 +76,22 @@ const awsApplicationThirdPartyVulnerabilitiesCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions: extensions2,
-  executor
-});
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "gcp_application_first_party_vulnerabilities"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "aws_application_third_party_vulnerabilities"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: true,
+      behavior: ["-*"]
+    })
   },
-  tags: Object.assign(Object.create(null), {
-    omit: true,
-    behavior: ["-*"]
-  })
+  executor: executor
 };
-const gcpApplicationFirstPartyVulnerabilitiesCodec = recordCodec({
+const awsApplicationThirdPartyVulnerabilitiesCodec = recordCodec(spec_awsApplicationThirdPartyVulnerabilities);
+const spec_gcpApplicationFirstPartyVulnerabilities = {
   name: "gcpApplicationFirstPartyVulnerabilities",
   identifier: sql.identifier("polymorphic", "gcp_application_first_party_vulnerabilities"),
   attributes: Object.assign(Object.create(null), {
@@ -126,22 +115,22 @@ const gcpApplicationFirstPartyVulnerabilitiesCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions: extensions3,
-  executor
-});
-const extensions4 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "gcp_application_third_party_vulnerabilities"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "gcp_application_first_party_vulnerabilities"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: true,
+      behavior: ["-*"]
+    })
   },
-  tags: Object.assign(Object.create(null), {
-    omit: true,
-    behavior: ["-*"]
-  })
+  executor: executor
 };
-const gcpApplicationThirdPartyVulnerabilitiesCodec = recordCodec({
+const gcpApplicationFirstPartyVulnerabilitiesCodec = recordCodec(spec_gcpApplicationFirstPartyVulnerabilities);
+const spec_gcpApplicationThirdPartyVulnerabilities = {
   name: "gcpApplicationThirdPartyVulnerabilities",
   identifier: sql.identifier("polymorphic", "gcp_application_third_party_vulnerabilities"),
   attributes: Object.assign(Object.create(null), {
@@ -165,33 +154,44 @@ const gcpApplicationThirdPartyVulnerabilitiesCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions: extensions4,
-  executor
-});
-const organizationsAttributes = Object.assign(Object.create(null), {
-  organization_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "gcp_application_third_party_vulnerabilities"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: true,
+      behavior: ["-*"]
+    })
   },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const organizationsCodec = recordCodec({
+  executor: executor
+};
+const gcpApplicationThirdPartyVulnerabilitiesCodec = recordCodec(spec_gcpApplicationThirdPartyVulnerabilities);
+const spec_organizations = {
   name: "organizations",
   identifier: sql.identifier("polymorphic", "organizations"),
-  attributes: organizationsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    organization_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -204,75 +204,63 @@ const organizationsCodec = recordCodec({
       unionMember: "PersonOrOrganization"
     })
   },
-  executor
-});
-const peopleAttributes = Object.assign(Object.create(null), {
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  username: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "people"
-  },
-  tags: Object.assign(Object.create(null), {
-    unionMember: "PersonOrOrganization",
-    ref: "applications to:Application",
-    refVia: ["applications via:aws_applications", "applications via:gcp_applications"]
-  }),
-  refDefinitions: Object.assign(Object.create(null), {
-    applications: {
-      singular: false,
-      graphqlType: "Application",
-      sourceGraphqlType: undefined,
-      extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
-      }
-    }
-  })
+  executor: executor
 };
-const peopleCodec = recordCodec({
+const organizationsCodec = recordCodec(spec_organizations);
+const spec_people = {
   name: "people",
   identifier: sql.identifier("polymorphic", "people"),
-  attributes: peopleAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    username: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions6,
-  executor
-});
-const extensions7 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "priorities"
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "people"
+    },
+    tags: Object.assign(Object.create(null), {
+      unionMember: "PersonOrOrganization",
+      ref: "applications to:Application",
+      refVia: ["applications via:aws_applications", "applications via:gcp_applications"]
+    }),
+    refDefinitions: Object.assign(Object.create(null), {
+      applications: {
+        singular: false,
+        graphqlType: "Application",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      }
+    })
   },
-  tags: Object.assign(Object.create(null), {
-    omit: "create,update,delete,filter,order",
-    behavior: ["-insert -update -delete -filter -filterBy -order -orderBy"]
-  })
+  executor: executor
 };
-const prioritiesCodec = recordCodec({
+const peopleCodec = recordCodec(spec_people);
+const spec_priorities = {
   name: "priorities",
   identifier: sql.identifier("polymorphic", "priorities"),
   attributes: Object.assign(Object.create(null), {
@@ -296,9 +284,21 @@ const prioritiesCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions: extensions7,
-  executor
-});
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "priorities"
+    },
+    tags: Object.assign(Object.create(null), {
+      omit: "create,update,delete,filter,order",
+      behavior: ["-insert -update -delete -filter -filterBy -order -orderBy"]
+    })
+  },
+  executor: executor
+};
+const prioritiesCodec = recordCodec(spec_priorities);
 const itemTypeCodec = enumCodec({
   name: "itemType",
   identifier: sql.identifier("polymorphic", "item_type"),
@@ -313,140 +313,139 @@ const itemTypeCodec = enumCodec({
     tags: Object.create(null)
   }
 });
-const relationalChecklistsAttributes = Object.assign(Object.create(null), {
-  checklist_item_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  id: {
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  },
-  type: {
-    codec: itemTypeCodec,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  },
-  parent_id: {
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyChecklistItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  },
-  root_topic_id: {
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyChecklistItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    via: "relationalItemsByMyChecklistItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  },
-  position: {
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  },
-  created_at: {
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  },
-  updated_at: {
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  },
-  is_explicitly_archived: {
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  },
-  archived_at: {
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyChecklistItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const relationalChecklistsCodec = recordCodec({
+const spec_relationalChecklists = {
   name: "relationalChecklists",
   identifier: sql.identifier("polymorphic", "relational_checklists"),
-  attributes: relationalChecklistsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    checklist_item_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    id: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    },
+    type: {
+      codec: itemTypeCodec,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    },
+    parent_id: {
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyChecklistItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    },
+    root_topic_id: {
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyChecklistItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      via: "relationalItemsByMyChecklistItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    },
+    position: {
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    },
+    created_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    },
+    updated_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    },
+    is_explicitly_archived: {
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    },
+    archived_at: {
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyChecklistItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -458,32 +457,32 @@ const relationalChecklistsCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor
-});
-const relationalItemRelationCompositePksAttributes = Object.assign(Object.create(null), {
-  parent_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  child_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const relationalItemRelationCompositePksCodec = recordCodec({
+  executor: executor
+};
+const relationalChecklistsCodec = recordCodec(spec_relationalChecklists);
+const spec_relationalItemRelationCompositePks = {
   name: "relationalItemRelationCompositePks",
   identifier: sql.identifier("polymorphic", "relational_item_relation_composite_pks"),
-  attributes: relationalItemRelationCompositePksAttributes,
+  attributes: Object.assign(Object.create(null), {
+    parent_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    child_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -494,142 +493,142 @@ const relationalItemRelationCompositePksCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const relationalTopicsAttributes = Object.assign(Object.create(null), {
-  topic_item_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  id: {
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyTopicItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.id.extensions.tags
-    }
-  },
-  type: {
-    codec: itemTypeCodec,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyTopicItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.type.extensions.tags
-    }
-  },
-  parent_id: {
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyTopicItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.parent_id.extensions.tags
-    }
-  },
-  root_topic_id: {
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyTopicItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.root_topic_id.extensions.tags
-    }
-  },
-  author_id: {
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    via: "relationalItemsByMyTopicItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.author_id.extensions.tags
-    }
-  },
-  position: {
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyTopicItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.position.extensions.tags
-    }
-  },
-  created_at: {
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyTopicItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.created_at.extensions.tags
-    }
-  },
-  updated_at: {
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyTopicItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.updated_at.extensions.tags
-    }
-  },
-  is_explicitly_archived: {
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyTopicItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.is_explicitly_archived.extensions.tags
-    }
-  },
-  archived_at: {
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyTopicItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.archived_at.extensions.tags
-    }
-  }
-});
-const relationalTopicsCodec = recordCodec({
+  executor: executor
+};
+const relationalItemRelationCompositePksCodec = recordCodec(spec_relationalItemRelationCompositePks);
+const spec_relationalTopics = {
   name: "relationalTopics",
   identifier: sql.identifier("polymorphic", "relational_topics"),
-  attributes: relationalTopicsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    topic_item_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    id: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyTopicItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.id.extensions.tags
+      }
+    },
+    type: {
+      codec: itemTypeCodec,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyTopicItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.type.extensions.tags
+      }
+    },
+    parent_id: {
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyTopicItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.parent_id.extensions.tags
+      }
+    },
+    root_topic_id: {
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyTopicItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.root_topic_id.extensions.tags
+      }
+    },
+    author_id: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      via: "relationalItemsByMyTopicItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.author_id.extensions.tags
+      }
+    },
+    position: {
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyTopicItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.position.extensions.tags
+      }
+    },
+    created_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyTopicItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.created_at.extensions.tags
+      }
+    },
+    updated_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyTopicItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.updated_at.extensions.tags
+      }
+    },
+    is_explicitly_archived: {
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyTopicItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.is_explicitly_archived.extensions.tags
+      }
+    },
+    archived_at: {
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyTopicItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.archived_at.extensions.tags
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -641,32 +640,32 @@ const relationalTopicsCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor
-});
-const singleTableItemRelationCompositePksAttributes = Object.assign(Object.create(null), {
-  parent_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  child_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const singleTableItemRelationCompositePksCodec = recordCodec({
+  executor: executor
+};
+const relationalTopicsCodec = recordCodec(spec_relationalTopics);
+const spec_singleTableItemRelationCompositePks = {
   name: "singleTableItemRelationCompositePks",
   identifier: sql.identifier("polymorphic", "single_table_item_relation_composite_pks"),
-  attributes: singleTableItemRelationCompositePksAttributes,
+  attributes: Object.assign(Object.create(null), {
+    parent_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    child_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -677,151 +676,151 @@ const singleTableItemRelationCompositePksCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const relationalChecklistItemsAttributes = Object.assign(Object.create(null), {
-  checklist_item_item_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  description: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  note: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  id: {
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.id.extensions.tags
-    }
-  },
-  type: {
-    codec: itemTypeCodec,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.type.extensions.tags
-    }
-  },
-  parent_id: {
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyChecklistItemItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.parent_id.extensions.tags
-    }
-  },
-  root_topic_id: {
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyChecklistItemItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.root_topic_id.extensions.tags
-    }
-  },
-  author_id: {
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    via: "relationalItemsByMyChecklistItemItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.author_id.extensions.tags
-    }
-  },
-  position: {
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.position.extensions.tags
-    }
-  },
-  created_at: {
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.created_at.extensions.tags
-    }
-  },
-  updated_at: {
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.updated_at.extensions.tags
-    }
-  },
-  is_explicitly_archived: {
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.is_explicitly_archived.extensions.tags
-    }
-  },
-  archived_at: {
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyChecklistItemItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.archived_at.extensions.tags
-    }
-  }
-});
-const relationalChecklistItemsCodec = recordCodec({
+  executor: executor
+};
+const singleTableItemRelationCompositePksCodec = recordCodec(spec_singleTableItemRelationCompositePks);
+const spec_relationalChecklistItems = {
   name: "relationalChecklistItems",
   identifier: sql.identifier("polymorphic", "relational_checklist_items"),
-  attributes: relationalChecklistItemsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    checklist_item_item_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    description: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    note: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    id: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.id.extensions.tags
+      }
+    },
+    type: {
+      codec: itemTypeCodec,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.type.extensions.tags
+      }
+    },
+    parent_id: {
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyChecklistItemItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.parent_id.extensions.tags
+      }
+    },
+    root_topic_id: {
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyChecklistItemItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.root_topic_id.extensions.tags
+      }
+    },
+    author_id: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      via: "relationalItemsByMyChecklistItemItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.author_id.extensions.tags
+      }
+    },
+    position: {
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.position.extensions.tags
+      }
+    },
+    created_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.created_at.extensions.tags
+      }
+    },
+    updated_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.updated_at.extensions.tags
+      }
+    },
+    is_explicitly_archived: {
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.is_explicitly_archived.extensions.tags
+      }
+    },
+    archived_at: {
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyChecklistItemItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.archived_at.extensions.tags
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -833,151 +832,151 @@ const relationalChecklistItemsCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor
-});
-const relationalDividersAttributes = Object.assign(Object.create(null), {
-  divider_item_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  color: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  id: {
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyDividerItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.id.extensions.tags
-    }
-  },
-  type: {
-    codec: itemTypeCodec,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyDividerItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.type.extensions.tags
-    }
-  },
-  parent_id: {
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyDividerItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.parent_id.extensions.tags
-    }
-  },
-  root_topic_id: {
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyDividerItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.root_topic_id.extensions.tags
-    }
-  },
-  author_id: {
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    via: "relationalItemsByMyDividerItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.author_id.extensions.tags
-    }
-  },
-  position: {
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyDividerItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.position.extensions.tags
-    }
-  },
-  created_at: {
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyDividerItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.created_at.extensions.tags
-    }
-  },
-  updated_at: {
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyDividerItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.updated_at.extensions.tags
-    }
-  },
-  is_explicitly_archived: {
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyDividerItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.is_explicitly_archived.extensions.tags
-    }
-  },
-  archived_at: {
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyDividerItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.archived_at.extensions.tags
-    }
-  }
-});
-const relationalDividersCodec = recordCodec({
+  executor: executor
+};
+const relationalChecklistItemsCodec = recordCodec(spec_relationalChecklistItems);
+const spec_relationalDividers = {
   name: "relationalDividers",
   identifier: sql.identifier("polymorphic", "relational_dividers"),
-  attributes: relationalDividersAttributes,
+  attributes: Object.assign(Object.create(null), {
+    divider_item_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    color: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    id: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyDividerItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.id.extensions.tags
+      }
+    },
+    type: {
+      codec: itemTypeCodec,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyDividerItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.type.extensions.tags
+      }
+    },
+    parent_id: {
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyDividerItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.parent_id.extensions.tags
+      }
+    },
+    root_topic_id: {
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyDividerItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.root_topic_id.extensions.tags
+      }
+    },
+    author_id: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      via: "relationalItemsByMyDividerItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.author_id.extensions.tags
+      }
+    },
+    position: {
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyDividerItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.position.extensions.tags
+      }
+    },
+    created_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyDividerItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.created_at.extensions.tags
+      }
+    },
+    updated_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyDividerItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.updated_at.extensions.tags
+      }
+    },
+    is_explicitly_archived: {
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyDividerItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.is_explicitly_archived.extensions.tags
+      }
+    },
+    archived_at: {
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyDividerItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.archived_at.extensions.tags
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -989,41 +988,41 @@ const relationalDividersCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor
-});
-const relationalItemRelationsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  parent_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  child_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const relationalItemRelationsCodec = recordCodec({
+  executor: executor
+};
+const relationalDividersCodec = recordCodec(spec_relationalDividers);
+const spec_relationalItemRelations = {
   name: "relationalItemRelations",
   identifier: sql.identifier("polymorphic", "relational_item_relations"),
-  attributes: relationalItemRelationsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    parent_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    child_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1034,41 +1033,41 @@ const relationalItemRelationsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const singleTableItemRelationsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  parent_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  child_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const singleTableItemRelationsCodec = recordCodec({
+  executor: executor
+};
+const relationalItemRelationsCodec = recordCodec(spec_relationalItemRelations);
+const spec_singleTableItemRelations = {
   name: "singleTableItemRelations",
   identifier: sql.identifier("polymorphic", "single_table_item_relations"),
-  attributes: singleTableItemRelationsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    parent_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    child_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1079,231 +1078,230 @@ const singleTableItemRelationsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const logEntriesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  organization_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions17 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "log_entries"
-  },
-  tags: Object.assign(Object.create(null), {
-    ref: "author to:PersonOrOrganization singular",
-    refVia: ["author via:people", "author via:organizations"]
-  }),
-  refDefinitions: Object.assign(Object.create(null), {
-    author: {
-      singular: true,
-      graphqlType: "PersonOrOrganization",
-      sourceGraphqlType: undefined,
-      extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
-      }
-    }
-  })
+  executor: executor
 };
-const logEntriesCodec = recordCodec({
+const singleTableItemRelationsCodec = recordCodec(spec_singleTableItemRelations);
+const spec_logEntries = {
   name: "logEntries",
   identifier: sql.identifier("polymorphic", "log_entries"),
-  attributes: logEntriesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    organization_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions17,
-  executor
-});
-const relationalPostsAttributes = Object.assign(Object.create(null), {
-  post_item_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "log_entries"
+    },
+    tags: Object.assign(Object.create(null), {
+      ref: "author to:PersonOrOrganization singular",
+      refVia: ["author via:people", "author via:organizations"]
+    }),
+    refDefinitions: Object.assign(Object.create(null), {
+      author: {
+        singular: true,
+        graphqlType: "PersonOrOrganization",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      }
+    })
   },
-  title: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  description: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  note: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  id: {
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyPostItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.id.extensions.tags
-    }
-  },
-  type: {
-    codec: itemTypeCodec,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyPostItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.type.extensions.tags
-    }
-  },
-  parent_id: {
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyPostItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.parent_id.extensions.tags
-    }
-  },
-  root_topic_id: {
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyPostItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.root_topic_id.extensions.tags
-    }
-  },
-  author_id: {
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    via: "relationalItemsByMyPostItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.author_id.extensions.tags
-    }
-  },
-  position: {
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyPostItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.position.extensions.tags
-    }
-  },
-  created_at: {
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyPostItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.created_at.extensions.tags
-    }
-  },
-  updated_at: {
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyPostItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.updated_at.extensions.tags
-    }
-  },
-  is_explicitly_archived: {
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyPostItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.is_explicitly_archived.extensions.tags
-    }
-  },
-  archived_at: {
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyPostItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.archived_at.extensions.tags
-    }
-  }
-});
-const relationalPostsCodec = recordCodec({
+  executor: executor
+};
+const logEntriesCodec = recordCodec(spec_logEntries);
+const spec_relationalPosts = {
   name: "relationalPosts",
   identifier: sql.identifier("polymorphic", "relational_posts"),
-  attributes: relationalPostsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    post_item_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    description: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    note: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    id: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyPostItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.id.extensions.tags
+      }
+    },
+    type: {
+      codec: itemTypeCodec,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyPostItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.type.extensions.tags
+      }
+    },
+    parent_id: {
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyPostItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.parent_id.extensions.tags
+      }
+    },
+    root_topic_id: {
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyPostItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.root_topic_id.extensions.tags
+      }
+    },
+    author_id: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      via: "relationalItemsByMyPostItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.author_id.extensions.tags
+      }
+    },
+    position: {
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyPostItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.position.extensions.tags
+      }
+    },
+    created_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyPostItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.created_at.extensions.tags
+      }
+    },
+    updated_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyPostItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.updated_at.extensions.tags
+      }
+    },
+    is_explicitly_archived: {
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyPostItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.is_explicitly_archived.extensions.tags
+      }
+    },
+    archived_at: {
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyPostItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.archived_at.extensions.tags
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1315,758 +1313,971 @@ const relationalPostsCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor
-});
-const firstPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  cvss_score: {
-    description: undefined,
-    codec: TYPES.float,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  team_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions19 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "first_party_vulnerabilities"
-  },
-  tags: Object.assign(Object.create(null), {
-    implements: "Vulnerability",
-    ref: ["applications to:Application plural", "owners to:PersonOrOrganization plural"],
-    refVia: ["applications via:aws_application_first_party_vulnerabilities;aws_applications", "applications via:gcp_application_first_party_vulnerabilities;gcp_applications", "owners via:aws_application_first_party_vulnerabilities;aws_applications;people", "owners via:aws_application_first_party_vulnerabilities;aws_applications;organizations", "owners via:gcp_application_first_party_vulnerabilities;gcp_applications;people", "owners via:gcp_application_first_party_vulnerabilities;gcp_applications;organizations"]
-  }),
-  refDefinitions: Object.assign(Object.create(null), {
-    applications: {
-      singular: false,
-      graphqlType: "Application",
-      sourceGraphqlType: undefined,
-      extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
-      }
-    },
-    owners: {
-      singular: false,
-      graphqlType: "PersonOrOrganization",
-      sourceGraphqlType: undefined,
-      extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
-      }
-    }
-  })
+  executor: executor
 };
-const firstPartyVulnerabilitiesCodec = recordCodec({
+const relationalPostsCodec = recordCodec(spec_relationalPosts);
+const spec_firstPartyVulnerabilities = {
   name: "firstPartyVulnerabilities",
   identifier: sql.identifier("polymorphic", "first_party_vulnerabilities"),
-  attributes: firstPartyVulnerabilitiesAttributes,
-  description: undefined,
-  extensions: extensions19,
-  executor
-});
-const thirdPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  cvss_score: {
-    description: undefined,
-    codec: TYPES.float,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  vendor_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions20 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "third_party_vulnerabilities"
-  },
-  tags: Object.assign(Object.create(null), {
-    implements: "Vulnerability",
-    ref: ["applications to:Application plural", "owners to:PersonOrOrganization plural"],
-    refVia: ["applications via:aws_application_third_party_vulnerabilities;aws_applications", "applications via:gcp_application_third_party_vulnerabilities;gcp_applications", "owners via:aws_application_third_party_vulnerabilities;aws_applications;people", "owners via:aws_application_third_party_vulnerabilities;aws_applications;organizations", "owners via:gcp_application_third_party_vulnerabilities;gcp_applications;people", "owners via:gcp_application_third_party_vulnerabilities;gcp_applications;organizations"]
-  }),
-  refDefinitions: Object.assign(Object.create(null), {
-    applications: {
-      singular: false,
-      graphqlType: "Application",
-      sourceGraphqlType: undefined,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
       extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
+        tags: {}
       }
     },
-    owners: {
-      singular: false,
-      graphqlType: "PersonOrOrganization",
-      sourceGraphqlType: undefined,
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
       extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
+        tags: {}
+      }
+    },
+    cvss_score: {
+      description: undefined,
+      codec: TYPES.float,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    team_name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
       }
     }
-  })
+  }),
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "first_party_vulnerabilities"
+    },
+    tags: Object.assign(Object.create(null), {
+      implements: "Vulnerability",
+      ref: ["applications to:Application plural", "owners to:PersonOrOrganization plural"],
+      refVia: ["applications via:aws_application_first_party_vulnerabilities;aws_applications", "applications via:gcp_application_first_party_vulnerabilities;gcp_applications", "owners via:aws_application_first_party_vulnerabilities;aws_applications;people", "owners via:aws_application_first_party_vulnerabilities;aws_applications;organizations", "owners via:gcp_application_first_party_vulnerabilities;gcp_applications;people", "owners via:gcp_application_first_party_vulnerabilities;gcp_applications;organizations"]
+    }),
+    refDefinitions: Object.assign(Object.create(null), {
+      applications: {
+        singular: false,
+        graphqlType: "Application",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      },
+      owners: {
+        singular: false,
+        graphqlType: "PersonOrOrganization",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      }
+    })
+  },
+  executor: executor
 };
-const thirdPartyVulnerabilitiesCodec = recordCodec({
+const firstPartyVulnerabilitiesCodec = recordCodec(spec_firstPartyVulnerabilities);
+const spec_thirdPartyVulnerabilities = {
   name: "thirdPartyVulnerabilities",
   identifier: sql.identifier("polymorphic", "third_party_vulnerabilities"),
-  attributes: thirdPartyVulnerabilitiesAttributes,
-  description: undefined,
-  extensions: extensions20,
-  executor
-});
-const awsApplicationsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_deployed: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  organization_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  aws_id: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions21 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "aws_applications"
-  },
-  tags: Object.assign(Object.create(null), {
-    implements: "Application",
-    ref: ["vulnerabilities to:Vulnerability plural", "owner to:PersonOrOrganization singular"],
-    refVia: ["vulnerabilities via:(id)->aws_application_first_party_vulnerabilities(aws_application_id);(first_party_vulnerability_id)->first_party_vulnerabilities(id)", "vulnerabilities via:(id)->aws_application_third_party_vulnerabilities(aws_application_id);(third_party_vulnerability_id)->third_party_vulnerabilities(id)", "owner via:people", "owner via:organizations"]
-  }),
-  refDefinitions: Object.assign(Object.create(null), {
-    vulnerabilities: {
-      singular: false,
-      graphqlType: "Vulnerability",
-      sourceGraphqlType: undefined,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
       extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
+        tags: {}
       }
     },
-    owner: {
-      singular: true,
-      graphqlType: "PersonOrOrganization",
-      sourceGraphqlType: undefined,
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
       extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
+        tags: {}
+      }
+    },
+    cvss_score: {
+      description: undefined,
+      codec: TYPES.float,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    vendor_name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
       }
     }
-  })
+  }),
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "third_party_vulnerabilities"
+    },
+    tags: Object.assign(Object.create(null), {
+      implements: "Vulnerability",
+      ref: ["applications to:Application plural", "owners to:PersonOrOrganization plural"],
+      refVia: ["applications via:aws_application_third_party_vulnerabilities;aws_applications", "applications via:gcp_application_third_party_vulnerabilities;gcp_applications", "owners via:aws_application_third_party_vulnerabilities;aws_applications;people", "owners via:aws_application_third_party_vulnerabilities;aws_applications;organizations", "owners via:gcp_application_third_party_vulnerabilities;gcp_applications;people", "owners via:gcp_application_third_party_vulnerabilities;gcp_applications;organizations"]
+    }),
+    refDefinitions: Object.assign(Object.create(null), {
+      applications: {
+        singular: false,
+        graphqlType: "Application",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      },
+      owners: {
+        singular: false,
+        graphqlType: "PersonOrOrganization",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      }
+    })
+  },
+  executor: executor
 };
-const awsApplicationsCodec = recordCodec({
+const thirdPartyVulnerabilitiesCodec = recordCodec(spec_thirdPartyVulnerabilities);
+const spec_awsApplications = {
   name: "awsApplications",
   identifier: sql.identifier("polymorphic", "aws_applications"),
-  attributes: awsApplicationsAttributes,
-  description: undefined,
-  extensions: extensions21,
-  executor
-});
-const gcpApplicationsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_deployed: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  organization_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  gcp_id: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions22 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "gcp_applications"
-  },
-  tags: Object.assign(Object.create(null), {
-    implements: "Application",
-    ref: ["vulnerabilities to:Vulnerability plural", "owner to:PersonOrOrganization singular"],
-    refVia: ["vulnerabilities via:(id)->gcp_application_first_party_vulnerabilities(gcp_application_id);(first_party_vulnerability_id)->first_party_vulnerabilities(id)", "vulnerabilities via:(id)->gcp_application_third_party_vulnerabilities(gcp_application_id);(third_party_vulnerability_id)->third_party_vulnerabilities(id)", "owner via:people", "owner via:organizations"]
-  }),
-  refDefinitions: Object.assign(Object.create(null), {
-    vulnerabilities: {
-      singular: false,
-      graphqlType: "Vulnerability",
-      sourceGraphqlType: undefined,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
       extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
+        tags: {}
       }
     },
-    owner: {
-      singular: true,
-      graphqlType: "PersonOrOrganization",
-      sourceGraphqlType: undefined,
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
       extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
+        tags: {}
+      }
+    },
+    last_deployed: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    organization_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    aws_id: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
       }
     }
-  })
+  }),
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "aws_applications"
+    },
+    tags: Object.assign(Object.create(null), {
+      implements: "Application",
+      ref: ["vulnerabilities to:Vulnerability plural", "owner to:PersonOrOrganization singular"],
+      refVia: ["vulnerabilities via:(id)->aws_application_first_party_vulnerabilities(aws_application_id);(first_party_vulnerability_id)->first_party_vulnerabilities(id)", "vulnerabilities via:(id)->aws_application_third_party_vulnerabilities(aws_application_id);(third_party_vulnerability_id)->third_party_vulnerabilities(id)", "owner via:people", "owner via:organizations"]
+    }),
+    refDefinitions: Object.assign(Object.create(null), {
+      vulnerabilities: {
+        singular: false,
+        graphqlType: "Vulnerability",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      },
+      owner: {
+        singular: true,
+        graphqlType: "PersonOrOrganization",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      }
+    })
+  },
+  executor: executor
 };
-const gcpApplicationsCodec = recordCodec({
+const awsApplicationsCodec = recordCodec(spec_awsApplications);
+const spec_gcpApplications = {
   name: "gcpApplications",
   identifier: sql.identifier("polymorphic", "gcp_applications"),
-  attributes: gcpApplicationsAttributes,
-  description: undefined,
-  extensions: extensions22,
-  executor
-});
-const singleTableItemsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  type: {
-    description: undefined,
-    codec: itemTypeCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  parent_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  root_topic_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  position: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  created_at: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  updated_at: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  is_explicitly_archived: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  archived_at: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  description: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  note: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  color: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  priority_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions23 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "single_table_items"
-  },
-  tags: Object.assign(Object.create(null), {
-    interface: "mode:single type:type",
-    type: ["TOPIC name:SingleTableTopic attributes:title!", "POST name:SingleTablePost attributes:title>subject,description,note,priority_id", "DIVIDER name:SingleTableDivider attributes:title,color", "CHECKLIST name:SingleTableChecklist attributes:title", "CHECKLIST_ITEM name:SingleTableChecklistItem attributes:description,note,priority_id"],
-    ref: ["rootTopic to:SingleTableTopic singular via:(root_topic_id)->polymorphic.single_table_items(id)", "rootChecklistTopic from:SingleTableChecklist to:SingleTableTopic singular via:(root_topic_id)->polymorphic.single_table_items(id)"]
-  }),
-  refDefinitions: Object.assign(Object.create(null), {
-    rootTopic: {
-      singular: true,
-      graphqlType: "SingleTableTopic",
-      sourceGraphqlType: undefined,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
       extensions: {
-        via: "(root_topic_id)->polymorphic.single_table_items(id)",
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_deployed: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    organization_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    gcp_id: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "gcp_applications"
+    },
+    tags: Object.assign(Object.create(null), {
+      implements: "Application",
+      ref: ["vulnerabilities to:Vulnerability plural", "owner to:PersonOrOrganization singular"],
+      refVia: ["vulnerabilities via:(id)->gcp_application_first_party_vulnerabilities(gcp_application_id);(first_party_vulnerability_id)->first_party_vulnerabilities(id)", "vulnerabilities via:(id)->gcp_application_third_party_vulnerabilities(gcp_application_id);(third_party_vulnerability_id)->third_party_vulnerabilities(id)", "owner via:people", "owner via:organizations"]
+    }),
+    refDefinitions: Object.assign(Object.create(null), {
+      vulnerabilities: {
+        singular: false,
+        graphqlType: "Vulnerability",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      },
+      owner: {
+        singular: true,
+        graphqlType: "PersonOrOrganization",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      }
+    })
+  },
+  executor: executor
+};
+const gcpApplicationsCodec = recordCodec(spec_gcpApplications);
+const spec_singleTableItems = {
+  name: "singleTableItems",
+  identifier: sql.identifier("polymorphic", "single_table_items"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    type: {
+      description: undefined,
+      codec: itemTypeCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    parent_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    root_topic_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    position: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    created_at: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    updated_at: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    is_explicitly_archived: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    archived_at: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    description: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    note: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    color: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    priority_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "single_table_items"
+    },
+    tags: Object.assign(Object.create(null), {
+      interface: "mode:single type:type",
+      type: ["TOPIC name:SingleTableTopic attributes:title!", "POST name:SingleTablePost attributes:title>subject,description,note,priority_id", "DIVIDER name:SingleTableDivider attributes:title,color", "CHECKLIST name:SingleTableChecklist attributes:title", "CHECKLIST_ITEM name:SingleTableChecklistItem attributes:description,note,priority_id"],
+      ref: ["rootTopic to:SingleTableTopic singular via:(root_topic_id)->polymorphic.single_table_items(id)", "rootChecklistTopic from:SingleTableChecklist to:SingleTableTopic singular via:(root_topic_id)->polymorphic.single_table_items(id)"]
+    }),
+    refDefinitions: Object.assign(Object.create(null), {
+      rootTopic: {
+        singular: true,
+        graphqlType: "SingleTableTopic",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: "(root_topic_id)->polymorphic.single_table_items(id)",
+          tags: {
+            behavior: undefined
+          }
+        }
+      },
+      rootChecklistTopic: {
+        singular: true,
+        graphqlType: "SingleTableTopic",
+        sourceGraphqlType: "SingleTableChecklist",
+        extensions: {
+          via: "(root_topic_id)->polymorphic.single_table_items(id)",
+          tags: {
+            behavior: undefined
+          }
+        }
+      }
+    })
+  },
+  executor: executor,
+  polymorphism: {
+    mode: "single",
+    commonAttributes: ["id", "type", "parent_id", "root_topic_id", "author_id", "position", "created_at", "updated_at", "is_explicitly_archived", "archived_at"],
+    typeAttributes: ["type"],
+    types: Object.assign(Object.create(null), {
+      TOPIC: {
+        name: "SingleTableTopic",
+        attributes: [{
+          attribute: "title",
+          isNotNull: true,
+          rename: undefined
+        }]
+      },
+      POST: {
+        name: "SingleTablePost",
+        attributes: [{
+          attribute: "title",
+          isNotNull: false,
+          rename: "subject"
+        }, {
+          attribute: "description",
+          isNotNull: false,
+          rename: undefined
+        }, {
+          attribute: "note",
+          isNotNull: false,
+          rename: undefined
+        }, {
+          attribute: "priority_id",
+          isNotNull: false,
+          rename: undefined
+        }]
+      },
+      DIVIDER: {
+        name: "SingleTableDivider",
+        attributes: [{
+          attribute: "title",
+          isNotNull: false,
+          rename: undefined
+        }, {
+          attribute: "color",
+          isNotNull: false,
+          rename: undefined
+        }]
+      },
+      CHECKLIST: {
+        name: "SingleTableChecklist",
+        attributes: [{
+          attribute: "title",
+          isNotNull: false,
+          rename: undefined
+        }]
+      },
+      CHECKLIST_ITEM: {
+        name: "SingleTableChecklistItem",
+        attributes: [{
+          attribute: "description",
+          isNotNull: false,
+          rename: undefined
+        }, {
+          attribute: "note",
+          isNotNull: false,
+          rename: undefined
+        }, {
+          attribute: "priority_id",
+          isNotNull: false,
+          rename: undefined
+        }]
+      }
+    })
+  }
+};
+const singleTableItemsCodec = recordCodec(spec_singleTableItems);
+const spec_relationalItems = {
+  name: "relationalItems",
+  identifier: sql.identifier("polymorphic", "relational_items"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.id.extensions.tags
+      }
+    },
+    type: {
+      description: undefined,
+      codec: itemTypeCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.type.extensions.tags
+      }
+    },
+    parent_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.parent_id.extensions.tags
+      }
+    },
+    root_topic_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.root_topic_id.extensions.tags
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.author_id.extensions.tags
+      }
+    },
+    position: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.position.extensions.tags
+      }
+    },
+    created_at: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.created_at.extensions.tags
+      }
+    },
+    updated_at: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.updated_at.extensions.tags
+      }
+    },
+    is_explicitly_archived: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.is_explicitly_archived.extensions.tags
+      }
+    },
+    archived_at: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.archived_at.extensions.tags
+      }
+    }
+  }),
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_items"
+    },
+    tags: Object.assign(Object.create(null), {
+      interface: "mode:relational",
+      type: ["TOPIC references:relational_topics", "POST references:relational_posts", "DIVIDER references:relational_dividers", "CHECKLIST references:relational_checklists", "CHECKLIST_ITEM references:relational_checklist_items"]
+    })
+  },
+  executor: executor,
+  polymorphism: {
+    mode: "relational",
+    typeAttributes: ["type"],
+    types: Object.assign(Object.create(null), {
+      TOPIC: {
+        name: "RelationalTopic",
+        references: "relational_topics",
+        relationName: "relationalTopicsByTheirTopicItemId"
+      },
+      POST: {
+        name: "RelationalPost",
+        references: "relational_posts",
+        relationName: "relationalPostsByTheirPostItemId"
+      },
+      DIVIDER: {
+        name: "RelationalDivider",
+        references: "relational_dividers",
+        relationName: "relationalDividersByTheirDividerItemId"
+      },
+      CHECKLIST: {
+        name: "RelationalChecklist",
+        references: "relational_checklists",
+        relationName: "relationalChecklistsByTheirChecklistItemId"
+      },
+      CHECKLIST_ITEM: {
+        name: "RelationalChecklistItem",
+        references: "relational_checklist_items",
+        relationName: "relationalChecklistItemsByTheirChecklistItemItemId"
+      }
+    })
+  }
+};
+const relationalItemsCodec = recordCodec(spec_relationalItems);
+const spec_Application = {
+  name: "Application",
+  identifier: sql.identifier("polymorphic", "applications"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
         tags: {
-          behavior: undefined
+          notNull: true
         }
       }
     },
-    rootChecklistTopic: {
-      singular: true,
-      graphqlType: "SingleTableTopic",
-      sourceGraphqlType: "SingleTableChecklist",
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
       extensions: {
-        via: "(root_topic_id)->polymorphic.single_table_items(id)",
         tags: {
-          behavior: undefined
+          notNull: true
+        }
+      }
+    },
+    last_deployed: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
+  description: undefined,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "applications"
+    },
+    tags: Object.assign(Object.create(null), {
+      interface: "mode:union",
+      name: "Application",
+      behavior: "node",
+      ref: ["vulnerabilities to:Vulnerability plural", "owner to:PersonOrOrganization singular"]
+    }),
+    refDefinitions: Object.assign(Object.create(null), {
+      vulnerabilities: {
+        singular: false,
+        graphqlType: "Vulnerability",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      },
+      owner: {
+        singular: true,
+        graphqlType: "PersonOrOrganization",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      }
+    })
+  },
+  executor: executor,
+  polymorphism: {
+    mode: "union"
+  }
+};
+const spec_Vulnerability = {
+  name: "Vulnerability",
+  identifier: sql.identifier("polymorphic", "vulnerabilities"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          notNull: true
+        }
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          notNull: true
+        }
+      }
+    },
+    cvss_score: {
+      description: undefined,
+      codec: TYPES.float,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          notNull: true
         }
       }
     }
-  })
-};
-const singleTableItemsCodec = recordCodec({
-  name: "singleTableItems",
-  identifier: sql.identifier("polymorphic", "single_table_items"),
-  attributes: singleTableItemsAttributes,
+  }),
   description: undefined,
-  extensions: extensions23,
-  executor
-});
-const relationalItemsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: relationalChecklistsAttributes.id.extensions.tags
-    }
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "vulnerabilities"
+    },
+    tags: Object.assign(Object.create(null), {
+      interface: "mode:union",
+      name: "Vulnerability",
+      behavior: "node",
+      ref: ["applications to:Application plural", "owners to:PersonOrOrganization plural"]
+    }),
+    refDefinitions: Object.assign(Object.create(null), {
+      applications: {
+        singular: false,
+        graphqlType: "Application",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      },
+      owners: {
+        singular: false,
+        graphqlType: "PersonOrOrganization",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      }
+    })
   },
-  type: {
-    description: undefined,
-    codec: itemTypeCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: relationalChecklistsAttributes.type.extensions.tags
-    }
-  },
-  parent_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: relationalChecklistsAttributes.parent_id.extensions.tags
-    }
-  },
-  root_topic_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: relationalChecklistsAttributes.root_topic_id.extensions.tags
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: relationalChecklistsAttributes.author_id.extensions.tags
-    }
-  },
-  position: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: relationalChecklistsAttributes.position.extensions.tags
-    }
-  },
-  created_at: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: relationalChecklistsAttributes.created_at.extensions.tags
-    }
-  },
-  updated_at: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: relationalChecklistsAttributes.updated_at.extensions.tags
-    }
-  },
-  is_explicitly_archived: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: relationalChecklistsAttributes.is_explicitly_archived.extensions.tags
-    }
-  },
-  archived_at: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: relationalChecklistsAttributes.archived_at.extensions.tags
-    }
+  executor: executor,
+  polymorphism: {
+    mode: "union"
   }
-});
-const extensions24 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_items"
-  },
-  tags: Object.assign(Object.create(null), {
-    interface: "mode:relational",
-    type: ["TOPIC references:relational_topics", "POST references:relational_posts", "DIVIDER references:relational_dividers", "CHECKLIST references:relational_checklists", "CHECKLIST_ITEM references:relational_checklist_items"]
-  })
 };
-const relationalItemsCodec = recordCodec({
-  name: "relationalItems",
-  identifier: sql.identifier("polymorphic", "relational_items"),
-  attributes: relationalItemsAttributes,
+const spec_ZeroImplementation = {
+  name: "ZeroImplementation",
+  identifier: sql.identifier("polymorphic", "zero_implementation"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions24,
-  executor
-});
-const ApplicationAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        notNull: true
-      }
-    }
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "zero_implementation"
+    },
+    tags: Object.assign(Object.create(null), {
+      interface: "mode:union",
+      name: "ZeroImplementation",
+      behavior: "node"
+    })
   },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        notNull: true
-      }
-    }
-  },
-  last_deployed: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  executor: executor,
+  polymorphism: {
+    mode: "union"
   }
-});
-const VulnerabilityAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        notNull: true
-      }
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        notNull: true
-      }
-    }
-  },
-  cvss_score: {
-    description: undefined,
-    codec: TYPES.float,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        notNull: true
-      }
-    }
-  }
-});
-const ZeroImplementationAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
+};
 const registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws_application_first_party_vulnerabilities = {
   executor,
   name: "aws_application_first_party_vulnerabilities",
@@ -2092,7 +2303,7 @@ const registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws
     },
     tags: {
       omit: true,
-      behavior: extensions.tags.behavior
+      behavior: spec_awsApplicationFirstPartyVulnerabilities.extensions.tags.behavior
     }
   }
 };
@@ -2121,7 +2332,7 @@ const registryConfig_pgResources_aws_application_third_party_vulnerabilities_aws
     },
     tags: {
       omit: true,
-      behavior: extensions2.tags.behavior
+      behavior: spec_awsApplicationThirdPartyVulnerabilities.extensions.tags.behavior
     }
   }
 };
@@ -2150,7 +2361,7 @@ const registryConfig_pgResources_gcp_application_first_party_vulnerabilities_gcp
     },
     tags: {
       omit: true,
-      behavior: extensions3.tags.behavior
+      behavior: spec_gcpApplicationFirstPartyVulnerabilities.extensions.tags.behavior
     }
   }
 };
@@ -2179,7 +2390,7 @@ const registryConfig_pgResources_gcp_application_third_party_vulnerabilities_gcp
     },
     tags: {
       omit: true,
-      behavior: extensions4.tags.behavior
+      behavior: spec_gcpApplicationThirdPartyVulnerabilities.extensions.tags.behavior
     }
   }
 };
@@ -2253,7 +2464,7 @@ const registryConfig_pgResources_people_people = {
     tags: {
       unionMember: "PersonOrOrganization",
       ref: "applications to:Application",
-      refVia: extensions6.tags.refVia
+      refVia: spec_people.extensions.tags.refVia
     }
   }
 };
@@ -2282,7 +2493,7 @@ const registryConfig_pgResources_priorities_priorities = {
     },
     tags: {
       omit: "create,update,delete,filter,order",
-      behavior: extensions7.tags.behavior
+      behavior: spec_priorities.extensions.tags.behavior
     }
   }
 };
@@ -2542,7 +2753,7 @@ const registryConfig_pgResources_log_entries_log_entries = {
     },
     tags: {
       ref: "author to:PersonOrOrganization singular",
-      refVia: extensions17.tags.refVia
+      refVia: spec_logEntries.extensions.tags.refVia
     }
   }
 };
@@ -2599,8 +2810,8 @@ const registryConfig_pgResources_first_party_vulnerabilities_first_party_vulnera
     },
     tags: {
       implements: "Vulnerability",
-      ref: extensions19.tags.ref,
-      refVia: extensions19.tags.refVia
+      ref: spec_firstPartyVulnerabilities.extensions.tags.ref,
+      refVia: spec_firstPartyVulnerabilities.extensions.tags.refVia
     }
   }
 };
@@ -2630,8 +2841,8 @@ const registryConfig_pgResources_third_party_vulnerabilities_third_party_vulnera
     },
     tags: {
       implements: "Vulnerability",
-      ref: extensions20.tags.ref,
-      refVia: extensions20.tags.refVia
+      ref: spec_thirdPartyVulnerabilities.extensions.tags.ref,
+      refVia: spec_thirdPartyVulnerabilities.extensions.tags.refVia
     }
   }
 };
@@ -2661,8 +2872,8 @@ const registryConfig_pgResources_aws_applications_aws_applications = {
     },
     tags: {
       implements: "Application",
-      ref: extensions21.tags.ref,
-      refVia: extensions21.tags.refVia
+      ref: spec_awsApplications.extensions.tags.ref,
+      refVia: spec_awsApplications.extensions.tags.refVia
     }
   }
 };
@@ -2692,8 +2903,8 @@ const registryConfig_pgResources_gcp_applications_gcp_applications = {
     },
     tags: {
       implements: "Application",
-      ref: extensions22.tags.ref,
-      refVia: extensions22.tags.refVia
+      ref: spec_gcpApplications.extensions.tags.ref,
+      refVia: spec_gcpApplications.extensions.tags.refVia
     }
   }
 };
@@ -2724,8 +2935,8 @@ const registryConfig_pgResources_single_table_items_single_table_items = {
     },
     tags: {
       interface: "mode:single type:type",
-      type: extensions23.tags.type,
-      ref: extensions23.tags.ref
+      type: spec_singleTableItems.extensions.tags.type,
+      ref: spec_singleTableItems.extensions.tags.ref
     }
   }
 };
@@ -2757,7 +2968,7 @@ const registryConfig_pgResources_relational_items_relational_items = {
     },
     tags: {
       interface: "mode:relational",
-      type: extensions24.tags.type
+      type: spec_relationalItems.extensions.tags.type
     }
   }
 };
@@ -2795,116 +3006,9 @@ const registryConfig = {
     relationalItems: relationalItemsCodec,
     varchar: TYPES.varchar,
     bpchar: TYPES.bpchar,
-    Application: recordCodec({
-      name: "Application",
-      identifier: sql.identifier("polymorphic", "applications"),
-      attributes: ApplicationAttributes,
-      description: undefined,
-      extensions: {
-        isTableLike: false,
-        pg: {
-          serviceName: "main",
-          schemaName: "polymorphic",
-          name: "applications"
-        },
-        tags: Object.assign(Object.create(null), {
-          interface: "mode:union",
-          name: "Application",
-          behavior: "node",
-          ref: ["vulnerabilities to:Vulnerability plural", "owner to:PersonOrOrganization singular"]
-        }),
-        refDefinitions: Object.assign(Object.create(null), {
-          vulnerabilities: {
-            singular: false,
-            graphqlType: "Vulnerability",
-            sourceGraphqlType: undefined,
-            extensions: {
-              via: undefined,
-              tags: {
-                behavior: undefined
-              }
-            }
-          },
-          owner: {
-            singular: true,
-            graphqlType: "PersonOrOrganization",
-            sourceGraphqlType: undefined,
-            extensions: {
-              via: undefined,
-              tags: {
-                behavior: undefined
-              }
-            }
-          }
-        })
-      },
-      executor
-    }),
-    Vulnerability: recordCodec({
-      name: "Vulnerability",
-      identifier: sql.identifier("polymorphic", "vulnerabilities"),
-      attributes: VulnerabilityAttributes,
-      description: undefined,
-      extensions: {
-        isTableLike: false,
-        pg: {
-          serviceName: "main",
-          schemaName: "polymorphic",
-          name: "vulnerabilities"
-        },
-        tags: Object.assign(Object.create(null), {
-          interface: "mode:union",
-          name: "Vulnerability",
-          behavior: "node",
-          ref: ["applications to:Application plural", "owners to:PersonOrOrganization plural"]
-        }),
-        refDefinitions: Object.assign(Object.create(null), {
-          applications: {
-            singular: false,
-            graphqlType: "Application",
-            sourceGraphqlType: undefined,
-            extensions: {
-              via: undefined,
-              tags: {
-                behavior: undefined
-              }
-            }
-          },
-          owners: {
-            singular: false,
-            graphqlType: "PersonOrOrganization",
-            sourceGraphqlType: undefined,
-            extensions: {
-              via: undefined,
-              tags: {
-                behavior: undefined
-              }
-            }
-          }
-        })
-      },
-      executor
-    }),
-    ZeroImplementation: recordCodec({
-      name: "ZeroImplementation",
-      identifier: sql.identifier("polymorphic", "zero_implementation"),
-      attributes: ZeroImplementationAttributes,
-      description: undefined,
-      extensions: {
-        isTableLike: false,
-        pg: {
-          serviceName: "main",
-          schemaName: "polymorphic",
-          name: "zero_implementation"
-        },
-        tags: Object.assign(Object.create(null), {
-          interface: "mode:union",
-          name: "ZeroImplementation",
-          behavior: "node"
-        })
-      },
-      executor
-    })
+    Application: recordCodec(spec_Application),
+    Vulnerability: recordCodec(spec_Vulnerability),
+    ZeroImplementation: recordCodec(spec_ZeroImplementation)
   }),
   pgResources: Object.assign(Object.create(null), {
     aws_application_first_party_vulnerabilities: registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws_application_first_party_vulnerabilities,
@@ -4106,6 +4210,9 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
 };
 const otherSource_single_table_item_relationsPgResource = registry.pgResources["single_table_item_relations"];
 const otherSource_single_table_item_relation_composite_pksPgResource = registry.pgResources["single_table_item_relation_composite_pks"];
+function BigIntSerialize(value) {
+  return "" + value;
+}
 const otherSource_log_entriesPgResource = registry.pgResources["log_entries"];
 const otherSource_relational_itemsPgResource = registry.pgResources["relational_items"];
 const otherSource_aws_applicationsPgResource = registry.pgResources["aws_applications"];
@@ -12460,6 +12567,26 @@ export const plans = {
       });
     }
   },
+  BigInt: {
+    serialize: BigIntSerialize,
+    parseValue: BigIntSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigInt" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  Datetime: {
+    serialize: BigIntSerialize,
+    parseValue: BigIntSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   Person: {
     __assertStep: assertPgClassSingleStep,
     personId($record) {
@@ -12763,7 +12890,7 @@ export const plans = {
           }, Object.create(null));
         }
         const $list = pgUnionAll({
-          attributes: ApplicationAttributes,
+          attributes: spec_Application.attributes,
           resourceByTypeName,
           members,
           name: "applications"
@@ -13078,6 +13205,16 @@ export const plans = {
       }
     }
   },
+  Cursor: {
+    serialize: BigIntSerialize,
+    parseValue: BigIntSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   LogEntriesOrderBy: {
     NATURAL: {
       applyPlan() {}
@@ -13267,7 +13404,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), logEntriesAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_logEntries.attributes.id.codec)}`;
             }
           });
         }
@@ -13290,7 +13427,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), logEntriesAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_logEntries.attributes.person_id.codec)}`;
             }
           });
         }
@@ -13313,7 +13450,7 @@ export const plans = {
             type: "attribute",
             attribute: "organization_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), logEntriesAttributes.organization_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_logEntries.attributes.organization_id.codec)}`;
             }
           });
         }
@@ -13336,7 +13473,7 @@ export const plans = {
             type: "attribute",
             attribute: "text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), logEntriesAttributes.text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_logEntries.attributes.text.codec)}`;
             }
           });
         }
@@ -13406,7 +13543,7 @@ export const plans = {
           }, Object.create(null));
         }
         const $list = pgUnionAll({
-          attributes: VulnerabilityAttributes,
+          attributes: spec_Vulnerability.attributes,
           resourceByTypeName: resourceByTypeName3,
           members: members3,
           name: "vulnerabilities"
@@ -13713,7 +13850,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), VulnerabilityAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_Vulnerability.attributes.id.codec)}`;
             }
           });
         }
@@ -13736,7 +13873,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), VulnerabilityAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_Vulnerability.attributes.name.codec)}`;
             }
           });
         }
@@ -13759,7 +13896,7 @@ export const plans = {
             type: "attribute",
             attribute: "cvss_score",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), VulnerabilityAttributes.cvss_score.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_Vulnerability.attributes.cvss_score.codec)}`;
             }
           });
         }
@@ -14034,7 +14171,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_awsApplications.attributes.id.codec)}`;
             }
           });
         }
@@ -14057,7 +14194,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_awsApplications.attributes.name.codec)}`;
             }
           });
         }
@@ -14080,7 +14217,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_deployed",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.last_deployed.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_awsApplications.attributes.last_deployed.codec)}`;
             }
           });
         }
@@ -14103,7 +14240,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_awsApplications.attributes.person_id.codec)}`;
             }
           });
         }
@@ -14126,7 +14263,7 @@ export const plans = {
             type: "attribute",
             attribute: "organization_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.organization_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_awsApplications.attributes.organization_id.codec)}`;
             }
           });
         }
@@ -14149,7 +14286,7 @@ export const plans = {
             type: "attribute",
             attribute: "aws_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.aws_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_awsApplications.attributes.aws_id.codec)}`;
             }
           });
         }
@@ -14219,7 +14356,7 @@ export const plans = {
           }, Object.create(null));
         }
         const $list = pgUnionAll({
-          attributes: VulnerabilityAttributes,
+          attributes: spec_Vulnerability.attributes,
           resourceByTypeName: resourceByTypeName5,
           members: members5,
           name: "vulnerabilities"
@@ -14582,7 +14719,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_gcpApplications.attributes.id.codec)}`;
             }
           });
         }
@@ -14605,7 +14742,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_gcpApplications.attributes.name.codec)}`;
             }
           });
         }
@@ -14628,7 +14765,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_deployed",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.last_deployed.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_gcpApplications.attributes.last_deployed.codec)}`;
             }
           });
         }
@@ -14651,7 +14788,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_gcpApplications.attributes.person_id.codec)}`;
             }
           });
         }
@@ -14674,7 +14811,7 @@ export const plans = {
             type: "attribute",
             attribute: "organization_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.organization_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_gcpApplications.attributes.organization_id.codec)}`;
             }
           });
         }
@@ -14697,7 +14834,7 @@ export const plans = {
             type: "attribute",
             attribute: "gcp_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.gcp_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_gcpApplications.attributes.gcp_id.codec)}`;
             }
           });
         }
@@ -15133,7 +15270,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItems.attributes.id.codec)}`;
             }
           });
         }
@@ -15156,7 +15293,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItems.attributes.type.codec)}`;
             }
           });
         }
@@ -15179,7 +15316,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItems.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -15202,7 +15339,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItems.attributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -15225,7 +15362,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItems.attributes.author_id.codec)}`;
             }
           });
         }
@@ -15248,7 +15385,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItems.attributes.position.codec)}`;
             }
           });
         }
@@ -15271,7 +15408,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItems.attributes.created_at.codec)}`;
             }
           });
         }
@@ -15294,7 +15431,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItems.attributes.updated_at.codec)}`;
             }
           });
         }
@@ -15317,7 +15454,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItems.attributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -15340,7 +15477,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItems.attributes.archived_at.codec)}`;
             }
           });
         }
@@ -15858,7 +15995,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.id.codec)}`;
             }
           });
         }
@@ -15881,7 +16018,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.type.codec)}`;
             }
           });
         }
@@ -15904,7 +16041,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -15927,7 +16064,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -15950,7 +16087,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.author_id.codec)}`;
             }
           });
         }
@@ -15973,7 +16110,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.position.codec)}`;
             }
           });
         }
@@ -15996,7 +16133,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.created_at.codec)}`;
             }
           });
         }
@@ -16019,7 +16156,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.updated_at.codec)}`;
             }
           });
         }
@@ -16042,7 +16179,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -16065,7 +16202,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.archived_at.codec)}`;
             }
           });
         }
@@ -16197,7 +16334,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), ApplicationAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_Application.attributes.id.codec)}`;
             }
           });
         }
@@ -16220,7 +16357,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), ApplicationAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_Application.attributes.name.codec)}`;
             }
           });
         }
@@ -16243,7 +16380,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_deployed",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), ApplicationAttributes.last_deployed.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_Application.attributes.last_deployed.codec)}`;
             }
           });
         }
@@ -16498,7 +16635,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemRelationsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItemRelations.attributes.id.codec)}`;
             }
           });
         }
@@ -16521,7 +16658,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemRelationsAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItemRelations.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -16544,7 +16681,7 @@ export const plans = {
             type: "attribute",
             attribute: "child_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemRelationsAttributes.child_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItemRelations.attributes.child_id.codec)}`;
             }
           });
         }
@@ -16674,7 +16811,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemRelationCompositePksAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItemRelationCompositePks.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -16697,7 +16834,7 @@ export const plans = {
             type: "attribute",
             attribute: "child_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemRelationCompositePksAttributes.child_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItemRelationCompositePks.attributes.child_id.codec)}`;
             }
           });
         }
@@ -18807,7 +18944,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemRelationsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItemRelations.attributes.id.codec)}`;
             }
           });
         }
@@ -18830,7 +18967,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemRelationsAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItemRelations.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -18853,7 +18990,7 @@ export const plans = {
             type: "attribute",
             attribute: "child_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemRelationsAttributes.child_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItemRelations.attributes.child_id.codec)}`;
             }
           });
         }
@@ -18983,7 +19120,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemRelationCompositePksAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItemRelationCompositePks.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -19006,7 +19143,7 @@ export const plans = {
             type: "attribute",
             attribute: "child_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemRelationCompositePksAttributes.child_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItemRelationCompositePks.attributes.child_id.codec)}`;
             }
           });
         }
@@ -21179,7 +21316,7 @@ export const plans = {
     allVulnerabilities: {
       plan() {
         const $list = pgUnionAll({
-          attributes: VulnerabilityAttributes,
+          attributes: spec_Vulnerability.attributes,
           resourceByTypeName: resourceByTypeName7,
           members: members7,
           name: "Vulnerability"
@@ -21245,7 +21382,7 @@ export const plans = {
     allApplications: {
       plan() {
         const $list = pgUnionAll({
-          attributes: ApplicationAttributes,
+          attributes: spec_Application.attributes,
           resourceByTypeName: resourceByTypeName8,
           members: members8,
           name: "Application"
@@ -21311,7 +21448,7 @@ export const plans = {
     allZeroImplementations: {
       plan() {
         const $list = pgUnionAll({
-          attributes: ZeroImplementationAttributes,
+          attributes: spec_ZeroImplementation.attributes,
           resourceByTypeName: resourceByTypeName9,
           members: members9,
           name: "ZeroImplementation"
@@ -22388,7 +22525,7 @@ export const plans = {
           }, Object.create(null));
         }
         const $list = pgUnionAll({
-          attributes: ApplicationAttributes,
+          attributes: spec_Application.attributes,
           resourceByTypeName: resourceByTypeName10,
           members: members10,
           name: "applications"
@@ -22514,7 +22651,7 @@ export const plans = {
           }, Object.create(null));
         }
         const $list = pgUnionAll({
-          attributes: ApplicationAttributes,
+          attributes: spec_Application.attributes,
           resourceByTypeName: resourceByTypeName12,
           members: members12,
           name: "applications"
@@ -22725,7 +22862,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), ZeroImplementationAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_ZeroImplementation.attributes.id.codec)}`;
             }
           });
         }
@@ -22748,7 +22885,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), ZeroImplementationAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_ZeroImplementation.attributes.name.codec)}`;
             }
           });
         }
@@ -22903,7 +23040,7 @@ export const plans = {
             type: "attribute",
             attribute: "organization_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), organizationsAttributes.organization_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_organizations.attributes.organization_id.codec)}`;
             }
           });
         }
@@ -22926,7 +23063,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), organizationsAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_organizations.attributes.name.codec)}`;
             }
           });
         }
@@ -23081,7 +23218,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), peopleAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_people.attributes.person_id.codec)}`;
             }
           });
         }
@@ -23104,7 +23241,7 @@ export const plans = {
             type: "attribute",
             attribute: "username",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), peopleAttributes.username.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_people.attributes.username.codec)}`;
             }
           });
         }
@@ -23590,7 +23727,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.title.codec)}`;
             }
           });
         }
@@ -23613,7 +23750,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.id.codec)}`;
             }
           });
         }
@@ -23636,7 +23773,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.type.codec)}`;
             }
           });
         }
@@ -23659,7 +23796,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -23682,7 +23819,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -23705,7 +23842,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.author_id.codec)}`;
             }
           });
         }
@@ -23728,7 +23865,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.position.codec)}`;
             }
           });
         }
@@ -23751,7 +23888,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.created_at.codec)}`;
             }
           });
         }
@@ -23774,7 +23911,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.updated_at.codec)}`;
             }
           });
         }
@@ -23797,7 +23934,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -23820,7 +23957,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.archived_at.codec)}`;
             }
           });
         }
@@ -24281,7 +24418,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.title.codec)}`;
             }
           });
         }
@@ -24304,7 +24441,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.id.codec)}`;
             }
           });
         }
@@ -24327,7 +24464,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.type.codec)}`;
             }
           });
         }
@@ -24350,7 +24487,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -24373,7 +24510,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -24396,7 +24533,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.author_id.codec)}`;
             }
           });
         }
@@ -24419,7 +24556,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.position.codec)}`;
             }
           });
         }
@@ -24442,7 +24579,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.created_at.codec)}`;
             }
           });
         }
@@ -24465,7 +24602,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.updated_at.codec)}`;
             }
           });
         }
@@ -24488,7 +24625,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -24511,7 +24648,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.archived_at.codec)}`;
             }
           });
         }
@@ -25006,7 +25143,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.description.codec)}`;
             }
           });
         }
@@ -25029,7 +25166,7 @@ export const plans = {
             type: "attribute",
             attribute: "note",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.note.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.note.codec)}`;
             }
           });
         }
@@ -25052,7 +25189,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.id.codec)}`;
             }
           });
         }
@@ -25075,7 +25212,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.type.codec)}`;
             }
           });
         }
@@ -25098,7 +25235,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -25121,7 +25258,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -25144,7 +25281,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.author_id.codec)}`;
             }
           });
         }
@@ -25167,7 +25304,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.position.codec)}`;
             }
           });
         }
@@ -25190,7 +25327,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.created_at.codec)}`;
             }
           });
         }
@@ -25213,7 +25350,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.updated_at.codec)}`;
             }
           });
         }
@@ -25236,7 +25373,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -25259,7 +25396,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.archived_at.codec)}`;
             }
           });
         }
@@ -25754,7 +25891,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.title.codec)}`;
             }
           });
         }
@@ -25777,7 +25914,7 @@ export const plans = {
             type: "attribute",
             attribute: "color",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.color.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.color.codec)}`;
             }
           });
         }
@@ -25800,7 +25937,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.id.codec)}`;
             }
           });
         }
@@ -25823,7 +25960,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.type.codec)}`;
             }
           });
         }
@@ -25846,7 +25983,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -25869,7 +26006,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -25892,7 +26029,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.author_id.codec)}`;
             }
           });
         }
@@ -25915,7 +26052,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.position.codec)}`;
             }
           });
         }
@@ -25938,7 +26075,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.created_at.codec)}`;
             }
           });
         }
@@ -25961,7 +26098,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.updated_at.codec)}`;
             }
           });
         }
@@ -25984,7 +26121,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -26007,7 +26144,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.archived_at.codec)}`;
             }
           });
         }
@@ -26536,7 +26673,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.title.codec)}`;
             }
           });
         }
@@ -26559,7 +26696,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.description.codec)}`;
             }
           });
         }
@@ -26582,7 +26719,7 @@ export const plans = {
             type: "attribute",
             attribute: "note",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.note.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.note.codec)}`;
             }
           });
         }
@@ -26605,7 +26742,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.id.codec)}`;
             }
           });
         }
@@ -26628,7 +26765,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.type.codec)}`;
             }
           });
         }
@@ -26651,7 +26788,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -26674,7 +26811,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -26697,7 +26834,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.author_id.codec)}`;
             }
           });
         }
@@ -26720,7 +26857,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.position.codec)}`;
             }
           });
         }
@@ -26743,7 +26880,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.created_at.codec)}`;
             }
           });
         }
@@ -26766,7 +26903,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.updated_at.codec)}`;
             }
           });
         }
@@ -26789,7 +26926,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -26812,7 +26949,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.archived_at.codec)}`;
             }
           });
         }
@@ -27035,7 +27172,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), firstPartyVulnerabilitiesAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_firstPartyVulnerabilities.attributes.id.codec)}`;
             }
           });
         }
@@ -27058,7 +27195,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), firstPartyVulnerabilitiesAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_firstPartyVulnerabilities.attributes.name.codec)}`;
             }
           });
         }
@@ -27081,7 +27218,7 @@ export const plans = {
             type: "attribute",
             attribute: "cvss_score",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), firstPartyVulnerabilitiesAttributes.cvss_score.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_firstPartyVulnerabilities.attributes.cvss_score.codec)}`;
             }
           });
         }
@@ -27104,7 +27241,7 @@ export const plans = {
             type: "attribute",
             attribute: "team_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), firstPartyVulnerabilitiesAttributes.team_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_firstPartyVulnerabilities.attributes.team_name.codec)}`;
             }
           });
         }
@@ -27327,7 +27464,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), thirdPartyVulnerabilitiesAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_thirdPartyVulnerabilities.attributes.id.codec)}`;
             }
           });
         }
@@ -27350,7 +27487,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), thirdPartyVulnerabilitiesAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_thirdPartyVulnerabilities.attributes.name.codec)}`;
             }
           });
         }
@@ -27373,7 +27510,7 @@ export const plans = {
             type: "attribute",
             attribute: "cvss_score",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), thirdPartyVulnerabilitiesAttributes.cvss_score.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_thirdPartyVulnerabilities.attributes.cvss_score.codec)}`;
             }
           });
         }
@@ -27396,7 +27533,7 @@ export const plans = {
             type: "attribute",
             attribute: "vendor_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), thirdPartyVulnerabilitiesAttributes.vendor_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_thirdPartyVulnerabilities.attributes.vendor_name.codec)}`;
             }
           });
         }
@@ -28202,6 +28339,9 @@ export const plans = {
     }
   },
   OrganizationInput: {
+    "__inputPlan": function OrganizationInput_inputPlan() {
+      return object(Object.create(null));
+    },
     organizationId: {
       applyPlan($insert, val) {
         $insert.set("organization_id", val.get());
@@ -28276,6 +28416,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -28360,6 +28503,9 @@ export const plans = {
     }
   },
   RelationalItemRelationCompositePkInput: {
+    "__inputPlan": function RelationalItemRelationCompositePkInput_inputPlan() {
+      return object(Object.create(null));
+    },
     parentId: {
       applyPlan($insert, val) {
         $insert.set("parent_id", val.get());
@@ -28444,6 +28590,9 @@ export const plans = {
     }
   },
   SingleTableItemRelationCompositePkInput: {
+    "__inputPlan": function SingleTableItemRelationCompositePkInput_inputPlan() {
+      return object(Object.create(null));
+    },
     parentId: {
       applyPlan($insert, val) {
         $insert.set("parent_id", val.get());
@@ -28528,6 +28677,9 @@ export const plans = {
     }
   },
   RelationalItemRelationInput: {
+    "__inputPlan": function RelationalItemRelationInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -28619,6 +28771,9 @@ export const plans = {
     }
   },
   SingleTableItemRelationInput: {
+    "__inputPlan": function SingleTableItemRelationInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -28710,6 +28865,9 @@ export const plans = {
     }
   },
   LogEntryInput: {
+    "__inputPlan": function LogEntryInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -28798,6 +28956,9 @@ export const plans = {
     }
   },
   FirstPartyVulnerabilityInput: {
+    "__inputPlan": function FirstPartyVulnerabilityInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -28886,6 +29047,9 @@ export const plans = {
     }
   },
   ThirdPartyVulnerabilityInput: {
+    "__inputPlan": function ThirdPartyVulnerabilityInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -28984,6 +29148,9 @@ export const plans = {
     }
   },
   AwsApplicationInput: {
+    "__inputPlan": function AwsApplicationInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -29096,6 +29263,9 @@ export const plans = {
     }
   },
   GcpApplicationInput: {
+    "__inputPlan": function GcpApplicationInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -29197,6 +29367,9 @@ export const plans = {
     }
   },
   OrganizationPatch: {
+    "__inputPlan": function OrganizationPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     organizationId: {
       applyPlan($insert, val) {
         $insert.set("organization_id", val.get());
@@ -29284,6 +29457,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -29382,6 +29558,9 @@ export const plans = {
     }
   },
   RelationalItemRelationCompositePkPatch: {
+    "__inputPlan": function RelationalItemRelationCompositePkPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     parentId: {
       applyPlan($insert, val) {
         $insert.set("parent_id", val.get());
@@ -29466,6 +29645,9 @@ export const plans = {
     }
   },
   SingleTableItemRelationCompositePkPatch: {
+    "__inputPlan": function SingleTableItemRelationCompositePkPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     parentId: {
       applyPlan($insert, val) {
         $insert.set("parent_id", val.get());
@@ -29549,6 +29731,9 @@ export const plans = {
     }
   },
   RelationalItemRelationPatch: {
+    "__inputPlan": function RelationalItemRelationPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -29654,6 +29839,9 @@ export const plans = {
     }
   },
   SingleTableItemRelationPatch: {
+    "__inputPlan": function SingleTableItemRelationPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -29759,6 +29947,9 @@ export const plans = {
     }
   },
   LogEntryPatch: {
+    "__inputPlan": function LogEntryPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -29846,6 +30037,9 @@ export const plans = {
     }
   },
   FirstPartyVulnerabilityPatch: {
+    "__inputPlan": function FirstPartyVulnerabilityPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -29933,6 +30127,9 @@ export const plans = {
     }
   },
   ThirdPartyVulnerabilityPatch: {
+    "__inputPlan": function ThirdPartyVulnerabilityPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -30030,6 +30227,9 @@ export const plans = {
     }
   },
   AwsApplicationPatch: {
+    "__inputPlan": function AwsApplicationPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -30141,6 +30341,9 @@ export const plans = {
     }
   },
   GcpApplicationPatch: {
+    "__inputPlan": function GcpApplicationPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, makeRegistry, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgUpdateSingle, recordCodec } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId } from "grafast";
+import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -58,20 +75,7 @@ const executor = new PgExecutor({
     });
   }
 });
-const extensions = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "post"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "post_table",
-    omit: true,
-    behavior: ["-*"]
-  })
-};
-const post_tableCodec = recordCodec({
+const spec_post_table = {
   name: "post_table",
   identifier: sql.identifier("smart_comment_relations", "post"),
   attributes: Object.assign(Object.create(null), {
@@ -86,24 +90,36 @@ const post_tableCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions,
-  executor
-});
-const postsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const postsCodec = recordCodec({
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "post"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "post_table",
+      omit: true,
+      behavior: ["-*"]
+    })
+  },
+  executor: executor
+};
+const post_tableCodec = recordCodec(spec_post_table);
+const spec_posts = {
   name: "posts",
   identifier: sql.identifier("smart_comment_relations", "post_view"),
-  attributes: postsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -117,22 +133,10 @@ const postsCodec = recordCodec({
       primaryKey: "id"
     })
   },
-  executor
-});
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "offer"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "offer_table",
-    omit: true,
-    behavior: ["-*"]
-  })
+  executor: executor
 };
-const offer_tableCodec = recordCodec({
+const postsCodec = recordCodec(spec_posts);
+const spec_offer_table = {
   name: "offer_table",
   identifier: sql.identifier("smart_comment_relations", "offer"),
   attributes: Object.assign(Object.create(null), {
@@ -156,33 +160,45 @@ const offer_tableCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions: extensions3,
-  executor
-});
-const offersAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "offer"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "offer_table",
+      omit: true,
+      behavior: ["-*"]
+    })
   },
-  post_id: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const offersCodec = recordCodec({
+  executor: executor
+};
+const offer_tableCodec = recordCodec(spec_offer_table);
+const spec_offers = {
   name: "offers",
   identifier: sql.identifier("smart_comment_relations", "offer_view"),
-  attributes: offersAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    post_id: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -197,32 +213,32 @@ const offersCodec = recordCodec({
       foreignKey: "(post_id) references post_view (id)"
     })
   },
-  executor
-});
-const streetsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const streetsCodec = recordCodec({
+  executor: executor
+};
+const offersCodec = recordCodec(spec_offers);
+const spec_streets = {
   name: "streets",
   identifier: sql.identifier("smart_comment_relations", "streets"),
-  attributes: streetsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -235,41 +251,41 @@ const streetsCodec = recordCodec({
       unique: "name"
     })
   },
-  executor
-});
-const propertiesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  street_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name_or_number: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const propertiesCodec = recordCodec({
+  executor: executor
+};
+const streetsCodec = recordCodec(spec_streets);
+const spec_properties = {
   name: "properties",
   identifier: sql.identifier("smart_comment_relations", "properties"),
-  attributes: propertiesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    street_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name_or_number: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -280,41 +296,41 @@ const propertiesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const streetPropertyAttributes = Object.assign(Object.create(null), {
-  str_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  prop_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  current_owner: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const streetPropertyCodec = recordCodec({
+  executor: executor
+};
+const propertiesCodec = recordCodec(spec_properties);
+const spec_streetProperty = {
   name: "streetProperty",
   identifier: sql.identifier("smart_comment_relations", "street_property"),
-  attributes: streetPropertyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    str_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    prop_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    current_owner: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -325,148 +341,147 @@ const streetPropertyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const housesAttributes = Object.assign(Object.create(null), {
-  building_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  property_name_or_number: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        notNull: true
-      }
-    }
-  },
-  street_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        notNull: true
-      }
-    }
-  },
-  street_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  building_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  property_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  floors: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "houses"
-  },
-  tags: Object.assign(Object.create(null), {
-    primaryKey: "street_id,property_id",
-    foreignKey: ["(street_id) references smart_comment_relations.streets", "(building_id) references smart_comment_relations.buildings (id)", "(property_id) references properties", "(street_id, property_id) references street_property (str_id, prop_id)"]
-  })
+  executor: executor
 };
-const housesCodec = recordCodec({
+const streetPropertyCodec = recordCodec(spec_streetProperty);
+const spec_houses = {
   name: "houses",
   identifier: sql.identifier("smart_comment_relations", "houses"),
-  attributes: housesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    building_name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    property_name_or_number: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          notNull: true
+        }
+      }
+    },
+    street_name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          notNull: true
+        }
+      }
+    },
+    street_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    building_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    property_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    floors: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions8,
-  executor
-});
-const buildingsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "houses"
+    },
+    tags: Object.assign(Object.create(null), {
+      primaryKey: "street_id,property_id",
+      foreignKey: ["(street_id) references smart_comment_relations.streets", "(building_id) references smart_comment_relations.buildings (id)", "(property_id) references properties", "(street_id, property_id) references street_property (str_id, prop_id)"]
+    })
   },
-  property_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  floors: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  is_primary: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const buildingsCodec = recordCodec({
+  executor: executor
+};
+const housesCodec = recordCodec(spec_houses);
+const spec_buildings = {
   name: "buildings",
   identifier: sql.identifier("smart_comment_relations", "buildings"),
-  attributes: buildingsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    property_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    floors: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    is_primary: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -479,8 +494,9 @@ const buildingsCodec = recordCodec({
       foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
     })
   },
-  executor
-});
+  executor: executor
+};
+const buildingsCodec = recordCodec(spec_buildings);
 const registryConfig_pgResources_post_table_post_table = {
   executor,
   name: "post_table",
@@ -507,7 +523,7 @@ const registryConfig_pgResources_post_table_post_table = {
     tags: {
       name: "post_table",
       omit: true,
-      behavior: extensions.tags.behavior
+      behavior: spec_post_table.extensions.tags.behavior
     }
   }
 };
@@ -567,7 +583,7 @@ const registryConfig_pgResources_offer_table_offer_table = {
     tags: {
       name: "offer_table",
       omit: true,
-      behavior: extensions3.tags.behavior
+      behavior: spec_offer_table.extensions.tags.behavior
     }
   }
 };
@@ -718,7 +734,7 @@ const registryConfig_pgResources_houses_houses = {
     },
     tags: {
       primaryKey: "street_id,property_id",
-      foreignKey: extensions8.tags.foreignKey,
+      foreignKey: spec_houses.extensions.tags.foreignKey,
       behavior: ["-insert", "-update", "-delete"]
     }
   }
@@ -1374,6 +1390,9 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
+function CursorSerialize(value) {
+  return "" + value;
+}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
@@ -4410,6 +4429,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: CursorSerialize,
+    parseValue: CursorSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -4546,7 +4575,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), offersAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_offers.attributes.id.codec)}`;
             }
           });
         }
@@ -4569,7 +4598,7 @@ export const plans = {
             type: "attribute",
             attribute: "post_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), offersAttributes.post_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_offers.attributes.post_id.codec)}`;
             }
           });
         }
@@ -5521,7 +5550,7 @@ export const plans = {
             type: "attribute",
             attribute: "building_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.building_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_houses.attributes.building_name.codec)}`;
             }
           });
         }
@@ -5544,7 +5573,7 @@ export const plans = {
             type: "attribute",
             attribute: "property_name_or_number",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.property_name_or_number.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_houses.attributes.property_name_or_number.codec)}`;
             }
           });
         }
@@ -5567,7 +5596,7 @@ export const plans = {
             type: "attribute",
             attribute: "street_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.street_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_houses.attributes.street_name.codec)}`;
             }
           });
         }
@@ -5590,7 +5619,7 @@ export const plans = {
             type: "attribute",
             attribute: "street_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.street_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_houses.attributes.street_id.codec)}`;
             }
           });
         }
@@ -5613,7 +5642,7 @@ export const plans = {
             type: "attribute",
             attribute: "building_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.building_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_houses.attributes.building_id.codec)}`;
             }
           });
         }
@@ -5636,7 +5665,7 @@ export const plans = {
             type: "attribute",
             attribute: "property_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.property_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_houses.attributes.property_id.codec)}`;
             }
           });
         }
@@ -5659,7 +5688,7 @@ export const plans = {
             type: "attribute",
             attribute: "floors",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.floors.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_houses.attributes.floors.codec)}`;
             }
           });
         }
@@ -5832,7 +5861,7 @@ export const plans = {
             type: "attribute",
             attribute: "str_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), streetPropertyAttributes.str_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_streetProperty.attributes.str_id.codec)}`;
             }
           });
         }
@@ -5855,7 +5884,7 @@ export const plans = {
             type: "attribute",
             attribute: "prop_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), streetPropertyAttributes.prop_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_streetProperty.attributes.prop_id.codec)}`;
             }
           });
         }
@@ -5878,7 +5907,7 @@ export const plans = {
             type: "attribute",
             attribute: "current_owner",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), streetPropertyAttributes.current_owner.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_streetProperty.attributes.current_owner.codec)}`;
             }
           });
         }
@@ -6135,7 +6164,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_buildings.attributes.id.codec)}`;
             }
           });
         }
@@ -6158,7 +6187,7 @@ export const plans = {
             type: "attribute",
             attribute: "property_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.property_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_buildings.attributes.property_id.codec)}`;
             }
           });
         }
@@ -6181,7 +6210,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_buildings.attributes.name.codec)}`;
             }
           });
         }
@@ -6204,7 +6233,7 @@ export const plans = {
             type: "attribute",
             attribute: "floors",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.floors.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_buildings.attributes.floors.codec)}`;
             }
           });
         }
@@ -6227,7 +6256,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_primary",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.is_primary.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_buildings.attributes.is_primary.codec)}`;
             }
           });
         }
@@ -6400,7 +6429,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), propertiesAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_properties.attributes.id.codec)}`;
             }
           });
         }
@@ -6423,7 +6452,7 @@ export const plans = {
             type: "attribute",
             attribute: "street_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), propertiesAttributes.street_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_properties.attributes.street_id.codec)}`;
             }
           });
         }
@@ -6446,7 +6475,7 @@ export const plans = {
             type: "attribute",
             attribute: "name_or_number",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), propertiesAttributes.name_or_number.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_properties.attributes.name_or_number.codec)}`;
             }
           });
         }
@@ -6567,7 +6596,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_posts.attributes.id.codec)}`;
             }
           });
         }
@@ -6722,7 +6751,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), streetsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_streets.attributes.id.codec)}`;
             }
           });
         }
@@ -6745,7 +6774,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), streetsAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_streets.attributes.name.codec)}`;
             }
           });
         }
@@ -7364,6 +7393,9 @@ export const plans = {
     }
   },
   PostInput: {
+    "__inputPlan": function PostInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7436,6 +7468,9 @@ export const plans = {
     }
   },
   OfferInput: {
+    "__inputPlan": function OfferInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7510,6 +7545,9 @@ export const plans = {
     }
   },
   StreetInput: {
+    "__inputPlan": function StreetInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7589,6 +7627,9 @@ export const plans = {
     }
   },
   PropertyInput: {
+    "__inputPlan": function PropertyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7680,6 +7721,9 @@ export const plans = {
     }
   },
   StreetPropertyInput: {
+    "__inputPlan": function StreetPropertyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     strId: {
       applyPlan($insert, val) {
         $insert.set("str_id", val.get());
@@ -7771,6 +7815,9 @@ export const plans = {
     }
   },
   BuildingInput: {
+    "__inputPlan": function BuildingInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7865,6 +7912,9 @@ export const plans = {
     }
   },
   PostPatch: {
+    "__inputPlan": function PostPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7950,6 +8000,9 @@ export const plans = {
     }
   },
   OfferPatch: {
+    "__inputPlan": function OfferPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -8037,6 +8090,9 @@ export const plans = {
     }
   },
   StreetPatch: {
+    "__inputPlan": function StreetPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -8143,6 +8199,9 @@ export const plans = {
     }
   },
   PropertyPatch: {
+    "__inputPlan": function PropertyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -8247,6 +8306,9 @@ export const plans = {
     }
   },
   StreetPropertyPatch: {
+    "__inputPlan": function StreetPropertyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     strId: {
       applyPlan($insert, val) {
         $insert.set("str_id", val.get());
@@ -8352,6 +8414,9 @@ export const plans = {
     }
   },
   BuildingPatch: {
+    "__inputPlan": function BuildingPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, makeRegistry, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgUpdateSingle, recordCodec } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId } from "grafast";
+import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -58,20 +75,7 @@ const executor = new PgExecutor({
     });
   }
 });
-const extensions = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "post"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "post_table",
-    omit: true,
-    behavior: ["-*"]
-  })
-};
-const post_tableCodec = recordCodec({
+const spec_post_table = {
   name: "post_table",
   identifier: sql.identifier("smart_comment_relations", "post"),
   attributes: Object.assign(Object.create(null), {
@@ -86,24 +90,36 @@ const post_tableCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions,
-  executor
-});
-const postsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const postsCodec = recordCodec({
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "post"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "post_table",
+      omit: true,
+      behavior: ["-*"]
+    })
+  },
+  executor: executor
+};
+const post_tableCodec = recordCodec(spec_post_table);
+const spec_posts = {
   name: "posts",
   identifier: sql.identifier("smart_comment_relations", "post_view"),
-  attributes: postsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -117,22 +133,10 @@ const postsCodec = recordCodec({
       primaryKey: "id"
     })
   },
-  executor
-});
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "offer"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "offer_table",
-    omit: true,
-    behavior: ["-*"]
-  })
+  executor: executor
 };
-const offer_tableCodec = recordCodec({
+const postsCodec = recordCodec(spec_posts);
+const spec_offer_table = {
   name: "offer_table",
   identifier: sql.identifier("smart_comment_relations", "offer"),
   attributes: Object.assign(Object.create(null), {
@@ -156,33 +160,45 @@ const offer_tableCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions: extensions3,
-  executor
-});
-const offersAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "offer"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "offer_table",
+      omit: true,
+      behavior: ["-*"]
+    })
   },
-  post_id: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const offersCodec = recordCodec({
+  executor: executor
+};
+const offer_tableCodec = recordCodec(spec_offer_table);
+const spec_offers = {
   name: "offers",
   identifier: sql.identifier("smart_comment_relations", "offer_view"),
-  attributes: offersAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    post_id: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -197,32 +213,32 @@ const offersCodec = recordCodec({
       foreignKey: "(post_id) references post"
     })
   },
-  executor
-});
-const streetsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const streetsCodec = recordCodec({
+  executor: executor
+};
+const offersCodec = recordCodec(spec_offers);
+const spec_streets = {
   name: "streets",
   identifier: sql.identifier("smart_comment_relations", "streets"),
-  attributes: streetsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -235,41 +251,41 @@ const streetsCodec = recordCodec({
       unique: "name"
     })
   },
-  executor
-});
-const propertiesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  street_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name_or_number: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const propertiesCodec = recordCodec({
+  executor: executor
+};
+const streetsCodec = recordCodec(spec_streets);
+const spec_properties = {
   name: "properties",
   identifier: sql.identifier("smart_comment_relations", "properties"),
-  attributes: propertiesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    street_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name_or_number: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -280,41 +296,41 @@ const propertiesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const streetPropertyAttributes = Object.assign(Object.create(null), {
-  str_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  prop_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  current_owner: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const streetPropertyCodec = recordCodec({
+  executor: executor
+};
+const propertiesCodec = recordCodec(spec_properties);
+const spec_streetProperty = {
   name: "streetProperty",
   identifier: sql.identifier("smart_comment_relations", "street_property"),
-  attributes: streetPropertyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    str_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    prop_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    current_owner: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -325,148 +341,147 @@ const streetPropertyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const housesAttributes = Object.assign(Object.create(null), {
-  building_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  property_name_or_number: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        notNull: true
-      }
-    }
-  },
-  street_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        notNull: true
-      }
-    }
-  },
-  street_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  building_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  property_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  floors: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "houses"
-  },
-  tags: Object.assign(Object.create(null), {
-    primaryKey: "street_id,property_id",
-    foreignKey: ["(street_id) references smart_comment_relations.streets", "(building_id) references smart_comment_relations.buildings (id)", "(property_id) references properties", "(street_id, property_id) references street_property (str_id, prop_id)"]
-  })
+  executor: executor
 };
-const housesCodec = recordCodec({
+const streetPropertyCodec = recordCodec(spec_streetProperty);
+const spec_houses = {
   name: "houses",
   identifier: sql.identifier("smart_comment_relations", "houses"),
-  attributes: housesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    building_name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    property_name_or_number: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          notNull: true
+        }
+      }
+    },
+    street_name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          notNull: true
+        }
+      }
+    },
+    street_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    building_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    property_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    floors: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions8,
-  executor
-});
-const buildingsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "houses"
+    },
+    tags: Object.assign(Object.create(null), {
+      primaryKey: "street_id,property_id",
+      foreignKey: ["(street_id) references smart_comment_relations.streets", "(building_id) references smart_comment_relations.buildings (id)", "(property_id) references properties", "(street_id, property_id) references street_property (str_id, prop_id)"]
+    })
   },
-  property_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  floors: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  is_primary: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const buildingsCodec = recordCodec({
+  executor: executor
+};
+const housesCodec = recordCodec(spec_houses);
+const spec_buildings = {
   name: "buildings",
   identifier: sql.identifier("smart_comment_relations", "buildings"),
-  attributes: buildingsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    property_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    floors: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    is_primary: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -479,8 +494,9 @@ const buildingsCodec = recordCodec({
       foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
     })
   },
-  executor
-});
+  executor: executor
+};
+const buildingsCodec = recordCodec(spec_buildings);
 const registryConfig_pgResources_post_table_post_table = {
   executor,
   name: "post_table",
@@ -507,7 +523,7 @@ const registryConfig_pgResources_post_table_post_table = {
     tags: {
       name: "post_table",
       omit: true,
-      behavior: extensions.tags.behavior
+      behavior: spec_post_table.extensions.tags.behavior
     }
   }
 };
@@ -545,7 +561,7 @@ const registryConfig_pgResources_offer_table_offer_table = {
     tags: {
       name: "offer_table",
       omit: true,
-      behavior: extensions3.tags.behavior
+      behavior: spec_offer_table.extensions.tags.behavior
     }
   }
 };
@@ -696,7 +712,7 @@ const registryConfig_pgResources_houses_houses = {
     },
     tags: {
       primaryKey: "street_id,property_id",
-      foreignKey: extensions8.tags.foreignKey,
+      foreignKey: spec_houses.extensions.tags.foreignKey,
       behavior: ["-insert", "-update", "-delete"]
     }
   }
@@ -1371,6 +1387,9 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
+function CursorSerialize(value) {
+  return "" + value;
+}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
@@ -4932,6 +4951,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: CursorSerialize,
+    parseValue: CursorSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -5238,7 +5267,7 @@ export const plans = {
             type: "attribute",
             attribute: "building_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.building_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_houses.attributes.building_name.codec)}`;
             }
           });
         }
@@ -5261,7 +5290,7 @@ export const plans = {
             type: "attribute",
             attribute: "property_name_or_number",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.property_name_or_number.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_houses.attributes.property_name_or_number.codec)}`;
             }
           });
         }
@@ -5284,7 +5313,7 @@ export const plans = {
             type: "attribute",
             attribute: "street_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.street_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_houses.attributes.street_name.codec)}`;
             }
           });
         }
@@ -5307,7 +5336,7 @@ export const plans = {
             type: "attribute",
             attribute: "street_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.street_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_houses.attributes.street_id.codec)}`;
             }
           });
         }
@@ -5330,7 +5359,7 @@ export const plans = {
             type: "attribute",
             attribute: "building_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.building_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_houses.attributes.building_id.codec)}`;
             }
           });
         }
@@ -5353,7 +5382,7 @@ export const plans = {
             type: "attribute",
             attribute: "property_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.property_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_houses.attributes.property_id.codec)}`;
             }
           });
         }
@@ -5376,7 +5405,7 @@ export const plans = {
             type: "attribute",
             attribute: "floors",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.floors.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_houses.attributes.floors.codec)}`;
             }
           });
         }
@@ -5549,7 +5578,7 @@ export const plans = {
             type: "attribute",
             attribute: "str_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), streetPropertyAttributes.str_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_streetProperty.attributes.str_id.codec)}`;
             }
           });
         }
@@ -5572,7 +5601,7 @@ export const plans = {
             type: "attribute",
             attribute: "prop_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), streetPropertyAttributes.prop_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_streetProperty.attributes.prop_id.codec)}`;
             }
           });
         }
@@ -5595,7 +5624,7 @@ export const plans = {
             type: "attribute",
             attribute: "current_owner",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), streetPropertyAttributes.current_owner.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_streetProperty.attributes.current_owner.codec)}`;
             }
           });
         }
@@ -5852,7 +5881,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_buildings.attributes.id.codec)}`;
             }
           });
         }
@@ -5875,7 +5904,7 @@ export const plans = {
             type: "attribute",
             attribute: "property_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.property_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_buildings.attributes.property_id.codec)}`;
             }
           });
         }
@@ -5898,7 +5927,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_buildings.attributes.name.codec)}`;
             }
           });
         }
@@ -5921,7 +5950,7 @@ export const plans = {
             type: "attribute",
             attribute: "floors",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.floors.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_buildings.attributes.floors.codec)}`;
             }
           });
         }
@@ -5944,7 +5973,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_primary",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.is_primary.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_buildings.attributes.is_primary.codec)}`;
             }
           });
         }
@@ -6117,7 +6146,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), propertiesAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_properties.attributes.id.codec)}`;
             }
           });
         }
@@ -6140,7 +6169,7 @@ export const plans = {
             type: "attribute",
             attribute: "street_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), propertiesAttributes.street_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_properties.attributes.street_id.codec)}`;
             }
           });
         }
@@ -6163,7 +6192,7 @@ export const plans = {
             type: "attribute",
             attribute: "name_or_number",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), propertiesAttributes.name_or_number.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_properties.attributes.name_or_number.codec)}`;
             }
           });
         }
@@ -6284,7 +6313,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_posts.attributes.id.codec)}`;
             }
           });
         }
@@ -6439,7 +6468,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), offersAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_offers.attributes.id.codec)}`;
             }
           });
         }
@@ -6462,7 +6491,7 @@ export const plans = {
             type: "attribute",
             attribute: "post_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), offersAttributes.post_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_offers.attributes.post_id.codec)}`;
             }
           });
         }
@@ -6617,7 +6646,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), streetsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_streets.attributes.id.codec)}`;
             }
           });
         }
@@ -6640,7 +6669,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), streetsAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_streets.attributes.name.codec)}`;
             }
           });
         }
@@ -7259,6 +7288,9 @@ export const plans = {
     }
   },
   PostInput: {
+    "__inputPlan": function PostInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7326,6 +7358,9 @@ export const plans = {
     }
   },
   OfferInput: {
+    "__inputPlan": function OfferInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7400,6 +7435,9 @@ export const plans = {
     }
   },
   StreetInput: {
+    "__inputPlan": function StreetInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7479,6 +7517,9 @@ export const plans = {
     }
   },
   PropertyInput: {
+    "__inputPlan": function PropertyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7570,6 +7611,9 @@ export const plans = {
     }
   },
   StreetPropertyInput: {
+    "__inputPlan": function StreetPropertyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     strId: {
       applyPlan($insert, val) {
         $insert.set("str_id", val.get());
@@ -7661,6 +7705,9 @@ export const plans = {
     }
   },
   BuildingInput: {
+    "__inputPlan": function BuildingInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7755,6 +7802,9 @@ export const plans = {
     }
   },
   PostPatch: {
+    "__inputPlan": function PostPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7835,6 +7885,9 @@ export const plans = {
     }
   },
   OfferPatch: {
+    "__inputPlan": function OfferPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7922,6 +7975,9 @@ export const plans = {
     }
   },
   StreetPatch: {
+    "__inputPlan": function StreetPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -8028,6 +8084,9 @@ export const plans = {
     }
   },
   PropertyPatch: {
+    "__inputPlan": function PropertyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -8132,6 +8191,9 @@ export const plans = {
     }
   },
   StreetPropertyPatch: {
+    "__inputPlan": function StreetPropertyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     strId: {
       applyPlan($insert, val) {
         $insert.set("str_id", val.get());
@@ -8237,6 +8299,9 @@ export const plans = {
     }
   },
   BuildingPatch: {
+    "__inputPlan": function BuildingPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post_view.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post_view.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, makeRegistry, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgUpdateSingle, recordCodec } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId } from "grafast";
+import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -58,20 +75,7 @@ const executor = new PgExecutor({
     });
   }
 });
-const extensions = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "post"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "post_table",
-    omit: true,
-    behavior: ["-*"]
-  })
-};
-const post_tableCodec = recordCodec({
+const spec_post_table = {
   name: "post_table",
   identifier: sql.identifier("smart_comment_relations", "post"),
   attributes: Object.assign(Object.create(null), {
@@ -86,24 +90,36 @@ const post_tableCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions,
-  executor
-});
-const postsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const postsCodec = recordCodec({
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "post"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "post_table",
+      omit: true,
+      behavior: ["-*"]
+    })
+  },
+  executor: executor
+};
+const post_tableCodec = recordCodec(spec_post_table);
+const spec_posts = {
   name: "posts",
   identifier: sql.identifier("smart_comment_relations", "post_view"),
-  attributes: postsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -117,22 +133,10 @@ const postsCodec = recordCodec({
       primaryKey: "id"
     })
   },
-  executor
-});
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "offer"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "offer_table",
-    omit: true,
-    behavior: ["-*"]
-  })
+  executor: executor
 };
-const offer_tableCodec = recordCodec({
+const postsCodec = recordCodec(spec_posts);
+const spec_offer_table = {
   name: "offer_table",
   identifier: sql.identifier("smart_comment_relations", "offer"),
   attributes: Object.assign(Object.create(null), {
@@ -156,33 +160,45 @@ const offer_tableCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions: extensions3,
-  executor
-});
-const offersAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "offer"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "offer_table",
+      omit: true,
+      behavior: ["-*"]
+    })
   },
-  post_id: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const offersCodec = recordCodec({
+  executor: executor
+};
+const offer_tableCodec = recordCodec(spec_offer_table);
+const spec_offers = {
   name: "offers",
   identifier: sql.identifier("smart_comment_relations", "offer_view"),
-  attributes: offersAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    post_id: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -197,32 +213,32 @@ const offersCodec = recordCodec({
       foreignKey: "(post_id) references post_view"
     })
   },
-  executor
-});
-const streetsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const streetsCodec = recordCodec({
+  executor: executor
+};
+const offersCodec = recordCodec(spec_offers);
+const spec_streets = {
   name: "streets",
   identifier: sql.identifier("smart_comment_relations", "streets"),
-  attributes: streetsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -235,41 +251,41 @@ const streetsCodec = recordCodec({
       unique: "name"
     })
   },
-  executor
-});
-const propertiesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  street_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name_or_number: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const propertiesCodec = recordCodec({
+  executor: executor
+};
+const streetsCodec = recordCodec(spec_streets);
+const spec_properties = {
   name: "properties",
   identifier: sql.identifier("smart_comment_relations", "properties"),
-  attributes: propertiesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    street_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name_or_number: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -280,41 +296,41 @@ const propertiesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const streetPropertyAttributes = Object.assign(Object.create(null), {
-  str_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  prop_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  current_owner: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const streetPropertyCodec = recordCodec({
+  executor: executor
+};
+const propertiesCodec = recordCodec(spec_properties);
+const spec_streetProperty = {
   name: "streetProperty",
   identifier: sql.identifier("smart_comment_relations", "street_property"),
-  attributes: streetPropertyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    str_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    prop_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    current_owner: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -325,148 +341,147 @@ const streetPropertyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const housesAttributes = Object.assign(Object.create(null), {
-  building_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  property_name_or_number: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        notNull: true
-      }
-    }
-  },
-  street_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        notNull: true
-      }
-    }
-  },
-  street_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  building_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  property_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  floors: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "houses"
-  },
-  tags: Object.assign(Object.create(null), {
-    primaryKey: "street_id,property_id",
-    foreignKey: ["(street_id) references smart_comment_relations.streets", "(building_id) references smart_comment_relations.buildings (id)", "(property_id) references properties", "(street_id, property_id) references street_property (str_id, prop_id)"]
-  })
+  executor: executor
 };
-const housesCodec = recordCodec({
+const streetPropertyCodec = recordCodec(spec_streetProperty);
+const spec_houses = {
   name: "houses",
   identifier: sql.identifier("smart_comment_relations", "houses"),
-  attributes: housesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    building_name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    property_name_or_number: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          notNull: true
+        }
+      }
+    },
+    street_name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          notNull: true
+        }
+      }
+    },
+    street_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    building_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    property_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    floors: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions8,
-  executor
-});
-const buildingsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "houses"
+    },
+    tags: Object.assign(Object.create(null), {
+      primaryKey: "street_id,property_id",
+      foreignKey: ["(street_id) references smart_comment_relations.streets", "(building_id) references smart_comment_relations.buildings (id)", "(property_id) references properties", "(street_id, property_id) references street_property (str_id, prop_id)"]
+    })
   },
-  property_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  floors: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  is_primary: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const buildingsCodec = recordCodec({
+  executor: executor
+};
+const housesCodec = recordCodec(spec_houses);
+const spec_buildings = {
   name: "buildings",
   identifier: sql.identifier("smart_comment_relations", "buildings"),
-  attributes: buildingsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    property_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    floors: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    is_primary: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -479,8 +494,9 @@ const buildingsCodec = recordCodec({
       foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
     })
   },
-  executor
-});
+  executor: executor
+};
+const buildingsCodec = recordCodec(spec_buildings);
 const registryConfig_pgResources_post_table_post_table = {
   executor,
   name: "post_table",
@@ -507,7 +523,7 @@ const registryConfig_pgResources_post_table_post_table = {
     tags: {
       name: "post_table",
       omit: true,
-      behavior: extensions.tags.behavior
+      behavior: spec_post_table.extensions.tags.behavior
     }
   }
 };
@@ -567,7 +583,7 @@ const registryConfig_pgResources_offer_table_offer_table = {
     tags: {
       name: "offer_table",
       omit: true,
-      behavior: extensions3.tags.behavior
+      behavior: spec_offer_table.extensions.tags.behavior
     }
   }
 };
@@ -718,7 +734,7 @@ const registryConfig_pgResources_houses_houses = {
     },
     tags: {
       primaryKey: "street_id,property_id",
-      foreignKey: extensions8.tags.foreignKey,
+      foreignKey: spec_houses.extensions.tags.foreignKey,
       behavior: ["-insert", "-update", "-delete"]
     }
   }
@@ -1374,6 +1390,9 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
+function CursorSerialize(value) {
+  return "" + value;
+}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Post, $nodeId);
@@ -4410,6 +4429,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: CursorSerialize,
+    parseValue: CursorSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -4546,7 +4575,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), offersAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_offers.attributes.id.codec)}`;
             }
           });
         }
@@ -4569,7 +4598,7 @@ export const plans = {
             type: "attribute",
             attribute: "post_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), offersAttributes.post_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_offers.attributes.post_id.codec)}`;
             }
           });
         }
@@ -5521,7 +5550,7 @@ export const plans = {
             type: "attribute",
             attribute: "building_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.building_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_houses.attributes.building_name.codec)}`;
             }
           });
         }
@@ -5544,7 +5573,7 @@ export const plans = {
             type: "attribute",
             attribute: "property_name_or_number",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.property_name_or_number.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_houses.attributes.property_name_or_number.codec)}`;
             }
           });
         }
@@ -5567,7 +5596,7 @@ export const plans = {
             type: "attribute",
             attribute: "street_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.street_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_houses.attributes.street_name.codec)}`;
             }
           });
         }
@@ -5590,7 +5619,7 @@ export const plans = {
             type: "attribute",
             attribute: "street_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.street_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_houses.attributes.street_id.codec)}`;
             }
           });
         }
@@ -5613,7 +5642,7 @@ export const plans = {
             type: "attribute",
             attribute: "building_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.building_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_houses.attributes.building_id.codec)}`;
             }
           });
         }
@@ -5636,7 +5665,7 @@ export const plans = {
             type: "attribute",
             attribute: "property_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.property_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_houses.attributes.property_id.codec)}`;
             }
           });
         }
@@ -5659,7 +5688,7 @@ export const plans = {
             type: "attribute",
             attribute: "floors",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.floors.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_houses.attributes.floors.codec)}`;
             }
           });
         }
@@ -5832,7 +5861,7 @@ export const plans = {
             type: "attribute",
             attribute: "str_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), streetPropertyAttributes.str_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_streetProperty.attributes.str_id.codec)}`;
             }
           });
         }
@@ -5855,7 +5884,7 @@ export const plans = {
             type: "attribute",
             attribute: "prop_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), streetPropertyAttributes.prop_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_streetProperty.attributes.prop_id.codec)}`;
             }
           });
         }
@@ -5878,7 +5907,7 @@ export const plans = {
             type: "attribute",
             attribute: "current_owner",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), streetPropertyAttributes.current_owner.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_streetProperty.attributes.current_owner.codec)}`;
             }
           });
         }
@@ -6135,7 +6164,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_buildings.attributes.id.codec)}`;
             }
           });
         }
@@ -6158,7 +6187,7 @@ export const plans = {
             type: "attribute",
             attribute: "property_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.property_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_buildings.attributes.property_id.codec)}`;
             }
           });
         }
@@ -6181,7 +6210,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_buildings.attributes.name.codec)}`;
             }
           });
         }
@@ -6204,7 +6233,7 @@ export const plans = {
             type: "attribute",
             attribute: "floors",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.floors.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_buildings.attributes.floors.codec)}`;
             }
           });
         }
@@ -6227,7 +6256,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_primary",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.is_primary.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_buildings.attributes.is_primary.codec)}`;
             }
           });
         }
@@ -6400,7 +6429,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), propertiesAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_properties.attributes.id.codec)}`;
             }
           });
         }
@@ -6423,7 +6452,7 @@ export const plans = {
             type: "attribute",
             attribute: "street_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), propertiesAttributes.street_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_properties.attributes.street_id.codec)}`;
             }
           });
         }
@@ -6446,7 +6475,7 @@ export const plans = {
             type: "attribute",
             attribute: "name_or_number",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), propertiesAttributes.name_or_number.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_properties.attributes.name_or_number.codec)}`;
             }
           });
         }
@@ -6567,7 +6596,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_posts.attributes.id.codec)}`;
             }
           });
         }
@@ -6722,7 +6751,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), streetsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_streets.attributes.id.codec)}`;
             }
           });
         }
@@ -6745,7 +6774,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), streetsAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_streets.attributes.name.codec)}`;
             }
           });
         }
@@ -7364,6 +7393,9 @@ export const plans = {
     }
   },
   PostInput: {
+    "__inputPlan": function PostInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7436,6 +7468,9 @@ export const plans = {
     }
   },
   OfferInput: {
+    "__inputPlan": function OfferInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7510,6 +7545,9 @@ export const plans = {
     }
   },
   StreetInput: {
+    "__inputPlan": function StreetInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7589,6 +7627,9 @@ export const plans = {
     }
   },
   PropertyInput: {
+    "__inputPlan": function PropertyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7680,6 +7721,9 @@ export const plans = {
     }
   },
   StreetPropertyInput: {
+    "__inputPlan": function StreetPropertyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     strId: {
       applyPlan($insert, val) {
         $insert.set("str_id", val.get());
@@ -7771,6 +7815,9 @@ export const plans = {
     }
   },
   BuildingInput: {
+    "__inputPlan": function BuildingInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7865,6 +7912,9 @@ export const plans = {
     }
   },
   PostPatch: {
+    "__inputPlan": function PostPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7950,6 +8000,9 @@ export const plans = {
     }
   },
   OfferPatch: {
+    "__inputPlan": function OfferPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -8037,6 +8090,9 @@ export const plans = {
     }
   },
   StreetPatch: {
+    "__inputPlan": function StreetPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -8143,6 +8199,9 @@ export const plans = {
     }
   },
   PropertyPatch: {
+    "__inputPlan": function PropertyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -8247,6 +8306,9 @@ export const plans = {
     }
   },
   StreetPropertyPatch: {
+    "__inputPlan": function StreetPropertyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     strId: {
       applyPlan($insert, val) {
         $insert.set("str_id", val.get());
@@ -8352,6 +8414,9 @@ export const plans = {
     }
   },
   BuildingPatch: {
+    "__inputPlan": function BuildingPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.view_fake_unique.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.view_fake_unique.1.export.mjs
@@ -1,17 +1,22 @@
 import { PgDeleteSingleStep, PgExecutor, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, makeRegistry, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgUpdateSingle, recordCodec } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, inhibitOnNull, lambda, list, makeGrafastSchema, node, object, rootValue, specFromNodeId } from "grafast";
+import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const handler = {
   typeName: "Query",
   codec: {
     name: "raw",
-    encode(value) {
+    encode: Object.assign(function rawEncode(value) {
       return typeof value === "string" ? value : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function rawDecode(value) {
       return typeof value === "string" ? value : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   },
   match(specifier) {
     return specifier === "query";
@@ -28,24 +33,36 @@ const handler = {
 };
 const nodeIdCodecs_base64JSON_base64JSON = {
   name: "base64JSON",
-  encode(value) {
-    return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
-  },
-  decode(value) {
-    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
-  }
+  encode: (() => {
+    function base64JSONEncode(value) {
+      return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+    }
+    base64JSONEncode.isSyncAndSafe = true; // Optimization
+    return base64JSONEncode;
+  })(),
+  decode: (() => {
+    function base64JSONDecode(value) {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+    }
+    base64JSONDecode.isSyncAndSafe = true; // Optimization
+    return base64JSONDecode;
+  })()
 };
 const nodeIdCodecs = Object.assign(Object.create(null), {
   raw: handler.codec,
   base64JSON: nodeIdCodecs_base64JSON_base64JSON,
   pipeString: {
     name: "pipeString",
-    encode(value) {
+    encode: Object.assign(function pipeStringEncode(value) {
       return Array.isArray(value) ? value.join("|") : null;
-    },
-    decode(value) {
+    }, {
+      isSyncAndSafe: true
+    }),
+    decode: Object.assign(function pipeStringDecode(value) {
       return typeof value === "string" ? value.split("|") : null;
-    }
+    }, {
+      isSyncAndSafe: true
+    })
   }
 });
 const executor = new PgExecutor({
@@ -58,20 +75,7 @@ const executor = new PgExecutor({
     });
   }
 });
-const extensions = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "post"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "post_table",
-    omit: true,
-    behavior: ["-*"]
-  })
-};
-const post_tableCodec = recordCodec({
+const spec_post_table = {
   name: "post_table",
   identifier: sql.identifier("smart_comment_relations", "post"),
   attributes: Object.assign(Object.create(null), {
@@ -86,24 +90,36 @@ const post_tableCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions,
-  executor
-});
-const postsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const postsCodec = recordCodec({
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "post"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "post_table",
+      omit: true,
+      behavior: ["-*"]
+    })
+  },
+  executor: executor
+};
+const post_tableCodec = recordCodec(spec_post_table);
+const spec_posts = {
   name: "posts",
   identifier: sql.identifier("smart_comment_relations", "post_view"),
-  attributes: postsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -117,22 +133,10 @@ const postsCodec = recordCodec({
       unique: "id"
     })
   },
-  executor
-});
-const extensions3 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "offer"
-  },
-  tags: Object.assign(Object.create(null), {
-    name: "offer_table",
-    omit: true,
-    behavior: ["-*"]
-  })
+  executor: executor
 };
-const offer_tableCodec = recordCodec({
+const postsCodec = recordCodec(spec_posts);
+const spec_offer_table = {
   name: "offer_table",
   identifier: sql.identifier("smart_comment_relations", "offer"),
   attributes: Object.assign(Object.create(null), {
@@ -156,33 +160,45 @@ const offer_tableCodec = recordCodec({
     }
   }),
   description: undefined,
-  extensions: extensions3,
-  executor
-});
-const offersAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "offer"
+    },
+    tags: Object.assign(Object.create(null), {
+      name: "offer_table",
+      omit: true,
+      behavior: ["-*"]
+    })
   },
-  post_id: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const offersCodec = recordCodec({
+  executor: executor
+};
+const offer_tableCodec = recordCodec(spec_offer_table);
+const spec_offers = {
   name: "offers",
   identifier: sql.identifier("smart_comment_relations", "offer_view"),
-  attributes: offersAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    post_id: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -197,32 +213,32 @@ const offersCodec = recordCodec({
       foreignKey: "(post_id) references post_view(id)"
     })
   },
-  executor
-});
-const streetsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const streetsCodec = recordCodec({
+  executor: executor
+};
+const offersCodec = recordCodec(spec_offers);
+const spec_streets = {
   name: "streets",
   identifier: sql.identifier("smart_comment_relations", "streets"),
-  attributes: streetsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -235,41 +251,41 @@ const streetsCodec = recordCodec({
       unique: "name"
     })
   },
-  executor
-});
-const propertiesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  street_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name_or_number: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const propertiesCodec = recordCodec({
+  executor: executor
+};
+const streetsCodec = recordCodec(spec_streets);
+const spec_properties = {
   name: "properties",
   identifier: sql.identifier("smart_comment_relations", "properties"),
-  attributes: propertiesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    street_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name_or_number: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -280,41 +296,41 @@ const propertiesCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const streetPropertyAttributes = Object.assign(Object.create(null), {
-  str_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  prop_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  current_owner: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const streetPropertyCodec = recordCodec({
+  executor: executor
+};
+const propertiesCodec = recordCodec(spec_properties);
+const spec_streetProperty = {
   name: "streetProperty",
   identifier: sql.identifier("smart_comment_relations", "street_property"),
-  attributes: streetPropertyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    str_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    prop_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    current_owner: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -325,148 +341,147 @@ const streetPropertyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const housesAttributes = Object.assign(Object.create(null), {
-  building_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  property_name_or_number: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        notNull: true
-      }
-    }
-  },
-  street_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        notNull: true
-      }
-    }
-  },
-  street_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  building_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  property_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  floors: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions8 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "smart_comment_relations",
-    name: "houses"
-  },
-  tags: Object.assign(Object.create(null), {
-    primaryKey: "street_id,property_id",
-    foreignKey: ["(street_id) references smart_comment_relations.streets", "(building_id) references smart_comment_relations.buildings (id)", "(property_id) references properties", "(street_id, property_id) references street_property (str_id, prop_id)"]
-  })
+  executor: executor
 };
-const housesCodec = recordCodec({
+const streetPropertyCodec = recordCodec(spec_streetProperty);
+const spec_houses = {
   name: "houses",
   identifier: sql.identifier("smart_comment_relations", "houses"),
-  attributes: housesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    building_name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    property_name_or_number: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          notNull: true
+        }
+      }
+    },
+    street_name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          notNull: true
+        }
+      }
+    },
+    street_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    building_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    property_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    floors: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions8,
-  executor
-});
-const buildingsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "smart_comment_relations",
+      name: "houses"
+    },
+    tags: Object.assign(Object.create(null), {
+      primaryKey: "street_id,property_id",
+      foreignKey: ["(street_id) references smart_comment_relations.streets", "(building_id) references smart_comment_relations.buildings (id)", "(property_id) references properties", "(street_id, property_id) references street_property (str_id, prop_id)"]
+    })
   },
-  property_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  floors: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  is_primary: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const buildingsCodec = recordCodec({
+  executor: executor
+};
+const housesCodec = recordCodec(spec_houses);
+const spec_buildings = {
   name: "buildings",
   identifier: sql.identifier("smart_comment_relations", "buildings"),
-  attributes: buildingsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    property_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    floors: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    is_primary: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -479,8 +494,9 @@ const buildingsCodec = recordCodec({
       foreignKey: "(name) references streets (name)|@fieldName namedAfterStreet|@foreignFieldName buildingsNamedAfterStreet|@foreignSimpleFieldName buildingsNamedAfterStreetList"
     })
   },
-  executor
-});
+  executor: executor
+};
+const buildingsCodec = recordCodec(spec_buildings);
 const registryConfig_pgResources_post_table_post_table = {
   executor,
   name: "post_table",
@@ -507,7 +523,7 @@ const registryConfig_pgResources_post_table_post_table = {
     tags: {
       name: "post_table",
       omit: true,
-      behavior: extensions.tags.behavior
+      behavior: spec_post_table.extensions.tags.behavior
     }
   }
 };
@@ -566,7 +582,7 @@ const registryConfig_pgResources_offer_table_offer_table = {
     tags: {
       name: "offer_table",
       omit: true,
-      behavior: extensions3.tags.behavior
+      behavior: spec_offer_table.extensions.tags.behavior
     }
   }
 };
@@ -717,7 +733,7 @@ const registryConfig_pgResources_houses_houses = {
     },
     tags: {
       primaryKey: "street_id,property_id",
-      foreignKey: extensions8.tags.foreignKey,
+      foreignKey: spec_houses.extensions.tags.foreignKey,
       behavior: ["-insert", "-update", "-delete"]
     }
   }
@@ -1346,6 +1362,9 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
     plan($select);
   });
 };
+function CursorSerialize(value) {
+  return "" + value;
+}
 const specFromArgs = args => {
   const $nodeId = args.get(["input", "nodeId"]);
   return specFromNodeId(nodeIdHandlerByTypeName.Offer, $nodeId);
@@ -4281,6 +4300,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: CursorSerialize,
+    parseValue: CursorSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -4417,7 +4446,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), offersAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_offers.attributes.id.codec)}`;
             }
           });
         }
@@ -4440,7 +4469,7 @@ export const plans = {
             type: "attribute",
             attribute: "post_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), offersAttributes.post_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_offers.attributes.post_id.codec)}`;
             }
           });
         }
@@ -5392,7 +5421,7 @@ export const plans = {
             type: "attribute",
             attribute: "building_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.building_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_houses.attributes.building_name.codec)}`;
             }
           });
         }
@@ -5415,7 +5444,7 @@ export const plans = {
             type: "attribute",
             attribute: "property_name_or_number",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.property_name_or_number.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_houses.attributes.property_name_or_number.codec)}`;
             }
           });
         }
@@ -5438,7 +5467,7 @@ export const plans = {
             type: "attribute",
             attribute: "street_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.street_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_houses.attributes.street_name.codec)}`;
             }
           });
         }
@@ -5461,7 +5490,7 @@ export const plans = {
             type: "attribute",
             attribute: "street_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.street_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_houses.attributes.street_id.codec)}`;
             }
           });
         }
@@ -5484,7 +5513,7 @@ export const plans = {
             type: "attribute",
             attribute: "building_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.building_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_houses.attributes.building_id.codec)}`;
             }
           });
         }
@@ -5507,7 +5536,7 @@ export const plans = {
             type: "attribute",
             attribute: "property_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.property_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_houses.attributes.property_id.codec)}`;
             }
           });
         }
@@ -5530,7 +5559,7 @@ export const plans = {
             type: "attribute",
             attribute: "floors",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), housesAttributes.floors.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_houses.attributes.floors.codec)}`;
             }
           });
         }
@@ -5703,7 +5732,7 @@ export const plans = {
             type: "attribute",
             attribute: "str_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), streetPropertyAttributes.str_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_streetProperty.attributes.str_id.codec)}`;
             }
           });
         }
@@ -5726,7 +5755,7 @@ export const plans = {
             type: "attribute",
             attribute: "prop_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), streetPropertyAttributes.prop_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_streetProperty.attributes.prop_id.codec)}`;
             }
           });
         }
@@ -5749,7 +5778,7 @@ export const plans = {
             type: "attribute",
             attribute: "current_owner",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), streetPropertyAttributes.current_owner.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_streetProperty.attributes.current_owner.codec)}`;
             }
           });
         }
@@ -6006,7 +6035,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_buildings.attributes.id.codec)}`;
             }
           });
         }
@@ -6029,7 +6058,7 @@ export const plans = {
             type: "attribute",
             attribute: "property_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.property_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_buildings.attributes.property_id.codec)}`;
             }
           });
         }
@@ -6052,7 +6081,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_buildings.attributes.name.codec)}`;
             }
           });
         }
@@ -6075,7 +6104,7 @@ export const plans = {
             type: "attribute",
             attribute: "floors",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.floors.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_buildings.attributes.floors.codec)}`;
             }
           });
         }
@@ -6098,7 +6127,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_primary",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), buildingsAttributes.is_primary.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_buildings.attributes.is_primary.codec)}`;
             }
           });
         }
@@ -6271,7 +6300,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), propertiesAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_properties.attributes.id.codec)}`;
             }
           });
         }
@@ -6294,7 +6323,7 @@ export const plans = {
             type: "attribute",
             attribute: "street_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), propertiesAttributes.street_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_properties.attributes.street_id.codec)}`;
             }
           });
         }
@@ -6317,7 +6346,7 @@ export const plans = {
             type: "attribute",
             attribute: "name_or_number",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), propertiesAttributes.name_or_number.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_properties.attributes.name_or_number.codec)}`;
             }
           });
         }
@@ -6406,7 +6435,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_posts.attributes.id.codec)}`;
             }
           });
         }
@@ -6561,7 +6590,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), streetsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_streets.attributes.id.codec)}`;
             }
           });
         }
@@ -6584,7 +6613,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), streetsAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_streets.attributes.name.codec)}`;
             }
           });
         }
@@ -7140,6 +7169,9 @@ export const plans = {
     }
   },
   PostInput: {
+    "__inputPlan": function PostInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7212,6 +7244,9 @@ export const plans = {
     }
   },
   OfferInput: {
+    "__inputPlan": function OfferInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7286,6 +7321,9 @@ export const plans = {
     }
   },
   StreetInput: {
+    "__inputPlan": function StreetInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7365,6 +7403,9 @@ export const plans = {
     }
   },
   PropertyInput: {
+    "__inputPlan": function PropertyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7456,6 +7497,9 @@ export const plans = {
     }
   },
   StreetPropertyInput: {
+    "__inputPlan": function StreetPropertyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     strId: {
       applyPlan($insert, val) {
         $insert.set("str_id", val.get());
@@ -7547,6 +7591,9 @@ export const plans = {
     }
   },
   BuildingInput: {
+    "__inputPlan": function BuildingInput_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7610,6 +7657,9 @@ export const plans = {
     }
   },
   PostPatch: {
+    "__inputPlan": function PostPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7681,6 +7731,9 @@ export const plans = {
     }
   },
   OfferPatch: {
+    "__inputPlan": function OfferPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7768,6 +7821,9 @@ export const plans = {
     }
   },
   StreetPatch: {
+    "__inputPlan": function StreetPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7874,6 +7930,9 @@ export const plans = {
     }
   },
   PropertyPatch: {
+    "__inputPlan": function PropertyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -7978,6 +8037,9 @@ export const plans = {
     }
   },
   StreetPropertyPatch: {
+    "__inputPlan": function StreetPropertyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     strId: {
       applyPlan($insert, val) {
         $insert.set("str_id", val.get());
@@ -8083,6 +8145,9 @@ export const plans = {
     }
   },
   BuildingPatch: {
+    "__inputPlan": function BuildingPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     id: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v5/core.ts
+++ b/postgraphile/postgraphile/__tests__/schema/v5/core.ts
@@ -13,7 +13,7 @@ import {
   withPoolClientTransaction,
 } from "../../helpers.js";
 
-jest.setTimeout(30000);
+jest.setTimeout(60000);
 
 let countByPath = Object.create(null);
 

--- a/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.1.export.mjs
@@ -1,5 +1,6 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, domainOfCodec, enumCodec, listOfCodec, makeRegistry, pgClassExpression, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgSelectFromRecords, pgSelectSingleFromRecord, pgUpdateSingle, rangeOfCodec, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, access, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, makeGrafastSchema, object, rootValue, stepAMayDependOnStepB } from "grafast";
+import { GraphQLError, GraphQLInt, GraphQLString, Kind, valueFromASTUntyped } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
 const executor = new PgExecutor({
@@ -396,21 +397,20 @@ const pgCatalogTextArrayCodec = listOfCodec(TYPES.text, {
   description: undefined,
   name: "pgCatalogTextArray"
 });
-const nonUpdatableViewAttributes = Object.assign(Object.create(null), {
-  "?column?": {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const nonUpdatableViewCodec = recordCodec({
+const spec_nonUpdatableView = {
   name: "nonUpdatableView",
   identifier: sql.identifier("a", "non_updatable_view"),
-  attributes: nonUpdatableViewAttributes,
+  attributes: Object.assign(Object.create(null), {
+    "?column?": {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -421,23 +421,23 @@ const nonUpdatableViewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const inputsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const inputsCodec = recordCodec({
+  executor: executor
+};
+const nonUpdatableViewCodec = recordCodec(spec_nonUpdatableView);
+const spec_inputs = {
   name: "inputs",
   identifier: sql.identifier("a", "inputs"),
-  attributes: inputsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Should output as Input",
   extensions: {
     isTableLike: true,
@@ -448,23 +448,23 @@ const inputsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const patchsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const patchsCodec = recordCodec({
+  executor: executor
+};
+const inputsCodec = recordCodec(spec_inputs);
+const spec_patchs = {
   name: "patchs",
   identifier: sql.identifier("a", "patchs"),
-  attributes: patchsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Should output as Patch",
   extensions: {
     isTableLike: true,
@@ -475,23 +475,23 @@ const patchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const reservedAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const reservedCodec = recordCodec({
+  executor: executor
+};
+const patchsCodec = recordCodec(spec_patchs);
+const spec_reserved = {
   name: "reserved",
   identifier: sql.identifier("a", "reserved"),
-  attributes: reservedAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -502,23 +502,23 @@ const reservedCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const reservedPatchsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const reservedPatchsCodec = recordCodec({
+  executor: executor
+};
+const reservedCodec = recordCodec(spec_reserved);
+const spec_reservedPatchs = {
   name: "reservedPatchs",
   identifier: sql.identifier("a", "reservedPatchs"),
-  attributes: reservedPatchsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "`reservedPatchs` table should get renamed to ReservedPatchRecord to prevent clashes with ReservedPatch from `reserved` table",
   extensions: {
     isTableLike: true,
@@ -529,23 +529,23 @@ const reservedPatchsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const reservedInputAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const reservedInputCodec = recordCodec({
+  executor: executor
+};
+const reservedPatchsCodec = recordCodec(spec_reservedPatchs);
+const spec_reservedInput = {
   name: "reservedInput",
   identifier: sql.identifier("a", "reserved_input"),
-  attributes: reservedInputAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "`reserved_input` table should get renamed to ReservedInputRecord to prevent clashes with ReservedInput from `reserved` table",
   extensions: {
     isTableLike: true,
@@ -556,32 +556,32 @@ const reservedInputCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const defaultValueAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  null_value: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const defaultValueCodec = recordCodec({
+  executor: executor
+};
+const reservedInputCodec = recordCodec(spec_reservedInput);
+const spec_defaultValue = {
   name: "defaultValue",
   identifier: sql.identifier("a", "default_value"),
-  attributes: defaultValueAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    null_value: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -592,41 +592,41 @@ const defaultValueCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const foreignKeyAttributes = Object.assign(Object.create(null), {
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_key_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_key_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const foreignKeyCodec = recordCodec({
+  executor: executor
+};
+const defaultValueCodec = recordCodec(spec_defaultValue);
+const spec_foreignKey = {
   name: "foreignKey",
   identifier: sql.identifier("a", "foreign_key"),
-  attributes: foreignKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_key_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_key_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -637,32 +637,32 @@ const foreignKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const noPrimaryKeyAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  str: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const noPrimaryKeyCodec = recordCodec({
+  executor: executor
+};
+const foreignKeyCodec = recordCodec(spec_foreignKey);
+const spec_noPrimaryKey = {
   name: "noPrimaryKey",
   identifier: sql.identifier("a", "no_primary_key"),
-  attributes: noPrimaryKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    str: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -673,41 +673,41 @@ const noPrimaryKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const testviewAttributes = Object.assign(Object.create(null), {
-  testviewid: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const testviewCodec = recordCodec({
+  executor: executor
+};
+const noPrimaryKeyCodec = recordCodec(spec_noPrimaryKey);
+const spec_testview = {
   name: "testview",
   identifier: sql.identifier("a", "testview"),
-  attributes: testviewAttributes,
+  attributes: Object.assign(Object.create(null), {
+    testviewid: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -718,32 +718,32 @@ const testviewCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const uniqueForeignKeyAttributes = Object.assign(Object.create(null), {
-  compound_key_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_key_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const uniqueForeignKeyCodec = recordCodec({
+  executor: executor
+};
+const testviewCodec = recordCodec(spec_testview);
+const spec_uniqueForeignKey = {
   name: "uniqueForeignKey",
   identifier: sql.identifier("a", "unique_foreign_key"),
-  attributes: uniqueForeignKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    compound_key_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_key_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -756,32 +756,32 @@ const uniqueForeignKeyCodec = recordCodec({
       omit: "create,update,delete,all,order,filter"
     })
   },
-  executor
-});
-const cMyTableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  json_data: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const cMyTableCodec = recordCodec({
+  executor: executor
+};
+const uniqueForeignKeyCodec = recordCodec(spec_uniqueForeignKey);
+const spec_cMyTable = {
   name: "cMyTable",
   identifier: sql.identifier("c", "my_table"),
-  attributes: cMyTableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    json_data: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -792,34 +792,34 @@ const cMyTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const cPersonSecretAttributes = Object.assign(Object.create(null), {
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  sekrit: {
-    description: "A secret held by the associated Person",
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "secret"
-      }
-    }
-  }
-});
-const cPersonSecretCodec = recordCodec({
+  executor: executor
+};
+const cMyTableCodec = recordCodec(spec_cMyTable);
+const spec_cPersonSecret = {
   name: "cPersonSecret",
   identifier: sql.identifier("c", "person_secret"),
-  attributes: cPersonSecretAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    sekrit: {
+      description: "A secret held by the associated Person",
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "secret"
+        }
+      }
+    }
+  }),
   description: "Tracks the person's secret",
   extensions: {
     isTableLike: true,
@@ -832,41 +832,41 @@ const cPersonSecretCodec = recordCodec({
       deprecated: "This is deprecated (comment on table c.person_secret)."
     })
   },
-  executor
-});
-const viewTableAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const viewTableCodec = recordCodec({
+  executor: executor
+};
+const cPersonSecretCodec = recordCodec(spec_cPersonSecret);
+const spec_viewTable = {
   name: "viewTable",
   identifier: sql.identifier("a", "view_table"),
-  attributes: viewTableAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -877,50 +877,50 @@ const viewTableCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const bUpdatableViewAttributes = Object.assign(Object.create(null), {
-  x: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  description: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  constant: {
-    description: "This is constantly 2",
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const bUpdatableViewCodec = recordCodec({
+  executor: executor
+};
+const viewTableCodec = recordCodec(spec_viewTable);
+const spec_bUpdatableView = {
   name: "bUpdatableView",
   identifier: sql.identifier("b", "updatable_view"),
-  attributes: bUpdatableViewAttributes,
+  attributes: Object.assign(Object.create(null), {
+    x: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    description: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    constant: {
+      description: "This is constantly 2",
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "YOYOYO!!",
   extensions: {
     isTableLike: true,
@@ -933,41 +933,41 @@ const bUpdatableViewCodec = recordCodec({
       uniqueKey: "x"
     })
   },
-  executor
-});
-const cCompoundKeyAttributes = Object.assign(Object.create(null), {
-  person_id_2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id_1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  extra: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const cCompoundKeyCodec = recordCodec({
+  executor: executor
+};
+const bUpdatableViewCodec = recordCodec(spec_bUpdatableView);
+const spec_cCompoundKey = {
   name: "cCompoundKey",
   identifier: sql.identifier("c", "compound_key"),
-  attributes: cCompoundKeyAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id_2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id_1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    extra: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -978,50 +978,50 @@ const cCompoundKeyCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const similarTable1Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  col1: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col2: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col3: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const similarTable1Codec = recordCodec({
+  executor: executor
+};
+const cCompoundKeyCodec = recordCodec(spec_cCompoundKey);
+const spec_similarTable1 = {
   name: "similarTable1",
   identifier: sql.identifier("a", "similar_table_1"),
-  attributes: similarTable1Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    col1: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col2: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col3: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1032,50 +1032,50 @@ const similarTable1Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const similarTable2Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  col3: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col4: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  col5: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const similarTable2Codec = recordCodec({
+  executor: executor
+};
+const similarTable1Codec = recordCodec(spec_similarTable1);
+const spec_similarTable2 = {
   name: "similarTable2",
   identifier: sql.identifier("a", "similar_table_2"),
-  attributes: similarTable2Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    col3: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col4: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    col5: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1086,50 +1086,50 @@ const similarTable2Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const cNullTestRecordAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_int: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  non_null_text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const cNullTestRecordCodec = recordCodec({
+  executor: executor
+};
+const similarTable2Codec = recordCodec(spec_similarTable2);
+const spec_cNullTestRecord = {
   name: "cNullTestRecord",
   identifier: sql.identifier("c", "null_test_record"),
-  attributes: cNullTestRecordAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_int: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    non_null_text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1140,8 +1140,9 @@ const cNullTestRecordCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const cNullTestRecordCodec = recordCodec(spec_cNullTestRecord);
 const pgCatalogUuidArrayCodec = listOfCodec(TYPES.uuid, {
   extensions: {
     pg: {
@@ -1155,39 +1156,38 @@ const pgCatalogUuidArrayCodec = listOfCodec(TYPES.uuid, {
   description: undefined,
   name: "pgCatalogUuidArray"
 });
-const cEdgeCaseAttributes = Object.assign(Object.create(null), {
-  not_null_has_default: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  wont_cast_easy: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  row_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const cEdgeCaseCodec = recordCodec({
+const spec_cEdgeCase = {
   name: "cEdgeCase",
   identifier: sql.identifier("c", "edge_case"),
-  attributes: cEdgeCaseAttributes,
+  attributes: Object.assign(Object.create(null), {
+    not_null_has_default: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    wont_cast_easy: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    row_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1198,50 +1198,50 @@ const cEdgeCaseCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const cLeftArmAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  length_in_metres: {
-    description: undefined,
-    codec: TYPES.float,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  mood: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const cLeftArmCodec = recordCodec({
+  executor: executor
+};
+const cEdgeCaseCodec = recordCodec(spec_cEdgeCase);
+const spec_cLeftArm = {
   name: "cLeftArm",
   identifier: sql.identifier("c", "left_arm"),
-  attributes: cLeftArmAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    length_in_metres: {
+      description: undefined,
+      codec: TYPES.float,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    mood: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Tracks metadata about the left arms of various people",
   extensions: {
     isTableLike: true,
@@ -1252,8 +1252,9 @@ const cLeftArmCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const cLeftArmCodec = recordCodec(spec_cLeftArm);
 const bJwtTokenCodec = recordCodec({
   name: "bJwtToken",
   identifier: sql.identifier("b", "jwt_token"),
@@ -1314,7 +1315,7 @@ const bJwtTokenCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const cNotNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "cNotNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
@@ -1328,30 +1329,29 @@ const cNotNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "cNotNullTimesta
   },
   notNull: true
 });
-const cIssue756Attributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  ts: {
-    description: undefined,
-    codec: cNotNullTimestampCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const cIssue756Codec = recordCodec({
+const spec_cIssue756 = {
   name: "cIssue756",
   identifier: sql.identifier("c", "issue756"),
-  attributes: cIssue756Attributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    ts: {
+      description: undefined,
+      codec: cNotNullTimestampCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1362,8 +1362,9 @@ const cIssue756Codec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const cIssue756Codec = recordCodec(spec_cIssue756);
 const bAuthPayloadCodec = recordCodec({
   name: "bAuthPayload",
   identifier: sql.identifier("b", "auth_payload"),
@@ -1408,7 +1409,7 @@ const bAuthPayloadCodec = recordCodec({
       foreignKey: "(id) references c.person"
     })
   },
-  executor
+  executor: executor
 });
 const bColorCodec = enumCodec({
   name: "bColor",
@@ -1539,7 +1540,7 @@ const cCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const registryConfig_pgCodecs_CFuncOutOutCompoundTypeRecord_CFuncOutOutCompoundTypeRecord = recordCodec({
   name: "CFuncOutOutCompoundTypeRecord",
@@ -1661,7 +1662,7 @@ const comptypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   extensions: {
@@ -1676,66 +1677,65 @@ const comptypeArrayCodec = listOfCodec(comptypeCodec, {
   description: undefined,
   name: "comptypeArray"
 });
-const postAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  headline: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  body: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  enums: {
-    description: undefined,
-    codec: anEnumArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  comptypes: {
-    description: undefined,
-    codec: comptypeArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const postCodec = recordCodec({
+const spec_post = {
   name: "post",
   identifier: sql.identifier("a", "post"),
-  attributes: postAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    headline: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    body: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    enums: {
+      description: undefined,
+      codec: anEnumArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    comptypes: {
+      description: undefined,
+      codec: comptypeArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1746,8 +1746,9 @@ const postCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const postCodec = recordCodec(spec_post);
 const registryConfig_pgCodecs_CQueryOutputTwoRowsRecord_CQueryOutputTwoRowsRecord = recordCodec({
   name: "CQueryOutputTwoRowsRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
@@ -1894,117 +1895,116 @@ const bWrappedUrlCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
-const cPersonAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: "The primary unique identifier for the person",
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_full_name: {
-    description: "The person\u2019s name",
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        name: "name"
-      }
-    }
-  },
-  aliases: {
-    description: undefined,
-    codec: pgCatalogTextArrayCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  about: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  email: {
-    description: undefined,
-    codec: bEmailCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  site: {
-    description: undefined,
-    codec: bWrappedUrlCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        deprecated: "Don\u2019t use me"
-      }
-    }
-  },
-  config: {
-    description: undefined,
-    codec: TYPES.hstore,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_login_from_ip: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_login_from_subnet: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  user_mac: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  created_at: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const cPersonCodec = recordCodec({
+const spec_cPerson = {
   name: "cPerson",
   identifier: sql.identifier("c", "person"),
-  attributes: cPersonAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: "The primary unique identifier for the person",
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_full_name: {
+      description: "The person\u2019s name",
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          name: "name"
+        }
+      }
+    },
+    aliases: {
+      description: undefined,
+      codec: pgCatalogTextArrayCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    about: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    email: {
+      description: undefined,
+      codec: bEmailCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    site: {
+      description: undefined,
+      codec: bWrappedUrlCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          deprecated: "Don\u2019t use me"
+        }
+      }
+    },
+    config: {
+      description: undefined,
+      codec: TYPES.hstore,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_login_from_ip: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_login_from_subnet: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    user_mac: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    created_at: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: "Person test comment",
   extensions: {
     isTableLike: true,
@@ -2015,8 +2015,9 @@ const cPersonCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
+  executor: executor
+};
+const cPersonCodec = recordCodec(spec_cPerson);
 const registryConfig_pgCodecs_CPersonComputedFirstArgInoutOutRecord_CPersonComputedFirstArgInoutOutRecord = recordCodec({
   name: "CPersonComputedFirstArgInoutOutRecord",
   identifier: sql`ANONYMOUS_TYPE_DO_NOT_REFERENCE`,
@@ -2349,7 +2350,7 @@ const bNestedCompoundTypeCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
+  executor: executor
 });
 const cTextArrayDomainCodec = domainOfCodec(pgCatalogTextArrayCodec, "cTextArrayDomain", sql.identifier("c", "text_array_domain"), {
   description: undefined,
@@ -2401,7 +2402,7 @@ const pgCatalogByteaArrayCodec = listOfCodec(TYPES.bytea, {
   description: undefined,
   name: "pgCatalogByteaArray"
 });
-const bTypesAttributes_ltree_codec_ltree = {
+const spec_bTypes_attributes_ltree_codec_ltree = {
   name: "ltree",
   sqlType: sql`ltree`,
   toPg(str) {
@@ -2413,469 +2414,468 @@ const bTypesAttributes_ltree_codec_ltree = {
   executor: null,
   attributes: undefined
 };
-const bTypesAttributes_ltree_array_codec_ltree_ = listOfCodec(bTypesAttributes_ltree_codec_ltree);
-const bTypesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  smallint: {
-    description: undefined,
-    codec: TYPES.int2,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bigint: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numeric: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  decimal: {
-    description: undefined,
-    codec: TYPES.numeric,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  boolean: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  varchar: {
-    description: undefined,
-    codec: TYPES.varchar,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum: {
-    description: undefined,
-    codec: bColorCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  enum_array: {
-    description: undefined,
-    codec: bColorArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain: {
-    description: undefined,
-    codec: anIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  domain2: {
-    description: undefined,
-    codec: bAnotherIntCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array: {
-    description: undefined,
-    codec: pgCatalogTextArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  json: {
-    description: undefined,
-    codec: TYPES.json,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  jsonb: {
-    description: undefined,
-    codec: TYPES.jsonb,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_range: {
-    description: undefined,
-    codec: pgCatalogNumrangeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  numrange: {
-    description: undefined,
-    codec: pgCatalogNumrangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  daterange: {
-    description: undefined,
-    codec: pgCatalogDaterangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  an_int_range: {
-    description: undefined,
-    codec: anIntRangeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamp: {
-    description: undefined,
-    codec: TYPES.timestamp,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timestamptz: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  date: {
-    description: undefined,
-    codec: TYPES.date,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  time: {
-    description: undefined,
-    codec: TYPES.time,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  timetz: {
-    description: undefined,
-    codec: TYPES.timetz,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval: {
-    description: undefined,
-    codec: TYPES.interval,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  interval_array: {
-    description: undefined,
-    codec: pgCatalogIntervalArrayCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  money: {
-    description: undefined,
-    codec: TYPES.money,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  compound_type: {
-    description: undefined,
-    codec: cCompoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nested_compound_type: {
-    description: undefined,
-    codec: bNestedCompoundTypeCodec,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_compound_type: {
-    description: undefined,
-    codec: cCompoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullable_nested_compound_type: {
-    description: undefined,
-    codec: bNestedCompoundTypeCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  point: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  nullablePoint: {
-    description: undefined,
-    codec: TYPES.point,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  inet: {
-    description: undefined,
-    codec: TYPES.inet,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  cidr: {
-    description: undefined,
-    codec: TYPES.cidr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  macaddr: {
-    description: undefined,
-    codec: TYPES.macaddr,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regproc: {
-    description: undefined,
-    codec: TYPES.regproc,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regprocedure: {
-    description: undefined,
-    codec: TYPES.regprocedure,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoper: {
-    description: undefined,
-    codec: TYPES.regoper,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regoperator: {
-    description: undefined,
-    codec: TYPES.regoperator,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regclass: {
-    description: undefined,
-    codec: TYPES.regclass,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regtype: {
-    description: undefined,
-    codec: TYPES.regtype,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regconfig: {
-    description: undefined,
-    codec: TYPES.regconfig,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  regdictionary: {
-    description: undefined,
-    codec: TYPES.regdictionary,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text_array_domain: {
-    description: undefined,
-    codec: cTextArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  int8_array_domain: {
-    description: undefined,
-    codec: cInt8ArrayDomainCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea: {
-    description: undefined,
-    codec: TYPES.bytea,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  bytea_array: {
-    description: undefined,
-    codec: pgCatalogByteaArrayCodec,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree: {
-    description: undefined,
-    codec: bTypesAttributes_ltree_codec_ltree,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  ltree_array: {
-    description: undefined,
-    codec: bTypesAttributes_ltree_array_codec_ltree_,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions46 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "b",
-    name: "types"
-  },
-  tags: Object.assign(Object.create(null), {
-    foreignKey: ["(smallint) references a.post", "(id) references a.post"]
-  })
-};
-const bTypesCodec = recordCodec({
+const spec_bTypes_attributes_ltree_array_codec_ltree_ = listOfCodec(spec_bTypes_attributes_ltree_codec_ltree);
+const spec_bTypes = {
   name: "bTypes",
   identifier: sql.identifier("b", "types"),
-  attributes: bTypesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    smallint: {
+      description: undefined,
+      codec: TYPES.int2,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bigint: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numeric: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    decimal: {
+      description: undefined,
+      codec: TYPES.numeric,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    boolean: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    varchar: {
+      description: undefined,
+      codec: TYPES.varchar,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum: {
+      description: undefined,
+      codec: bColorCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    enum_array: {
+      description: undefined,
+      codec: bColorArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain: {
+      description: undefined,
+      codec: anIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    domain2: {
+      description: undefined,
+      codec: bAnotherIntCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array: {
+      description: undefined,
+      codec: pgCatalogTextArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    json: {
+      description: undefined,
+      codec: TYPES.json,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    jsonb: {
+      description: undefined,
+      codec: TYPES.jsonb,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_range: {
+      description: undefined,
+      codec: pgCatalogNumrangeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    numrange: {
+      description: undefined,
+      codec: pgCatalogNumrangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    daterange: {
+      description: undefined,
+      codec: pgCatalogDaterangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    an_int_range: {
+      description: undefined,
+      codec: anIntRangeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamp: {
+      description: undefined,
+      codec: TYPES.timestamp,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timestamptz: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    date: {
+      description: undefined,
+      codec: TYPES.date,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    time: {
+      description: undefined,
+      codec: TYPES.time,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    timetz: {
+      description: undefined,
+      codec: TYPES.timetz,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval: {
+      description: undefined,
+      codec: TYPES.interval,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    interval_array: {
+      description: undefined,
+      codec: pgCatalogIntervalArrayCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    money: {
+      description: undefined,
+      codec: TYPES.money,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    compound_type: {
+      description: undefined,
+      codec: cCompoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nested_compound_type: {
+      description: undefined,
+      codec: bNestedCompoundTypeCodec,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_compound_type: {
+      description: undefined,
+      codec: cCompoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullable_nested_compound_type: {
+      description: undefined,
+      codec: bNestedCompoundTypeCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    point: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    nullablePoint: {
+      description: undefined,
+      codec: TYPES.point,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    inet: {
+      description: undefined,
+      codec: TYPES.inet,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    cidr: {
+      description: undefined,
+      codec: TYPES.cidr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    macaddr: {
+      description: undefined,
+      codec: TYPES.macaddr,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regproc: {
+      description: undefined,
+      codec: TYPES.regproc,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regprocedure: {
+      description: undefined,
+      codec: TYPES.regprocedure,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoper: {
+      description: undefined,
+      codec: TYPES.regoper,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regoperator: {
+      description: undefined,
+      codec: TYPES.regoperator,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regclass: {
+      description: undefined,
+      codec: TYPES.regclass,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regtype: {
+      description: undefined,
+      codec: TYPES.regtype,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regconfig: {
+      description: undefined,
+      codec: TYPES.regconfig,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    regdictionary: {
+      description: undefined,
+      codec: TYPES.regdictionary,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text_array_domain: {
+      description: undefined,
+      codec: cTextArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    int8_array_domain: {
+      description: undefined,
+      codec: cInt8ArrayDomainCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea: {
+      description: undefined,
+      codec: TYPES.bytea,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    bytea_array: {
+      description: undefined,
+      codec: pgCatalogByteaArrayCodec,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree: {
+      description: undefined,
+      codec: spec_bTypes_attributes_ltree_codec_ltree,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    ltree_array: {
+      description: undefined,
+      codec: spec_bTypes_attributes_ltree_array_codec_ltree_,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions46,
-  executor
-});
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "b",
+      name: "types"
+    },
+    tags: Object.assign(Object.create(null), {
+      foreignKey: ["(smallint) references a.post", "(id) references a.post"]
+    })
+  },
+  executor: executor
+};
+const bTypesCodec = recordCodec(spec_bTypes);
 const pgCatalogInt4ArrayCodec = listOfCodec(TYPES.int, {
   extensions: {
     pg: {
@@ -3416,7 +3416,7 @@ const registryConfig_pgResources_b_types_b_types = {
       name: "types"
     },
     tags: {
-      foreignKey: extensions46.tags.foreignKey
+      foreignKey: spec_bTypes.extensions.tags.foreignKey
     }
   }
 };
@@ -3539,8 +3539,8 @@ const registry = makeRegistry({
     cInt8ArrayDomain: cInt8ArrayDomainCodec,
     bytea: TYPES.bytea,
     pgCatalogByteaArray: pgCatalogByteaArrayCodec,
-    ltree: bTypesAttributes_ltree_codec_ltree,
-    "ltree[]": bTypesAttributes_ltree_array_codec_ltree_,
+    ltree: spec_bTypes_attributes_ltree_codec_ltree,
+    "ltree[]": spec_bTypes_attributes_ltree_array_codec_ltree_,
     bpchar: TYPES.bpchar,
     cCompoundTypeArray: listOfCodec(cCompoundTypeCodec, {
       extensions: {
@@ -3627,7 +3627,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor
+      executor: executor
     }),
     tablefuncCrosstab3: recordCodec({
       name: "tablefuncCrosstab3",
@@ -3680,7 +3680,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor
+      executor: executor
     }),
     tablefuncCrosstab4: recordCodec({
       name: "tablefuncCrosstab4",
@@ -3742,7 +3742,7 @@ const registry = makeRegistry({
         },
         tags: Object.create(null)
       },
-      executor
+      executor: executor
     })
   }),
   pgResources: Object.assign(Object.create(null), {
@@ -11996,6 +11996,15 @@ const makeArgs68 = (args, path = []) => {
   }
   return selectArgs;
 };
+function UUIDSerialize(value) {
+  return "" + value;
+}
+const coerce = string => {
+  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
+    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
+  }
+  return string;
+};
 const argDetailsSimple69 = [];
 const makeArgs69 = (args, path = []) => {
   const selectArgs = [];
@@ -12500,6 +12509,60 @@ const makeArgs77 = (args, path = []) => {
 const resource_post_computed_compound_type_arrayPgResource = registry.pgResources["post_computed_compound_type_array"];
 const resource_frmcdc_comptypePgResource = registry.pgResources["frmcdc_comptype"];
 const resource_frmcdc_bNestedCompoundTypePgResource = registry.pgResources["frmcdc_bNestedCompoundType"];
+function LTreeParseValue(value) {
+  return value;
+}
+const isValidHstoreObject = obj => {
+  if (obj === null) {
+    // Null is okay
+    return true;
+  } else if (typeof obj === "object") {
+    // A hash with string/null values is also okay
+    const keys = Object.keys(obj);
+    for (const key of keys) {
+      const val = obj[key];
+      if (val === null) {
+        // Null is okay
+      } else if (typeof val === "string") {
+        // String is okay
+      } else {
+        // Everything else is invalid.
+        return false;
+      }
+    }
+    return true;
+  } else {
+    // Everything else is invalid.
+    return false;
+  }
+};
+const parseValueLiteral = (ast, variables) => {
+  switch (ast.kind) {
+    case Kind.INT:
+    case Kind.FLOAT:
+      // Number isn't really okay, but we'll coerce it to a string anyway.
+      return String(parseFloat(ast.value));
+    case Kind.STRING:
+      // String is okay.
+      return String(ast.value);
+    case Kind.NULL:
+      // Null is okay.
+      return null;
+    case Kind.VARIABLE:
+      {
+        // Variable is okay if that variable is either a string or null.
+        const name = ast.name.value;
+        const value = variables ? variables[name] : undefined;
+        if (value === null || typeof value === "string") {
+          return value;
+        }
+        return undefined;
+      }
+    default:
+      // Everything else is invalid.
+      return undefined;
+  }
+};
 const argDetailsSimple78 = [];
 const makeArgs78 = (args, path = []) => {
   const selectArgs = [];
@@ -28026,6 +28089,11 @@ export const plans = {
       return $record.get("o");
     }
   },
+  BEmail: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
   CPersonComputedFirstArgInoutOutRecord: {
     __assertStep: assertPgClassSingleStep,
     person($record) {
@@ -28226,6 +28294,19 @@ export const plans = {
     },
     fooBar($record) {
       return $record.get("foo_bar");
+    }
+  },
+  UUID: {
+    serialize: UUIDSerialize,
+    parseValue(value) {
+      return coerce("" + value);
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // ERRORS: add name to this error
+        throw new GraphQLError(`${"UUID" ?? "This scalar"} can only parse string values (kind = '${ast.kind}')`);
+      }
+      return coerce(ast.value);
     }
   },
   BEnumCaps: {
@@ -28722,6 +28803,16 @@ export const plans = {
       return $edge.node();
     }
   },
+  Cursor: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   PageInfo: {
     __assertStep: assertPageInfoCapableStep,
     hasNextPage($pageInfo) {
@@ -28738,6 +28829,9 @@ export const plans = {
     }
   },
   CCompoundTypeInput: {
+    "__inputPlan": function CCompoundTypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     a: {
       applyPlan($insert, val) {
         $insert.set("a", val.get());
@@ -28857,6 +28951,16 @@ export const plans = {
     },
     isOptimised($record) {
       return $record.get("is_optimised");
+    }
+  },
+  Datetime: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   BTypeConnection: {
@@ -29059,12 +29163,102 @@ export const plans = {
       });
     }
   },
+  BigInt: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigInt" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  BigFloat: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigFloat" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  AnInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
+  BAnotherInt: {
+    serialize: GraphQLInt.serialize,
+    parseValue: GraphQLInt.parseValue,
+    parseLiteral: GraphQLInt.parseLiteral
+  },
+  JSON: {
+    serialize(value) {
+      return value;
+    },
+    parseValue(value) {
+      return value;
+    },
+    parseLiteral: (() => {
+      const parseLiteralToObject = (ast, variables) => {
+        switch (ast.kind) {
+          case Kind.STRING:
+          case Kind.BOOLEAN:
+            return ast.value;
+          case Kind.INT:
+          case Kind.FLOAT:
+            return parseFloat(ast.value);
+          case Kind.OBJECT:
+            {
+              const value = Object.create(null);
+              ast.fields.forEach(field => {
+                value[field.name.value] = parseLiteralToObject(field.value, variables);
+              });
+              return value;
+            }
+          case Kind.LIST:
+            return ast.values.map(n => parseLiteralToObject(n, variables));
+          case Kind.NULL:
+            return null;
+          case Kind.VARIABLE:
+            {
+              const name = ast.name.value;
+              return variables ? variables[name] : undefined;
+            }
+          default:
+            return undefined;
+        }
+      };
+      return parseLiteralToObject;
+    })()
+  },
   BigFloatRange: {},
   BigFloatRangeBound: {},
   DateRange: {},
   DateRangeBound: {},
+  Date: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Date" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   AnIntRange: {},
   AnIntRangeBound: {},
+  Time: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Time" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   BNestedCompoundType: {
     __assertStep: assertPgClassSingleStep,
     a($record) {
@@ -29090,6 +29284,148 @@ export const plans = {
     }
   },
   Point: {},
+  InternetAddress: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"InternetAddress" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  CidrAddress: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"CidrAddress" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  MacAddress: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"MacAddress" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProc: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProc" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegProcedure: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegProcedure" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOper: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOper" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegOperator: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegOperator" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegClass: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegClass" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegType: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegType" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegConfig: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegConfig" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  RegDictionary: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"RegDictionary" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  Base64EncodedBinary: {
+    serialize(data) {
+      if (Buffer.isBuffer(data)) {
+        return data.toString("base64");
+      } else {
+        throw new Error(`Base64EncodeBinary can only be used with Node.js buffers.`);
+      }
+    },
+    parseValue(data) {
+      if (typeof data === "string") {
+        return Buffer.from(data, "base64");
+      } else {
+        throw new GraphQLError("Base64EncodedBinary can only parse string values.");
+      }
+    },
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        // TODO: add name to this error
+        throw new GraphQLError("Base64EncodedBinary can only parse string values");
+      }
+      return Buffer.from(ast.value, "base64");
+    }
+  },
+  LTree: {
+    serialize(x) {
+      return x;
+    },
+    parseValue: LTreeParseValue,
+    parseLiteral(node, variables) {
+      return LTreeParseValue(valueFromASTUntyped(node, variables));
+    }
+  },
   BTypeEdge: {
     __assertStep: assertEdgeCapableStep,
     cursor($edge) {
@@ -30274,7 +30610,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.id.codec)}`;
             }
           });
         }
@@ -30297,7 +30633,7 @@ export const plans = {
             type: "attribute",
             attribute: "smallint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.smallint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.smallint.codec)}`;
             }
           });
         }
@@ -30320,7 +30656,7 @@ export const plans = {
             type: "attribute",
             attribute: "bigint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.bigint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.bigint.codec)}`;
             }
           });
         }
@@ -30343,7 +30679,7 @@ export const plans = {
             type: "attribute",
             attribute: "numeric",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.numeric.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.numeric.codec)}`;
             }
           });
         }
@@ -30366,7 +30702,7 @@ export const plans = {
             type: "attribute",
             attribute: "decimal",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.decimal.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.decimal.codec)}`;
             }
           });
         }
@@ -30389,7 +30725,7 @@ export const plans = {
             type: "attribute",
             attribute: "boolean",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.boolean.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.boolean.codec)}`;
             }
           });
         }
@@ -30412,7 +30748,7 @@ export const plans = {
             type: "attribute",
             attribute: "varchar",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.varchar.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.varchar.codec)}`;
             }
           });
         }
@@ -30435,7 +30771,7 @@ export const plans = {
             type: "attribute",
             attribute: "enum",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.enum.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.enum.codec)}`;
             }
           });
         }
@@ -30458,7 +30794,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.domain.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.domain.codec)}`;
             }
           });
         }
@@ -30481,7 +30817,7 @@ export const plans = {
             type: "attribute",
             attribute: "domain2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.domain2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.domain2.codec)}`;
             }
           });
         }
@@ -30504,7 +30840,7 @@ export const plans = {
             type: "attribute",
             attribute: "json",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.json.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.json.codec)}`;
             }
           });
         }
@@ -30527,7 +30863,7 @@ export const plans = {
             type: "attribute",
             attribute: "jsonb",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.jsonb.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.jsonb.codec)}`;
             }
           });
         }
@@ -30550,7 +30886,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamp",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.timestamp.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.timestamp.codec)}`;
             }
           });
         }
@@ -30573,7 +30909,7 @@ export const plans = {
             type: "attribute",
             attribute: "timestamptz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.timestamptz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.timestamptz.codec)}`;
             }
           });
         }
@@ -30596,7 +30932,7 @@ export const plans = {
             type: "attribute",
             attribute: "date",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.date.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.date.codec)}`;
             }
           });
         }
@@ -30619,7 +30955,7 @@ export const plans = {
             type: "attribute",
             attribute: "time",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.time.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.time.codec)}`;
             }
           });
         }
@@ -30642,7 +30978,7 @@ export const plans = {
             type: "attribute",
             attribute: "timetz",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.timetz.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.timetz.codec)}`;
             }
           });
         }
@@ -30665,7 +31001,7 @@ export const plans = {
             type: "attribute",
             attribute: "interval",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.interval.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.interval.codec)}`;
             }
           });
         }
@@ -30688,7 +31024,7 @@ export const plans = {
             type: "attribute",
             attribute: "money",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.money.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.money.codec)}`;
             }
           });
         }
@@ -30711,7 +31047,7 @@ export const plans = {
             type: "attribute",
             attribute: "point",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.point.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.point.codec)}`;
             }
           });
         }
@@ -30734,7 +31070,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullablePoint",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.nullablePoint.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.nullablePoint.codec)}`;
             }
           });
         }
@@ -30757,7 +31093,7 @@ export const plans = {
             type: "attribute",
             attribute: "inet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.inet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.inet.codec)}`;
             }
           });
         }
@@ -30780,7 +31116,7 @@ export const plans = {
             type: "attribute",
             attribute: "cidr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.cidr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.cidr.codec)}`;
             }
           });
         }
@@ -30803,7 +31139,7 @@ export const plans = {
             type: "attribute",
             attribute: "macaddr",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.macaddr.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.macaddr.codec)}`;
             }
           });
         }
@@ -30826,7 +31162,7 @@ export const plans = {
             type: "attribute",
             attribute: "regproc",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.regproc.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.regproc.codec)}`;
             }
           });
         }
@@ -30849,7 +31185,7 @@ export const plans = {
             type: "attribute",
             attribute: "regprocedure",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.regprocedure.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.regprocedure.codec)}`;
             }
           });
         }
@@ -30872,7 +31208,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoper",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.regoper.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.regoper.codec)}`;
             }
           });
         }
@@ -30895,7 +31231,7 @@ export const plans = {
             type: "attribute",
             attribute: "regoperator",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.regoperator.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.regoperator.codec)}`;
             }
           });
         }
@@ -30918,7 +31254,7 @@ export const plans = {
             type: "attribute",
             attribute: "regclass",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.regclass.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.regclass.codec)}`;
             }
           });
         }
@@ -30941,7 +31277,7 @@ export const plans = {
             type: "attribute",
             attribute: "regtype",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.regtype.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.regtype.codec)}`;
             }
           });
         }
@@ -30964,7 +31300,7 @@ export const plans = {
             type: "attribute",
             attribute: "regconfig",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.regconfig.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.regconfig.codec)}`;
             }
           });
         }
@@ -30987,7 +31323,7 @@ export const plans = {
             type: "attribute",
             attribute: "regdictionary",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.regdictionary.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.regdictionary.codec)}`;
             }
           });
         }
@@ -31010,7 +31346,7 @@ export const plans = {
             type: "attribute",
             attribute: "ltree",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bTypesAttributes.ltree.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bTypes.attributes.ltree.codec)}`;
             }
           });
         }
@@ -31052,6 +31388,50 @@ export const plans = {
     __assertStep: assertPgClassSingleStep,
     url($record) {
       return $record.get("url");
+    }
+  },
+  BNotNullUrl: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
+  KeyValueHash: {
+    serialize(value) {
+      return value;
+    },
+    parseValue(obj) {
+      if (isValidHstoreObject(obj)) {
+        return obj;
+      }
+      throw new GraphQLError(`This is not a valid ${"KeyValueHash"} object, it must be a key/value hash where keys and values are both strings (or null).`);
+    },
+    parseLiteral(ast, variables) {
+      switch (ast.kind) {
+        case Kind.OBJECT:
+          {
+            const value = ast.fields.reduce((memo, field) => {
+              memo[field.name.value] = parseValueLiteral(field.value, variables);
+              return memo;
+            }, Object.create(null));
+            if (!isValidHstoreObject(value)) {
+              return undefined;
+            }
+            return value;
+          }
+        case Kind.NULL:
+          return null;
+        case Kind.VARIABLE:
+          {
+            const name = ast.name.value;
+            const value = variables ? variables[name] : undefined;
+            if (!isValidHstoreObject(value)) {
+              return undefined;
+            }
+            return value;
+          }
+        default:
+          return undefined;
+      }
     }
   },
   PostConnection: {
@@ -31268,7 +31648,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.id.codec)}`;
             }
           });
         }
@@ -31291,7 +31671,7 @@ export const plans = {
             type: "attribute",
             attribute: "headline",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.headline.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.headline.codec)}`;
             }
           });
         }
@@ -31314,7 +31694,7 @@ export const plans = {
             type: "attribute",
             attribute: "body",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.body.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.body.codec)}`;
             }
           });
         }
@@ -31337,7 +31717,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), postAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_post.attributes.author_id.codec)}`;
             }
           });
         }
@@ -31517,7 +31897,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_foreignKey.attributes.person_id.codec)}`;
             }
           });
         }
@@ -31540,7 +31920,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_foreignKey.attributes.compound_key_1.codec)}`;
             }
           });
         }
@@ -31563,7 +31943,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), foreignKeyAttributes.compound_key_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_foreignKey.attributes.compound_key_2.codec)}`;
             }
           });
         }
@@ -31786,7 +32166,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cCompoundKeyAttributes.person_id_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_cCompoundKey.attributes.person_id_2.codec)}`;
             }
           });
         }
@@ -31809,7 +32189,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cCompoundKeyAttributes.person_id_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_cCompoundKey.attributes.person_id_1.codec)}`;
             }
           });
         }
@@ -31832,7 +32212,7 @@ export const plans = {
             type: "attribute",
             attribute: "extra",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cCompoundKeyAttributes.extra.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_cCompoundKey.attributes.extra.codec)}`;
             }
           });
         }
@@ -31914,6 +32294,16 @@ export const plans = {
     },
     ts($record) {
       return $record.get("ts");
+    }
+  },
+  CNotNullTimestamp: {
+    serialize: UUIDSerialize,
+    parseValue: UUIDSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
     }
   },
   CFuncOutSetofConnection: {
@@ -32404,7 +32794,7 @@ export const plans = {
             type: "attribute",
             attribute: "?column?",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), nonUpdatableViewAttributes["?column?"].codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_nonUpdatableView.attributes["?column?"].codec)}`;
             }
           });
         }
@@ -32525,7 +32915,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), inputsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_inputs.attributes.id.codec)}`;
             }
           });
         }
@@ -32646,7 +33036,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), patchsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_patchs.attributes.id.codec)}`;
             }
           });
         }
@@ -32767,7 +33157,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reserved.attributes.id.codec)}`;
             }
           });
         }
@@ -32888,7 +33278,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedPatchsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reservedPatchs.attributes.id.codec)}`;
             }
           });
         }
@@ -33009,7 +33399,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), reservedInputAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_reservedInput.attributes.id.codec)}`;
             }
           });
         }
@@ -33164,7 +33554,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_defaultValue.attributes.id.codec)}`;
             }
           });
         }
@@ -33187,7 +33577,7 @@ export const plans = {
             type: "attribute",
             attribute: "null_value",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), defaultValueAttributes.null_value.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_defaultValue.attributes.null_value.codec)}`;
             }
           });
         }
@@ -33310,7 +33700,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_noPrimaryKey.attributes.id.codec)}`;
             }
           });
         }
@@ -33333,7 +33723,7 @@ export const plans = {
             type: "attribute",
             attribute: "str",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), noPrimaryKeyAttributes.str.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_noPrimaryKey.attributes.str.codec)}`;
             }
           });
         }
@@ -33502,7 +33892,7 @@ export const plans = {
             type: "attribute",
             attribute: "testviewid",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.testviewid.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_testview.attributes.testviewid.codec)}`;
             }
           });
         }
@@ -33525,7 +33915,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_testview.attributes.col1.codec)}`;
             }
           });
         }
@@ -33548,7 +33938,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), testviewAttributes.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_testview.attributes.col2.codec)}`;
             }
           });
         }
@@ -33671,7 +34061,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), uniqueForeignKeyAttributes.compound_key_1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_uniqueForeignKey.attributes.compound_key_1.codec)}`;
             }
           });
         }
@@ -33694,7 +34084,7 @@ export const plans = {
             type: "attribute",
             attribute: "compound_key_2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), uniqueForeignKeyAttributes.compound_key_2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_uniqueForeignKey.attributes.compound_key_2.codec)}`;
             }
           });
         }
@@ -33849,7 +34239,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cMyTableAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_cMyTable.attributes.id.codec)}`;
             }
           });
         }
@@ -33872,7 +34262,7 @@ export const plans = {
             type: "attribute",
             attribute: "json_data",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cMyTableAttributes.json_data.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_cMyTable.attributes.json_data.codec)}`;
             }
           });
         }
@@ -34027,7 +34417,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cPersonSecretAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_cPersonSecret.attributes.person_id.codec)}`;
             }
           });
         }
@@ -34050,7 +34440,7 @@ export const plans = {
             type: "attribute",
             attribute: "sekrit",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cPersonSecretAttributes.sekrit.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_cPersonSecret.attributes.sekrit.codec)}`;
             }
           });
         }
@@ -34239,7 +34629,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_viewTable.attributes.id.codec)}`;
             }
           });
         }
@@ -34262,7 +34652,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_viewTable.attributes.col1.codec)}`;
             }
           });
         }
@@ -34285,7 +34675,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), viewTableAttributes.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_viewTable.attributes.col2.codec)}`;
             }
           });
         }
@@ -34491,7 +34881,7 @@ export const plans = {
             type: "attribute",
             attribute: "x",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bUpdatableViewAttributes.x.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bUpdatableView.attributes.x.codec)}`;
             }
           });
         }
@@ -34514,7 +34904,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bUpdatableViewAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bUpdatableView.attributes.name.codec)}`;
             }
           });
         }
@@ -34537,7 +34927,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bUpdatableViewAttributes.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bUpdatableView.attributes.description.codec)}`;
             }
           });
         }
@@ -34560,7 +34950,7 @@ export const plans = {
             type: "attribute",
             attribute: "constant",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), bUpdatableViewAttributes.constant.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_bUpdatableView.attributes.constant.codec)}`;
             }
           });
         }
@@ -34783,7 +35173,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.id.codec)}`;
             }
           });
         }
@@ -34806,7 +35196,7 @@ export const plans = {
             type: "attribute",
             attribute: "col1",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col1.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.col1.codec)}`;
             }
           });
         }
@@ -34829,7 +35219,7 @@ export const plans = {
             type: "attribute",
             attribute: "col2",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col2.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.col2.codec)}`;
             }
           });
         }
@@ -34852,7 +35242,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable1Attributes.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable1.attributes.col3.codec)}`;
             }
           });
         }
@@ -35075,7 +35465,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.id.codec)}`;
             }
           });
         }
@@ -35098,7 +35488,7 @@ export const plans = {
             type: "attribute",
             attribute: "col3",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col3.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.col3.codec)}`;
             }
           });
         }
@@ -35121,7 +35511,7 @@ export const plans = {
             type: "attribute",
             attribute: "col4",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col4.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.col4.codec)}`;
             }
           });
         }
@@ -35144,7 +35534,7 @@ export const plans = {
             type: "attribute",
             attribute: "col5",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), similarTable2Attributes.col5.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_similarTable2.attributes.col5.codec)}`;
             }
           });
         }
@@ -35367,7 +35757,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cNullTestRecordAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_cNullTestRecord.attributes.id.codec)}`;
             }
           });
         }
@@ -35390,7 +35780,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cNullTestRecordAttributes.nullable_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_cNullTestRecord.attributes.nullable_text.codec)}`;
             }
           });
         }
@@ -35413,7 +35803,7 @@ export const plans = {
             type: "attribute",
             attribute: "nullable_int",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cNullTestRecordAttributes.nullable_int.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_cNullTestRecord.attributes.nullable_int.codec)}`;
             }
           });
         }
@@ -35436,7 +35826,7 @@ export const plans = {
             type: "attribute",
             attribute: "non_null_text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cNullTestRecordAttributes.non_null_text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_cNullTestRecord.attributes.non_null_text.codec)}`;
             }
           });
         }
@@ -35639,7 +36029,7 @@ export const plans = {
             type: "attribute",
             attribute: "not_null_has_default",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cEdgeCaseAttributes.not_null_has_default.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_cEdgeCase.attributes.not_null_has_default.codec)}`;
             }
           });
         }
@@ -35662,7 +36052,7 @@ export const plans = {
             type: "attribute",
             attribute: "wont_cast_easy",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cEdgeCaseAttributes.wont_cast_easy.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_cEdgeCase.attributes.wont_cast_easy.codec)}`;
             }
           });
         }
@@ -35685,7 +36075,7 @@ export const plans = {
             type: "attribute",
             attribute: "row_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cEdgeCaseAttributes.row_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_cEdgeCase.attributes.row_id.codec)}`;
             }
           });
         }
@@ -35908,7 +36298,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cLeftArmAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_cLeftArm.attributes.id.codec)}`;
             }
           });
         }
@@ -35931,7 +36321,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cLeftArmAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_cLeftArm.attributes.person_id.codec)}`;
             }
           });
         }
@@ -35954,7 +36344,7 @@ export const plans = {
             type: "attribute",
             attribute: "length_in_metres",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cLeftArmAttributes.length_in_metres.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_cLeftArm.attributes.length_in_metres.codec)}`;
             }
           });
         }
@@ -35977,7 +36367,7 @@ export const plans = {
             type: "attribute",
             attribute: "mood",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cLeftArmAttributes.mood.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_cLeftArm.attributes.mood.codec)}`;
             }
           });
         }
@@ -36132,7 +36522,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cIssue756Attributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_cIssue756.attributes.id.codec)}`;
             }
           });
         }
@@ -36155,7 +36545,7 @@ export const plans = {
             type: "attribute",
             attribute: "ts",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cIssue756Attributes.ts.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_cIssue756.attributes.ts.codec)}`;
             }
           });
         }
@@ -36523,7 +36913,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cPersonAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_cPerson.attributes.id.codec)}`;
             }
           });
         }
@@ -36546,7 +36936,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_full_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cPersonAttributes.person_full_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_cPerson.attributes.person_full_name.codec)}`;
             }
           });
         }
@@ -36569,7 +36959,7 @@ export const plans = {
             type: "attribute",
             attribute: "about",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cPersonAttributes.about.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_cPerson.attributes.about.codec)}`;
             }
           });
         }
@@ -36592,7 +36982,7 @@ export const plans = {
             type: "attribute",
             attribute: "email",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cPersonAttributes.email.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_cPerson.attributes.email.codec)}`;
             }
           });
         }
@@ -36615,7 +37005,7 @@ export const plans = {
             type: "attribute",
             attribute: "config",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cPersonAttributes.config.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_cPerson.attributes.config.codec)}`;
             }
           });
         }
@@ -36638,7 +37028,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_ip",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cPersonAttributes.last_login_from_ip.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_cPerson.attributes.last_login_from_ip.codec)}`;
             }
           });
         }
@@ -36661,7 +37051,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_login_from_subnet",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cPersonAttributes.last_login_from_subnet.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_cPerson.attributes.last_login_from_subnet.codec)}`;
             }
           });
         }
@@ -36684,7 +37074,7 @@ export const plans = {
             type: "attribute",
             attribute: "user_mac",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cPersonAttributes.user_mac.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_cPerson.attributes.user_mac.codec)}`;
             }
           });
         }
@@ -36707,7 +37097,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), cPersonAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_cPerson.attributes.created_at.codec)}`;
             }
           });
         }
@@ -39522,6 +39912,11 @@ export const plans = {
       return rootValue();
     }
   },
+  BGuid: {
+    serialize: GraphQLString.serialize,
+    parseValue: GraphQLString.parseValue,
+    parseLiteral: GraphQLString.parseLiteral
+  },
   BGuidFnInput: {
     clientMutationId: {
       applyPlan($input, val) {
@@ -39708,6 +40103,9 @@ export const plans = {
     leftArm: undefined
   },
   CLeftArmBaseInput: {
+    "__inputPlan": function CLeftArmBaseInput_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -40087,6 +40485,9 @@ export const plans = {
     suffix: undefined
   },
   PostInput: {
+    "__inputPlan": function PostInput_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -40131,6 +40532,9 @@ export const plans = {
     }
   },
   ComptypeInput: {
+    "__inputPlan": function ComptypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     schedule: {
       applyPlan($insert, val) {
         $insert.set("schedule", val.get());
@@ -40543,6 +40947,9 @@ export const plans = {
     }
   },
   InputInput: {
+    "__inputPlan": function InputInput_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -40610,6 +41017,9 @@ export const plans = {
     }
   },
   PatchInput: {
+    "__inputPlan": function PatchInput_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -40677,6 +41087,9 @@ export const plans = {
     }
   },
   ReservedInput: {
+    "__inputPlan": function ReservedInput_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -40744,6 +41157,9 @@ export const plans = {
     }
   },
   ReservedPatchRecordInput: {
+    "__inputPlan": function ReservedPatchRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -40811,6 +41227,9 @@ export const plans = {
     }
   },
   ReservedInputRecordInput: {
+    "__inputPlan": function ReservedInputRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -40878,6 +41297,9 @@ export const plans = {
     }
   },
   DefaultValueInput: {
+    "__inputPlan": function DefaultValueInput_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -40921,6 +41343,9 @@ export const plans = {
     }
   },
   ForeignKeyInput: {
+    "__inputPlan": function ForeignKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -40971,6 +41396,9 @@ export const plans = {
     }
   },
   NoPrimaryKeyInput: {
+    "__inputPlan": function NoPrimaryKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -41014,6 +41442,9 @@ export const plans = {
     }
   },
   TestviewInput: {
+    "__inputPlan": function TestviewInput_inputPlan() {
+      return object(Object.create(null));
+    },
     testviewid: {
       applyPlan($insert, val) {
         $insert.set("testviewid", val.get());
@@ -41064,6 +41495,9 @@ export const plans = {
     }
   },
   UniqueForeignKeyInput: {
+    "__inputPlan": function UniqueForeignKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     compoundKey1: {
       applyPlan($insert, val) {
         $insert.set("compound_key_1", val.get());
@@ -41138,6 +41572,9 @@ export const plans = {
     }
   },
   CMyTableInput: {
+    "__inputPlan": function CMyTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -41212,6 +41649,9 @@ export const plans = {
     }
   },
   CPersonSecretInput: {
+    "__inputPlan": function CPersonSecretInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -41286,6 +41726,9 @@ export const plans = {
     }
   },
   ViewTableInput: {
+    "__inputPlan": function ViewTableInput_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -41336,6 +41779,9 @@ export const plans = {
     }
   },
   BUpdatableViewInput: {
+    "__inputPlan": function BUpdatableViewInput_inputPlan() {
+      return object(Object.create(null));
+    },
     x: {
       applyPlan($insert, val) {
         $insert.set("x", val.get());
@@ -41424,6 +41870,9 @@ export const plans = {
     }
   },
   CCompoundKeyInput: {
+    "__inputPlan": function CCompoundKeyInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId2: {
       applyPlan($insert, val) {
         $insert.set("person_id_2", val.get());
@@ -41505,6 +41954,9 @@ export const plans = {
     }
   },
   SimilarTable1Input: {
+    "__inputPlan": function SimilarTable1Input_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -41593,6 +42045,9 @@ export const plans = {
     }
   },
   SimilarTable2Input: {
+    "__inputPlan": function SimilarTable2Input_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -41681,6 +42136,9 @@ export const plans = {
     }
   },
   CNullTestRecordInput: {
+    "__inputPlan": function CNullTestRecordInput_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -41738,6 +42196,9 @@ export const plans = {
     }
   },
   CEdgeCaseInput: {
+    "__inputPlan": function CEdgeCaseInput_inputPlan() {
+      return object(Object.create(null));
+    },
     notNullHasDefault: {
       applyPlan($insert, val) {
         $insert.set("not_null_has_default", val.get());
@@ -41819,6 +42280,9 @@ export const plans = {
     }
   },
   CLeftArmInput: {
+    "__inputPlan": function CLeftArmInput_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -41907,6 +42371,9 @@ export const plans = {
     }
   },
   CIssue756Input: {
+    "__inputPlan": function CIssue756Input_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -42039,6 +42506,9 @@ export const plans = {
     }
   },
   CPersonInput: {
+    "__inputPlan": function CPersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -42118,6 +42588,9 @@ export const plans = {
     }
   },
   BWrappedUrlInput: {
+    "__inputPlan": function BWrappedUrlInput_inputPlan() {
+      return object(Object.create(null));
+    },
     url: {
       applyPlan($insert, val) {
         $insert.set("url", val.get());
@@ -42185,6 +42658,9 @@ export const plans = {
     }
   },
   BTypeInput: {
+    "__inputPlan": function BTypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -42554,6 +43030,9 @@ export const plans = {
     inclusive: undefined
   },
   BNestedCompoundTypeInput: {
+    "__inputPlan": function BNestedCompoundTypeInput_inputPlan() {
+      return object(Object.create(null));
+    },
     a: {
       applyPlan($insert, val) {
         $insert.set("a", val.get());
@@ -42634,6 +43113,9 @@ export const plans = {
     }
   },
   InputPatch: {
+    "__inputPlan": function InputPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -42700,6 +43182,9 @@ export const plans = {
     }
   },
   PatchPatch: {
+    "__inputPlan": function PatchPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -42766,6 +43251,9 @@ export const plans = {
     }
   },
   ReservedPatch: {
+    "__inputPlan": function ReservedPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -42832,6 +43320,9 @@ export const plans = {
     }
   },
   ReservedPatchRecordPatch: {
+    "__inputPlan": function ReservedPatchRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -42898,6 +43389,9 @@ export const plans = {
     }
   },
   ReservedInputRecordPatch: {
+    "__inputPlan": function ReservedInputRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -42964,6 +43458,9 @@ export const plans = {
     }
   },
   DefaultValuePatch: {
+    "__inputPlan": function DefaultValuePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43006,6 +43503,9 @@ export const plans = {
     }
   },
   NoPrimaryKeyPatch: {
+    "__inputPlan": function NoPrimaryKeyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43049,6 +43549,9 @@ export const plans = {
     }
   },
   UniqueForeignKeyPatch: {
+    "__inputPlan": function UniqueForeignKeyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     compoundKey1: {
       applyPlan($insert, val) {
         $insert.set("compound_key_1", val.get());
@@ -43122,6 +43625,9 @@ export const plans = {
     }
   },
   CMyTablePatch: {
+    "__inputPlan": function CMyTablePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43195,6 +43701,9 @@ export const plans = {
     }
   },
   CPersonSecretPatch: {
+    "__inputPlan": function CPersonSecretPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -43268,6 +43777,9 @@ export const plans = {
     }
   },
   ViewTablePatch: {
+    "__inputPlan": function ViewTablePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43349,6 +43861,9 @@ export const plans = {
     }
   },
   CCompoundKeyPatch: {
+    "__inputPlan": function CCompoundKeyPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     personId2: {
       applyPlan($insert, val) {
         $insert.set("person_id_2", val.get());
@@ -43429,6 +43944,9 @@ export const plans = {
     }
   },
   SimilarTable1Patch: {
+    "__inputPlan": function SimilarTable1Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43516,6 +44034,9 @@ export const plans = {
     }
   },
   SimilarTable2Patch: {
+    "__inputPlan": function SimilarTable2Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43603,6 +44124,9 @@ export const plans = {
     }
   },
   CNullTestRecordPatch: {
+    "__inputPlan": function CNullTestRecordPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43690,6 +44214,9 @@ export const plans = {
     }
   },
   CLeftArmPatch: {
+    "__inputPlan": function CLeftArmPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43791,6 +44318,9 @@ export const plans = {
     }
   },
   CIssue756Patch: {
+    "__inputPlan": function CIssue756Patch_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43864,6 +44394,9 @@ export const plans = {
     }
   },
   PostPatch: {
+    "__inputPlan": function PostPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -43965,6 +44498,9 @@ export const plans = {
     }
   },
   CPersonPatch: {
+    "__inputPlan": function CPersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -44115,6 +44651,9 @@ export const plans = {
     }
   },
   BTypePatch: {
+    "__inputPlan": function BTypePatch_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.polymorphic.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.polymorphic.1.export.mjs
@@ -1,27 +1,8 @@
 import { PgDeleteSingleStep, PgExecutor, PgResource, PgSelectStep, PgUnionAllStep, TYPES, assertPgClassSingleStep, enumCodec, makeRegistry, pgDeleteSingle, pgInsertSingle, pgSelectFromRecord, pgUnionAll, pgUpdateSingle, recordCodec, sqlFromArgDigests } from "@dataplan/pg";
 import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, assertEdgeCapableStep, assertExecutableStep, assertPageInfoCapableStep, connection, constant, context, first, getEnumValueConfig, makeGrafastSchema, object, rootValue } from "grafast";
+import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
-const awsApplicationFirstPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
-  aws_application_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  first_party_vulnerability_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -32,10 +13,29 @@ const executor = new PgExecutor({
     });
   }
 });
-const awsApplicationFirstPartyVulnerabilitiesCodec = recordCodec({
+const spec_awsApplicationFirstPartyVulnerabilities = {
   name: "awsApplicationFirstPartyVulnerabilities",
   identifier: sql.identifier("polymorphic", "aws_application_first_party_vulnerabilities"),
-  attributes: awsApplicationFirstPartyVulnerabilitiesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    aws_application_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    first_party_vulnerability_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -48,32 +48,32 @@ const awsApplicationFirstPartyVulnerabilitiesCodec = recordCodec({
       omit: true
     })
   },
-  executor
-});
-const awsApplicationThirdPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
-  aws_application_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  third_party_vulnerability_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const awsApplicationThirdPartyVulnerabilitiesCodec = recordCodec({
+  executor: executor
+};
+const awsApplicationFirstPartyVulnerabilitiesCodec = recordCodec(spec_awsApplicationFirstPartyVulnerabilities);
+const spec_awsApplicationThirdPartyVulnerabilities = {
   name: "awsApplicationThirdPartyVulnerabilities",
   identifier: sql.identifier("polymorphic", "aws_application_third_party_vulnerabilities"),
-  attributes: awsApplicationThirdPartyVulnerabilitiesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    aws_application_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    third_party_vulnerability_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -86,32 +86,32 @@ const awsApplicationThirdPartyVulnerabilitiesCodec = recordCodec({
       omit: true
     })
   },
-  executor
-});
-const gcpApplicationFirstPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
-  gcp_application_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  first_party_vulnerability_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const gcpApplicationFirstPartyVulnerabilitiesCodec = recordCodec({
+  executor: executor
+};
+const awsApplicationThirdPartyVulnerabilitiesCodec = recordCodec(spec_awsApplicationThirdPartyVulnerabilities);
+const spec_gcpApplicationFirstPartyVulnerabilities = {
   name: "gcpApplicationFirstPartyVulnerabilities",
   identifier: sql.identifier("polymorphic", "gcp_application_first_party_vulnerabilities"),
-  attributes: gcpApplicationFirstPartyVulnerabilitiesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    gcp_application_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    first_party_vulnerability_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -124,32 +124,32 @@ const gcpApplicationFirstPartyVulnerabilitiesCodec = recordCodec({
       omit: true
     })
   },
-  executor
-});
-const gcpApplicationThirdPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
-  gcp_application_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  third_party_vulnerability_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const gcpApplicationThirdPartyVulnerabilitiesCodec = recordCodec({
+  executor: executor
+};
+const gcpApplicationFirstPartyVulnerabilitiesCodec = recordCodec(spec_gcpApplicationFirstPartyVulnerabilities);
+const spec_gcpApplicationThirdPartyVulnerabilities = {
   name: "gcpApplicationThirdPartyVulnerabilities",
   identifier: sql.identifier("polymorphic", "gcp_application_third_party_vulnerabilities"),
-  attributes: gcpApplicationThirdPartyVulnerabilitiesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    gcp_application_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    third_party_vulnerability_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -162,32 +162,32 @@ const gcpApplicationThirdPartyVulnerabilitiesCodec = recordCodec({
       omit: true
     })
   },
-  executor
-});
-const organizationsAttributes = Object.assign(Object.create(null), {
-  organization_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const organizationsCodec = recordCodec({
+  executor: executor
+};
+const gcpApplicationThirdPartyVulnerabilitiesCodec = recordCodec(spec_gcpApplicationThirdPartyVulnerabilities);
+const spec_organizations = {
   name: "organizations",
   identifier: sql.identifier("polymorphic", "organizations"),
-  attributes: organizationsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    organization_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -200,86 +200,85 @@ const organizationsCodec = recordCodec({
       unionMember: "PersonOrOrganization"
     })
   },
-  executor
-});
-const peopleAttributes = Object.assign(Object.create(null), {
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  username: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions6 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "people"
-  },
-  tags: Object.assign(Object.create(null), {
-    unionMember: "PersonOrOrganization",
-    ref: "applications to:Application",
-    refVia: ["applications via:aws_applications", "applications via:gcp_applications"]
-  }),
-  refDefinitions: Object.assign(Object.create(null), {
-    applications: {
-      singular: false,
-      graphqlType: "Application",
-      sourceGraphqlType: undefined,
-      extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
-      }
-    }
-  })
+  executor: executor
 };
-const peopleCodec = recordCodec({
+const organizationsCodec = recordCodec(spec_organizations);
+const spec_people = {
   name: "people",
   identifier: sql.identifier("polymorphic", "people"),
-  attributes: peopleAttributes,
+  attributes: Object.assign(Object.create(null), {
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    username: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions6,
-  executor
-});
-const prioritiesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "people"
+    },
+    tags: Object.assign(Object.create(null), {
+      unionMember: "PersonOrOrganization",
+      ref: "applications to:Application",
+      refVia: ["applications via:aws_applications", "applications via:gcp_applications"]
+    }),
+    refDefinitions: Object.assign(Object.create(null), {
+      applications: {
+        singular: false,
+        graphqlType: "Application",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      }
+    })
   },
-  title: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const prioritiesCodec = recordCodec({
+  executor: executor
+};
+const peopleCodec = recordCodec(spec_people);
+const spec_priorities = {
   name: "priorities",
   identifier: sql.identifier("polymorphic", "priorities"),
-  attributes: prioritiesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -292,8 +291,9 @@ const prioritiesCodec = recordCodec({
       omit: "create,update,delete,filter,order"
     })
   },
-  executor
-});
+  executor: executor
+};
+const prioritiesCodec = recordCodec(spec_priorities);
 const itemTypeCodec = enumCodec({
   name: "itemType",
   identifier: sql.identifier("polymorphic", "item_type"),
@@ -308,140 +308,139 @@ const itemTypeCodec = enumCodec({
     tags: Object.create(null)
   }
 });
-const relationalChecklistsAttributes = Object.assign(Object.create(null), {
-  checklist_item_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  id: {
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  },
-  type: {
-    codec: itemTypeCodec,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  },
-  parent_id: {
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyChecklistItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  },
-  root_topic_id: {
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyChecklistItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    via: "relationalItemsByMyChecklistItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  },
-  position: {
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  },
-  created_at: {
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  },
-  updated_at: {
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  },
-  is_explicitly_archived: {
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  },
-  archived_at: {
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyChecklistItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const relationalChecklistsCodec = recordCodec({
+const spec_relationalChecklists = {
   name: "relationalChecklists",
   identifier: sql.identifier("polymorphic", "relational_checklists"),
-  attributes: relationalChecklistsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    checklist_item_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    id: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    },
+    type: {
+      codec: itemTypeCodec,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    },
+    parent_id: {
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyChecklistItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    },
+    root_topic_id: {
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyChecklistItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      via: "relationalItemsByMyChecklistItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    },
+    position: {
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    },
+    created_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    },
+    updated_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    },
+    is_explicitly_archived: {
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    },
+    archived_at: {
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyChecklistItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -453,32 +452,32 @@ const relationalChecklistsCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor
-});
-const relationalItemRelationCompositePksAttributes = Object.assign(Object.create(null), {
-  parent_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  child_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const relationalItemRelationCompositePksCodec = recordCodec({
+  executor: executor
+};
+const relationalChecklistsCodec = recordCodec(spec_relationalChecklists);
+const spec_relationalItemRelationCompositePks = {
   name: "relationalItemRelationCompositePks",
   identifier: sql.identifier("polymorphic", "relational_item_relation_composite_pks"),
-  attributes: relationalItemRelationCompositePksAttributes,
+  attributes: Object.assign(Object.create(null), {
+    parent_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    child_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -489,142 +488,142 @@ const relationalItemRelationCompositePksCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const relationalTopicsAttributes = Object.assign(Object.create(null), {
-  topic_item_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  id: {
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyTopicItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.id.extensions.tags
-    }
-  },
-  type: {
-    codec: itemTypeCodec,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyTopicItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.type.extensions.tags
-    }
-  },
-  parent_id: {
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyTopicItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.parent_id.extensions.tags
-    }
-  },
-  root_topic_id: {
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyTopicItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.root_topic_id.extensions.tags
-    }
-  },
-  author_id: {
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    via: "relationalItemsByMyTopicItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.author_id.extensions.tags
-    }
-  },
-  position: {
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyTopicItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.position.extensions.tags
-    }
-  },
-  created_at: {
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyTopicItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.created_at.extensions.tags
-    }
-  },
-  updated_at: {
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyTopicItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.updated_at.extensions.tags
-    }
-  },
-  is_explicitly_archived: {
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyTopicItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.is_explicitly_archived.extensions.tags
-    }
-  },
-  archived_at: {
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyTopicItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.archived_at.extensions.tags
-    }
-  }
-});
-const relationalTopicsCodec = recordCodec({
+  executor: executor
+};
+const relationalItemRelationCompositePksCodec = recordCodec(spec_relationalItemRelationCompositePks);
+const spec_relationalTopics = {
   name: "relationalTopics",
   identifier: sql.identifier("polymorphic", "relational_topics"),
-  attributes: relationalTopicsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    topic_item_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    id: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyTopicItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.id.extensions.tags
+      }
+    },
+    type: {
+      codec: itemTypeCodec,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyTopicItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.type.extensions.tags
+      }
+    },
+    parent_id: {
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyTopicItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.parent_id.extensions.tags
+      }
+    },
+    root_topic_id: {
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyTopicItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.root_topic_id.extensions.tags
+      }
+    },
+    author_id: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      via: "relationalItemsByMyTopicItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.author_id.extensions.tags
+      }
+    },
+    position: {
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyTopicItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.position.extensions.tags
+      }
+    },
+    created_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyTopicItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.created_at.extensions.tags
+      }
+    },
+    updated_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyTopicItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.updated_at.extensions.tags
+      }
+    },
+    is_explicitly_archived: {
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyTopicItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.is_explicitly_archived.extensions.tags
+      }
+    },
+    archived_at: {
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyTopicItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.archived_at.extensions.tags
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -636,32 +635,32 @@ const relationalTopicsCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor
-});
-const singleTableItemRelationCompositePksAttributes = Object.assign(Object.create(null), {
-  parent_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  child_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const singleTableItemRelationCompositePksCodec = recordCodec({
+  executor: executor
+};
+const relationalTopicsCodec = recordCodec(spec_relationalTopics);
+const spec_singleTableItemRelationCompositePks = {
   name: "singleTableItemRelationCompositePks",
   identifier: sql.identifier("polymorphic", "single_table_item_relation_composite_pks"),
-  attributes: singleTableItemRelationCompositePksAttributes,
+  attributes: Object.assign(Object.create(null), {
+    parent_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    child_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -672,151 +671,151 @@ const singleTableItemRelationCompositePksCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const relationalChecklistItemsAttributes = Object.assign(Object.create(null), {
-  checklist_item_item_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  description: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  note: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  id: {
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.id.extensions.tags
-    }
-  },
-  type: {
-    codec: itemTypeCodec,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.type.extensions.tags
-    }
-  },
-  parent_id: {
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyChecklistItemItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.parent_id.extensions.tags
-    }
-  },
-  root_topic_id: {
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyChecklistItemItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.root_topic_id.extensions.tags
-    }
-  },
-  author_id: {
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    via: "relationalItemsByMyChecklistItemItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.author_id.extensions.tags
-    }
-  },
-  position: {
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.position.extensions.tags
-    }
-  },
-  created_at: {
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.created_at.extensions.tags
-    }
-  },
-  updated_at: {
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.updated_at.extensions.tags
-    }
-  },
-  is_explicitly_archived: {
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyChecklistItemItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.is_explicitly_archived.extensions.tags
-    }
-  },
-  archived_at: {
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyChecklistItemItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.archived_at.extensions.tags
-    }
-  }
-});
-const relationalChecklistItemsCodec = recordCodec({
+  executor: executor
+};
+const singleTableItemRelationCompositePksCodec = recordCodec(spec_singleTableItemRelationCompositePks);
+const spec_relationalChecklistItems = {
   name: "relationalChecklistItems",
   identifier: sql.identifier("polymorphic", "relational_checklist_items"),
-  attributes: relationalChecklistItemsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    checklist_item_item_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    description: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    note: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    id: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.id.extensions.tags
+      }
+    },
+    type: {
+      codec: itemTypeCodec,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.type.extensions.tags
+      }
+    },
+    parent_id: {
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyChecklistItemItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.parent_id.extensions.tags
+      }
+    },
+    root_topic_id: {
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyChecklistItemItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.root_topic_id.extensions.tags
+      }
+    },
+    author_id: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      via: "relationalItemsByMyChecklistItemItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.author_id.extensions.tags
+      }
+    },
+    position: {
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.position.extensions.tags
+      }
+    },
+    created_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.created_at.extensions.tags
+      }
+    },
+    updated_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.updated_at.extensions.tags
+      }
+    },
+    is_explicitly_archived: {
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyChecklistItemItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.is_explicitly_archived.extensions.tags
+      }
+    },
+    archived_at: {
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyChecklistItemItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.archived_at.extensions.tags
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -828,151 +827,151 @@ const relationalChecklistItemsCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor
-});
-const relationalDividersAttributes = Object.assign(Object.create(null), {
-  divider_item_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  color: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  id: {
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyDividerItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.id.extensions.tags
-    }
-  },
-  type: {
-    codec: itemTypeCodec,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyDividerItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.type.extensions.tags
-    }
-  },
-  parent_id: {
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyDividerItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.parent_id.extensions.tags
-    }
-  },
-  root_topic_id: {
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyDividerItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.root_topic_id.extensions.tags
-    }
-  },
-  author_id: {
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    via: "relationalItemsByMyDividerItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.author_id.extensions.tags
-    }
-  },
-  position: {
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyDividerItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.position.extensions.tags
-    }
-  },
-  created_at: {
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyDividerItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.created_at.extensions.tags
-    }
-  },
-  updated_at: {
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyDividerItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.updated_at.extensions.tags
-    }
-  },
-  is_explicitly_archived: {
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyDividerItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.is_explicitly_archived.extensions.tags
-    }
-  },
-  archived_at: {
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyDividerItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.archived_at.extensions.tags
-    }
-  }
-});
-const relationalDividersCodec = recordCodec({
+  executor: executor
+};
+const relationalChecklistItemsCodec = recordCodec(spec_relationalChecklistItems);
+const spec_relationalDividers = {
   name: "relationalDividers",
   identifier: sql.identifier("polymorphic", "relational_dividers"),
-  attributes: relationalDividersAttributes,
+  attributes: Object.assign(Object.create(null), {
+    divider_item_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    color: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    id: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyDividerItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.id.extensions.tags
+      }
+    },
+    type: {
+      codec: itemTypeCodec,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyDividerItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.type.extensions.tags
+      }
+    },
+    parent_id: {
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyDividerItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.parent_id.extensions.tags
+      }
+    },
+    root_topic_id: {
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyDividerItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.root_topic_id.extensions.tags
+      }
+    },
+    author_id: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      via: "relationalItemsByMyDividerItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.author_id.extensions.tags
+      }
+    },
+    position: {
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyDividerItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.position.extensions.tags
+      }
+    },
+    created_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyDividerItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.created_at.extensions.tags
+      }
+    },
+    updated_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyDividerItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.updated_at.extensions.tags
+      }
+    },
+    is_explicitly_archived: {
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyDividerItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.is_explicitly_archived.extensions.tags
+      }
+    },
+    archived_at: {
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyDividerItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.archived_at.extensions.tags
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -984,41 +983,41 @@ const relationalDividersCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor
-});
-const relationalItemRelationsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  parent_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  child_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const relationalItemRelationsCodec = recordCodec({
+  executor: executor
+};
+const relationalDividersCodec = recordCodec(spec_relationalDividers);
+const spec_relationalItemRelations = {
   name: "relationalItemRelations",
   identifier: sql.identifier("polymorphic", "relational_item_relations"),
-  attributes: relationalItemRelationsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    parent_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    child_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1029,41 +1028,41 @@ const relationalItemRelationsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const singleTableItemRelationsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  parent_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  child_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const singleTableItemRelationsCodec = recordCodec({
+  executor: executor
+};
+const relationalItemRelationsCodec = recordCodec(spec_relationalItemRelations);
+const spec_singleTableItemRelations = {
   name: "singleTableItemRelations",
   identifier: sql.identifier("polymorphic", "single_table_item_relations"),
-  attributes: singleTableItemRelationsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    parent_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    child_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1074,231 +1073,230 @@ const singleTableItemRelationsCodec = recordCodec({
     },
     tags: Object.create(null)
   },
-  executor
-});
-const logEntriesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  organization_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  text: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions17 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "log_entries"
-  },
-  tags: Object.assign(Object.create(null), {
-    ref: "author to:PersonOrOrganization singular",
-    refVia: ["author via:people", "author via:organizations"]
-  }),
-  refDefinitions: Object.assign(Object.create(null), {
-    author: {
-      singular: true,
-      graphqlType: "PersonOrOrganization",
-      sourceGraphqlType: undefined,
-      extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
-      }
-    }
-  })
+  executor: executor
 };
-const logEntriesCodec = recordCodec({
+const singleTableItemRelationsCodec = recordCodec(spec_singleTableItemRelations);
+const spec_logEntries = {
   name: "logEntries",
   identifier: sql.identifier("polymorphic", "log_entries"),
-  attributes: logEntriesAttributes,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    organization_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    text: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions17,
-  executor
-});
-const relationalPostsAttributes = Object.assign(Object.create(null), {
-  post_item_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "log_entries"
+    },
+    tags: Object.assign(Object.create(null), {
+      ref: "author to:PersonOrOrganization singular",
+      refVia: ["author via:people", "author via:organizations"]
+    }),
+    refDefinitions: Object.assign(Object.create(null), {
+      author: {
+        singular: true,
+        graphqlType: "PersonOrOrganization",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      }
+    })
   },
-  title: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  description: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  note: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  id: {
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyPostItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.id.extensions.tags
-    }
-  },
-  type: {
-    codec: itemTypeCodec,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyPostItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.type.extensions.tags
-    }
-  },
-  parent_id: {
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyPostItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.parent_id.extensions.tags
-    }
-  },
-  root_topic_id: {
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyPostItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.root_topic_id.extensions.tags
-    }
-  },
-  author_id: {
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    via: "relationalItemsByMyPostItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.author_id.extensions.tags
-    }
-  },
-  position: {
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyPostItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.position.extensions.tags
-    }
-  },
-  created_at: {
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyPostItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.created_at.extensions.tags
-    }
-  },
-  updated_at: {
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyPostItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.updated_at.extensions.tags
-    }
-  },
-  is_explicitly_archived: {
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    via: "relationalItemsByMyPostItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.is_explicitly_archived.extensions.tags
-    }
-  },
-  archived_at: {
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    via: "relationalItemsByMyPostItemId",
-    restrictedAccess: undefined,
-    description: undefined,
-    extensions: {
-      tags: relationalChecklistsAttributes.archived_at.extensions.tags
-    }
-  }
-});
-const relationalPostsCodec = recordCodec({
+  executor: executor
+};
+const logEntriesCodec = recordCodec(spec_logEntries);
+const spec_relationalPosts = {
   name: "relationalPosts",
   identifier: sql.identifier("polymorphic", "relational_posts"),
-  attributes: relationalPostsAttributes,
+  attributes: Object.assign(Object.create(null), {
+    post_item_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    description: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    note: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    id: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyPostItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.id.extensions.tags
+      }
+    },
+    type: {
+      codec: itemTypeCodec,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyPostItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.type.extensions.tags
+      }
+    },
+    parent_id: {
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyPostItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.parent_id.extensions.tags
+      }
+    },
+    root_topic_id: {
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyPostItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.root_topic_id.extensions.tags
+      }
+    },
+    author_id: {
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      via: "relationalItemsByMyPostItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.author_id.extensions.tags
+      }
+    },
+    position: {
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyPostItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.position.extensions.tags
+      }
+    },
+    created_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyPostItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.created_at.extensions.tags
+      }
+    },
+    updated_at: {
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyPostItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.updated_at.extensions.tags
+      }
+    },
+    is_explicitly_archived: {
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      via: "relationalItemsByMyPostItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.is_explicitly_archived.extensions.tags
+      }
+    },
+    archived_at: {
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      via: "relationalItemsByMyPostItemId",
+      restrictedAccess: undefined,
+      description: undefined,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.archived_at.extensions.tags
+      }
+    }
+  }),
   description: undefined,
   extensions: {
     isTableLike: true,
@@ -1310,758 +1308,971 @@ const relationalPostsCodec = recordCodec({
     tags: Object.create(null),
     relationalInterfaceCodecName: "relationalItems"
   },
-  executor
-});
-const firstPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  cvss_score: {
-    description: undefined,
-    codec: TYPES.float,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  team_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions19 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "first_party_vulnerabilities"
-  },
-  tags: Object.assign(Object.create(null), {
-    implements: "Vulnerability",
-    ref: ["applications to:Application plural", "owners to:PersonOrOrganization plural"],
-    refVia: ["applications via:aws_application_first_party_vulnerabilities;aws_applications", "applications via:gcp_application_first_party_vulnerabilities;gcp_applications", "owners via:aws_application_first_party_vulnerabilities;aws_applications;people", "owners via:aws_application_first_party_vulnerabilities;aws_applications;organizations", "owners via:gcp_application_first_party_vulnerabilities;gcp_applications;people", "owners via:gcp_application_first_party_vulnerabilities;gcp_applications;organizations"]
-  }),
-  refDefinitions: Object.assign(Object.create(null), {
-    applications: {
-      singular: false,
-      graphqlType: "Application",
-      sourceGraphqlType: undefined,
-      extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
-      }
-    },
-    owners: {
-      singular: false,
-      graphqlType: "PersonOrOrganization",
-      sourceGraphqlType: undefined,
-      extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
-      }
-    }
-  })
+  executor: executor
 };
-const firstPartyVulnerabilitiesCodec = recordCodec({
+const relationalPostsCodec = recordCodec(spec_relationalPosts);
+const spec_firstPartyVulnerabilities = {
   name: "firstPartyVulnerabilities",
   identifier: sql.identifier("polymorphic", "first_party_vulnerabilities"),
-  attributes: firstPartyVulnerabilitiesAttributes,
-  description: undefined,
-  extensions: extensions19,
-  executor
-});
-const thirdPartyVulnerabilitiesAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  cvss_score: {
-    description: undefined,
-    codec: TYPES.float,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  vendor_name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions20 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "third_party_vulnerabilities"
-  },
-  tags: Object.assign(Object.create(null), {
-    implements: "Vulnerability",
-    ref: ["applications to:Application plural", "owners to:PersonOrOrganization plural"],
-    refVia: ["applications via:aws_application_third_party_vulnerabilities;aws_applications", "applications via:gcp_application_third_party_vulnerabilities;gcp_applications", "owners via:aws_application_third_party_vulnerabilities;aws_applications;people", "owners via:aws_application_third_party_vulnerabilities;aws_applications;organizations", "owners via:gcp_application_third_party_vulnerabilities;gcp_applications;people", "owners via:gcp_application_third_party_vulnerabilities;gcp_applications;organizations"]
-  }),
-  refDefinitions: Object.assign(Object.create(null), {
-    applications: {
-      singular: false,
-      graphqlType: "Application",
-      sourceGraphqlType: undefined,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
       extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
+        tags: {}
       }
     },
-    owners: {
-      singular: false,
-      graphqlType: "PersonOrOrganization",
-      sourceGraphqlType: undefined,
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
       extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
+        tags: {}
+      }
+    },
+    cvss_score: {
+      description: undefined,
+      codec: TYPES.float,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    team_name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
       }
     }
-  })
+  }),
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "first_party_vulnerabilities"
+    },
+    tags: Object.assign(Object.create(null), {
+      implements: "Vulnerability",
+      ref: ["applications to:Application plural", "owners to:PersonOrOrganization plural"],
+      refVia: ["applications via:aws_application_first_party_vulnerabilities;aws_applications", "applications via:gcp_application_first_party_vulnerabilities;gcp_applications", "owners via:aws_application_first_party_vulnerabilities;aws_applications;people", "owners via:aws_application_first_party_vulnerabilities;aws_applications;organizations", "owners via:gcp_application_first_party_vulnerabilities;gcp_applications;people", "owners via:gcp_application_first_party_vulnerabilities;gcp_applications;organizations"]
+    }),
+    refDefinitions: Object.assign(Object.create(null), {
+      applications: {
+        singular: false,
+        graphqlType: "Application",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      },
+      owners: {
+        singular: false,
+        graphqlType: "PersonOrOrganization",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      }
+    })
+  },
+  executor: executor
 };
-const thirdPartyVulnerabilitiesCodec = recordCodec({
+const firstPartyVulnerabilitiesCodec = recordCodec(spec_firstPartyVulnerabilities);
+const spec_thirdPartyVulnerabilities = {
   name: "thirdPartyVulnerabilities",
   identifier: sql.identifier("polymorphic", "third_party_vulnerabilities"),
-  attributes: thirdPartyVulnerabilitiesAttributes,
-  description: undefined,
-  extensions: extensions20,
-  executor
-});
-const awsApplicationsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_deployed: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  organization_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  aws_id: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions21 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "aws_applications"
-  },
-  tags: Object.assign(Object.create(null), {
-    implements: "Application",
-    ref: ["vulnerabilities to:Vulnerability plural", "owner to:PersonOrOrganization singular"],
-    refVia: ["vulnerabilities via:(id)->aws_application_first_party_vulnerabilities(aws_application_id);(first_party_vulnerability_id)->first_party_vulnerabilities(id)", "vulnerabilities via:(id)->aws_application_third_party_vulnerabilities(aws_application_id);(third_party_vulnerability_id)->third_party_vulnerabilities(id)", "owner via:people", "owner via:organizations"]
-  }),
-  refDefinitions: Object.assign(Object.create(null), {
-    vulnerabilities: {
-      singular: false,
-      graphqlType: "Vulnerability",
-      sourceGraphqlType: undefined,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
       extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
+        tags: {}
       }
     },
-    owner: {
-      singular: true,
-      graphqlType: "PersonOrOrganization",
-      sourceGraphqlType: undefined,
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
       extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
+        tags: {}
+      }
+    },
+    cvss_score: {
+      description: undefined,
+      codec: TYPES.float,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    vendor_name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
       }
     }
-  })
+  }),
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "third_party_vulnerabilities"
+    },
+    tags: Object.assign(Object.create(null), {
+      implements: "Vulnerability",
+      ref: ["applications to:Application plural", "owners to:PersonOrOrganization plural"],
+      refVia: ["applications via:aws_application_third_party_vulnerabilities;aws_applications", "applications via:gcp_application_third_party_vulnerabilities;gcp_applications", "owners via:aws_application_third_party_vulnerabilities;aws_applications;people", "owners via:aws_application_third_party_vulnerabilities;aws_applications;organizations", "owners via:gcp_application_third_party_vulnerabilities;gcp_applications;people", "owners via:gcp_application_third_party_vulnerabilities;gcp_applications;organizations"]
+    }),
+    refDefinitions: Object.assign(Object.create(null), {
+      applications: {
+        singular: false,
+        graphqlType: "Application",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      },
+      owners: {
+        singular: false,
+        graphqlType: "PersonOrOrganization",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      }
+    })
+  },
+  executor: executor
 };
-const awsApplicationsCodec = recordCodec({
+const thirdPartyVulnerabilitiesCodec = recordCodec(spec_thirdPartyVulnerabilities);
+const spec_awsApplications = {
   name: "awsApplications",
   identifier: sql.identifier("polymorphic", "aws_applications"),
-  attributes: awsApplicationsAttributes,
-  description: undefined,
-  extensions: extensions21,
-  executor
-});
-const gcpApplicationsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  last_deployed: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  person_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  organization_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  gcp_id: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions22 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "gcp_applications"
-  },
-  tags: Object.assign(Object.create(null), {
-    implements: "Application",
-    ref: ["vulnerabilities to:Vulnerability plural", "owner to:PersonOrOrganization singular"],
-    refVia: ["vulnerabilities via:(id)->gcp_application_first_party_vulnerabilities(gcp_application_id);(first_party_vulnerability_id)->first_party_vulnerabilities(id)", "vulnerabilities via:(id)->gcp_application_third_party_vulnerabilities(gcp_application_id);(third_party_vulnerability_id)->third_party_vulnerabilities(id)", "owner via:people", "owner via:organizations"]
-  }),
-  refDefinitions: Object.assign(Object.create(null), {
-    vulnerabilities: {
-      singular: false,
-      graphqlType: "Vulnerability",
-      sourceGraphqlType: undefined,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
       extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
+        tags: {}
       }
     },
-    owner: {
-      singular: true,
-      graphqlType: "PersonOrOrganization",
-      sourceGraphqlType: undefined,
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
       extensions: {
-        via: undefined,
-        tags: {
-          behavior: undefined
-        }
+        tags: {}
+      }
+    },
+    last_deployed: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    organization_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    aws_id: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
       }
     }
-  })
+  }),
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "aws_applications"
+    },
+    tags: Object.assign(Object.create(null), {
+      implements: "Application",
+      ref: ["vulnerabilities to:Vulnerability plural", "owner to:PersonOrOrganization singular"],
+      refVia: ["vulnerabilities via:(id)->aws_application_first_party_vulnerabilities(aws_application_id);(first_party_vulnerability_id)->first_party_vulnerabilities(id)", "vulnerabilities via:(id)->aws_application_third_party_vulnerabilities(aws_application_id);(third_party_vulnerability_id)->third_party_vulnerabilities(id)", "owner via:people", "owner via:organizations"]
+    }),
+    refDefinitions: Object.assign(Object.create(null), {
+      vulnerabilities: {
+        singular: false,
+        graphqlType: "Vulnerability",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      },
+      owner: {
+        singular: true,
+        graphqlType: "PersonOrOrganization",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      }
+    })
+  },
+  executor: executor
 };
-const gcpApplicationsCodec = recordCodec({
+const awsApplicationsCodec = recordCodec(spec_awsApplications);
+const spec_gcpApplications = {
   name: "gcpApplications",
   identifier: sql.identifier("polymorphic", "gcp_applications"),
-  attributes: gcpApplicationsAttributes,
-  description: undefined,
-  extensions: extensions22,
-  executor
-});
-const singleTableItemsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  type: {
-    description: undefined,
-    codec: itemTypeCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  parent_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  root_topic_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  position: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  created_at: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  updated_at: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  is_explicitly_archived: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: {}
-    }
-  },
-  archived_at: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  title: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  description: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  note: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  color: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  priority_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
-const extensions23 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "single_table_items"
-  },
-  tags: Object.assign(Object.create(null), {
-    interface: "mode:single type:type",
-    type: ["TOPIC name:SingleTableTopic attributes:title!", "POST name:SingleTablePost attributes:title>subject,description,note,priority_id", "DIVIDER name:SingleTableDivider attributes:title,color", "CHECKLIST name:SingleTableChecklist attributes:title", "CHECKLIST_ITEM name:SingleTableChecklistItem attributes:description,note,priority_id"],
-    ref: ["rootTopic to:SingleTableTopic singular via:(root_topic_id)->polymorphic.single_table_items(id)", "rootChecklistTopic from:SingleTableChecklist to:SingleTableTopic singular via:(root_topic_id)->polymorphic.single_table_items(id)"]
-  }),
-  refDefinitions: Object.assign(Object.create(null), {
-    rootTopic: {
-      singular: true,
-      graphqlType: "SingleTableTopic",
-      sourceGraphqlType: undefined,
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
       extensions: {
-        via: "(root_topic_id)->polymorphic.single_table_items(id)",
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    last_deployed: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    person_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    organization_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    gcp_id: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "gcp_applications"
+    },
+    tags: Object.assign(Object.create(null), {
+      implements: "Application",
+      ref: ["vulnerabilities to:Vulnerability plural", "owner to:PersonOrOrganization singular"],
+      refVia: ["vulnerabilities via:(id)->gcp_application_first_party_vulnerabilities(gcp_application_id);(first_party_vulnerability_id)->first_party_vulnerabilities(id)", "vulnerabilities via:(id)->gcp_application_third_party_vulnerabilities(gcp_application_id);(third_party_vulnerability_id)->third_party_vulnerabilities(id)", "owner via:people", "owner via:organizations"]
+    }),
+    refDefinitions: Object.assign(Object.create(null), {
+      vulnerabilities: {
+        singular: false,
+        graphqlType: "Vulnerability",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      },
+      owner: {
+        singular: true,
+        graphqlType: "PersonOrOrganization",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      }
+    })
+  },
+  executor: executor
+};
+const gcpApplicationsCodec = recordCodec(spec_gcpApplications);
+const spec_singleTableItems = {
+  name: "singleTableItems",
+  identifier: sql.identifier("polymorphic", "single_table_items"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    type: {
+      description: undefined,
+      codec: itemTypeCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    parent_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    root_topic_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    position: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    created_at: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    updated_at: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    is_explicitly_archived: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: {}
+      }
+    },
+    archived_at: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    title: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    description: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    note: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    color: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    priority_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "single_table_items"
+    },
+    tags: Object.assign(Object.create(null), {
+      interface: "mode:single type:type",
+      type: ["TOPIC name:SingleTableTopic attributes:title!", "POST name:SingleTablePost attributes:title>subject,description,note,priority_id", "DIVIDER name:SingleTableDivider attributes:title,color", "CHECKLIST name:SingleTableChecklist attributes:title", "CHECKLIST_ITEM name:SingleTableChecklistItem attributes:description,note,priority_id"],
+      ref: ["rootTopic to:SingleTableTopic singular via:(root_topic_id)->polymorphic.single_table_items(id)", "rootChecklistTopic from:SingleTableChecklist to:SingleTableTopic singular via:(root_topic_id)->polymorphic.single_table_items(id)"]
+    }),
+    refDefinitions: Object.assign(Object.create(null), {
+      rootTopic: {
+        singular: true,
+        graphqlType: "SingleTableTopic",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: "(root_topic_id)->polymorphic.single_table_items(id)",
+          tags: {
+            behavior: undefined
+          }
+        }
+      },
+      rootChecklistTopic: {
+        singular: true,
+        graphqlType: "SingleTableTopic",
+        sourceGraphqlType: "SingleTableChecklist",
+        extensions: {
+          via: "(root_topic_id)->polymorphic.single_table_items(id)",
+          tags: {
+            behavior: undefined
+          }
+        }
+      }
+    })
+  },
+  executor: executor,
+  polymorphism: {
+    mode: "single",
+    commonAttributes: ["id", "type", "parent_id", "root_topic_id", "author_id", "position", "created_at", "updated_at", "is_explicitly_archived", "archived_at"],
+    typeAttributes: ["type"],
+    types: Object.assign(Object.create(null), {
+      TOPIC: {
+        name: "SingleTableTopic",
+        attributes: [{
+          attribute: "title",
+          isNotNull: true,
+          rename: undefined
+        }]
+      },
+      POST: {
+        name: "SingleTablePost",
+        attributes: [{
+          attribute: "title",
+          isNotNull: false,
+          rename: "subject"
+        }, {
+          attribute: "description",
+          isNotNull: false,
+          rename: undefined
+        }, {
+          attribute: "note",
+          isNotNull: false,
+          rename: undefined
+        }, {
+          attribute: "priority_id",
+          isNotNull: false,
+          rename: undefined
+        }]
+      },
+      DIVIDER: {
+        name: "SingleTableDivider",
+        attributes: [{
+          attribute: "title",
+          isNotNull: false,
+          rename: undefined
+        }, {
+          attribute: "color",
+          isNotNull: false,
+          rename: undefined
+        }]
+      },
+      CHECKLIST: {
+        name: "SingleTableChecklist",
+        attributes: [{
+          attribute: "title",
+          isNotNull: false,
+          rename: undefined
+        }]
+      },
+      CHECKLIST_ITEM: {
+        name: "SingleTableChecklistItem",
+        attributes: [{
+          attribute: "description",
+          isNotNull: false,
+          rename: undefined
+        }, {
+          attribute: "note",
+          isNotNull: false,
+          rename: undefined
+        }, {
+          attribute: "priority_id",
+          isNotNull: false,
+          rename: undefined
+        }]
+      }
+    })
+  }
+};
+const singleTableItemsCodec = recordCodec(spec_singleTableItems);
+const spec_relationalItems = {
+  name: "relationalItems",
+  identifier: sql.identifier("polymorphic", "relational_items"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.id.extensions.tags
+      }
+    },
+    type: {
+      description: undefined,
+      codec: itemTypeCodec,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.type.extensions.tags
+      }
+    },
+    parent_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.parent_id.extensions.tags
+      }
+    },
+    root_topic_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.root_topic_id.extensions.tags
+      }
+    },
+    author_id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.author_id.extensions.tags
+      }
+    },
+    position: {
+      description: undefined,
+      codec: TYPES.bigint,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.position.extensions.tags
+      }
+    },
+    created_at: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.created_at.extensions.tags
+      }
+    },
+    updated_at: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.updated_at.extensions.tags
+      }
+    },
+    is_explicitly_archived: {
+      description: undefined,
+      codec: TYPES.boolean,
+      notNull: true,
+      hasDefault: true,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.is_explicitly_archived.extensions.tags
+      }
+    },
+    archived_at: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: spec_relationalChecklists.attributes.archived_at.extensions.tags
+      }
+    }
+  }),
+  description: undefined,
+  extensions: {
+    isTableLike: true,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "relational_items"
+    },
+    tags: Object.assign(Object.create(null), {
+      interface: "mode:relational",
+      type: ["TOPIC references:relational_topics", "POST references:relational_posts", "DIVIDER references:relational_dividers", "CHECKLIST references:relational_checklists", "CHECKLIST_ITEM references:relational_checklist_items"]
+    })
+  },
+  executor: executor,
+  polymorphism: {
+    mode: "relational",
+    typeAttributes: ["type"],
+    types: Object.assign(Object.create(null), {
+      TOPIC: {
+        name: "RelationalTopic",
+        references: "relational_topics",
+        relationName: "relationalTopicsByTheirTopicItemId"
+      },
+      POST: {
+        name: "RelationalPost",
+        references: "relational_posts",
+        relationName: "relationalPostsByTheirPostItemId"
+      },
+      DIVIDER: {
+        name: "RelationalDivider",
+        references: "relational_dividers",
+        relationName: "relationalDividersByTheirDividerItemId"
+      },
+      CHECKLIST: {
+        name: "RelationalChecklist",
+        references: "relational_checklists",
+        relationName: "relationalChecklistsByTheirChecklistItemId"
+      },
+      CHECKLIST_ITEM: {
+        name: "RelationalChecklistItem",
+        references: "relational_checklist_items",
+        relationName: "relationalChecklistItemsByTheirChecklistItemItemId"
+      }
+    })
+  }
+};
+const relationalItemsCodec = recordCodec(spec_relationalItems);
+const spec_Application = {
+  name: "Application",
+  identifier: sql.identifier("polymorphic", "applications"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
         tags: {
-          behavior: undefined
+          notNull: true
         }
       }
     },
-    rootChecklistTopic: {
-      singular: true,
-      graphqlType: "SingleTableTopic",
-      sourceGraphqlType: "SingleTableChecklist",
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
       extensions: {
-        via: "(root_topic_id)->polymorphic.single_table_items(id)",
         tags: {
-          behavior: undefined
+          notNull: true
+        }
+      }
+    },
+    last_deployed: {
+      description: undefined,
+      codec: TYPES.timestamptz,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
+  description: undefined,
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "applications"
+    },
+    tags: Object.assign(Object.create(null), {
+      interface: "mode:union",
+      name: "Application",
+      behavior: "node",
+      ref: ["vulnerabilities to:Vulnerability plural", "owner to:PersonOrOrganization singular"]
+    }),
+    refDefinitions: Object.assign(Object.create(null), {
+      vulnerabilities: {
+        singular: false,
+        graphqlType: "Vulnerability",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      },
+      owner: {
+        singular: true,
+        graphqlType: "PersonOrOrganization",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      }
+    })
+  },
+  executor: executor,
+  polymorphism: {
+    mode: "union"
+  }
+};
+const spec_Vulnerability = {
+  name: "Vulnerability",
+  identifier: sql.identifier("polymorphic", "vulnerabilities"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          notNull: true
+        }
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          notNull: true
+        }
+      }
+    },
+    cvss_score: {
+      description: undefined,
+      codec: TYPES.float,
+      notNull: true,
+      hasDefault: false,
+      extensions: {
+        tags: {
+          notNull: true
         }
       }
     }
-  })
-};
-const singleTableItemsCodec = recordCodec({
-  name: "singleTableItems",
-  identifier: sql.identifier("polymorphic", "single_table_items"),
-  attributes: singleTableItemsAttributes,
+  }),
   description: undefined,
-  extensions: extensions23,
-  executor
-});
-const relationalItemsAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: relationalChecklistsAttributes.id.extensions.tags
-    }
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "vulnerabilities"
+    },
+    tags: Object.assign(Object.create(null), {
+      interface: "mode:union",
+      name: "Vulnerability",
+      behavior: "node",
+      ref: ["applications to:Application plural", "owners to:PersonOrOrganization plural"]
+    }),
+    refDefinitions: Object.assign(Object.create(null), {
+      applications: {
+        singular: false,
+        graphqlType: "Application",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      },
+      owners: {
+        singular: false,
+        graphqlType: "PersonOrOrganization",
+        sourceGraphqlType: undefined,
+        extensions: {
+          via: undefined,
+          tags: {
+            behavior: undefined
+          }
+        }
+      }
+    })
   },
-  type: {
-    description: undefined,
-    codec: itemTypeCodec,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: relationalChecklistsAttributes.type.extensions.tags
-    }
-  },
-  parent_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: relationalChecklistsAttributes.parent_id.extensions.tags
-    }
-  },
-  root_topic_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: relationalChecklistsAttributes.root_topic_id.extensions.tags
-    }
-  },
-  author_id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: relationalChecklistsAttributes.author_id.extensions.tags
-    }
-  },
-  position: {
-    description: undefined,
-    codec: TYPES.bigint,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: relationalChecklistsAttributes.position.extensions.tags
-    }
-  },
-  created_at: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: relationalChecklistsAttributes.created_at.extensions.tags
-    }
-  },
-  updated_at: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: relationalChecklistsAttributes.updated_at.extensions.tags
-    }
-  },
-  is_explicitly_archived: {
-    description: undefined,
-    codec: TYPES.boolean,
-    notNull: true,
-    hasDefault: true,
-    extensions: {
-      tags: relationalChecklistsAttributes.is_explicitly_archived.extensions.tags
-    }
-  },
-  archived_at: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: relationalChecklistsAttributes.archived_at.extensions.tags
-    }
+  executor: executor,
+  polymorphism: {
+    mode: "union"
   }
-});
-const extensions24 = {
-  isTableLike: true,
-  pg: {
-    serviceName: "main",
-    schemaName: "polymorphic",
-    name: "relational_items"
-  },
-  tags: Object.assign(Object.create(null), {
-    interface: "mode:relational",
-    type: ["TOPIC references:relational_topics", "POST references:relational_posts", "DIVIDER references:relational_dividers", "CHECKLIST references:relational_checklists", "CHECKLIST_ITEM references:relational_checklist_items"]
-  })
 };
-const relationalItemsCodec = recordCodec({
-  name: "relationalItems",
-  identifier: sql.identifier("polymorphic", "relational_items"),
-  attributes: relationalItemsAttributes,
+const spec_ZeroImplementation = {
+  name: "ZeroImplementation",
+  identifier: sql.identifier("polymorphic", "zero_implementation"),
+  attributes: Object.assign(Object.create(null), {
+    id: {
+      description: undefined,
+      codec: TYPES.int,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    },
+    name: {
+      description: undefined,
+      codec: TYPES.text,
+      notNull: false,
+      hasDefault: false,
+      extensions: {
+        tags: {}
+      }
+    }
+  }),
   description: undefined,
-  extensions: extensions24,
-  executor
-});
-const ApplicationAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        notNull: true
-      }
-    }
+  extensions: {
+    isTableLike: false,
+    pg: {
+      serviceName: "main",
+      schemaName: "polymorphic",
+      name: "zero_implementation"
+    },
+    tags: Object.assign(Object.create(null), {
+      interface: "mode:union",
+      name: "ZeroImplementation",
+      behavior: "node"
+    })
   },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        notNull: true
-      }
-    }
-  },
-  last_deployed: {
-    description: undefined,
-    codec: TYPES.timestamptz,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
+  executor: executor,
+  polymorphism: {
+    mode: "union"
   }
-});
-const VulnerabilityAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        notNull: true
-      }
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        notNull: true
-      }
-    }
-  },
-  cvss_score: {
-    description: undefined,
-    codec: TYPES.float,
-    notNull: true,
-    hasDefault: false,
-    extensions: {
-      tags: {
-        notNull: true
-      }
-    }
-  }
-});
-const ZeroImplementationAttributes = Object.assign(Object.create(null), {
-  id: {
-    description: undefined,
-    codec: TYPES.int,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  },
-  name: {
-    description: undefined,
-    codec: TYPES.text,
-    notNull: false,
-    hasDefault: false,
-    extensions: {
-      tags: {}
-    }
-  }
-});
+};
 const aws_application_first_party_vulnerabilitiesUniques = [{
   isPrimary: true,
   attributes: ["aws_application_id", "first_party_vulnerability_id"],
@@ -2248,7 +2459,7 @@ const registryConfig_pgResources_people_people = {
     tags: {
       unionMember: "PersonOrOrganization",
       ref: "applications to:Application",
-      refVia: extensions6.tags.refVia
+      refVia: spec_people.extensions.tags.refVia
     }
   }
 };
@@ -2537,7 +2748,7 @@ const registryConfig_pgResources_log_entries_log_entries = {
     },
     tags: {
       ref: "author to:PersonOrOrganization singular",
-      refVia: extensions17.tags.refVia
+      refVia: spec_logEntries.extensions.tags.refVia
     }
   }
 };
@@ -2594,8 +2805,8 @@ const registryConfig_pgResources_first_party_vulnerabilities_first_party_vulnera
     },
     tags: {
       implements: "Vulnerability",
-      ref: extensions19.tags.ref,
-      refVia: extensions19.tags.refVia
+      ref: spec_firstPartyVulnerabilities.extensions.tags.ref,
+      refVia: spec_firstPartyVulnerabilities.extensions.tags.refVia
     }
   }
 };
@@ -2625,8 +2836,8 @@ const registryConfig_pgResources_third_party_vulnerabilities_third_party_vulnera
     },
     tags: {
       implements: "Vulnerability",
-      ref: extensions20.tags.ref,
-      refVia: extensions20.tags.refVia
+      ref: spec_thirdPartyVulnerabilities.extensions.tags.ref,
+      refVia: spec_thirdPartyVulnerabilities.extensions.tags.refVia
     }
   }
 };
@@ -2656,8 +2867,8 @@ const registryConfig_pgResources_aws_applications_aws_applications = {
     },
     tags: {
       implements: "Application",
-      ref: extensions21.tags.ref,
-      refVia: extensions21.tags.refVia
+      ref: spec_awsApplications.extensions.tags.ref,
+      refVia: spec_awsApplications.extensions.tags.refVia
     }
   }
 };
@@ -2687,8 +2898,8 @@ const registryConfig_pgResources_gcp_applications_gcp_applications = {
     },
     tags: {
       implements: "Application",
-      ref: extensions22.tags.ref,
-      refVia: extensions22.tags.refVia
+      ref: spec_gcpApplications.extensions.tags.ref,
+      refVia: spec_gcpApplications.extensions.tags.refVia
     }
   }
 };
@@ -2719,8 +2930,8 @@ const registryConfig_pgResources_single_table_items_single_table_items = {
     },
     tags: {
       interface: "mode:single type:type",
-      type: extensions23.tags.type,
-      ref: extensions23.tags.ref
+      type: spec_singleTableItems.extensions.tags.type,
+      ref: spec_singleTableItems.extensions.tags.ref
     }
   }
 };
@@ -2752,7 +2963,7 @@ const registryConfig_pgResources_relational_items_relational_items = {
     },
     tags: {
       interface: "mode:relational",
-      type: extensions24.tags.type
+      type: spec_relationalItems.extensions.tags.type
     }
   }
 };
@@ -2790,116 +3001,9 @@ const registryConfig = {
     relationalItems: relationalItemsCodec,
     varchar: TYPES.varchar,
     bpchar: TYPES.bpchar,
-    Application: recordCodec({
-      name: "Application",
-      identifier: sql.identifier("polymorphic", "applications"),
-      attributes: ApplicationAttributes,
-      description: undefined,
-      extensions: {
-        isTableLike: false,
-        pg: {
-          serviceName: "main",
-          schemaName: "polymorphic",
-          name: "applications"
-        },
-        tags: Object.assign(Object.create(null), {
-          interface: "mode:union",
-          name: "Application",
-          behavior: "node",
-          ref: ["vulnerabilities to:Vulnerability plural", "owner to:PersonOrOrganization singular"]
-        }),
-        refDefinitions: Object.assign(Object.create(null), {
-          vulnerabilities: {
-            singular: false,
-            graphqlType: "Vulnerability",
-            sourceGraphqlType: undefined,
-            extensions: {
-              via: undefined,
-              tags: {
-                behavior: undefined
-              }
-            }
-          },
-          owner: {
-            singular: true,
-            graphqlType: "PersonOrOrganization",
-            sourceGraphqlType: undefined,
-            extensions: {
-              via: undefined,
-              tags: {
-                behavior: undefined
-              }
-            }
-          }
-        })
-      },
-      executor
-    }),
-    Vulnerability: recordCodec({
-      name: "Vulnerability",
-      identifier: sql.identifier("polymorphic", "vulnerabilities"),
-      attributes: VulnerabilityAttributes,
-      description: undefined,
-      extensions: {
-        isTableLike: false,
-        pg: {
-          serviceName: "main",
-          schemaName: "polymorphic",
-          name: "vulnerabilities"
-        },
-        tags: Object.assign(Object.create(null), {
-          interface: "mode:union",
-          name: "Vulnerability",
-          behavior: "node",
-          ref: ["applications to:Application plural", "owners to:PersonOrOrganization plural"]
-        }),
-        refDefinitions: Object.assign(Object.create(null), {
-          applications: {
-            singular: false,
-            graphqlType: "Application",
-            sourceGraphqlType: undefined,
-            extensions: {
-              via: undefined,
-              tags: {
-                behavior: undefined
-              }
-            }
-          },
-          owners: {
-            singular: false,
-            graphqlType: "PersonOrOrganization",
-            sourceGraphqlType: undefined,
-            extensions: {
-              via: undefined,
-              tags: {
-                behavior: undefined
-              }
-            }
-          }
-        })
-      },
-      executor
-    }),
-    ZeroImplementation: recordCodec({
-      name: "ZeroImplementation",
-      identifier: sql.identifier("polymorphic", "zero_implementation"),
-      attributes: ZeroImplementationAttributes,
-      description: undefined,
-      extensions: {
-        isTableLike: false,
-        pg: {
-          serviceName: "main",
-          schemaName: "polymorphic",
-          name: "zero_implementation"
-        },
-        tags: Object.assign(Object.create(null), {
-          interface: "mode:union",
-          name: "ZeroImplementation",
-          behavior: "node"
-        })
-      },
-      executor
-    })
+    Application: recordCodec(spec_Application),
+    Vulnerability: recordCodec(spec_Vulnerability),
+    ZeroImplementation: recordCodec(spec_ZeroImplementation)
   }),
   pgResources: Object.assign(Object.create(null), {
     aws_application_first_party_vulnerabilities: registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws_application_first_party_vulnerabilities,
@@ -4101,6 +4205,9 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
 };
 const otherSource_single_table_item_relationsPgResource = registry.pgResources["single_table_item_relations"];
 const otherSource_single_table_item_relation_composite_pksPgResource = registry.pgResources["single_table_item_relation_composite_pks"];
+function BigIntSerialize(value) {
+  return "" + value;
+}
 const otherSource_log_entriesPgResource = registry.pgResources["log_entries"];
 const otherSource_relational_itemsPgResource = registry.pgResources["relational_items"];
 const otherSource_aws_applicationsPgResource = registry.pgResources["aws_applications"];
@@ -13868,6 +13975,26 @@ export const plans = {
       });
     }
   },
+  BigInt: {
+    serialize: BigIntSerialize,
+    parseValue: BigIntSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"BigInt" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
+  Datetime: {
+    serialize: BigIntSerialize,
+    parseValue: BigIntSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Datetime" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   Person: {
     __assertStep: assertPgClassSingleStep,
     personId($record) {
@@ -14171,7 +14298,7 @@ export const plans = {
           }, Object.create(null));
         }
         const $list = pgUnionAll({
-          attributes: ApplicationAttributes,
+          attributes: spec_Application.attributes,
           resourceByTypeName,
           members,
           name: "applications"
@@ -14486,6 +14613,16 @@ export const plans = {
       }
     }
   },
+  Cursor: {
+    serialize: BigIntSerialize,
+    parseValue: BigIntSerialize,
+    parseLiteral(ast) {
+      if (ast.kind !== Kind.STRING) {
+        throw new GraphQLError(`${"Cursor" ?? "This scalar"} can only parse string values (kind='${ast.kind}')`);
+      }
+      return ast.value;
+    }
+  },
   LogEntryOrderBy: {
     NATURAL: {
       applyPlan() {}
@@ -14675,7 +14812,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), logEntriesAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_logEntries.attributes.id.codec)}`;
             }
           });
         }
@@ -14698,7 +14835,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), logEntriesAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_logEntries.attributes.person_id.codec)}`;
             }
           });
         }
@@ -14721,7 +14858,7 @@ export const plans = {
             type: "attribute",
             attribute: "organization_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), logEntriesAttributes.organization_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_logEntries.attributes.organization_id.codec)}`;
             }
           });
         }
@@ -14744,7 +14881,7 @@ export const plans = {
             type: "attribute",
             attribute: "text",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), logEntriesAttributes.text.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_logEntries.attributes.text.codec)}`;
             }
           });
         }
@@ -14926,7 +15063,7 @@ export const plans = {
           }, Object.create(null));
         }
         const $list = pgUnionAll({
-          attributes: VulnerabilityAttributes,
+          attributes: spec_Vulnerability.attributes,
           resourceByTypeName: resourceByTypeName3,
           members: members3,
           name: "vulnerabilities"
@@ -15286,7 +15423,7 @@ export const plans = {
           }, Object.create(null));
         }
         const $list = pgUnionAll({
-          attributes: ApplicationAttributes,
+          attributes: spec_Application.attributes,
           resourceByTypeName: resourceByTypeName5,
           members: members5,
           name: "applications"
@@ -15504,7 +15641,7 @@ export const plans = {
             type: "attribute",
             attribute: "aws_application_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationFirstPartyVulnerabilitiesAttributes.aws_application_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_awsApplicationFirstPartyVulnerabilities.attributes.aws_application_id.codec)}`;
             }
           });
         }
@@ -15527,7 +15664,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_party_vulnerability_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationFirstPartyVulnerabilitiesAttributes.first_party_vulnerability_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_awsApplicationFirstPartyVulnerabilities.attributes.first_party_vulnerability_id.codec)}`;
             }
           });
         }
@@ -15728,7 +15865,7 @@ export const plans = {
           }, Object.create(null));
         }
         const $list = pgUnionAll({
-          attributes: VulnerabilityAttributes,
+          attributes: spec_Vulnerability.attributes,
           resourceByTypeName: resourceByTypeName7,
           members: members7,
           name: "vulnerabilities"
@@ -15946,7 +16083,7 @@ export const plans = {
             type: "attribute",
             attribute: "gcp_application_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationFirstPartyVulnerabilitiesAttributes.gcp_application_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_gcpApplicationFirstPartyVulnerabilities.attributes.gcp_application_id.codec)}`;
             }
           });
         }
@@ -15969,7 +16106,7 @@ export const plans = {
             type: "attribute",
             attribute: "first_party_vulnerability_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationFirstPartyVulnerabilitiesAttributes.first_party_vulnerability_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_gcpApplicationFirstPartyVulnerabilities.attributes.first_party_vulnerability_id.codec)}`;
             }
           });
         }
@@ -16154,7 +16291,7 @@ export const plans = {
           }, Object.create(null));
         }
         const $list = pgUnionAll({
-          attributes: ApplicationAttributes,
+          attributes: spec_Application.attributes,
           resourceByTypeName: resourceByTypeName9,
           members: members9,
           name: "applications"
@@ -16416,7 +16553,7 @@ export const plans = {
             type: "attribute",
             attribute: "aws_application_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationThirdPartyVulnerabilitiesAttributes.aws_application_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_awsApplicationThirdPartyVulnerabilities.attributes.aws_application_id.codec)}`;
             }
           });
         }
@@ -16439,7 +16576,7 @@ export const plans = {
             type: "attribute",
             attribute: "third_party_vulnerability_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationThirdPartyVulnerabilitiesAttributes.third_party_vulnerability_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_awsApplicationThirdPartyVulnerabilities.attributes.third_party_vulnerability_id.codec)}`;
             }
           });
         }
@@ -16569,7 +16706,7 @@ export const plans = {
             type: "attribute",
             attribute: "gcp_application_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationThirdPartyVulnerabilitiesAttributes.gcp_application_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_gcpApplicationThirdPartyVulnerabilities.attributes.gcp_application_id.codec)}`;
             }
           });
         }
@@ -16592,7 +16729,7 @@ export const plans = {
             type: "attribute",
             attribute: "third_party_vulnerability_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationThirdPartyVulnerabilitiesAttributes.third_party_vulnerability_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_gcpApplicationThirdPartyVulnerabilities.attributes.third_party_vulnerability_id.codec)}`;
             }
           });
         }
@@ -16724,7 +16861,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), ApplicationAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_Application.attributes.id.codec)}`;
             }
           });
         }
@@ -16747,7 +16884,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), ApplicationAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_Application.attributes.name.codec)}`;
             }
           });
         }
@@ -16770,7 +16907,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_deployed",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), ApplicationAttributes.last_deployed.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_Application.attributes.last_deployed.codec)}`;
             }
           });
         }
@@ -16911,7 +17048,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), VulnerabilityAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_Vulnerability.attributes.id.codec)}`;
             }
           });
         }
@@ -16934,7 +17071,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), VulnerabilityAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_Vulnerability.attributes.name.codec)}`;
             }
           });
         }
@@ -16957,7 +17094,7 @@ export const plans = {
             type: "attribute",
             attribute: "cvss_score",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), VulnerabilityAttributes.cvss_score.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_Vulnerability.attributes.cvss_score.codec)}`;
             }
           });
         }
@@ -17250,7 +17387,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_awsApplications.attributes.id.codec)}`;
             }
           });
         }
@@ -17273,7 +17410,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_awsApplications.attributes.name.codec)}`;
             }
           });
         }
@@ -17296,7 +17433,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_deployed",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.last_deployed.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_awsApplications.attributes.last_deployed.codec)}`;
             }
           });
         }
@@ -17319,7 +17456,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_awsApplications.attributes.person_id.codec)}`;
             }
           });
         }
@@ -17342,7 +17479,7 @@ export const plans = {
             type: "attribute",
             attribute: "organization_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.organization_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_awsApplications.attributes.organization_id.codec)}`;
             }
           });
         }
@@ -17365,7 +17502,7 @@ export const plans = {
             type: "attribute",
             attribute: "aws_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), awsApplicationsAttributes.aws_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_awsApplications.attributes.aws_id.codec)}`;
             }
           });
         }
@@ -17656,7 +17793,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_gcpApplications.attributes.id.codec)}`;
             }
           });
         }
@@ -17679,7 +17816,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_gcpApplications.attributes.name.codec)}`;
             }
           });
         }
@@ -17702,7 +17839,7 @@ export const plans = {
             type: "attribute",
             attribute: "last_deployed",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.last_deployed.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_gcpApplications.attributes.last_deployed.codec)}`;
             }
           });
         }
@@ -17725,7 +17862,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_gcpApplications.attributes.person_id.codec)}`;
             }
           });
         }
@@ -17748,7 +17885,7 @@ export const plans = {
             type: "attribute",
             attribute: "organization_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.organization_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_gcpApplications.attributes.organization_id.codec)}`;
             }
           });
         }
@@ -17771,7 +17908,7 @@ export const plans = {
             type: "attribute",
             attribute: "gcp_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), gcpApplicationsAttributes.gcp_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_gcpApplications.attributes.gcp_id.codec)}`;
             }
           });
         }
@@ -18207,7 +18344,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItems.attributes.id.codec)}`;
             }
           });
         }
@@ -18230,7 +18367,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItems.attributes.type.codec)}`;
             }
           });
         }
@@ -18253,7 +18390,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItems.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -18276,7 +18413,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItems.attributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -18299,7 +18436,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItems.attributes.author_id.codec)}`;
             }
           });
         }
@@ -18322,7 +18459,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItems.attributes.position.codec)}`;
             }
           });
         }
@@ -18345,7 +18482,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItems.attributes.created_at.codec)}`;
             }
           });
         }
@@ -18368,7 +18505,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItems.attributes.updated_at.codec)}`;
             }
           });
         }
@@ -18391,7 +18528,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItems.attributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -18414,7 +18551,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemsAttributes.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItems.attributes.archived_at.codec)}`;
             }
           });
         }
@@ -18932,7 +19069,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.id.codec)}`;
             }
           });
         }
@@ -18955,7 +19092,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.type.codec)}`;
             }
           });
         }
@@ -18978,7 +19115,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -19001,7 +19138,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -19024,7 +19161,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.author_id.codec)}`;
             }
           });
         }
@@ -19047,7 +19184,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.position.codec)}`;
             }
           });
         }
@@ -19070,7 +19207,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.created_at.codec)}`;
             }
           });
         }
@@ -19093,7 +19230,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.updated_at.codec)}`;
             }
           });
         }
@@ -19116,7 +19253,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -19139,7 +19276,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemsAttributes.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItems.attributes.archived_at.codec)}`;
             }
           });
         }
@@ -19394,7 +19531,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemRelationsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItemRelations.attributes.id.codec)}`;
             }
           });
         }
@@ -19417,7 +19554,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemRelationsAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItemRelations.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -19440,7 +19577,7 @@ export const plans = {
             type: "attribute",
             attribute: "child_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemRelationsAttributes.child_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItemRelations.attributes.child_id.codec)}`;
             }
           });
         }
@@ -19570,7 +19707,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemRelationCompositePksAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItemRelationCompositePks.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -19593,7 +19730,7 @@ export const plans = {
             type: "attribute",
             attribute: "child_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), singleTableItemRelationCompositePksAttributes.child_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_singleTableItemRelationCompositePks.attributes.child_id.codec)}`;
             }
           });
         }
@@ -21703,7 +21840,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemRelationsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItemRelations.attributes.id.codec)}`;
             }
           });
         }
@@ -21726,7 +21863,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemRelationsAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItemRelations.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -21749,7 +21886,7 @@ export const plans = {
             type: "attribute",
             attribute: "child_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemRelationsAttributes.child_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItemRelations.attributes.child_id.codec)}`;
             }
           });
         }
@@ -21879,7 +22016,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemRelationCompositePksAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItemRelationCompositePks.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -21902,7 +22039,7 @@ export const plans = {
             type: "attribute",
             attribute: "child_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalItemRelationCompositePksAttributes.child_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalItemRelationCompositePks.attributes.child_id.codec)}`;
             }
           });
         }
@@ -24123,7 +24260,7 @@ export const plans = {
     allVulnerabilities: {
       plan() {
         const $list = pgUnionAll({
-          attributes: VulnerabilityAttributes,
+          attributes: spec_Vulnerability.attributes,
           resourceByTypeName: resourceByTypeName11,
           members: members11,
           name: "Vulnerability"
@@ -24189,7 +24326,7 @@ export const plans = {
     allApplications: {
       plan() {
         const $list = pgUnionAll({
-          attributes: ApplicationAttributes,
+          attributes: spec_Application.attributes,
           resourceByTypeName: resourceByTypeName12,
           members: members12,
           name: "Application"
@@ -24255,7 +24392,7 @@ export const plans = {
     allZeroImplementations: {
       plan() {
         const $list = pgUnionAll({
-          attributes: ZeroImplementationAttributes,
+          attributes: spec_ZeroImplementation.attributes,
           resourceByTypeName: resourceByTypeName13,
           members: members13,
           name: "ZeroImplementation"
@@ -25645,7 +25782,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), ZeroImplementationAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_ZeroImplementation.attributes.id.codec)}`;
             }
           });
         }
@@ -25668,7 +25805,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), ZeroImplementationAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_ZeroImplementation.attributes.name.codec)}`;
             }
           });
         }
@@ -25823,7 +25960,7 @@ export const plans = {
             type: "attribute",
             attribute: "organization_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), organizationsAttributes.organization_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_organizations.attributes.organization_id.codec)}`;
             }
           });
         }
@@ -25846,7 +25983,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), organizationsAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_organizations.attributes.name.codec)}`;
             }
           });
         }
@@ -26001,7 +26138,7 @@ export const plans = {
             type: "attribute",
             attribute: "person_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), peopleAttributes.person_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_people.attributes.person_id.codec)}`;
             }
           });
         }
@@ -26024,7 +26161,7 @@ export const plans = {
             type: "attribute",
             attribute: "username",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), peopleAttributes.username.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_people.attributes.username.codec)}`;
             }
           });
         }
@@ -26179,7 +26316,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), prioritiesAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_priorities.attributes.id.codec)}`;
             }
           });
         }
@@ -26202,7 +26339,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), prioritiesAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_priorities.attributes.title.codec)}`;
             }
           });
         }
@@ -26663,7 +26800,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.title.codec)}`;
             }
           });
         }
@@ -26686,7 +26823,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.id.codec)}`;
             }
           });
         }
@@ -26709,7 +26846,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.type.codec)}`;
             }
           });
         }
@@ -26732,7 +26869,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -26755,7 +26892,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -26778,7 +26915,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.author_id.codec)}`;
             }
           });
         }
@@ -26801,7 +26938,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.position.codec)}`;
             }
           });
         }
@@ -26824,7 +26961,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.created_at.codec)}`;
             }
           });
         }
@@ -26847,7 +26984,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.updated_at.codec)}`;
             }
           });
         }
@@ -26870,7 +27007,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -26893,7 +27030,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistsAttributes.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklists.attributes.archived_at.codec)}`;
             }
           });
         }
@@ -27354,7 +27491,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.title.codec)}`;
             }
           });
         }
@@ -27377,7 +27514,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.id.codec)}`;
             }
           });
         }
@@ -27400,7 +27537,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.type.codec)}`;
             }
           });
         }
@@ -27423,7 +27560,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -27446,7 +27583,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -27469,7 +27606,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.author_id.codec)}`;
             }
           });
         }
@@ -27492,7 +27629,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.position.codec)}`;
             }
           });
         }
@@ -27515,7 +27652,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.created_at.codec)}`;
             }
           });
         }
@@ -27538,7 +27675,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.updated_at.codec)}`;
             }
           });
         }
@@ -27561,7 +27698,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -27584,7 +27721,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalTopicsAttributes.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalTopics.attributes.archived_at.codec)}`;
             }
           });
         }
@@ -28079,7 +28216,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.description.codec)}`;
             }
           });
         }
@@ -28102,7 +28239,7 @@ export const plans = {
             type: "attribute",
             attribute: "note",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.note.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.note.codec)}`;
             }
           });
         }
@@ -28125,7 +28262,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.id.codec)}`;
             }
           });
         }
@@ -28148,7 +28285,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.type.codec)}`;
             }
           });
         }
@@ -28171,7 +28308,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -28194,7 +28331,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -28217,7 +28354,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.author_id.codec)}`;
             }
           });
         }
@@ -28240,7 +28377,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.position.codec)}`;
             }
           });
         }
@@ -28263,7 +28400,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.created_at.codec)}`;
             }
           });
         }
@@ -28286,7 +28423,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.updated_at.codec)}`;
             }
           });
         }
@@ -28309,7 +28446,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -28332,7 +28469,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalChecklistItemsAttributes.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalChecklistItems.attributes.archived_at.codec)}`;
             }
           });
         }
@@ -28827,7 +28964,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.title.codec)}`;
             }
           });
         }
@@ -28850,7 +28987,7 @@ export const plans = {
             type: "attribute",
             attribute: "color",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.color.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.color.codec)}`;
             }
           });
         }
@@ -28873,7 +29010,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.id.codec)}`;
             }
           });
         }
@@ -28896,7 +29033,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.type.codec)}`;
             }
           });
         }
@@ -28919,7 +29056,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -28942,7 +29079,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -28965,7 +29102,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.author_id.codec)}`;
             }
           });
         }
@@ -28988,7 +29125,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.position.codec)}`;
             }
           });
         }
@@ -29011,7 +29148,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.created_at.codec)}`;
             }
           });
         }
@@ -29034,7 +29171,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.updated_at.codec)}`;
             }
           });
         }
@@ -29057,7 +29194,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -29080,7 +29217,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalDividersAttributes.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalDividers.attributes.archived_at.codec)}`;
             }
           });
         }
@@ -29609,7 +29746,7 @@ export const plans = {
             type: "attribute",
             attribute: "title",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.title.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.title.codec)}`;
             }
           });
         }
@@ -29632,7 +29769,7 @@ export const plans = {
             type: "attribute",
             attribute: "description",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.description.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.description.codec)}`;
             }
           });
         }
@@ -29655,7 +29792,7 @@ export const plans = {
             type: "attribute",
             attribute: "note",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.note.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.note.codec)}`;
             }
           });
         }
@@ -29678,7 +29815,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.id.codec)}`;
             }
           });
         }
@@ -29701,7 +29838,7 @@ export const plans = {
             type: "attribute",
             attribute: "type",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.type.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.type.codec)}`;
             }
           });
         }
@@ -29724,7 +29861,7 @@ export const plans = {
             type: "attribute",
             attribute: "parent_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.parent_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.parent_id.codec)}`;
             }
           });
         }
@@ -29747,7 +29884,7 @@ export const plans = {
             type: "attribute",
             attribute: "root_topic_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.root_topic_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.root_topic_id.codec)}`;
             }
           });
         }
@@ -29770,7 +29907,7 @@ export const plans = {
             type: "attribute",
             attribute: "author_id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.author_id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.author_id.codec)}`;
             }
           });
         }
@@ -29793,7 +29930,7 @@ export const plans = {
             type: "attribute",
             attribute: "position",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.position.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.position.codec)}`;
             }
           });
         }
@@ -29816,7 +29953,7 @@ export const plans = {
             type: "attribute",
             attribute: "created_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.created_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.created_at.codec)}`;
             }
           });
         }
@@ -29839,7 +29976,7 @@ export const plans = {
             type: "attribute",
             attribute: "updated_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.updated_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.updated_at.codec)}`;
             }
           });
         }
@@ -29862,7 +29999,7 @@ export const plans = {
             type: "attribute",
             attribute: "is_explicitly_archived",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.is_explicitly_archived.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.is_explicitly_archived.codec)}`;
             }
           });
         }
@@ -29885,7 +30022,7 @@ export const plans = {
             type: "attribute",
             attribute: "archived_at",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), relationalPostsAttributes.archived_at.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_relationalPosts.attributes.archived_at.codec)}`;
             }
           });
         }
@@ -30108,7 +30245,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), firstPartyVulnerabilitiesAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_firstPartyVulnerabilities.attributes.id.codec)}`;
             }
           });
         }
@@ -30131,7 +30268,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), firstPartyVulnerabilitiesAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_firstPartyVulnerabilities.attributes.name.codec)}`;
             }
           });
         }
@@ -30154,7 +30291,7 @@ export const plans = {
             type: "attribute",
             attribute: "cvss_score",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), firstPartyVulnerabilitiesAttributes.cvss_score.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_firstPartyVulnerabilities.attributes.cvss_score.codec)}`;
             }
           });
         }
@@ -30177,7 +30314,7 @@ export const plans = {
             type: "attribute",
             attribute: "team_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), firstPartyVulnerabilitiesAttributes.team_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_firstPartyVulnerabilities.attributes.team_name.codec)}`;
             }
           });
         }
@@ -30400,7 +30537,7 @@ export const plans = {
             type: "attribute",
             attribute: "id",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), thirdPartyVulnerabilitiesAttributes.id.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_thirdPartyVulnerabilities.attributes.id.codec)}`;
             }
           });
         }
@@ -30423,7 +30560,7 @@ export const plans = {
             type: "attribute",
             attribute: "name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), thirdPartyVulnerabilitiesAttributes.name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_thirdPartyVulnerabilities.attributes.name.codec)}`;
             }
           });
         }
@@ -30446,7 +30583,7 @@ export const plans = {
             type: "attribute",
             attribute: "cvss_score",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), thirdPartyVulnerabilitiesAttributes.cvss_score.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_thirdPartyVulnerabilities.attributes.cvss_score.codec)}`;
             }
           });
         }
@@ -30469,7 +30606,7 @@ export const plans = {
             type: "attribute",
             attribute: "vendor_name",
             callback(expression) {
-              return sql`${expression} = ${$condition.placeholder(val.get(), thirdPartyVulnerabilitiesAttributes.vendor_name.codec)}`;
+              return sql`${expression} = ${$condition.placeholder(val.get(), spec_thirdPartyVulnerabilities.attributes.vendor_name.codec)}`;
             }
           });
         }
@@ -31548,6 +31685,9 @@ export const plans = {
     }
   },
   AwsApplicationFirstPartyVulnerabilityInput: {
+    "__inputPlan": function AwsApplicationFirstPartyVulnerabilityInput_inputPlan() {
+      return object(Object.create(null));
+    },
     awsApplicationId: {
       applyPlan($insert, val) {
         $insert.set("aws_application_id", val.get());
@@ -31622,6 +31762,9 @@ export const plans = {
     }
   },
   AwsApplicationThirdPartyVulnerabilityInput: {
+    "__inputPlan": function AwsApplicationThirdPartyVulnerabilityInput_inputPlan() {
+      return object(Object.create(null));
+    },
     awsApplicationId: {
       applyPlan($insert, val) {
         $insert.set("aws_application_id", val.get());
@@ -31696,6 +31839,9 @@ export const plans = {
     }
   },
   GcpApplicationFirstPartyVulnerabilityInput: {
+    "__inputPlan": function GcpApplicationFirstPartyVulnerabilityInput_inputPlan() {
+      return object(Object.create(null));
+    },
     gcpApplicationId: {
       applyPlan($insert, val) {
         $insert.set("gcp_application_id", val.get());
@@ -31770,6 +31916,9 @@ export const plans = {
     }
   },
   GcpApplicationThirdPartyVulnerabilityInput: {
+    "__inputPlan": function GcpApplicationThirdPartyVulnerabilityInput_inputPlan() {
+      return object(Object.create(null));
+    },
     gcpApplicationId: {
       applyPlan($insert, val) {
         $insert.set("gcp_application_id", val.get());
@@ -31844,6 +31993,9 @@ export const plans = {
     }
   },
   OrganizationInput: {
+    "__inputPlan": function OrganizationInput_inputPlan() {
+      return object(Object.create(null));
+    },
     organizationId: {
       applyPlan($insert, val) {
         $insert.set("organization_id", val.get());
@@ -31918,6 +32070,9 @@ export const plans = {
     }
   },
   PersonInput: {
+    "__inputPlan": function PersonInput_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -31992,6 +32147,9 @@ export const plans = {
     }
   },
   PriorityInput: {
+    "__inputPlan": function PriorityInput_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -32066,6 +32224,9 @@ export const plans = {
     }
   },
   RelationalItemRelationCompositePkInput: {
+    "__inputPlan": function RelationalItemRelationCompositePkInput_inputPlan() {
+      return object(Object.create(null));
+    },
     parentId: {
       applyPlan($insert, val) {
         $insert.set("parent_id", val.get());
@@ -32140,6 +32301,9 @@ export const plans = {
     }
   },
   SingleTableItemRelationCompositePkInput: {
+    "__inputPlan": function SingleTableItemRelationCompositePkInput_inputPlan() {
+      return object(Object.create(null));
+    },
     parentId: {
       applyPlan($insert, val) {
         $insert.set("parent_id", val.get());
@@ -32214,6 +32378,9 @@ export const plans = {
     }
   },
   RelationalItemRelationInput: {
+    "__inputPlan": function RelationalItemRelationInput_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -32295,6 +32462,9 @@ export const plans = {
     }
   },
   SingleTableItemRelationInput: {
+    "__inputPlan": function SingleTableItemRelationInput_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -32376,6 +32546,9 @@ export const plans = {
     }
   },
   LogEntryInput: {
+    "__inputPlan": function LogEntryInput_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -32464,6 +32637,9 @@ export const plans = {
     }
   },
   FirstPartyVulnerabilityInput: {
+    "__inputPlan": function FirstPartyVulnerabilityInput_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -32552,6 +32728,9 @@ export const plans = {
     }
   },
   ThirdPartyVulnerabilityInput: {
+    "__inputPlan": function ThirdPartyVulnerabilityInput_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -32640,6 +32819,9 @@ export const plans = {
     }
   },
   AwsApplicationInput: {
+    "__inputPlan": function AwsApplicationInput_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -32742,6 +32924,9 @@ export const plans = {
     }
   },
   GcpApplicationInput: {
+    "__inputPlan": function GcpApplicationInput_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -32844,6 +33029,9 @@ export const plans = {
     }
   },
   AwsApplicationFirstPartyVulnerabilityPatch: {
+    "__inputPlan": function AwsApplicationFirstPartyVulnerabilityPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     awsApplicationId: {
       applyPlan($insert, val) {
         $insert.set("aws_application_id", val.get());
@@ -32918,6 +33106,9 @@ export const plans = {
     }
   },
   AwsApplicationThirdPartyVulnerabilityPatch: {
+    "__inputPlan": function AwsApplicationThirdPartyVulnerabilityPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     awsApplicationId: {
       applyPlan($insert, val) {
         $insert.set("aws_application_id", val.get());
@@ -32992,6 +33183,9 @@ export const plans = {
     }
   },
   GcpApplicationFirstPartyVulnerabilityPatch: {
+    "__inputPlan": function GcpApplicationFirstPartyVulnerabilityPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     gcpApplicationId: {
       applyPlan($insert, val) {
         $insert.set("gcp_application_id", val.get());
@@ -33066,6 +33260,9 @@ export const plans = {
     }
   },
   GcpApplicationThirdPartyVulnerabilityPatch: {
+    "__inputPlan": function GcpApplicationThirdPartyVulnerabilityPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     gcpApplicationId: {
       applyPlan($insert, val) {
         $insert.set("gcp_application_id", val.get());
@@ -33139,6 +33336,9 @@ export const plans = {
     }
   },
   OrganizationPatch: {
+    "__inputPlan": function OrganizationPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     organizationId: {
       applyPlan($insert, val) {
         $insert.set("organization_id", val.get());
@@ -33226,6 +33426,9 @@ export const plans = {
     }
   },
   PersonPatch: {
+    "__inputPlan": function PersonPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     personId: {
       applyPlan($insert, val) {
         $insert.set("person_id", val.get());
@@ -33313,6 +33516,9 @@ export const plans = {
     }
   },
   PriorityPatch: {
+    "__inputPlan": function PriorityPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -33387,6 +33593,9 @@ export const plans = {
     }
   },
   RelationalItemRelationCompositePkPatch: {
+    "__inputPlan": function RelationalItemRelationCompositePkPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     parentId: {
       applyPlan($insert, val) {
         $insert.set("parent_id", val.get());
@@ -33461,6 +33670,9 @@ export const plans = {
     }
   },
   SingleTableItemRelationCompositePkPatch: {
+    "__inputPlan": function SingleTableItemRelationCompositePkPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     parentId: {
       applyPlan($insert, val) {
         $insert.set("parent_id", val.get());
@@ -33534,6 +33746,9 @@ export const plans = {
     }
   },
   RelationalItemRelationPatch: {
+    "__inputPlan": function RelationalItemRelationPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -33629,6 +33844,9 @@ export const plans = {
     }
   },
   SingleTableItemRelationPatch: {
+    "__inputPlan": function SingleTableItemRelationPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -33724,6 +33942,9 @@ export const plans = {
     }
   },
   LogEntryPatch: {
+    "__inputPlan": function LogEntryPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -33811,6 +34032,9 @@ export const plans = {
     }
   },
   FirstPartyVulnerabilityPatch: {
+    "__inputPlan": function FirstPartyVulnerabilityPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -33898,6 +34122,9 @@ export const plans = {
     }
   },
   ThirdPartyVulnerabilityPatch: {
+    "__inputPlan": function ThirdPartyVulnerabilityPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -33985,6 +34212,9 @@ export const plans = {
     }
   },
   AwsApplicationPatch: {
+    "__inputPlan": function AwsApplicationPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());
@@ -34086,6 +34316,9 @@ export const plans = {
     }
   },
   GcpApplicationPatch: {
+    "__inputPlan": function GcpApplicationPatch_inputPlan() {
+      return object(Object.create(null));
+    },
     rowId: {
       applyPlan($insert, val) {
         $insert.set("id", val.get());

--- a/postgraphile/postgraphile/package.json
+++ b/postgraphile/postgraphile/package.json
@@ -168,12 +168,14 @@
   },
   "bin": "./dist/cli-run.js",
   "scripts": {
-    "test": "yarn test:v4 && yarn test:polymorphic_etc && yarn test:mutations && yarn test:schema && yarn test:schema-exports",
-    "test:v4": "jest -i __tests__/queries/v4",
-    "test:polymorphic_etc": "jest -i __tests__/queries/polymorphic __tests__/queries/relay",
-    "test:mutations": "jest -i __tests__/mutations",
+    "test": "yarn test:operations && yarn test:schema && yarn test:schema-exports && yarn test:operations-exports",
+    "test:operations": "yarn test:operations:v4 && yarn test:operations:polymorphic_etc && yarn test:operations:mutations",
+    "test:operations:v4": "jest -i __tests__/queries/v4",
+    "test:operations:polymorphic_etc": "jest -i __tests__/queries/polymorphic __tests__/queries/relay",
+    "test:operations:mutations": "jest -i __tests__/mutations",
     "test:schema": "jest -i __tests__/schema",
     "test:schema-exports": "node scripts/test-schema-exports.mjs",
+    "test:operations-exports": "EXPORT_SCHEMA=1 yarn test:operations",
     "prepack": "tsc -b tsconfig.build.json"
   },
   "repository": {

--- a/postgraphile/postgraphile/package.json
+++ b/postgraphile/postgraphile/package.json
@@ -175,7 +175,8 @@
     "test:operations:mutations": "jest -i __tests__/mutations",
     "test:schema": "jest -i __tests__/schema",
     "test:schema-exports": "node scripts/test-schema-exports.mjs",
-    "test:operations-exports": "EXPORT_SCHEMA=1 yarn test:operations",
+    "test:operations-exports": "yarn test:operations-exports:typeDefs",
+    "test:operations-exports:typeDefs": "EXPORT_SCHEMA=typeDefs yarn test:operations",
     "prepack": "tsc -b tsconfig.build.json"
   },
   "repository": {

--- a/postgraphile/postgraphile/scripts/test-schema-exports.mjs
+++ b/postgraphile/postgraphile/scripts/test-schema-exports.mjs
@@ -2,8 +2,8 @@ import { readFile } from "fs/promises";
 import { glob } from "glob";
 import {
   isSchema,
-  printSchema,
   lexicographicSortSchema,
+  printSchema,
 } from "grafast/graphql";
 
 const TESTS = new URL("../__tests__", import.meta.url).pathname;

--- a/utils/graphile-export/src/exportSchema.ts
+++ b/utils/graphile-export/src/exportSchema.ts
@@ -1697,30 +1697,44 @@ function exportSchemaTypeDefs({
             `${type.name}.extensions.grafast.plan`,
           )
         : null;
-      if (planAST) {
+      if (
+        planAST ||
+        type.serialize !== GraphQLScalarType.prototype.serialize ||
+        type.parseValue !== GraphQLScalarType.prototype.parseValue ||
+        type.parseLiteral !== GraphQLScalarType.prototype.parseLiteral
+      ) {
         plansProperties.push(
           t.objectProperty(
             identifierOrLiteral(type.name),
             t.objectExpression(
               objectToObjectProperties({
-                serialize: convertToIdentifierViaAST(
-                  file,
-                  type.serialize,
-                  `${type.name}Serialize`,
-                  `${type.name}.serialize`,
-                ),
-                parseValue: convertToIdentifierViaAST(
-                  file,
-                  type.parseValue,
-                  `${type.name}ParseValue`,
-                  `${type.name}.parseValue`,
-                ),
-                parseLiteral: convertToIdentifierViaAST(
-                  file,
-                  type.parseLiteral,
-                  `${type.name}ParseLiteral`,
-                  `${type.name}.parseLiteral`,
-                ),
+                serialize:
+                  type.serialize !== GraphQLScalarType.prototype.serialize
+                    ? convertToIdentifierViaAST(
+                        file,
+                        type.serialize,
+                        `${type.name}Serialize`,
+                        `${type.name}.serialize`,
+                      )
+                    : null,
+                parseValue:
+                  type.parseValue !== GraphQLScalarType.prototype.parseValue
+                    ? convertToIdentifierViaAST(
+                        file,
+                        type.parseValue,
+                        `${type.name}ParseValue`,
+                        `${type.name}.parseValue`,
+                      )
+                    : null,
+                parseLiteral:
+                  type.parseLiteral !== GraphQLScalarType.prototype.parseLiteral
+                    ? convertToIdentifierViaAST(
+                        file,
+                        type.parseLiteral,
+                        `${type.name}ParseLiteral`,
+                        `${type.name}.parseLiteral`,
+                      )
+                    : null,
                 plan: planAST,
               }),
             ),

--- a/utils/graphile-export/src/exportSchema.ts
+++ b/utils/graphile-export/src/exportSchema.ts
@@ -1709,6 +1709,20 @@ function exportSchemaTypeDefs({
     } else if (type instanceof GraphQLInputObjectType) {
       const typeProperties: t.ObjectProperty[] = [];
 
+      if (type.extensions?.grafast?.inputPlan) {
+        typeProperties.push(
+          t.objectProperty(
+            identifierOrLiteral("__inputPlan"),
+            convertToIdentifierViaAST(
+              file,
+              type.extensions?.grafast.inputPlan,
+              `${type.name}.inputPlan`,
+              `${type.name}.extensions.grafast.inputPlan`,
+            ),
+          ),
+        );
+      }
+
       for (const [fieldName, field] of Object.entries(type.toConfig().fields)) {
         typeProperties.push(
           t.objectProperty(

--- a/utils/graphile-export/src/exportSchema.ts
+++ b/utils/graphile-export/src/exportSchema.ts
@@ -1902,6 +1902,8 @@ async function lint(code: string, rawFilePath: string | URL) {
     );
     return;
   }
+  const filePath =
+    typeof rawFilePath === "string" ? rawFilePath : rawFilePath.pathname;
   const { ESLint } = eslintModule;
   const eslint = new ESLint({
     useEslintrc: false, // Don't use external config
@@ -1928,16 +1930,18 @@ async function lint(code: string, rawFilePath: string | URL) {
     },
   });
 
-  const filePath =
-    typeof rawFilePath === "string" ? rawFilePath : rawFilePath.pathname;
-  const results = await eslint.lintText(code, { filePath });
+  const results = await eslint.lintText(code, {
+    warnIgnored: true,
+    // DO NOT PASS THE `filePath`; it can result in the file being ignored!
+  });
 
   if (results.length !== 1) {
+    console.dir({ filePath, results });
     throw new Error(`Expected ESLint results to have exactly one entry`);
   }
   const [result] = results;
 
-  if (result.errorCount > 0) {
+  if (result.warningCount > 0 || result.errorCount > 0) {
     console.log(
       `ESLint found problems in the export; this likely indicates some issue with \`EXPORTABLE\` calls`,
     );

--- a/utils/graphile-export/src/exportSchema.ts
+++ b/utils/graphile-export/src/exportSchema.ts
@@ -1558,16 +1558,10 @@ function exportSchemaGraphQLJS({
         "schema.extensions",
         "schema.extensions",
       ),
-      enableDeferStream: t.booleanLiteral(
-        process.env.ENABLE_DEFER_STREAM === "1",
-      ),
-      /*
-      // TODO: use the below once https://github.com/graphql/graphql-js/pull/3450 is fixed:
       enableDeferStream:
         config.enableDeferStream != null
           ? t.booleanLiteral(config.enableDeferStream)
           : null,
-          */
       assumeValid: null, // TODO: t.booleanLiteral(true),
     }),
   );
@@ -1926,6 +1920,14 @@ export async function exportSchemaAsString(
         "stream",
       ].includes(d.name),
   );
+
+  if (
+    process.env.ENABLE_DEFER_STREAM === "1" ||
+    config.directives.some((d) => d.name === "defer" || d.name === "skip")
+  ) {
+    // Ref: https://github.com/graphql/graphql-js/pull/3450
+    config.enableDeferStream = true;
+  }
 
   const file = new CodegenFile(options);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12422,13 +12422,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql@npm:^16.1.0-experimental-stream-defer.6":
-  version: 16.8.0
-  resolution: "graphql@npm:16.8.0"
-  checksum: 93a2e9e0ff33f05bb64c4f46595814549155e88d27e79a266e9493ded10e66afac0d15fdb44804321b2d54bf1ab25530f0817cb61f33cfb2fabd68ad4c627356
-  languageName: node
-  linkType: hard
-
 "gray-matter@npm:^4.0.3":
   version: 4.0.3
   resolution: "gray-matter@npm:4.0.3"


### PR DESCRIPTION
## Description

This PR sets up testing of the exported schemas by running the integration tests again, this time by generating the schema (as before) then exporting the schema, importing it, and using the imported version for running the tests. It's really inefficient right now, making the tests really slow, but worth it for peace of mind. In future this will need to be redeveloped to find all the schema configurations and then write out those schemas in advance and use them to run the tests against.

Then, of course, there were loads of hard to figure out errors/discrepancies which I had to track down. Roughly:

- `grafast`'s `makeGrafastSchema` has been rebuilt to follow better patterns (fixing issues with enums in the process)
- `grafast`'s `makeGrafastSchema` now supports `__inputPlan(){}` on an input object's plans
- `graphile-export` now exports the input object input plan in `typeDefs` mode
- `graphile-export` now detects functions with additional properties (e.g. `isSyncAndSafe: true`) and makes sure these properties are represented in the export
- `graphile-export` now outputs the `serialize`, `parseValue` and `parseLiteral` methods on custom scalars in `typeDefs` mode
- Marks a number of other things as `EXPORTABLE` to fix exports
- Removes `EXPORTABLE` from a couple of things to fix exports
- Fixes an issue with our linting of the exported schema where it might be ignored sometimes
- `ConstantStep` now supports `.get()` and `.at()` patterns
- Fix `enableDeferStream` detection in schema export by looking at directives in schema being exported

Fixes https://github.com/graphile/crystal/issues/2043
Fixes https://github.com/graphile/crystal/issues/2049

## Performance impact

Import/export only.

## Security impact

Improvement: more accurate exports are safer.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
