### PR TITLE
Ensure unary steps only perform unbatched execution once

### DIFF
--- a/.changeset/strange-schools-act.md
+++ b/.changeset/strange-schools-act.md
@@ -1,0 +1,6 @@
+---
+"grafast": patch
+---
+
+Hotfix: unbatched unary steps executed multiple times under certain
+circumstances leading to excessive logging.

--- a/grafast/grafast/src/engine/executeBucket.ts
+++ b/grafast/grafast/src/engine/executeBucket.ts
@@ -578,6 +578,12 @@ export function executeBucket(
           const step = sudo(
             _allSteps[allStepsIndex] as UnbatchedExecutableStep,
           );
+
+          // Unary steps only need to be processed once
+          if (step._isUnary && dataIndex !== 0) {
+            continue;
+          }
+
           try {
             const deps: any = [];
             const extra = extras[allStepsIndex];


### PR DESCRIPTION
## Description

Reported by @Dodobibi via Discord:

https://discord.com/channels/489127045289476126/953710447087980654/1238107976984694794

## Performance impact

Fixes major performance issue.

## Security impact

Improvement?

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
