### PR TITLE
Neater export of resource options

### DIFF
--- a/.changeset/afraid-starfishes-wink.md
+++ b/.changeset/afraid-starfishes-wink.md
@@ -1,0 +1,7 @@
+---
+"graphile-build-pg": patch
+"graphile-build": patch
+"postgraphile": patch
+---
+
+Improve exporting of resource options (neater export code)

--- a/graphile-build/graphile-build-pg/src/plugins/PgTablesPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgTablesPlugin.ts
@@ -7,7 +7,11 @@ import type {
 } from "@dataplan/pg";
 import { assertPgClassSingleStep, makePgResourceOptions } from "@dataplan/pg";
 import { object } from "grafast";
-import { EXPORTABLE, gatherConfig } from "graphile-build";
+import {
+  EXPORTABLE,
+  EXPORTABLE_OBJECT_CLONE,
+  gatherConfig,
+} from "graphile-build";
 import type { PgClass, PgConstraint, PgNamespace } from "pg-introspection";
 
 import { addBehaviorToTags, exportNameHint } from "../utils.js";
@@ -484,12 +488,7 @@ export const PgTablesPlugin: GraphileConfig.Plugin = {
 
           // Need to mark this exportable to avoid out-of-order access to
           // variables in the export
-          const entries = Object.entries(options);
-          const finalOptions = EXPORTABLE(
-            (entries) =>
-              Object.fromEntries(entries) as unknown as PgResourceOptions,
-            [entries],
-          );
+          const finalOptions = EXPORTABLE_OBJECT_CLONE(options);
 
           const resourceOptions = EXPORTABLE(
             (finalOptions, makePgResourceOptions) =>

--- a/graphile-build/graphile-build/package.json
+++ b/graphile-build/graphile-build/package.json
@@ -46,6 +46,7 @@
     "lodash": "^4.17.21",
     "pluralize": "^7.0.0",
     "semver": "^7.5.4",
+    "tamedevil": "workspace:^",
     "tslib": "^2.6.2"
   },
   "engines": {

--- a/graphile-build/graphile-build/src/global.ts
+++ b/graphile-build/graphile-build/src/global.ts
@@ -315,6 +315,7 @@ declare global {
         args: [...TScope],
         nameHint?: string,
       ): T;
+      EXPORTABLE_OBJECT_CLONE<T extends object>(obj: T): T;
       exportNameHint(obj: any, nameHint: string): void;
 
       /**

--- a/graphile-build/graphile-build/src/index.ts
+++ b/graphile-build/graphile-build/src/index.ts
@@ -39,6 +39,7 @@ export {
   constantCase,
   constantCaseAll,
   EXPORTABLE,
+  EXPORTABLE_OBJECT_CLONE,
   formatInsideUnderscores,
   gatherConfig,
   pluralize,

--- a/graphile-build/graphile-build/src/makeNewBuild.ts
+++ b/graphile-build/graphile-build/src/makeNewBuild.ts
@@ -25,6 +25,7 @@ import extend, { indent } from "./extend.js";
 import type SchemaBuilder from "./SchemaBuilder.js";
 import {
   EXPORTABLE,
+  EXPORTABLE_OBJECT_CLONE,
   exportNameHint,
   stringTypeSpec,
   wrapDescription,
@@ -146,6 +147,7 @@ export default function makeNewBuild(
 
     EXPORTABLE,
     exportNameHint,
+    EXPORTABLE_OBJECT_CLONE,
     grafast,
     graphql,
 

--- a/graphile-build/graphile-build/src/utils.ts
+++ b/graphile-build/graphile-build/src/utils.ts
@@ -8,6 +8,7 @@ import { GraphQLError, GraphQLObjectType, Kind } from "grafast/graphql";
 import camelCaseAll from "lodash/camelCase.js";
 import upperFirstAll from "lodash/upperFirst.js";
 import plz from "pluralize";
+import te from "tamedevil";
 
 export function EXPORTABLE<T, TScope extends any[]>(
   factory: (...args: TScope) => T,
@@ -26,6 +27,30 @@ export function EXPORTABLE<T, TScope extends any[]>(
     });
   }
   return fn;
+}
+
+export function EXPORTABLE_OBJECT_CLONE<T extends object>(obj: T): T {
+  if (Object.getPrototypeOf(obj) === Object.prototype) {
+    const keys = Object.keys(obj);
+    const values = Object.values(obj);
+    const fn = te.eval<any>`return (${te.join(
+      keys.map((_key, i) => te.identifier(`key${i}`)),
+      ", ",
+    )}) => ({${te.indent(
+      te.join(
+        keys.map(
+          (key, i) =>
+            te`${te.safeKeyOrThrow(key)}: ${te.identifier(`key${i}`)}`,
+        ),
+        ",\n",
+      ),
+    )}});`;
+    return EXPORTABLE(fn, values);
+  } else {
+    throw new Error(
+      "EXPORTABLE_OBJECT_CLONE can currently only be used with POJOs.",
+    );
+  }
 }
 
 export function exportNameHint(obj: any, nameHint: string): void {

--- a/graphile-build/graphile-build/src/utils.ts
+++ b/graphile-build/graphile-build/src/utils.ts
@@ -45,6 +45,7 @@ export function EXPORTABLE_OBJECT_CLONE<T extends object>(obj: T): T {
         ",\n",
       ),
     )}});`;
+    // eslint-disable-next-line graphile-export/exhaustive-deps
     return EXPORTABLE(fn, values);
   } else {
     throw new Error(

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.export.mjs
@@ -459,9 +459,10 @@ const textArrayCodec = listOfCodec(TYPES.text, {
   description: undefined,
   name: "textArray"
 });
+const nonUpdatableViewIdentifier = sql.identifier("a", "non_updatable_view");
 const spec_nonUpdatableView = {
   name: "nonUpdatableView",
-  identifier: sql.identifier("a", "non_updatable_view"),
+  identifier: nonUpdatableViewIdentifier,
   attributes: Object.assign(Object.create(null), {
     "?column?": {
       description: undefined,
@@ -486,9 +487,10 @@ const spec_nonUpdatableView = {
   executor: executor
 };
 const nonUpdatableViewCodec = recordCodec(spec_nonUpdatableView);
+const inputsIdentifier = sql.identifier("a", "inputs");
 const spec_inputs = {
   name: "inputs",
-  identifier: sql.identifier("a", "inputs"),
+  identifier: inputsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -513,9 +515,10 @@ const spec_inputs = {
   executor: executor
 };
 const inputsCodec = recordCodec(spec_inputs);
+const patchsIdentifier = sql.identifier("a", "patchs");
 const spec_patchs = {
   name: "patchs",
-  identifier: sql.identifier("a", "patchs"),
+  identifier: patchsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -540,9 +543,10 @@ const spec_patchs = {
   executor: executor
 };
 const patchsCodec = recordCodec(spec_patchs);
+const reservedIdentifier = sql.identifier("a", "reserved");
 const spec_reserved = {
   name: "reserved",
-  identifier: sql.identifier("a", "reserved"),
+  identifier: reservedIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -567,9 +571,10 @@ const spec_reserved = {
   executor: executor
 };
 const reservedCodec = recordCodec(spec_reserved);
+const reservedPatchsIdentifier = sql.identifier("a", "reservedPatchs");
 const spec_reservedPatchs = {
   name: "reservedPatchs",
-  identifier: sql.identifier("a", "reservedPatchs"),
+  identifier: reservedPatchsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -594,9 +599,10 @@ const spec_reservedPatchs = {
   executor: executor
 };
 const reservedPatchsCodec = recordCodec(spec_reservedPatchs);
+const reservedInputIdentifier = sql.identifier("a", "reserved_input");
 const spec_reservedInput = {
   name: "reservedInput",
-  identifier: sql.identifier("a", "reserved_input"),
+  identifier: reservedInputIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -621,9 +627,10 @@ const spec_reservedInput = {
   executor: executor
 };
 const reservedInputCodec = recordCodec(spec_reservedInput);
+const defaultValueIdentifier = sql.identifier("a", "default_value");
 const spec_defaultValue = {
   name: "defaultValue",
-  identifier: sql.identifier("a", "default_value"),
+  identifier: defaultValueIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -657,9 +664,10 @@ const spec_defaultValue = {
   executor: executor
 };
 const defaultValueCodec = recordCodec(spec_defaultValue);
+const foreignKeyIdentifier = sql.identifier("a", "foreign_key");
 const spec_foreignKey = {
   name: "foreignKey",
-  identifier: sql.identifier("a", "foreign_key"),
+  identifier: foreignKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id: {
       description: undefined,
@@ -702,9 +710,10 @@ const spec_foreignKey = {
   executor: executor
 };
 const foreignKeyCodec = recordCodec(spec_foreignKey);
+const noPrimaryKeyIdentifier = sql.identifier("a", "no_primary_key");
 const spec_noPrimaryKey = {
   name: "noPrimaryKey",
-  identifier: sql.identifier("a", "no_primary_key"),
+  identifier: noPrimaryKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -738,9 +747,10 @@ const spec_noPrimaryKey = {
   executor: executor
 };
 const noPrimaryKeyCodec = recordCodec(spec_noPrimaryKey);
+const testviewIdentifier = sql.identifier("a", "testview");
 const spec_testview = {
   name: "testview",
-  identifier: sql.identifier("a", "testview"),
+  identifier: testviewIdentifier,
   attributes: Object.assign(Object.create(null), {
     testviewid: {
       description: undefined,
@@ -783,9 +793,10 @@ const spec_testview = {
   executor: executor
 };
 const testviewCodec = recordCodec(spec_testview);
+const uniqueForeignKeyIdentifier = sql.identifier("a", "unique_foreign_key");
 const spec_uniqueForeignKey = {
   name: "uniqueForeignKey",
-  identifier: sql.identifier("a", "unique_foreign_key"),
+  identifier: uniqueForeignKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     compound_key_1: {
       description: undefined,
@@ -822,9 +833,10 @@ const spec_uniqueForeignKey = {
   executor: executor
 };
 const uniqueForeignKeyCodec = recordCodec(spec_uniqueForeignKey);
+const myTableIdentifier = sql.identifier("c", "my_table");
 const spec_myTable = {
   name: "myTable",
-  identifier: sql.identifier("c", "my_table"),
+  identifier: myTableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -858,9 +870,10 @@ const spec_myTable = {
   executor: executor
 };
 const myTableCodec = recordCodec(spec_myTable);
+const personSecretIdentifier = sql.identifier("c", "person_secret");
 const spec_personSecret = {
   name: "personSecret",
-  identifier: sql.identifier("c", "person_secret"),
+  identifier: personSecretIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id: {
       description: undefined,
@@ -898,9 +911,10 @@ const spec_personSecret = {
   executor: executor
 };
 const personSecretCodec = recordCodec(spec_personSecret);
+const viewTableIdentifier = sql.identifier("a", "view_table");
 const spec_viewTable = {
   name: "viewTable",
-  identifier: sql.identifier("a", "view_table"),
+  identifier: viewTableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -943,9 +957,10 @@ const spec_viewTable = {
   executor: executor
 };
 const viewTableCodec = recordCodec(spec_viewTable);
+const compoundKeyIdentifier = sql.identifier("c", "compound_key");
 const spec_compoundKey = {
   name: "compoundKey",
-  identifier: sql.identifier("c", "compound_key"),
+  identifier: compoundKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id_2: {
       description: undefined,
@@ -988,9 +1003,10 @@ const spec_compoundKey = {
   executor: executor
 };
 const compoundKeyCodec = recordCodec(spec_compoundKey);
+const similarTable1Identifier = sql.identifier("a", "similar_table_1");
 const spec_similarTable1 = {
   name: "similarTable1",
-  identifier: sql.identifier("a", "similar_table_1"),
+  identifier: similarTable1Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1042,9 +1058,10 @@ const spec_similarTable1 = {
   executor: executor
 };
 const similarTable1Codec = recordCodec(spec_similarTable1);
+const similarTable2Identifier = sql.identifier("a", "similar_table_2");
 const spec_similarTable2 = {
   name: "similarTable2",
-  identifier: sql.identifier("a", "similar_table_2"),
+  identifier: similarTable2Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1096,9 +1113,10 @@ const spec_similarTable2 = {
   executor: executor
 };
 const similarTable2Codec = recordCodec(spec_similarTable2);
+const updatableViewIdentifier = sql.identifier("b", "updatable_view");
 const spec_updatableView = {
   name: "updatableView",
-  identifier: sql.identifier("b", "updatable_view"),
+  identifier: updatableViewIdentifier,
   attributes: Object.assign(Object.create(null), {
     x: {
       description: undefined,
@@ -1153,9 +1171,10 @@ const spec_updatableView = {
   executor: executor
 };
 const updatableViewCodec = recordCodec(spec_updatableView);
+const nullTestRecordIdentifier = sql.identifier("c", "null_test_record");
 const spec_nullTestRecord = {
   name: "nullTestRecord",
-  identifier: sql.identifier("c", "null_test_record"),
+  identifier: nullTestRecordIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1220,9 +1239,10 @@ const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   description: undefined,
   name: "uuidArray"
 });
+const edgeCaseIdentifier = sql.identifier("c", "edge_case");
 const spec_edgeCase = {
   name: "edgeCase",
-  identifier: sql.identifier("c", "edge_case"),
+  identifier: edgeCaseIdentifier,
   attributes: Object.assign(Object.create(null), {
     not_null_has_default: {
       description: undefined,
@@ -1265,9 +1285,10 @@ const spec_edgeCase = {
   executor: executor
 };
 const edgeCaseCodec = recordCodec(spec_edgeCase);
+const leftArmIdentifier = sql.identifier("c", "left_arm");
 const spec_leftArm = {
   name: "leftArm",
-  identifier: sql.identifier("c", "left_arm"),
+  identifier: leftArmIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1319,9 +1340,10 @@ const spec_leftArm = {
   executor: executor
 };
 const leftArmCodec = recordCodec(spec_leftArm);
+const jwtTokenIdentifier = sql.identifier("b", "jwt_token");
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: sql.identifier("b", "jwt_token"),
+  identifier: jwtTokenIdentifier,
   attributes: Object.assign(Object.create(null), {
     role: {
       description: undefined,
@@ -1381,6 +1403,7 @@ const jwtTokenCodec = recordCodec({
   },
   executor: executor
 });
+const issue756Identifier = sql.identifier("c", "issue756");
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
   extensions: {
@@ -1395,7 +1418,7 @@ const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp
 });
 const spec_issue756 = {
   name: "issue756",
-  identifier: sql.identifier("c", "issue756"),
+  identifier: issue756Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1429,9 +1452,10 @@ const spec_issue756 = {
   executor: executor
 };
 const issue756Codec = recordCodec(spec_issue756);
+const authPayloadIdentifier = sql.identifier("b", "auth_payload");
 const authPayloadCodec = recordCodec({
   name: "authPayload",
-  identifier: sql.identifier("b", "auth_payload"),
+  identifier: authPayloadIdentifier,
   attributes: Object.assign(Object.create(null), {
     jwt: {
       description: undefined,
@@ -1475,6 +1499,7 @@ const authPayloadCodec = recordCodec({
   },
   executor: executor
 });
+const compoundTypeIdentifier = sql.identifier("c", "compound_type");
 const colorCodec = enumCodec({
   name: "color",
   identifier: sql.identifier("b", "color"),
@@ -1519,7 +1544,7 @@ const enumWithEmptyStringCodec = enumCodec({
 });
 const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: sql.identifier("c", "compound_type"),
+  identifier: compoundTypeIdentifier,
   attributes: Object.assign(Object.create(null), {
     a: {
       description: undefined,
@@ -1666,6 +1691,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor,
   isAnonymous: true
 });
+const postIdentifier = sql.identifier("a", "post");
 const anEnumCodec = enumCodec({
   name: "anEnum",
   identifier: sql.identifier("a", "an_enum"),
@@ -1743,7 +1769,7 @@ const comptypeArrayCodec = listOfCodec(comptypeCodec, {
 });
 const spec_post = {
   name: "post",
-  identifier: sql.identifier("a", "post"),
+  identifier: postIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1911,6 +1937,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor,
   isAnonymous: true
 });
+const personIdentifier = sql.identifier("c", "person");
 const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
   description: undefined,
   extensions: {
@@ -1963,7 +1990,7 @@ const wrappedUrlCodec = recordCodec({
 });
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("c", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: "The primary unique identifier for the person",
@@ -2302,6 +2329,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor,
   isAnonymous: true
 });
+const typesIdentifier = sql.identifier("b", "types");
 const colorArrayCodec = listOfCodec(colorCodec, {
   extensions: {
     pg: {
@@ -2481,7 +2509,7 @@ const spec_types_attributes_ltree_codec_ltree = {
 const spec_types_attributes_ltree_array_codec_ltree_ = listOfCodec(spec_types_attributes_ltree_codec_ltree);
 const spec_types = {
   name: "types",
-  identifier: sql.identifier("b", "types"),
+  identifier: typesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -3089,10 +3117,10 @@ const default_valueUniques = [{
   }
 }];
 const registryConfig_pgResources_foreign_key_foreign_key = {
-  executor,
+  executor: executor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
-  from: foreignKeyCodec.sqlType,
+  from: foreignKeyIdentifier,
   codec: foreignKeyCodec,
   uniques: [],
   isVirtual: false,
@@ -3108,10 +3136,10 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   }
 };
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
-  executor,
+  executor: executor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
-  from: uniqueForeignKeyCodec.sqlType,
+  from: uniqueForeignKeyIdentifier,
   codec: uniqueForeignKeyCodec,
   uniques: [{
     isPrimary: false,
@@ -3153,10 +3181,10 @@ const person_secretUniques = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor,
+  executor: executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: personSecretCodec.sqlType,
+  from: personSecretIdentifier,
   codec: personSecretCodec,
   uniques: person_secretUniques,
   isVirtual: false,
@@ -3190,10 +3218,10 @@ const compound_keyUniques = [{
   }
 }];
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor,
+  executor: executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: compoundKeyCodec.sqlType,
+  from: compoundKeyIdentifier,
   codec: compoundKeyCodec,
   uniques: compound_keyUniques,
   isVirtual: false,
@@ -3251,10 +3279,10 @@ const left_armUniques = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor,
+  executor: executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: leftArmCodec.sqlType,
+  from: leftArmIdentifier,
   codec: leftArmCodec,
   uniques: left_armUniques,
   isVirtual: false,
@@ -3271,10 +3299,10 @@ const registryConfig_pgResources_left_arm_left_arm = {
 };
 const authenticate_failFunctionIdentifer = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
-  executor,
+  executor: executor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
-  from: jwtTokenCodec.sqlType,
+  from: jwtTokenIdentifier,
   codec: jwtTokenCodec,
   uniques: [],
   isVirtual: true,
@@ -3301,10 +3329,10 @@ const issue756Uniques = [{
   }
 }];
 const registryConfig_pgResources_issue756_issue756 = {
-  executor,
+  executor: executor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: issue756Codec.sqlType,
+  from: issue756Identifier,
   codec: issue756Codec,
   uniques: issue756Uniques,
   isVirtual: false,
@@ -3347,10 +3375,10 @@ const postUniques = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor,
+  executor: executor,
   name: "post",
   identifier: "main.a.post",
-  from: postCodec.sqlType,
+  from: postIdentifier,
   codec: postCodec,
   uniques: postUniques,
   isVirtual: false,
@@ -3367,10 +3395,10 @@ const registryConfig_pgResources_post_post = {
 };
 const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_compound_type = {
-  executor,
+  executor: executor,
   name: "compound_type",
   identifier: "main.c.compound_type",
-  from: compoundTypeCodec.sqlType,
+  from: compoundTypeIdentifier,
   codec: compoundTypeCodec,
   uniques: [],
   isVirtual: true,
@@ -3428,10 +3456,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.c.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -3465,10 +3493,10 @@ const typesUniques = [{
   }
 }];
 const registryConfig_pgResources_types_types = {
-  executor,
+  executor: executor,
   name: "types",
   identifier: "main.b.types",
-  from: typesCodec.sqlType,
+  from: typesIdentifier,
   codec: typesCodec,
   uniques: typesUniques,
   isVirtual: false,
@@ -5666,10 +5694,10 @@ const registry = makeRegistry({
       description: undefined
     },
     non_updatable_view: {
-      executor,
+      executor: executor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
-      from: nonUpdatableViewCodec.sqlType,
+      from: nonUpdatableViewIdentifier,
       codec: nonUpdatableViewCodec,
       uniques: [],
       isVirtual: false,
@@ -5687,10 +5715,10 @@ const registry = makeRegistry({
       }
     },
     inputs: {
-      executor,
+      executor: executor,
       name: "inputs",
       identifier: "main.a.inputs",
-      from: inputsCodec.sqlType,
+      from: inputsIdentifier,
       codec: inputsCodec,
       uniques: inputsUniques,
       isVirtual: false,
@@ -5706,10 +5734,10 @@ const registry = makeRegistry({
       }
     },
     patchs: {
-      executor,
+      executor: executor,
       name: "patchs",
       identifier: "main.a.patchs",
-      from: patchsCodec.sqlType,
+      from: patchsIdentifier,
       codec: patchsCodec,
       uniques: patchsUniques,
       isVirtual: false,
@@ -5725,10 +5753,10 @@ const registry = makeRegistry({
       }
     },
     reserved: {
-      executor,
+      executor: executor,
       name: "reserved",
       identifier: "main.a.reserved",
-      from: reservedCodec.sqlType,
+      from: reservedIdentifier,
       codec: reservedCodec,
       uniques: reservedUniques,
       isVirtual: false,
@@ -5744,10 +5772,10 @@ const registry = makeRegistry({
       }
     },
     reservedPatchs: {
-      executor,
+      executor: executor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
-      from: reservedPatchsCodec.sqlType,
+      from: reservedPatchsIdentifier,
       codec: reservedPatchsCodec,
       uniques: reservedPatchsUniques,
       isVirtual: false,
@@ -5763,10 +5791,10 @@ const registry = makeRegistry({
       }
     },
     reserved_input: {
-      executor,
+      executor: executor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
-      from: reservedInputCodec.sqlType,
+      from: reservedInputIdentifier,
       codec: reservedInputCodec,
       uniques: reserved_inputUniques,
       isVirtual: false,
@@ -5782,10 +5810,10 @@ const registry = makeRegistry({
       }
     },
     default_value: {
-      executor,
+      executor: executor,
       name: "default_value",
       identifier: "main.a.default_value",
-      from: defaultValueCodec.sqlType,
+      from: defaultValueIdentifier,
       codec: defaultValueCodec,
       uniques: default_valueUniques,
       isVirtual: false,
@@ -5802,10 +5830,10 @@ const registry = makeRegistry({
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
-      executor,
+      executor: executor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
-      from: noPrimaryKeyCodec.sqlType,
+      from: noPrimaryKeyIdentifier,
       codec: noPrimaryKeyCodec,
       uniques: [{
         isPrimary: false,
@@ -5828,10 +5856,10 @@ const registry = makeRegistry({
       }
     },
     testview: {
-      executor,
+      executor: executor,
       name: "testview",
       identifier: "main.a.testview",
-      from: testviewCodec.sqlType,
+      from: testviewIdentifier,
       codec: testviewCodec,
       uniques: [],
       isVirtual: false,
@@ -5848,10 +5876,10 @@ const registry = makeRegistry({
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
-      executor,
+      executor: executor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: myTableCodec.sqlType,
+      from: myTableIdentifier,
       codec: myTableCodec,
       uniques: my_tableUniques,
       isVirtual: false,
@@ -5868,10 +5896,10 @@ const registry = makeRegistry({
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
-      executor,
+      executor: executor,
       name: "view_table",
       identifier: "main.a.view_table",
-      from: viewTableCodec.sqlType,
+      from: viewTableIdentifier,
       codec: viewTableCodec,
       uniques: view_tableUniques,
       isVirtual: false,
@@ -5888,10 +5916,10 @@ const registry = makeRegistry({
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
-      executor,
+      executor: executor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
-      from: similarTable1Codec.sqlType,
+      from: similarTable1Identifier,
       codec: similarTable1Codec,
       uniques: similar_table_1Uniques,
       isVirtual: false,
@@ -5907,10 +5935,10 @@ const registry = makeRegistry({
       }
     },
     similar_table_2: {
-      executor,
+      executor: executor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
-      from: similarTable2Codec.sqlType,
+      from: similarTable2Identifier,
       codec: similarTable2Codec,
       uniques: similar_table_2Uniques,
       isVirtual: false,
@@ -5926,10 +5954,10 @@ const registry = makeRegistry({
       }
     },
     updatable_view: {
-      executor,
+      executor: executor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
-      from: updatableViewCodec.sqlType,
+      from: updatableViewIdentifier,
       codec: updatableViewCodec,
       uniques: [{
         isPrimary: false,
@@ -5957,10 +5985,10 @@ const registry = makeRegistry({
       }
     },
     null_test_record: {
-      executor,
+      executor: executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: nullTestRecordCodec.sqlType,
+      from: nullTestRecordIdentifier,
       codec: nullTestRecordCodec,
       uniques: null_test_recordUniques,
       isVirtual: false,
@@ -6066,10 +6094,10 @@ const registry = makeRegistry({
       description: undefined
     },
     edge_case: {
-      executor,
+      executor: executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: edgeCaseCodec.sqlType,
+      from: edgeCaseIdentifier,
       codec: edgeCaseCodec,
       uniques: [],
       isVirtual: false,
@@ -6259,10 +6287,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     authenticate_payload: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "auth_payload",
       identifier: "main.b.auth_payload",
-      from: authPayloadCodec.sqlType,
+      from: authPayloadIdentifier,
       codec: authPayloadCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.inheritence.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.inheritence.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const fileIdentifier = sql.identifier("inheritence", "file");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const spec_file = {
   name: "file",
-  identifier: sql.identifier("inheritence", "file"),
+  identifier: fileIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -111,9 +112,10 @@ const spec_file = {
   executor: executor
 };
 const fileCodec = recordCodec(spec_file);
+const userIdentifier = sql.identifier("inheritence", "user");
 const spec_user = {
   name: "user",
-  identifier: sql.identifier("inheritence", "user"),
+  identifier: userIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -147,9 +149,10 @@ const spec_user = {
   executor: executor
 };
 const userCodec = recordCodec(spec_user);
+const userFileIdentifier = sql.identifier("inheritence", "user_file");
 const spec_userFile = {
   name: "userFile",
-  identifier: sql.identifier("inheritence", "user_file"),
+  identifier: userFileIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -209,10 +212,10 @@ const userUniques = [{
   }
 }];
 const registryConfig_pgResources_user_user = {
-  executor,
+  executor: executor,
   name: "user",
   identifier: "main.inheritence.user",
-  from: userCodec.sqlType,
+  from: userIdentifier,
   codec: userCodec,
   uniques: userUniques,
   isVirtual: false,
@@ -236,10 +239,10 @@ const user_fileUniques = [{
   }
 }];
 const registryConfig_pgResources_user_file_user_file = {
-  executor,
+  executor: executor,
   name: "user_file",
   identifier: "main.inheritence.user_file",
-  from: userFileCodec.sqlType,
+  from: userFileIdentifier,
   codec: userFileCodec,
   uniques: user_fileUniques,
   isVirtual: false,
@@ -266,10 +269,10 @@ const registry = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     file: {
-      executor,
+      executor: executor,
       name: "file",
       identifier: "main.inheritence.file",
-      from: fileCodec.sqlType,
+      from: fileIdentifier,
       codec: fileCodec,
       uniques: fileUniques,
       isVirtual: false,

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.nested_arrays.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.nested_arrays.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const tIdentifier = sql.identifier("nested_arrays", "t");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -192,7 +193,7 @@ const workingHoursCodec = domainOfCodec(workhoursArrayCodec, "workingHours", sql
 });
 const spec_t = {
   name: "t",
-  identifier: sql.identifier("nested_arrays", "t"),
+  identifier: tIdentifier,
   attributes: Object.assign(Object.create(null), {
     k: {
       description: undefined,
@@ -282,10 +283,10 @@ const registry = makeRegistry({
       description: undefined
     },
     t: {
-      executor,
+      executor: executor,
       name: "t",
       identifier: "main.nested_arrays.t",
-      from: tCodec.sqlType,
+      from: tIdentifier,
       codec: tCodec,
       uniques: tUniques,
       isVirtual: false,

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.export.mjs
@@ -459,9 +459,10 @@ const textArrayCodec = listOfCodec(TYPES.text, {
   description: undefined,
   name: "textArray"
 });
+const nonUpdatableViewIdentifier = sql.identifier("a", "non_updatable_view");
 const spec_nonUpdatableView = {
   name: "nonUpdatableView",
-  identifier: sql.identifier("a", "non_updatable_view"),
+  identifier: nonUpdatableViewIdentifier,
   attributes: Object.assign(Object.create(null), {
     "?column?": {
       description: undefined,
@@ -486,9 +487,10 @@ const spec_nonUpdatableView = {
   executor: executor
 };
 const nonUpdatableViewCodec = recordCodec(spec_nonUpdatableView);
+const inputsIdentifier = sql.identifier("a", "inputs");
 const spec_inputs = {
   name: "inputs",
-  identifier: sql.identifier("a", "inputs"),
+  identifier: inputsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -513,9 +515,10 @@ const spec_inputs = {
   executor: executor
 };
 const inputsCodec = recordCodec(spec_inputs);
+const patchsIdentifier = sql.identifier("a", "patchs");
 const spec_patchs = {
   name: "patchs",
-  identifier: sql.identifier("a", "patchs"),
+  identifier: patchsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -540,9 +543,10 @@ const spec_patchs = {
   executor: executor
 };
 const patchsCodec = recordCodec(spec_patchs);
+const reservedIdentifier = sql.identifier("a", "reserved");
 const spec_reserved = {
   name: "reserved",
-  identifier: sql.identifier("a", "reserved"),
+  identifier: reservedIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -567,9 +571,10 @@ const spec_reserved = {
   executor: executor
 };
 const reservedCodec = recordCodec(spec_reserved);
+const reservedPatchsIdentifier = sql.identifier("a", "reservedPatchs");
 const spec_reservedPatchs = {
   name: "reservedPatchs",
-  identifier: sql.identifier("a", "reservedPatchs"),
+  identifier: reservedPatchsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -594,9 +599,10 @@ const spec_reservedPatchs = {
   executor: executor
 };
 const reservedPatchsCodec = recordCodec(spec_reservedPatchs);
+const reservedInputIdentifier = sql.identifier("a", "reserved_input");
 const spec_reservedInput = {
   name: "reservedInput",
-  identifier: sql.identifier("a", "reserved_input"),
+  identifier: reservedInputIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -621,9 +627,10 @@ const spec_reservedInput = {
   executor: executor
 };
 const reservedInputCodec = recordCodec(spec_reservedInput);
+const defaultValueIdentifier = sql.identifier("a", "default_value");
 const spec_defaultValue = {
   name: "defaultValue",
-  identifier: sql.identifier("a", "default_value"),
+  identifier: defaultValueIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -657,9 +664,10 @@ const spec_defaultValue = {
   executor: executor
 };
 const defaultValueCodec = recordCodec(spec_defaultValue);
+const foreignKeyIdentifier = sql.identifier("a", "foreign_key");
 const spec_foreignKey = {
   name: "foreignKey",
-  identifier: sql.identifier("a", "foreign_key"),
+  identifier: foreignKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id: {
       description: undefined,
@@ -702,9 +710,10 @@ const spec_foreignKey = {
   executor: executor
 };
 const foreignKeyCodec = recordCodec(spec_foreignKey);
+const noPrimaryKeyIdentifier = sql.identifier("a", "no_primary_key");
 const spec_noPrimaryKey = {
   name: "noPrimaryKey",
-  identifier: sql.identifier("a", "no_primary_key"),
+  identifier: noPrimaryKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -738,9 +747,10 @@ const spec_noPrimaryKey = {
   executor: executor
 };
 const noPrimaryKeyCodec = recordCodec(spec_noPrimaryKey);
+const testviewIdentifier = sql.identifier("a", "testview");
 const spec_testview = {
   name: "testview",
-  identifier: sql.identifier("a", "testview"),
+  identifier: testviewIdentifier,
   attributes: Object.assign(Object.create(null), {
     testviewid: {
       description: undefined,
@@ -783,9 +793,10 @@ const spec_testview = {
   executor: executor
 };
 const testviewCodec = recordCodec(spec_testview);
+const uniqueForeignKeyIdentifier = sql.identifier("a", "unique_foreign_key");
 const spec_uniqueForeignKey = {
   name: "uniqueForeignKey",
-  identifier: sql.identifier("a", "unique_foreign_key"),
+  identifier: uniqueForeignKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     compound_key_1: {
       description: undefined,
@@ -822,9 +833,10 @@ const spec_uniqueForeignKey = {
   executor: executor
 };
 const uniqueForeignKeyCodec = recordCodec(spec_uniqueForeignKey);
+const myTableIdentifier = sql.identifier("c", "my_table");
 const spec_myTable = {
   name: "myTable",
-  identifier: sql.identifier("c", "my_table"),
+  identifier: myTableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -858,9 +870,10 @@ const spec_myTable = {
   executor: executor
 };
 const myTableCodec = recordCodec(spec_myTable);
+const personSecretIdentifier = sql.identifier("c", "person_secret");
 const spec_personSecret = {
   name: "personSecret",
-  identifier: sql.identifier("c", "person_secret"),
+  identifier: personSecretIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id: {
       description: undefined,
@@ -898,9 +911,10 @@ const spec_personSecret = {
   executor: executor
 };
 const personSecretCodec = recordCodec(spec_personSecret);
+const viewTableIdentifier = sql.identifier("a", "view_table");
 const spec_viewTable = {
   name: "viewTable",
-  identifier: sql.identifier("a", "view_table"),
+  identifier: viewTableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -943,9 +957,10 @@ const spec_viewTable = {
   executor: executor
 };
 const viewTableCodec = recordCodec(spec_viewTable);
+const compoundKeyIdentifier = sql.identifier("c", "compound_key");
 const spec_compoundKey = {
   name: "compoundKey",
-  identifier: sql.identifier("c", "compound_key"),
+  identifier: compoundKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id_2: {
       description: undefined,
@@ -988,9 +1003,10 @@ const spec_compoundKey = {
   executor: executor
 };
 const compoundKeyCodec = recordCodec(spec_compoundKey);
+const similarTable1Identifier = sql.identifier("a", "similar_table_1");
 const spec_similarTable1 = {
   name: "similarTable1",
-  identifier: sql.identifier("a", "similar_table_1"),
+  identifier: similarTable1Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1042,9 +1058,10 @@ const spec_similarTable1 = {
   executor: executor
 };
 const similarTable1Codec = recordCodec(spec_similarTable1);
+const similarTable2Identifier = sql.identifier("a", "similar_table_2");
 const spec_similarTable2 = {
   name: "similarTable2",
-  identifier: sql.identifier("a", "similar_table_2"),
+  identifier: similarTable2Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1096,9 +1113,10 @@ const spec_similarTable2 = {
   executor: executor
 };
 const similarTable2Codec = recordCodec(spec_similarTable2);
+const updatableViewIdentifier = sql.identifier("b", "updatable_view");
 const spec_updatableView = {
   name: "updatableView",
-  identifier: sql.identifier("b", "updatable_view"),
+  identifier: updatableViewIdentifier,
   attributes: Object.assign(Object.create(null), {
     x: {
       description: undefined,
@@ -1153,9 +1171,10 @@ const spec_updatableView = {
   executor: executor
 };
 const updatableViewCodec = recordCodec(spec_updatableView);
+const nullTestRecordIdentifier = sql.identifier("c", "null_test_record");
 const spec_nullTestRecord = {
   name: "nullTestRecord",
-  identifier: sql.identifier("c", "null_test_record"),
+  identifier: nullTestRecordIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1220,9 +1239,10 @@ const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   description: undefined,
   name: "uuidArray"
 });
+const edgeCaseIdentifier = sql.identifier("c", "edge_case");
 const spec_edgeCase = {
   name: "edgeCase",
-  identifier: sql.identifier("c", "edge_case"),
+  identifier: edgeCaseIdentifier,
   attributes: Object.assign(Object.create(null), {
     not_null_has_default: {
       description: undefined,
@@ -1265,9 +1285,10 @@ const spec_edgeCase = {
   executor: executor
 };
 const edgeCaseCodec = recordCodec(spec_edgeCase);
+const leftArmIdentifier = sql.identifier("c", "left_arm");
 const spec_leftArm = {
   name: "leftArm",
-  identifier: sql.identifier("c", "left_arm"),
+  identifier: leftArmIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1319,9 +1340,10 @@ const spec_leftArm = {
   executor: executor
 };
 const leftArmCodec = recordCodec(spec_leftArm);
+const jwtTokenIdentifier = sql.identifier("b", "jwt_token");
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: sql.identifier("b", "jwt_token"),
+  identifier: jwtTokenIdentifier,
   attributes: Object.assign(Object.create(null), {
     role: {
       description: undefined,
@@ -1381,6 +1403,7 @@ const jwtTokenCodec = recordCodec({
   },
   executor: executor
 });
+const issue756Identifier = sql.identifier("c", "issue756");
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
   extensions: {
@@ -1395,7 +1418,7 @@ const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp
 });
 const spec_issue756 = {
   name: "issue756",
-  identifier: sql.identifier("c", "issue756"),
+  identifier: issue756Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1429,9 +1452,10 @@ const spec_issue756 = {
   executor: executor
 };
 const issue756Codec = recordCodec(spec_issue756);
+const authPayloadIdentifier = sql.identifier("b", "auth_payload");
 const authPayloadCodec = recordCodec({
   name: "authPayload",
-  identifier: sql.identifier("b", "auth_payload"),
+  identifier: authPayloadIdentifier,
   attributes: Object.assign(Object.create(null), {
     jwt: {
       description: undefined,
@@ -1475,6 +1499,7 @@ const authPayloadCodec = recordCodec({
   },
   executor: executor
 });
+const compoundTypeIdentifier = sql.identifier("c", "compound_type");
 const colorCodec = enumCodec({
   name: "color",
   identifier: sql.identifier("b", "color"),
@@ -1519,7 +1544,7 @@ const enumWithEmptyStringCodec = enumCodec({
 });
 const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: sql.identifier("c", "compound_type"),
+  identifier: compoundTypeIdentifier,
   attributes: Object.assign(Object.create(null), {
     a: {
       description: undefined,
@@ -1666,6 +1691,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor,
   isAnonymous: true
 });
+const postIdentifier = sql.identifier("a", "post");
 const anEnumCodec = enumCodec({
   name: "anEnum",
   identifier: sql.identifier("a", "an_enum"),
@@ -1743,7 +1769,7 @@ const comptypeArrayCodec = listOfCodec(comptypeCodec, {
 });
 const spec_post = {
   name: "post",
-  identifier: sql.identifier("a", "post"),
+  identifier: postIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1911,6 +1937,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor,
   isAnonymous: true
 });
+const personIdentifier = sql.identifier("c", "person");
 const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
   description: undefined,
   extensions: {
@@ -1963,7 +1990,7 @@ const wrappedUrlCodec = recordCodec({
 });
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("c", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: "The primary unique identifier for the person",
@@ -2302,6 +2329,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor,
   isAnonymous: true
 });
+const typesIdentifier = sql.identifier("b", "types");
 const colorArrayCodec = listOfCodec(colorCodec, {
   extensions: {
     pg: {
@@ -2481,7 +2509,7 @@ const spec_types_attributes_ltree_codec_ltree = {
 const spec_types_attributes_ltree_array_codec_ltree_ = listOfCodec(spec_types_attributes_ltree_codec_ltree);
 const spec_types = {
   name: "types",
-  identifier: sql.identifier("b", "types"),
+  identifier: typesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -3089,10 +3117,10 @@ const default_valueUniques = [{
   }
 }];
 const registryConfig_pgResources_foreign_key_foreign_key = {
-  executor,
+  executor: executor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
-  from: foreignKeyCodec.sqlType,
+  from: foreignKeyIdentifier,
   codec: foreignKeyCodec,
   uniques: [],
   isVirtual: false,
@@ -3108,10 +3136,10 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   }
 };
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
-  executor,
+  executor: executor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
-  from: uniqueForeignKeyCodec.sqlType,
+  from: uniqueForeignKeyIdentifier,
   codec: uniqueForeignKeyCodec,
   uniques: [{
     isPrimary: false,
@@ -3153,10 +3181,10 @@ const person_secretUniques = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor,
+  executor: executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: personSecretCodec.sqlType,
+  from: personSecretIdentifier,
   codec: personSecretCodec,
   uniques: person_secretUniques,
   isVirtual: false,
@@ -3190,10 +3218,10 @@ const compound_keyUniques = [{
   }
 }];
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor,
+  executor: executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: compoundKeyCodec.sqlType,
+  from: compoundKeyIdentifier,
   codec: compoundKeyCodec,
   uniques: compound_keyUniques,
   isVirtual: false,
@@ -3251,10 +3279,10 @@ const left_armUniques = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor,
+  executor: executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: leftArmCodec.sqlType,
+  from: leftArmIdentifier,
   codec: leftArmCodec,
   uniques: left_armUniques,
   isVirtual: false,
@@ -3271,10 +3299,10 @@ const registryConfig_pgResources_left_arm_left_arm = {
 };
 const authenticate_failFunctionIdentifer = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
-  executor,
+  executor: executor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
-  from: jwtTokenCodec.sqlType,
+  from: jwtTokenIdentifier,
   codec: jwtTokenCodec,
   uniques: [],
   isVirtual: true,
@@ -3301,10 +3329,10 @@ const issue756Uniques = [{
   }
 }];
 const registryConfig_pgResources_issue756_issue756 = {
-  executor,
+  executor: executor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: issue756Codec.sqlType,
+  from: issue756Identifier,
   codec: issue756Codec,
   uniques: issue756Uniques,
   isVirtual: false,
@@ -3347,10 +3375,10 @@ const postUniques = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor,
+  executor: executor,
   name: "post",
   identifier: "main.a.post",
-  from: postCodec.sqlType,
+  from: postIdentifier,
   codec: postCodec,
   uniques: postUniques,
   isVirtual: false,
@@ -3367,10 +3395,10 @@ const registryConfig_pgResources_post_post = {
 };
 const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_compound_type = {
-  executor,
+  executor: executor,
   name: "compound_type",
   identifier: "main.c.compound_type",
-  from: compoundTypeCodec.sqlType,
+  from: compoundTypeIdentifier,
   codec: compoundTypeCodec,
   uniques: [],
   isVirtual: true,
@@ -3428,10 +3456,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.c.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -3465,10 +3493,10 @@ const typesUniques = [{
   }
 }];
 const registryConfig_pgResources_types_types = {
-  executor,
+  executor: executor,
   name: "types",
   identifier: "main.b.types",
-  from: typesCodec.sqlType,
+  from: typesIdentifier,
   codec: typesCodec,
   uniques: typesUniques,
   isVirtual: false,
@@ -5666,10 +5694,10 @@ const registry = makeRegistry({
       description: undefined
     },
     non_updatable_view: {
-      executor,
+      executor: executor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
-      from: nonUpdatableViewCodec.sqlType,
+      from: nonUpdatableViewIdentifier,
       codec: nonUpdatableViewCodec,
       uniques: [],
       isVirtual: false,
@@ -5687,10 +5715,10 @@ const registry = makeRegistry({
       }
     },
     inputs: {
-      executor,
+      executor: executor,
       name: "inputs",
       identifier: "main.a.inputs",
-      from: inputsCodec.sqlType,
+      from: inputsIdentifier,
       codec: inputsCodec,
       uniques: inputsUniques,
       isVirtual: false,
@@ -5706,10 +5734,10 @@ const registry = makeRegistry({
       }
     },
     patchs: {
-      executor,
+      executor: executor,
       name: "patchs",
       identifier: "main.a.patchs",
-      from: patchsCodec.sqlType,
+      from: patchsIdentifier,
       codec: patchsCodec,
       uniques: patchsUniques,
       isVirtual: false,
@@ -5725,10 +5753,10 @@ const registry = makeRegistry({
       }
     },
     reserved: {
-      executor,
+      executor: executor,
       name: "reserved",
       identifier: "main.a.reserved",
-      from: reservedCodec.sqlType,
+      from: reservedIdentifier,
       codec: reservedCodec,
       uniques: reservedUniques,
       isVirtual: false,
@@ -5744,10 +5772,10 @@ const registry = makeRegistry({
       }
     },
     reservedPatchs: {
-      executor,
+      executor: executor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
-      from: reservedPatchsCodec.sqlType,
+      from: reservedPatchsIdentifier,
       codec: reservedPatchsCodec,
       uniques: reservedPatchsUniques,
       isVirtual: false,
@@ -5763,10 +5791,10 @@ const registry = makeRegistry({
       }
     },
     reserved_input: {
-      executor,
+      executor: executor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
-      from: reservedInputCodec.sqlType,
+      from: reservedInputIdentifier,
       codec: reservedInputCodec,
       uniques: reserved_inputUniques,
       isVirtual: false,
@@ -5782,10 +5810,10 @@ const registry = makeRegistry({
       }
     },
     default_value: {
-      executor,
+      executor: executor,
       name: "default_value",
       identifier: "main.a.default_value",
-      from: defaultValueCodec.sqlType,
+      from: defaultValueIdentifier,
       codec: defaultValueCodec,
       uniques: default_valueUniques,
       isVirtual: false,
@@ -5802,10 +5830,10 @@ const registry = makeRegistry({
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
-      executor,
+      executor: executor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
-      from: noPrimaryKeyCodec.sqlType,
+      from: noPrimaryKeyIdentifier,
       codec: noPrimaryKeyCodec,
       uniques: [{
         isPrimary: false,
@@ -5828,10 +5856,10 @@ const registry = makeRegistry({
       }
     },
     testview: {
-      executor,
+      executor: executor,
       name: "testview",
       identifier: "main.a.testview",
-      from: testviewCodec.sqlType,
+      from: testviewIdentifier,
       codec: testviewCodec,
       uniques: [],
       isVirtual: false,
@@ -5848,10 +5876,10 @@ const registry = makeRegistry({
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
-      executor,
+      executor: executor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: myTableCodec.sqlType,
+      from: myTableIdentifier,
       codec: myTableCodec,
       uniques: my_tableUniques,
       isVirtual: false,
@@ -5868,10 +5896,10 @@ const registry = makeRegistry({
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
-      executor,
+      executor: executor,
       name: "view_table",
       identifier: "main.a.view_table",
-      from: viewTableCodec.sqlType,
+      from: viewTableIdentifier,
       codec: viewTableCodec,
       uniques: view_tableUniques,
       isVirtual: false,
@@ -5888,10 +5916,10 @@ const registry = makeRegistry({
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
-      executor,
+      executor: executor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
-      from: similarTable1Codec.sqlType,
+      from: similarTable1Identifier,
       codec: similarTable1Codec,
       uniques: similar_table_1Uniques,
       isVirtual: false,
@@ -5907,10 +5935,10 @@ const registry = makeRegistry({
       }
     },
     similar_table_2: {
-      executor,
+      executor: executor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
-      from: similarTable2Codec.sqlType,
+      from: similarTable2Identifier,
       codec: similarTable2Codec,
       uniques: similar_table_2Uniques,
       isVirtual: false,
@@ -5926,10 +5954,10 @@ const registry = makeRegistry({
       }
     },
     updatable_view: {
-      executor,
+      executor: executor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
-      from: updatableViewCodec.sqlType,
+      from: updatableViewIdentifier,
       codec: updatableViewCodec,
       uniques: [{
         isPrimary: false,
@@ -5957,10 +5985,10 @@ const registry = makeRegistry({
       }
     },
     null_test_record: {
-      executor,
+      executor: executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: nullTestRecordCodec.sqlType,
+      from: nullTestRecordIdentifier,
       codec: nullTestRecordCodec,
       uniques: null_test_recordUniques,
       isVirtual: false,
@@ -6066,10 +6094,10 @@ const registry = makeRegistry({
       description: undefined
     },
     edge_case: {
-      executor,
+      executor: executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: edgeCaseCodec.sqlType,
+      from: edgeCaseIdentifier,
       codec: edgeCaseCodec,
       uniques: [],
       isVirtual: false,
@@ -6259,10 +6287,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     authenticate_payload: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "auth_payload",
       identifier: "main.b.auth_payload",
-      from: authPayloadCodec.sqlType,
+      from: authPayloadIdentifier,
       codec: authPayloadCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/enum_tables.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/enum_tables.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const abcdIdentifier = sql.identifier("enum_tables", "abcd");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const spec_abcd = {
   name: "abcd",
-  identifier: sql.identifier("enum_tables", "abcd"),
+  identifier: abcdIdentifier,
   attributes: Object.assign(Object.create(null), {
     letter: {
       description: undefined,
@@ -117,9 +118,10 @@ const spec_abcd = {
   executor: executor
 };
 const abcdCodec = recordCodec(spec_abcd);
+const abcdViewIdentifier = sql.identifier("enum_tables", "abcd_view");
 const spec_abcdView = {
   name: "abcdView",
-  identifier: sql.identifier("enum_tables", "abcd_view"),
+  identifier: abcdViewIdentifier,
   attributes: Object.assign(Object.create(null), {
     letter: {
       description: undefined,
@@ -158,9 +160,10 @@ const spec_abcdView = {
   executor: executor
 };
 const abcdViewCodec = recordCodec(spec_abcdView);
+const simpleEnumIdentifier = sql.identifier("enum_tables", "simple_enum");
 const spec_simpleEnum = {
   name: "simpleEnum",
-  identifier: sql.identifier("enum_tables", "simple_enum"),
+  identifier: simpleEnumIdentifier,
   attributes: Object.assign(Object.create(null), {
     value: {
       description: undefined,
@@ -197,6 +200,7 @@ const spec_simpleEnum = {
   executor: executor
 };
 const simpleEnumCodec = recordCodec(spec_simpleEnum);
+const letterDescriptionsIdentifier = sql.identifier("enum_tables", "letter_descriptions");
 const spec_letterDescriptions_attributes_letter_codec_LetterAToDEnum = enumCodec({
   name: "LetterAToDEnum",
   identifier: TYPES.text.sqlType,
@@ -245,7 +249,7 @@ const spec_letterDescriptions_attributes_letter_via_view_codec_LetterAToDViaView
 });
 const spec_letterDescriptions = {
   name: "letterDescriptions",
-  identifier: sql.identifier("enum_tables", "letter_descriptions"),
+  identifier: letterDescriptionsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -299,6 +303,7 @@ const spec_letterDescriptions = {
   executor: executor
 };
 const letterDescriptionsCodec = recordCodec(spec_letterDescriptions);
+const referencingTableIdentifier = sql.identifier("enum_tables", "referencing_table");
 const spec_referencingTable_attributes_enum_1_codec_EnumTheFirstEnum = enumCodec({
   name: "EnumTheFirstEnum",
   identifier: TYPES.text.sqlType,
@@ -393,7 +398,7 @@ const spec_referencingTable_attributes_simple_enum_codec_SimpleEnumEnum = enumCo
 });
 const spec_referencingTable = {
   name: "referencingTable",
-  identifier: sql.identifier("enum_tables", "referencing_table"),
+  identifier: referencingTableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -454,9 +459,10 @@ const spec_referencingTable = {
   executor: executor
 };
 const referencingTableCodec = recordCodec(spec_referencingTable);
+const lotsOfEnumsIdentifier = sql.identifier("enum_tables", "lots_of_enums");
 const spec_lotsOfEnums = {
   name: "lotsOfEnums",
-  identifier: sql.identifier("enum_tables", "lots_of_enums"),
+  identifier: lotsOfEnumsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -530,10 +536,10 @@ const spec_lotsOfEnums = {
 };
 const lotsOfEnumsCodec = recordCodec(spec_lotsOfEnums);
 const registryConfig_pgResources_abcd_abcd = {
-  executor,
+  executor: executor,
   name: "abcd",
   identifier: "main.enum_tables.abcd",
-  from: abcdCodec.sqlType,
+  from: abcdIdentifier,
   codec: abcdCodec,
   uniques: [{
     isPrimary: true,
@@ -560,10 +566,10 @@ const registryConfig_pgResources_abcd_abcd = {
   }
 };
 const registryConfig_pgResources_abcd_view_abcd_view = {
-  executor,
+  executor: executor,
   name: "abcd_view",
   identifier: "main.enum_tables.abcd_view",
-  from: abcdViewCodec.sqlType,
+  from: abcdViewIdentifier,
   codec: abcdViewCodec,
   uniques: [{
     isPrimary: true,
@@ -591,10 +597,10 @@ const registryConfig_pgResources_abcd_view_abcd_view = {
   }
 };
 const registryConfig_pgResources_simple_enum_simple_enum = {
-  executor,
+  executor: executor,
   name: "simple_enum",
   identifier: "main.enum_tables.simple_enum",
-  from: simpleEnumCodec.sqlType,
+  from: simpleEnumIdentifier,
   codec: simpleEnumCodec,
   uniques: [{
     isPrimary: true,
@@ -643,10 +649,10 @@ const letter_descriptionsUniques = [{
   }
 }];
 const registryConfig_pgResources_letter_descriptions_letter_descriptions = {
-  executor,
+  executor: executor,
   name: "letter_descriptions",
   identifier: "main.enum_tables.letter_descriptions",
-  from: letterDescriptionsCodec.sqlType,
+  from: letterDescriptionsIdentifier,
   codec: letterDescriptionsCodec,
   uniques: letter_descriptionsUniques,
   isVirtual: false,
@@ -672,10 +678,10 @@ const referencing_tableUniques = [{
   }
 }];
 const registryConfig_pgResources_referencing_table_referencing_table = {
-  executor,
+  executor: executor,
   name: "referencing_table",
   identifier: "main.enum_tables.referencing_table",
-  from: referencingTableCodec.sqlType,
+  from: referencingTableIdentifier,
   codec: referencingTableCodec,
   uniques: referencing_tableUniques,
   isVirtual: false,
@@ -691,10 +697,10 @@ const registryConfig_pgResources_referencing_table_referencing_table = {
   }
 };
 const registryConfig_pgResources_lots_of_enums_lots_of_enums = {
-  executor,
+  executor: executor,
   name: "lots_of_enums",
   identifier: "main.enum_tables.lots_of_enums",
-  from: lotsOfEnumsCodec.sqlType,
+  from: lotsOfEnumsIdentifier,
   codec: lotsOfEnumsCodec,
   uniques: [{
     isPrimary: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.export.mjs
@@ -421,9 +421,10 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
   executor,
   isAnonymous: true
 });
+const myTableIdentifier = sql.identifier("c", "my_table");
 const spec_myTable = {
   name: "myTable",
-  identifier: sql.identifier("c", "my_table"),
+  identifier: myTableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -457,9 +458,10 @@ const spec_myTable = {
   executor: executor
 };
 const myTableCodec = recordCodec(spec_myTable);
+const personSecretIdentifier = sql.identifier("c", "person_secret");
 const spec_personSecret = {
   name: "personSecret",
-  identifier: sql.identifier("c", "person_secret"),
+  identifier: personSecretIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id: {
       description: undefined,
@@ -498,9 +500,10 @@ const spec_personSecret = {
   executor: executor
 };
 const personSecretCodec = recordCodec(spec_personSecret);
+const compoundKeyIdentifier = sql.identifier("c", "compound_key");
 const spec_compoundKey = {
   name: "compoundKey",
-  identifier: sql.identifier("c", "compound_key"),
+  identifier: compoundKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id_2: {
       description: undefined,
@@ -543,9 +546,10 @@ const spec_compoundKey = {
   executor: executor
 };
 const compoundKeyCodec = recordCodec(spec_compoundKey);
+const nullTestRecordIdentifier = sql.identifier("c", "null_test_record");
 const spec_nullTestRecord = {
   name: "nullTestRecord",
-  identifier: sql.identifier("c", "null_test_record"),
+  identifier: nullTestRecordIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -597,9 +601,10 @@ const spec_nullTestRecord = {
   executor: executor
 };
 const nullTestRecordCodec = recordCodec(spec_nullTestRecord);
+const edgeCaseIdentifier = sql.identifier("c", "edge_case");
 const spec_edgeCase = {
   name: "edgeCase",
-  identifier: sql.identifier("c", "edge_case"),
+  identifier: edgeCaseIdentifier,
   attributes: Object.assign(Object.create(null), {
     not_null_has_default: {
       description: undefined,
@@ -642,9 +647,10 @@ const spec_edgeCase = {
   executor: executor
 };
 const edgeCaseCodec = recordCodec(spec_edgeCase);
+const leftArmIdentifier = sql.identifier("c", "left_arm");
 const spec_leftArm = {
   name: "leftArm",
-  identifier: sql.identifier("c", "left_arm"),
+  identifier: leftArmIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -696,6 +702,7 @@ const spec_leftArm = {
   executor: executor
 };
 const leftArmCodec = recordCodec(spec_leftArm);
+const issue756Identifier = sql.identifier("c", "issue756");
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
   extensions: {
@@ -710,7 +717,7 @@ const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp
 });
 const spec_issue756 = {
   name: "issue756",
-  identifier: sql.identifier("c", "issue756"),
+  identifier: issue756Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -744,6 +751,7 @@ const spec_issue756 = {
   executor: executor
 };
 const issue756Codec = recordCodec(spec_issue756);
+const compoundTypeIdentifier = sql.identifier("c", "compound_type");
 const colorCodec = enumCodec({
   name: "color",
   identifier: sql.identifier("b", "color"),
@@ -788,7 +796,7 @@ const enumWithEmptyStringCodec = enumCodec({
 });
 const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: sql.identifier("c", "compound_type"),
+  identifier: compoundTypeIdentifier,
   attributes: Object.assign(Object.create(null), {
     a: {
       description: undefined,
@@ -1179,6 +1187,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor,
   isAnonymous: true
 });
+const personIdentifier = sql.identifier("c", "person");
 const textArrayCodec = listOfCodec(TYPES.text, {
   extensions: {
     pg: {
@@ -1244,7 +1253,7 @@ const wrappedUrlCodec = recordCodec({
 });
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("c", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: "The primary unique identifier for the person",
@@ -2308,10 +2317,10 @@ const person_secretUniques = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor,
+  executor: executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: personSecretCodec.sqlType,
+  from: personSecretIdentifier,
   codec: personSecretCodec,
   uniques: person_secretUniques,
   isVirtual: false,
@@ -2338,10 +2347,10 @@ const compound_keyUniques = [{
   }
 }];
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor,
+  executor: executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: compoundKeyCodec.sqlType,
+  from: compoundKeyIdentifier,
   codec: compoundKeyCodec,
   uniques: compound_keyUniques,
   isVirtual: false,
@@ -2382,10 +2391,10 @@ const left_armUniques = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor,
+  executor: executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: leftArmCodec.sqlType,
+  from: leftArmIdentifier,
   codec: leftArmCodec,
   uniques: left_armUniques,
   isVirtual: false,
@@ -2410,10 +2419,10 @@ const issue756Uniques = [{
   }
 }];
 const registryConfig_pgResources_issue756_issue756 = {
-  executor,
+  executor: executor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: issue756Codec.sqlType,
+  from: issue756Identifier,
   codec: issue756Codec,
   uniques: issue756Uniques,
   isVirtual: false,
@@ -2476,10 +2485,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.c.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -3557,10 +3566,10 @@ const registry = makeRegistry({
       description: undefined
     },
     my_table: {
-      executor,
+      executor: executor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: myTableCodec.sqlType,
+      from: myTableIdentifier,
       codec: myTableCodec,
       uniques: my_tableUniques,
       isVirtual: false,
@@ -3578,10 +3587,10 @@ const registry = makeRegistry({
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     null_test_record: {
-      executor,
+      executor: executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: nullTestRecordCodec.sqlType,
+      from: nullTestRecordIdentifier,
       codec: nullTestRecordCodec,
       uniques: null_test_recordUniques,
       isVirtual: false,
@@ -3648,10 +3657,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     edge_case: {
-      executor,
+      executor: executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: edgeCaseCodec.sqlType,
+      from: edgeCaseIdentifier,
       codec: edgeCaseCodec,
       uniques: [],
       isVirtual: false,
@@ -3979,10 +3988,10 @@ const registry = makeRegistry({
       description: undefined
     },
     compound_type_set_query: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "compound_type",
       identifier: "main.c.compound_type",
-      from: compoundTypeCodec.sqlType,
+      from: compoundTypeIdentifier,
       codec: compoundTypeCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-good.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-good.1.export.mjs
@@ -421,9 +421,10 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
   executor,
   isAnonymous: true
 });
+const myTableIdentifier = sql.identifier("c", "my_table");
 const spec_myTable = {
   name: "myTable",
-  identifier: sql.identifier("c", "my_table"),
+  identifier: myTableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -457,9 +458,10 @@ const spec_myTable = {
   executor: executor
 };
 const myTableCodec = recordCodec(spec_myTable);
+const personSecretIdentifier = sql.identifier("c", "person_secret");
 const spec_personSecret = {
   name: "personSecret",
-  identifier: sql.identifier("c", "person_secret"),
+  identifier: personSecretIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id: {
       description: undefined,
@@ -498,9 +500,10 @@ const spec_personSecret = {
   executor: executor
 };
 const personSecretCodec = recordCodec(spec_personSecret);
+const compoundKeyIdentifier = sql.identifier("c", "compound_key");
 const spec_compoundKey = {
   name: "compoundKey",
-  identifier: sql.identifier("c", "compound_key"),
+  identifier: compoundKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id_2: {
       description: undefined,
@@ -543,9 +546,10 @@ const spec_compoundKey = {
   executor: executor
 };
 const compoundKeyCodec = recordCodec(spec_compoundKey);
+const nullTestRecordIdentifier = sql.identifier("c", "null_test_record");
 const spec_nullTestRecord = {
   name: "nullTestRecord",
-  identifier: sql.identifier("c", "null_test_record"),
+  identifier: nullTestRecordIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -597,9 +601,10 @@ const spec_nullTestRecord = {
   executor: executor
 };
 const nullTestRecordCodec = recordCodec(spec_nullTestRecord);
+const edgeCaseIdentifier = sql.identifier("c", "edge_case");
 const spec_edgeCase = {
   name: "edgeCase",
-  identifier: sql.identifier("c", "edge_case"),
+  identifier: edgeCaseIdentifier,
   attributes: Object.assign(Object.create(null), {
     not_null_has_default: {
       description: undefined,
@@ -642,9 +647,10 @@ const spec_edgeCase = {
   executor: executor
 };
 const edgeCaseCodec = recordCodec(spec_edgeCase);
+const leftArmIdentifier = sql.identifier("c", "left_arm");
 const spec_leftArm = {
   name: "leftArm",
-  identifier: sql.identifier("c", "left_arm"),
+  identifier: leftArmIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -696,6 +702,7 @@ const spec_leftArm = {
   executor: executor
 };
 const leftArmCodec = recordCodec(spec_leftArm);
+const issue756Identifier = sql.identifier("c", "issue756");
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
   extensions: {
@@ -710,7 +717,7 @@ const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp
 });
 const spec_issue756 = {
   name: "issue756",
-  identifier: sql.identifier("c", "issue756"),
+  identifier: issue756Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -744,6 +751,7 @@ const spec_issue756 = {
   executor: executor
 };
 const issue756Codec = recordCodec(spec_issue756);
+const compoundTypeIdentifier = sql.identifier("c", "compound_type");
 const colorCodec = enumCodec({
   name: "color",
   identifier: sql.identifier("b", "color"),
@@ -788,7 +796,7 @@ const enumWithEmptyStringCodec = enumCodec({
 });
 const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: sql.identifier("c", "compound_type"),
+  identifier: compoundTypeIdentifier,
   attributes: Object.assign(Object.create(null), {
     a: {
       description: undefined,
@@ -1179,6 +1187,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor,
   isAnonymous: true
 });
+const personIdentifier = sql.identifier("c", "person");
 const textArrayCodec = listOfCodec(TYPES.text, {
   extensions: {
     pg: {
@@ -1244,7 +1253,7 @@ const wrappedUrlCodec = recordCodec({
 });
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("c", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: "The primary unique identifier for the person",
@@ -2308,10 +2317,10 @@ const person_secretUniques = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor,
+  executor: executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: personSecretCodec.sqlType,
+  from: personSecretIdentifier,
   codec: personSecretCodec,
   uniques: person_secretUniques,
   isVirtual: false,
@@ -2338,10 +2347,10 @@ const compound_keyUniques = [{
   }
 }];
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor,
+  executor: executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: compoundKeyCodec.sqlType,
+  from: compoundKeyIdentifier,
   codec: compoundKeyCodec,
   uniques: compound_keyUniques,
   isVirtual: false,
@@ -2382,10 +2391,10 @@ const left_armUniques = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor,
+  executor: executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: leftArmCodec.sqlType,
+  from: leftArmIdentifier,
   codec: leftArmCodec,
   uniques: left_armUniques,
   isVirtual: false,
@@ -2410,10 +2419,10 @@ const issue756Uniques = [{
   }
 }];
 const registryConfig_pgResources_issue756_issue756 = {
-  executor,
+  executor: executor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: issue756Codec.sqlType,
+  from: issue756Identifier,
   codec: issue756Codec,
   uniques: issue756Uniques,
   isVirtual: false,
@@ -2474,10 +2483,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.c.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -3555,10 +3564,10 @@ const registry = makeRegistry({
       description: undefined
     },
     my_table: {
-      executor,
+      executor: executor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: myTableCodec.sqlType,
+      from: myTableIdentifier,
       codec: myTableCodec,
       uniques: my_tableUniques,
       isVirtual: false,
@@ -3576,10 +3585,10 @@ const registry = makeRegistry({
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     null_test_record: {
-      executor,
+      executor: executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: nullTestRecordCodec.sqlType,
+      from: nullTestRecordIdentifier,
       codec: nullTestRecordCodec,
       uniques: null_test_recordUniques,
       isVirtual: false,
@@ -3646,10 +3655,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     edge_case: {
-      executor,
+      executor: executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: edgeCaseCodec.sqlType,
+      from: edgeCaseIdentifier,
       codec: edgeCaseCodec,
       uniques: [],
       isVirtual: false,
@@ -3977,10 +3986,10 @@ const registry = makeRegistry({
       description: undefined
     },
     compound_type_set_query: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "compound_type",
       identifier: "main.c.compound_type",
-      from: compoundTypeCodec.sqlType,
+      from: compoundTypeIdentifier,
       codec: compoundTypeCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.export.mjs
@@ -459,9 +459,10 @@ const textArrayCodec = listOfCodec(TYPES.text, {
   description: undefined,
   name: "textArray"
 });
+const nonUpdatableViewIdentifier = sql.identifier("a", "non_updatable_view");
 const spec_nonUpdatableView = {
   name: "nonUpdatableView",
-  identifier: sql.identifier("a", "non_updatable_view"),
+  identifier: nonUpdatableViewIdentifier,
   attributes: Object.assign(Object.create(null), {
     "?column?": {
       description: undefined,
@@ -486,9 +487,10 @@ const spec_nonUpdatableView = {
   executor: executor
 };
 const nonUpdatableViewCodec = recordCodec(spec_nonUpdatableView);
+const inputsIdentifier = sql.identifier("a", "inputs");
 const spec_inputs = {
   name: "inputs",
-  identifier: sql.identifier("a", "inputs"),
+  identifier: inputsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -513,9 +515,10 @@ const spec_inputs = {
   executor: executor
 };
 const inputsCodec = recordCodec(spec_inputs);
+const patchsIdentifier = sql.identifier("a", "patchs");
 const spec_patchs = {
   name: "patchs",
-  identifier: sql.identifier("a", "patchs"),
+  identifier: patchsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -540,9 +543,10 @@ const spec_patchs = {
   executor: executor
 };
 const patchsCodec = recordCodec(spec_patchs);
+const reservedIdentifier = sql.identifier("a", "reserved");
 const spec_reserved = {
   name: "reserved",
-  identifier: sql.identifier("a", "reserved"),
+  identifier: reservedIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -567,9 +571,10 @@ const spec_reserved = {
   executor: executor
 };
 const reservedCodec = recordCodec(spec_reserved);
+const reservedPatchsIdentifier = sql.identifier("a", "reservedPatchs");
 const spec_reservedPatchs = {
   name: "reservedPatchs",
-  identifier: sql.identifier("a", "reservedPatchs"),
+  identifier: reservedPatchsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -594,9 +599,10 @@ const spec_reservedPatchs = {
   executor: executor
 };
 const reservedPatchsCodec = recordCodec(spec_reservedPatchs);
+const reservedInputIdentifier = sql.identifier("a", "reserved_input");
 const spec_reservedInput = {
   name: "reservedInput",
-  identifier: sql.identifier("a", "reserved_input"),
+  identifier: reservedInputIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -621,9 +627,10 @@ const spec_reservedInput = {
   executor: executor
 };
 const reservedInputCodec = recordCodec(spec_reservedInput);
+const defaultValueIdentifier = sql.identifier("a", "default_value");
 const spec_defaultValue = {
   name: "defaultValue",
-  identifier: sql.identifier("a", "default_value"),
+  identifier: defaultValueIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -657,9 +664,10 @@ const spec_defaultValue = {
   executor: executor
 };
 const defaultValueCodec = recordCodec(spec_defaultValue);
+const foreignKeyIdentifier = sql.identifier("a", "foreign_key");
 const spec_foreignKey = {
   name: "foreignKey",
-  identifier: sql.identifier("a", "foreign_key"),
+  identifier: foreignKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id: {
       description: undefined,
@@ -702,9 +710,10 @@ const spec_foreignKey = {
   executor: executor
 };
 const foreignKeyCodec = recordCodec(spec_foreignKey);
+const noPrimaryKeyIdentifier = sql.identifier("a", "no_primary_key");
 const spec_noPrimaryKey = {
   name: "noPrimaryKey",
-  identifier: sql.identifier("a", "no_primary_key"),
+  identifier: noPrimaryKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -738,9 +747,10 @@ const spec_noPrimaryKey = {
   executor: executor
 };
 const noPrimaryKeyCodec = recordCodec(spec_noPrimaryKey);
+const testviewIdentifier = sql.identifier("a", "testview");
 const spec_testview = {
   name: "testview",
-  identifier: sql.identifier("a", "testview"),
+  identifier: testviewIdentifier,
   attributes: Object.assign(Object.create(null), {
     testviewid: {
       description: undefined,
@@ -783,9 +793,10 @@ const spec_testview = {
   executor: executor
 };
 const testviewCodec = recordCodec(spec_testview);
+const uniqueForeignKeyIdentifier = sql.identifier("a", "unique_foreign_key");
 const spec_uniqueForeignKey = {
   name: "uniqueForeignKey",
-  identifier: sql.identifier("a", "unique_foreign_key"),
+  identifier: uniqueForeignKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     compound_key_1: {
       description: undefined,
@@ -822,9 +833,10 @@ const spec_uniqueForeignKey = {
   executor: executor
 };
 const uniqueForeignKeyCodec = recordCodec(spec_uniqueForeignKey);
+const myTableIdentifier = sql.identifier("c", "my_table");
 const spec_myTable = {
   name: "myTable",
-  identifier: sql.identifier("c", "my_table"),
+  identifier: myTableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -858,9 +870,10 @@ const spec_myTable = {
   executor: executor
 };
 const myTableCodec = recordCodec(spec_myTable);
+const personSecretIdentifier = sql.identifier("c", "person_secret");
 const spec_personSecret = {
   name: "personSecret",
-  identifier: sql.identifier("c", "person_secret"),
+  identifier: personSecretIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id: {
       description: undefined,
@@ -898,9 +911,10 @@ const spec_personSecret = {
   executor: executor
 };
 const personSecretCodec = recordCodec(spec_personSecret);
+const viewTableIdentifier = sql.identifier("a", "view_table");
 const spec_viewTable = {
   name: "viewTable",
-  identifier: sql.identifier("a", "view_table"),
+  identifier: viewTableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -943,9 +957,10 @@ const spec_viewTable = {
   executor: executor
 };
 const viewTableCodec = recordCodec(spec_viewTable);
+const compoundKeyIdentifier = sql.identifier("c", "compound_key");
 const spec_compoundKey = {
   name: "compoundKey",
-  identifier: sql.identifier("c", "compound_key"),
+  identifier: compoundKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id_2: {
       description: undefined,
@@ -988,9 +1003,10 @@ const spec_compoundKey = {
   executor: executor
 };
 const compoundKeyCodec = recordCodec(spec_compoundKey);
+const similarTable1Identifier = sql.identifier("a", "similar_table_1");
 const spec_similarTable1 = {
   name: "similarTable1",
-  identifier: sql.identifier("a", "similar_table_1"),
+  identifier: similarTable1Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1042,9 +1058,10 @@ const spec_similarTable1 = {
   executor: executor
 };
 const similarTable1Codec = recordCodec(spec_similarTable1);
+const similarTable2Identifier = sql.identifier("a", "similar_table_2");
 const spec_similarTable2 = {
   name: "similarTable2",
-  identifier: sql.identifier("a", "similar_table_2"),
+  identifier: similarTable2Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1096,9 +1113,10 @@ const spec_similarTable2 = {
   executor: executor
 };
 const similarTable2Codec = recordCodec(spec_similarTable2);
+const updatableViewIdentifier = sql.identifier("b", "updatable_view");
 const spec_updatableView = {
   name: "updatableView",
-  identifier: sql.identifier("b", "updatable_view"),
+  identifier: updatableViewIdentifier,
   attributes: Object.assign(Object.create(null), {
     x: {
       description: undefined,
@@ -1153,9 +1171,10 @@ const spec_updatableView = {
   executor: executor
 };
 const updatableViewCodec = recordCodec(spec_updatableView);
+const nullTestRecordIdentifier = sql.identifier("c", "null_test_record");
 const spec_nullTestRecord = {
   name: "nullTestRecord",
-  identifier: sql.identifier("c", "null_test_record"),
+  identifier: nullTestRecordIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1220,9 +1239,10 @@ const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   description: undefined,
   name: "uuidArray"
 });
+const edgeCaseIdentifier = sql.identifier("c", "edge_case");
 const spec_edgeCase = {
   name: "edgeCase",
-  identifier: sql.identifier("c", "edge_case"),
+  identifier: edgeCaseIdentifier,
   attributes: Object.assign(Object.create(null), {
     not_null_has_default: {
       description: undefined,
@@ -1265,9 +1285,10 @@ const spec_edgeCase = {
   executor: executor
 };
 const edgeCaseCodec = recordCodec(spec_edgeCase);
+const leftArmIdentifier = sql.identifier("c", "left_arm");
 const spec_leftArm = {
   name: "leftArm",
-  identifier: sql.identifier("c", "left_arm"),
+  identifier: leftArmIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1319,9 +1340,10 @@ const spec_leftArm = {
   executor: executor
 };
 const leftArmCodec = recordCodec(spec_leftArm);
+const jwtTokenIdentifier = sql.identifier("b", "jwt_token");
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: sql.identifier("b", "jwt_token"),
+  identifier: jwtTokenIdentifier,
   attributes: Object.assign(Object.create(null), {
     role: {
       description: undefined,
@@ -1381,6 +1403,7 @@ const jwtTokenCodec = recordCodec({
   },
   executor: executor
 });
+const issue756Identifier = sql.identifier("c", "issue756");
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
   extensions: {
@@ -1395,7 +1418,7 @@ const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp
 });
 const spec_issue756 = {
   name: "issue756",
-  identifier: sql.identifier("c", "issue756"),
+  identifier: issue756Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1429,9 +1452,10 @@ const spec_issue756 = {
   executor: executor
 };
 const issue756Codec = recordCodec(spec_issue756);
+const authPayloadIdentifier = sql.identifier("b", "auth_payload");
 const authPayloadCodec = recordCodec({
   name: "authPayload",
-  identifier: sql.identifier("b", "auth_payload"),
+  identifier: authPayloadIdentifier,
   attributes: Object.assign(Object.create(null), {
     jwt: {
       description: undefined,
@@ -1475,6 +1499,7 @@ const authPayloadCodec = recordCodec({
   },
   executor: executor
 });
+const compoundTypeIdentifier = sql.identifier("c", "compound_type");
 const colorCodec = enumCodec({
   name: "color",
   identifier: sql.identifier("b", "color"),
@@ -1519,7 +1544,7 @@ const enumWithEmptyStringCodec = enumCodec({
 });
 const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: sql.identifier("c", "compound_type"),
+  identifier: compoundTypeIdentifier,
   attributes: Object.assign(Object.create(null), {
     a: {
       description: undefined,
@@ -1666,6 +1691,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor,
   isAnonymous: true
 });
+const postIdentifier = sql.identifier("a", "post");
 const anEnumCodec = enumCodec({
   name: "anEnum",
   identifier: sql.identifier("a", "an_enum"),
@@ -1743,7 +1769,7 @@ const comptypeArrayCodec = listOfCodec(comptypeCodec, {
 });
 const spec_post = {
   name: "post",
-  identifier: sql.identifier("a", "post"),
+  identifier: postIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1914,6 +1940,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor,
   isAnonymous: true
 });
+const personIdentifier = sql.identifier("c", "person");
 const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
   description: undefined,
   extensions: {
@@ -1966,7 +1993,7 @@ const wrappedUrlCodec = recordCodec({
 });
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("c", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: "The primary unique identifier for the person",
@@ -2305,6 +2332,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor,
   isAnonymous: true
 });
+const typesIdentifier = sql.identifier("b", "types");
 const colorArrayCodec = listOfCodec(colorCodec, {
   extensions: {
     pg: {
@@ -2484,7 +2512,7 @@ const spec_types_attributes_ltree_codec_ltree = {
 const spec_types_attributes_ltree_array_codec_ltree_ = listOfCodec(spec_types_attributes_ltree_codec_ltree);
 const spec_types = {
   name: "types",
-  identifier: sql.identifier("b", "types"),
+  identifier: typesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -3092,10 +3120,10 @@ const default_valueUniques = [{
   }
 }];
 const registryConfig_pgResources_foreign_key_foreign_key = {
-  executor,
+  executor: executor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
-  from: foreignKeyCodec.sqlType,
+  from: foreignKeyIdentifier,
   codec: foreignKeyCodec,
   uniques: [],
   isVirtual: false,
@@ -3111,10 +3139,10 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   }
 };
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
-  executor,
+  executor: executor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
-  from: uniqueForeignKeyCodec.sqlType,
+  from: uniqueForeignKeyIdentifier,
   codec: uniqueForeignKeyCodec,
   uniques: [{
     isPrimary: false,
@@ -3156,10 +3184,10 @@ const person_secretUniques = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor,
+  executor: executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: personSecretCodec.sqlType,
+  from: personSecretIdentifier,
   codec: personSecretCodec,
   uniques: person_secretUniques,
   isVirtual: false,
@@ -3193,10 +3221,10 @@ const compound_keyUniques = [{
   }
 }];
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor,
+  executor: executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: compoundKeyCodec.sqlType,
+  from: compoundKeyIdentifier,
   codec: compoundKeyCodec,
   uniques: compound_keyUniques,
   isVirtual: false,
@@ -3254,10 +3282,10 @@ const left_armUniques = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor,
+  executor: executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: leftArmCodec.sqlType,
+  from: leftArmIdentifier,
   codec: leftArmCodec,
   uniques: left_armUniques,
   isVirtual: false,
@@ -3274,10 +3302,10 @@ const registryConfig_pgResources_left_arm_left_arm = {
 };
 const authenticate_failFunctionIdentifer = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
-  executor,
+  executor: executor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
-  from: jwtTokenCodec.sqlType,
+  from: jwtTokenIdentifier,
   codec: jwtTokenCodec,
   uniques: [],
   isVirtual: true,
@@ -3304,10 +3332,10 @@ const issue756Uniques = [{
   }
 }];
 const registryConfig_pgResources_issue756_issue756 = {
-  executor,
+  executor: executor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: issue756Codec.sqlType,
+  from: issue756Identifier,
   codec: issue756Codec,
   uniques: issue756Uniques,
   isVirtual: false,
@@ -3350,10 +3378,10 @@ const postUniques = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor,
+  executor: executor,
   name: "post",
   identifier: "main.a.post",
-  from: postCodec.sqlType,
+  from: postIdentifier,
   codec: postCodec,
   uniques: postUniques,
   isVirtual: false,
@@ -3373,10 +3401,10 @@ const registryConfig_pgResources_post_post = {
 };
 const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_compound_type = {
-  executor,
+  executor: executor,
   name: "compound_type",
   identifier: "main.c.compound_type",
-  from: compoundTypeCodec.sqlType,
+  from: compoundTypeIdentifier,
   codec: compoundTypeCodec,
   uniques: [],
   isVirtual: true,
@@ -3435,10 +3463,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.c.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -3472,10 +3500,10 @@ const typesUniques = [{
   }
 }];
 const registryConfig_pgResources_types_types = {
-  executor,
+  executor: executor,
   name: "types",
   identifier: "main.b.types",
-  from: typesCodec.sqlType,
+  from: typesIdentifier,
   codec: typesCodec,
   uniques: typesUniques,
   isVirtual: false,
@@ -5673,10 +5701,10 @@ const registry = makeRegistry({
       description: undefined
     },
     non_updatable_view: {
-      executor,
+      executor: executor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
-      from: nonUpdatableViewCodec.sqlType,
+      from: nonUpdatableViewIdentifier,
       codec: nonUpdatableViewCodec,
       uniques: [],
       isVirtual: false,
@@ -5694,10 +5722,10 @@ const registry = makeRegistry({
       }
     },
     inputs: {
-      executor,
+      executor: executor,
       name: "inputs",
       identifier: "main.a.inputs",
-      from: inputsCodec.sqlType,
+      from: inputsIdentifier,
       codec: inputsCodec,
       uniques: inputsUniques,
       isVirtual: false,
@@ -5713,10 +5741,10 @@ const registry = makeRegistry({
       }
     },
     patchs: {
-      executor,
+      executor: executor,
       name: "patchs",
       identifier: "main.a.patchs",
-      from: patchsCodec.sqlType,
+      from: patchsIdentifier,
       codec: patchsCodec,
       uniques: patchsUniques,
       isVirtual: false,
@@ -5732,10 +5760,10 @@ const registry = makeRegistry({
       }
     },
     reserved: {
-      executor,
+      executor: executor,
       name: "reserved",
       identifier: "main.a.reserved",
-      from: reservedCodec.sqlType,
+      from: reservedIdentifier,
       codec: reservedCodec,
       uniques: reservedUniques,
       isVirtual: false,
@@ -5751,10 +5779,10 @@ const registry = makeRegistry({
       }
     },
     reservedPatchs: {
-      executor,
+      executor: executor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
-      from: reservedPatchsCodec.sqlType,
+      from: reservedPatchsIdentifier,
       codec: reservedPatchsCodec,
       uniques: reservedPatchsUniques,
       isVirtual: false,
@@ -5770,10 +5798,10 @@ const registry = makeRegistry({
       }
     },
     reserved_input: {
-      executor,
+      executor: executor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
-      from: reservedInputCodec.sqlType,
+      from: reservedInputIdentifier,
       codec: reservedInputCodec,
       uniques: reserved_inputUniques,
       isVirtual: false,
@@ -5789,10 +5817,10 @@ const registry = makeRegistry({
       }
     },
     default_value: {
-      executor,
+      executor: executor,
       name: "default_value",
       identifier: "main.a.default_value",
-      from: defaultValueCodec.sqlType,
+      from: defaultValueIdentifier,
       codec: defaultValueCodec,
       uniques: default_valueUniques,
       isVirtual: false,
@@ -5809,10 +5837,10 @@ const registry = makeRegistry({
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
-      executor,
+      executor: executor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
-      from: noPrimaryKeyCodec.sqlType,
+      from: noPrimaryKeyIdentifier,
       codec: noPrimaryKeyCodec,
       uniques: [{
         isPrimary: false,
@@ -5835,10 +5863,10 @@ const registry = makeRegistry({
       }
     },
     testview: {
-      executor,
+      executor: executor,
       name: "testview",
       identifier: "main.a.testview",
-      from: testviewCodec.sqlType,
+      from: testviewIdentifier,
       codec: testviewCodec,
       uniques: [],
       isVirtual: false,
@@ -5855,10 +5883,10 @@ const registry = makeRegistry({
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
-      executor,
+      executor: executor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: myTableCodec.sqlType,
+      from: myTableIdentifier,
       codec: myTableCodec,
       uniques: my_tableUniques,
       isVirtual: false,
@@ -5875,10 +5903,10 @@ const registry = makeRegistry({
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
-      executor,
+      executor: executor,
       name: "view_table",
       identifier: "main.a.view_table",
-      from: viewTableCodec.sqlType,
+      from: viewTableIdentifier,
       codec: viewTableCodec,
       uniques: view_tableUniques,
       isVirtual: false,
@@ -5895,10 +5923,10 @@ const registry = makeRegistry({
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
-      executor,
+      executor: executor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
-      from: similarTable1Codec.sqlType,
+      from: similarTable1Identifier,
       codec: similarTable1Codec,
       uniques: similar_table_1Uniques,
       isVirtual: false,
@@ -5914,10 +5942,10 @@ const registry = makeRegistry({
       }
     },
     similar_table_2: {
-      executor,
+      executor: executor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
-      from: similarTable2Codec.sqlType,
+      from: similarTable2Identifier,
       codec: similarTable2Codec,
       uniques: similar_table_2Uniques,
       isVirtual: false,
@@ -5933,10 +5961,10 @@ const registry = makeRegistry({
       }
     },
     updatable_view: {
-      executor,
+      executor: executor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
-      from: updatableViewCodec.sqlType,
+      from: updatableViewIdentifier,
       codec: updatableViewCodec,
       uniques: [{
         isPrimary: false,
@@ -5964,10 +5992,10 @@ const registry = makeRegistry({
       }
     },
     null_test_record: {
-      executor,
+      executor: executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: nullTestRecordCodec.sqlType,
+      from: nullTestRecordIdentifier,
       codec: nullTestRecordCodec,
       uniques: null_test_recordUniques,
       isVirtual: false,
@@ -6073,10 +6101,10 @@ const registry = makeRegistry({
       description: undefined
     },
     edge_case: {
-      executor,
+      executor: executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: edgeCaseCodec.sqlType,
+      from: edgeCaseIdentifier,
       codec: edgeCaseCodec,
       uniques: [],
       isVirtual: false,
@@ -6266,10 +6294,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     authenticate_payload: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "auth_payload",
       identifier: "main.b.auth_payload",
-      from: authPayloadCodec.sqlType,
+      from: authPayloadIdentifier,
       codec: authPayloadCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.export.mjs
@@ -459,9 +459,10 @@ const textArrayCodec = listOfCodec(TYPES.text, {
   description: undefined,
   name: "textArray"
 });
+const nonUpdatableViewIdentifier = sql.identifier("a", "non_updatable_view");
 const spec_nonUpdatableView = {
   name: "nonUpdatableView",
-  identifier: sql.identifier("a", "non_updatable_view"),
+  identifier: nonUpdatableViewIdentifier,
   attributes: Object.assign(Object.create(null), {
     "?column?": {
       description: undefined,
@@ -486,9 +487,10 @@ const spec_nonUpdatableView = {
   executor: executor
 };
 const nonUpdatableViewCodec = recordCodec(spec_nonUpdatableView);
+const inputsIdentifier = sql.identifier("a", "inputs");
 const spec_inputs = {
   name: "inputs",
-  identifier: sql.identifier("a", "inputs"),
+  identifier: inputsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -513,9 +515,10 @@ const spec_inputs = {
   executor: executor
 };
 const inputsCodec = recordCodec(spec_inputs);
+const patchsIdentifier = sql.identifier("a", "patchs");
 const spec_patchs = {
   name: "patchs",
-  identifier: sql.identifier("a", "patchs"),
+  identifier: patchsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -540,9 +543,10 @@ const spec_patchs = {
   executor: executor
 };
 const patchsCodec = recordCodec(spec_patchs);
+const reservedIdentifier = sql.identifier("a", "reserved");
 const spec_reserved = {
   name: "reserved",
-  identifier: sql.identifier("a", "reserved"),
+  identifier: reservedIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -567,9 +571,10 @@ const spec_reserved = {
   executor: executor
 };
 const reservedCodec = recordCodec(spec_reserved);
+const reservedPatchsIdentifier = sql.identifier("a", "reservedPatchs");
 const spec_reservedPatchs = {
   name: "reservedPatchs",
-  identifier: sql.identifier("a", "reservedPatchs"),
+  identifier: reservedPatchsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -594,9 +599,10 @@ const spec_reservedPatchs = {
   executor: executor
 };
 const reservedPatchsCodec = recordCodec(spec_reservedPatchs);
+const reservedInputIdentifier = sql.identifier("a", "reserved_input");
 const spec_reservedInput = {
   name: "reservedInput",
-  identifier: sql.identifier("a", "reserved_input"),
+  identifier: reservedInputIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -621,9 +627,10 @@ const spec_reservedInput = {
   executor: executor
 };
 const reservedInputCodec = recordCodec(spec_reservedInput);
+const defaultValueIdentifier = sql.identifier("a", "default_value");
 const spec_defaultValue = {
   name: "defaultValue",
-  identifier: sql.identifier("a", "default_value"),
+  identifier: defaultValueIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -657,9 +664,10 @@ const spec_defaultValue = {
   executor: executor
 };
 const defaultValueCodec = recordCodec(spec_defaultValue);
+const foreignKeyIdentifier = sql.identifier("a", "foreign_key");
 const spec_foreignKey = {
   name: "foreignKey",
-  identifier: sql.identifier("a", "foreign_key"),
+  identifier: foreignKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id: {
       description: undefined,
@@ -702,9 +710,10 @@ const spec_foreignKey = {
   executor: executor
 };
 const foreignKeyCodec = recordCodec(spec_foreignKey);
+const noPrimaryKeyIdentifier = sql.identifier("a", "no_primary_key");
 const spec_noPrimaryKey = {
   name: "noPrimaryKey",
-  identifier: sql.identifier("a", "no_primary_key"),
+  identifier: noPrimaryKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -738,9 +747,10 @@ const spec_noPrimaryKey = {
   executor: executor
 };
 const noPrimaryKeyCodec = recordCodec(spec_noPrimaryKey);
+const testviewIdentifier = sql.identifier("a", "testview");
 const spec_testview = {
   name: "testview",
-  identifier: sql.identifier("a", "testview"),
+  identifier: testviewIdentifier,
   attributes: Object.assign(Object.create(null), {
     testviewid: {
       description: undefined,
@@ -783,9 +793,10 @@ const spec_testview = {
   executor: executor
 };
 const testviewCodec = recordCodec(spec_testview);
+const uniqueForeignKeyIdentifier = sql.identifier("a", "unique_foreign_key");
 const spec_uniqueForeignKey = {
   name: "uniqueForeignKey",
-  identifier: sql.identifier("a", "unique_foreign_key"),
+  identifier: uniqueForeignKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     compound_key_1: {
       description: undefined,
@@ -822,9 +833,10 @@ const spec_uniqueForeignKey = {
   executor: executor
 };
 const uniqueForeignKeyCodec = recordCodec(spec_uniqueForeignKey);
+const myTableIdentifier = sql.identifier("c", "my_table");
 const spec_myTable = {
   name: "myTable",
-  identifier: sql.identifier("c", "my_table"),
+  identifier: myTableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -858,9 +870,10 @@ const spec_myTable = {
   executor: executor
 };
 const myTableCodec = recordCodec(spec_myTable);
+const personSecretIdentifier = sql.identifier("c", "person_secret");
 const spec_personSecret = {
   name: "personSecret",
-  identifier: sql.identifier("c", "person_secret"),
+  identifier: personSecretIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id: {
       description: undefined,
@@ -898,9 +911,10 @@ const spec_personSecret = {
   executor: executor
 };
 const personSecretCodec = recordCodec(spec_personSecret);
+const viewTableIdentifier = sql.identifier("a", "view_table");
 const spec_viewTable = {
   name: "viewTable",
-  identifier: sql.identifier("a", "view_table"),
+  identifier: viewTableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -943,9 +957,10 @@ const spec_viewTable = {
   executor: executor
 };
 const viewTableCodec = recordCodec(spec_viewTable);
+const compoundKeyIdentifier = sql.identifier("c", "compound_key");
 const spec_compoundKey = {
   name: "compoundKey",
-  identifier: sql.identifier("c", "compound_key"),
+  identifier: compoundKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id_2: {
       description: undefined,
@@ -988,9 +1003,10 @@ const spec_compoundKey = {
   executor: executor
 };
 const compoundKeyCodec = recordCodec(spec_compoundKey);
+const similarTable1Identifier = sql.identifier("a", "similar_table_1");
 const spec_similarTable1 = {
   name: "similarTable1",
-  identifier: sql.identifier("a", "similar_table_1"),
+  identifier: similarTable1Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1042,9 +1058,10 @@ const spec_similarTable1 = {
   executor: executor
 };
 const similarTable1Codec = recordCodec(spec_similarTable1);
+const similarTable2Identifier = sql.identifier("a", "similar_table_2");
 const spec_similarTable2 = {
   name: "similarTable2",
-  identifier: sql.identifier("a", "similar_table_2"),
+  identifier: similarTable2Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1096,9 +1113,10 @@ const spec_similarTable2 = {
   executor: executor
 };
 const similarTable2Codec = recordCodec(spec_similarTable2);
+const updatableViewIdentifier = sql.identifier("b", "updatable_view");
 const spec_updatableView = {
   name: "updatableView",
-  identifier: sql.identifier("b", "updatable_view"),
+  identifier: updatableViewIdentifier,
   attributes: Object.assign(Object.create(null), {
     x: {
       description: undefined,
@@ -1153,9 +1171,10 @@ const spec_updatableView = {
   executor: executor
 };
 const updatableViewCodec = recordCodec(spec_updatableView);
+const nullTestRecordIdentifier = sql.identifier("c", "null_test_record");
 const spec_nullTestRecord = {
   name: "nullTestRecord",
-  identifier: sql.identifier("c", "null_test_record"),
+  identifier: nullTestRecordIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1220,9 +1239,10 @@ const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   description: undefined,
   name: "uuidArray"
 });
+const edgeCaseIdentifier = sql.identifier("c", "edge_case");
 const spec_edgeCase = {
   name: "edgeCase",
-  identifier: sql.identifier("c", "edge_case"),
+  identifier: edgeCaseIdentifier,
   attributes: Object.assign(Object.create(null), {
     not_null_has_default: {
       description: undefined,
@@ -1265,9 +1285,10 @@ const spec_edgeCase = {
   executor: executor
 };
 const edgeCaseCodec = recordCodec(spec_edgeCase);
+const leftArmIdentifier = sql.identifier("c", "left_arm");
 const spec_leftArm = {
   name: "leftArm",
-  identifier: sql.identifier("c", "left_arm"),
+  identifier: leftArmIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1319,9 +1340,10 @@ const spec_leftArm = {
   executor: executor
 };
 const leftArmCodec = recordCodec(spec_leftArm);
+const jwtTokenIdentifier = sql.identifier("b", "jwt_token");
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: sql.identifier("b", "jwt_token"),
+  identifier: jwtTokenIdentifier,
   attributes: Object.assign(Object.create(null), {
     role: {
       description: undefined,
@@ -1381,6 +1403,7 @@ const jwtTokenCodec = recordCodec({
   },
   executor: executor
 });
+const issue756Identifier = sql.identifier("c", "issue756");
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
   extensions: {
@@ -1395,7 +1418,7 @@ const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp
 });
 const spec_issue756 = {
   name: "issue756",
-  identifier: sql.identifier("c", "issue756"),
+  identifier: issue756Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1429,9 +1452,10 @@ const spec_issue756 = {
   executor: executor
 };
 const issue756Codec = recordCodec(spec_issue756);
+const authPayloadIdentifier = sql.identifier("b", "auth_payload");
 const authPayloadCodec = recordCodec({
   name: "authPayload",
-  identifier: sql.identifier("b", "auth_payload"),
+  identifier: authPayloadIdentifier,
   attributes: Object.assign(Object.create(null), {
     jwt: {
       description: undefined,
@@ -1475,6 +1499,7 @@ const authPayloadCodec = recordCodec({
   },
   executor: executor
 });
+const compoundTypeIdentifier = sql.identifier("c", "compound_type");
 const colorCodec = enumCodec({
   name: "color",
   identifier: sql.identifier("b", "color"),
@@ -1519,7 +1544,7 @@ const enumWithEmptyStringCodec = enumCodec({
 });
 const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: sql.identifier("c", "compound_type"),
+  identifier: compoundTypeIdentifier,
   attributes: Object.assign(Object.create(null), {
     a: {
       description: undefined,
@@ -1666,6 +1691,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor,
   isAnonymous: true
 });
+const postIdentifier = sql.identifier("a", "post");
 const anEnumCodec = enumCodec({
   name: "anEnum",
   identifier: sql.identifier("a", "an_enum"),
@@ -1743,7 +1769,7 @@ const comptypeArrayCodec = listOfCodec(comptypeCodec, {
 });
 const spec_post = {
   name: "post",
-  identifier: sql.identifier("a", "post"),
+  identifier: postIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1911,6 +1937,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor,
   isAnonymous: true
 });
+const personIdentifier = sql.identifier("c", "person");
 const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
   description: undefined,
   extensions: {
@@ -1963,7 +1990,7 @@ const wrappedUrlCodec = recordCodec({
 });
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("c", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: "The primary unique identifier for the person",
@@ -2302,6 +2329,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor,
   isAnonymous: true
 });
+const typesIdentifier = sql.identifier("b", "types");
 const colorArrayCodec = listOfCodec(colorCodec, {
   extensions: {
     pg: {
@@ -2481,7 +2509,7 @@ const spec_types_attributes_ltree_codec_ltree = {
 const spec_types_attributes_ltree_array_codec_ltree_ = listOfCodec(spec_types_attributes_ltree_codec_ltree);
 const spec_types = {
   name: "types",
-  identifier: sql.identifier("b", "types"),
+  identifier: typesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -3089,10 +3117,10 @@ const default_valueUniques = [{
   }
 }];
 const registryConfig_pgResources_foreign_key_foreign_key = {
-  executor,
+  executor: executor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
-  from: foreignKeyCodec.sqlType,
+  from: foreignKeyIdentifier,
   codec: foreignKeyCodec,
   uniques: [],
   isVirtual: false,
@@ -3108,10 +3136,10 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   }
 };
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
-  executor,
+  executor: executor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
-  from: uniqueForeignKeyCodec.sqlType,
+  from: uniqueForeignKeyIdentifier,
   codec: uniqueForeignKeyCodec,
   uniques: [{
     isPrimary: false,
@@ -3153,10 +3181,10 @@ const person_secretUniques = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor,
+  executor: executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: personSecretCodec.sqlType,
+  from: personSecretIdentifier,
   codec: personSecretCodec,
   uniques: person_secretUniques,
   isVirtual: false,
@@ -3190,10 +3218,10 @@ const compound_keyUniques = [{
   }
 }];
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor,
+  executor: executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: compoundKeyCodec.sqlType,
+  from: compoundKeyIdentifier,
   codec: compoundKeyCodec,
   uniques: compound_keyUniques,
   isVirtual: false,
@@ -3251,10 +3279,10 @@ const left_armUniques = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor,
+  executor: executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: leftArmCodec.sqlType,
+  from: leftArmIdentifier,
   codec: leftArmCodec,
   uniques: left_armUniques,
   isVirtual: false,
@@ -3271,10 +3299,10 @@ const registryConfig_pgResources_left_arm_left_arm = {
 };
 const authenticate_failFunctionIdentifer = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
-  executor,
+  executor: executor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
-  from: jwtTokenCodec.sqlType,
+  from: jwtTokenIdentifier,
   codec: jwtTokenCodec,
   uniques: [],
   isVirtual: true,
@@ -3301,10 +3329,10 @@ const issue756Uniques = [{
   }
 }];
 const registryConfig_pgResources_issue756_issue756 = {
-  executor,
+  executor: executor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: issue756Codec.sqlType,
+  from: issue756Identifier,
   codec: issue756Codec,
   uniques: issue756Uniques,
   isVirtual: false,
@@ -3347,10 +3375,10 @@ const postUniques = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor,
+  executor: executor,
   name: "post",
   identifier: "main.a.post",
-  from: postCodec.sqlType,
+  from: postIdentifier,
   codec: postCodec,
   uniques: postUniques,
   isVirtual: false,
@@ -3367,10 +3395,10 @@ const registryConfig_pgResources_post_post = {
 };
 const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_compound_type = {
-  executor,
+  executor: executor,
   name: "compound_type",
   identifier: "main.c.compound_type",
-  from: compoundTypeCodec.sqlType,
+  from: compoundTypeIdentifier,
   codec: compoundTypeCodec,
   uniques: [],
   isVirtual: true,
@@ -3429,10 +3457,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.c.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -3466,10 +3494,10 @@ const typesUniques = [{
   }
 }];
 const registryConfig_pgResources_types_types = {
-  executor,
+  executor: executor,
   name: "types",
   identifier: "main.b.types",
-  from: typesCodec.sqlType,
+  from: typesIdentifier,
   codec: typesCodec,
   uniques: typesUniques,
   isVirtual: false,
@@ -5667,10 +5695,10 @@ const registry = makeRegistry({
       description: undefined
     },
     non_updatable_view: {
-      executor,
+      executor: executor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
-      from: nonUpdatableViewCodec.sqlType,
+      from: nonUpdatableViewIdentifier,
       codec: nonUpdatableViewCodec,
       uniques: [],
       isVirtual: false,
@@ -5688,10 +5716,10 @@ const registry = makeRegistry({
       }
     },
     inputs: {
-      executor,
+      executor: executor,
       name: "inputs",
       identifier: "main.a.inputs",
-      from: inputsCodec.sqlType,
+      from: inputsIdentifier,
       codec: inputsCodec,
       uniques: inputsUniques,
       isVirtual: false,
@@ -5707,10 +5735,10 @@ const registry = makeRegistry({
       }
     },
     patchs: {
-      executor,
+      executor: executor,
       name: "patchs",
       identifier: "main.a.patchs",
-      from: patchsCodec.sqlType,
+      from: patchsIdentifier,
       codec: patchsCodec,
       uniques: patchsUniques,
       isVirtual: false,
@@ -5726,10 +5754,10 @@ const registry = makeRegistry({
       }
     },
     reserved: {
-      executor,
+      executor: executor,
       name: "reserved",
       identifier: "main.a.reserved",
-      from: reservedCodec.sqlType,
+      from: reservedIdentifier,
       codec: reservedCodec,
       uniques: reservedUniques,
       isVirtual: false,
@@ -5745,10 +5773,10 @@ const registry = makeRegistry({
       }
     },
     reservedPatchs: {
-      executor,
+      executor: executor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
-      from: reservedPatchsCodec.sqlType,
+      from: reservedPatchsIdentifier,
       codec: reservedPatchsCodec,
       uniques: reservedPatchsUniques,
       isVirtual: false,
@@ -5764,10 +5792,10 @@ const registry = makeRegistry({
       }
     },
     reserved_input: {
-      executor,
+      executor: executor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
-      from: reservedInputCodec.sqlType,
+      from: reservedInputIdentifier,
       codec: reservedInputCodec,
       uniques: reserved_inputUniques,
       isVirtual: false,
@@ -5783,10 +5811,10 @@ const registry = makeRegistry({
       }
     },
     default_value: {
-      executor,
+      executor: executor,
       name: "default_value",
       identifier: "main.a.default_value",
-      from: defaultValueCodec.sqlType,
+      from: defaultValueIdentifier,
       codec: defaultValueCodec,
       uniques: default_valueUniques,
       isVirtual: false,
@@ -5803,10 +5831,10 @@ const registry = makeRegistry({
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
-      executor,
+      executor: executor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
-      from: noPrimaryKeyCodec.sqlType,
+      from: noPrimaryKeyIdentifier,
       codec: noPrimaryKeyCodec,
       uniques: [{
         isPrimary: false,
@@ -5829,10 +5857,10 @@ const registry = makeRegistry({
       }
     },
     testview: {
-      executor,
+      executor: executor,
       name: "testview",
       identifier: "main.a.testview",
-      from: testviewCodec.sqlType,
+      from: testviewIdentifier,
       codec: testviewCodec,
       uniques: [],
       isVirtual: false,
@@ -5849,10 +5877,10 @@ const registry = makeRegistry({
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
-      executor,
+      executor: executor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: myTableCodec.sqlType,
+      from: myTableIdentifier,
       codec: myTableCodec,
       uniques: my_tableUniques,
       isVirtual: false,
@@ -5869,10 +5897,10 @@ const registry = makeRegistry({
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
-      executor,
+      executor: executor,
       name: "view_table",
       identifier: "main.a.view_table",
-      from: viewTableCodec.sqlType,
+      from: viewTableIdentifier,
       codec: viewTableCodec,
       uniques: view_tableUniques,
       isVirtual: false,
@@ -5889,10 +5917,10 @@ const registry = makeRegistry({
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
-      executor,
+      executor: executor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
-      from: similarTable1Codec.sqlType,
+      from: similarTable1Identifier,
       codec: similarTable1Codec,
       uniques: similar_table_1Uniques,
       isVirtual: false,
@@ -5908,10 +5936,10 @@ const registry = makeRegistry({
       }
     },
     similar_table_2: {
-      executor,
+      executor: executor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
-      from: similarTable2Codec.sqlType,
+      from: similarTable2Identifier,
       codec: similarTable2Codec,
       uniques: similar_table_2Uniques,
       isVirtual: false,
@@ -5927,10 +5955,10 @@ const registry = makeRegistry({
       }
     },
     updatable_view: {
-      executor,
+      executor: executor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
-      from: updatableViewCodec.sqlType,
+      from: updatableViewIdentifier,
       codec: updatableViewCodec,
       uniques: [{
         isPrimary: false,
@@ -5958,10 +5986,10 @@ const registry = makeRegistry({
       }
     },
     null_test_record: {
-      executor,
+      executor: executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: nullTestRecordCodec.sqlType,
+      from: nullTestRecordIdentifier,
       codec: nullTestRecordCodec,
       uniques: null_test_recordUniques,
       isVirtual: false,
@@ -6067,10 +6095,10 @@ const registry = makeRegistry({
       description: undefined
     },
     edge_case: {
-      executor,
+      executor: executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: edgeCaseCodec.sqlType,
+      from: edgeCaseIdentifier,
       codec: edgeCaseCodec,
       uniques: [],
       isVirtual: false,
@@ -6260,10 +6288,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     authenticate_payload: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "auth_payload",
       identifier: "main.b.auth_payload",
-      from: authPayloadCodec.sqlType,
+      from: authPayloadIdentifier,
       codec: authPayloadCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/geometry.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/geometry.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const geomIdentifier = sql.identifier("geometry", "geom");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const spec_geom = {
   name: "geom",
-  identifier: sql.identifier("geometry", "geom"),
+  identifier: geomIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -199,10 +200,10 @@ const pgResource_geomPgResource = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     geom: {
-      executor,
+      executor: executor,
       name: "geom",
       identifier: "main.geometry.geom",
-      from: geomCodec.sqlType,
+      from: geomIdentifier,
       codec: geomCodec,
       uniques: geomUniques,
       isVirtual: false,

--- a/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.export.mjs
@@ -459,9 +459,10 @@ const textArrayCodec = listOfCodec(TYPES.text, {
   description: undefined,
   name: "textArray"
 });
+const nonUpdatableViewIdentifier = sql.identifier("a", "non_updatable_view");
 const nonUpdatableViewCodec = recordCodec({
   name: "nonUpdatableView",
-  identifier: sql.identifier("a", "non_updatable_view"),
+  identifier: nonUpdatableViewIdentifier,
   attributes: Object.assign(Object.create(null), {
     "?column?": {
       description: undefined,
@@ -487,9 +488,10 @@ const nonUpdatableViewCodec = recordCodec({
   },
   executor: executor
 });
+const inputsIdentifier = sql.identifier("a", "inputs");
 const spec_inputs = {
   name: "inputs",
-  identifier: sql.identifier("a", "inputs"),
+  identifier: inputsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -514,9 +516,10 @@ const spec_inputs = {
   executor: executor
 };
 const inputsCodec = recordCodec(spec_inputs);
+const patchsIdentifier = sql.identifier("a", "patchs");
 const spec_patchs = {
   name: "patchs",
-  identifier: sql.identifier("a", "patchs"),
+  identifier: patchsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -541,9 +544,10 @@ const spec_patchs = {
   executor: executor
 };
 const patchsCodec = recordCodec(spec_patchs);
+const reservedIdentifier = sql.identifier("a", "reserved");
 const spec_reserved = {
   name: "reserved",
-  identifier: sql.identifier("a", "reserved"),
+  identifier: reservedIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -568,9 +572,10 @@ const spec_reserved = {
   executor: executor
 };
 const reservedCodec = recordCodec(spec_reserved);
+const reservedPatchsIdentifier = sql.identifier("a", "reservedPatchs");
 const spec_reservedPatchs = {
   name: "reservedPatchs",
-  identifier: sql.identifier("a", "reservedPatchs"),
+  identifier: reservedPatchsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -595,9 +600,10 @@ const spec_reservedPatchs = {
   executor: executor
 };
 const reservedPatchsCodec = recordCodec(spec_reservedPatchs);
+const reservedInputIdentifier = sql.identifier("a", "reserved_input");
 const spec_reservedInput = {
   name: "reservedInput",
-  identifier: sql.identifier("a", "reserved_input"),
+  identifier: reservedInputIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -622,9 +628,10 @@ const spec_reservedInput = {
   executor: executor
 };
 const reservedInputCodec = recordCodec(spec_reservedInput);
+const defaultValueIdentifier = sql.identifier("a", "default_value");
 const spec_defaultValue = {
   name: "defaultValue",
-  identifier: sql.identifier("a", "default_value"),
+  identifier: defaultValueIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -660,9 +667,10 @@ const spec_defaultValue = {
   executor: executor
 };
 const defaultValueCodec = recordCodec(spec_defaultValue);
+const foreignKeyIdentifier = sql.identifier("a", "foreign_key");
 const foreignKeyCodec = recordCodec({
   name: "foreignKey",
-  identifier: sql.identifier("a", "foreign_key"),
+  identifier: foreignKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id: {
       description: undefined,
@@ -710,9 +718,10 @@ const foreignKeyCodec = recordCodec({
   },
   executor: executor
 });
+const noPrimaryKeyIdentifier = sql.identifier("a", "no_primary_key");
 const spec_noPrimaryKey = {
   name: "noPrimaryKey",
-  identifier: sql.identifier("a", "no_primary_key"),
+  identifier: noPrimaryKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -748,9 +757,10 @@ const spec_noPrimaryKey = {
   executor: executor
 };
 const noPrimaryKeyCodec = recordCodec(spec_noPrimaryKey);
+const testviewIdentifier = sql.identifier("a", "testview");
 const testviewCodec = recordCodec({
   name: "testview",
-  identifier: sql.identifier("a", "testview"),
+  identifier: testviewIdentifier,
   attributes: Object.assign(Object.create(null), {
     testviewid: {
       description: undefined,
@@ -798,9 +808,10 @@ const testviewCodec = recordCodec({
   },
   executor: executor
 });
+const uniqueForeignKeyIdentifier = sql.identifier("a", "unique_foreign_key");
 const spec_uniqueForeignKey = {
   name: "uniqueForeignKey",
-  identifier: sql.identifier("a", "unique_foreign_key"),
+  identifier: uniqueForeignKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     compound_key_1: {
       description: undefined,
@@ -839,9 +850,10 @@ const spec_uniqueForeignKey = {
   executor: executor
 };
 const uniqueForeignKeyCodec = recordCodec(spec_uniqueForeignKey);
+const myTableIdentifier = sql.identifier("c", "my_table");
 const spec_myTable = {
   name: "myTable",
-  identifier: sql.identifier("c", "my_table"),
+  identifier: myTableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -877,9 +889,10 @@ const spec_myTable = {
   executor: executor
 };
 const myTableCodec = recordCodec(spec_myTable);
+const personSecretIdentifier = sql.identifier("c", "person_secret");
 const spec_personSecret = {
   name: "personSecret",
-  identifier: sql.identifier("c", "person_secret"),
+  identifier: personSecretIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id: {
       description: undefined,
@@ -918,9 +931,10 @@ const spec_personSecret = {
   executor: executor
 };
 const personSecretCodec = recordCodec(spec_personSecret);
+const viewTableIdentifier = sql.identifier("a", "view_table");
 const spec_viewTable = {
   name: "viewTable",
-  identifier: sql.identifier("a", "view_table"),
+  identifier: viewTableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -967,9 +981,10 @@ const spec_viewTable = {
   executor: executor
 };
 const viewTableCodec = recordCodec(spec_viewTable);
+const compoundKeyIdentifier = sql.identifier("c", "compound_key");
 const spec_compoundKey = {
   name: "compoundKey",
-  identifier: sql.identifier("c", "compound_key"),
+  identifier: compoundKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id_2: {
       description: undefined,
@@ -1016,9 +1031,10 @@ const spec_compoundKey = {
   executor: executor
 };
 const compoundKeyCodec = recordCodec(spec_compoundKey);
+const similarTable1Identifier = sql.identifier("a", "similar_table_1");
 const spec_similarTable1 = {
   name: "similarTable1",
-  identifier: sql.identifier("a", "similar_table_1"),
+  identifier: similarTable1Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1076,9 +1092,10 @@ const spec_similarTable1 = {
   executor: executor
 };
 const similarTable1Codec = recordCodec(spec_similarTable1);
+const similarTable2Identifier = sql.identifier("a", "similar_table_2");
 const spec_similarTable2 = {
   name: "similarTable2",
-  identifier: sql.identifier("a", "similar_table_2"),
+  identifier: similarTable2Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1136,9 +1153,10 @@ const spec_similarTable2 = {
   executor: executor
 };
 const similarTable2Codec = recordCodec(spec_similarTable2);
+const updatableViewIdentifier = sql.identifier("b", "updatable_view");
 const updatableViewCodec = recordCodec({
   name: "updatableView",
-  identifier: sql.identifier("b", "updatable_view"),
+  identifier: updatableViewIdentifier,
   attributes: Object.assign(Object.create(null), {
     x: {
       description: undefined,
@@ -1200,9 +1218,10 @@ const updatableViewCodec = recordCodec({
   },
   executor: executor
 });
+const nullTestRecordIdentifier = sql.identifier("c", "null_test_record");
 const spec_nullTestRecord = {
   name: "nullTestRecord",
-  identifier: sql.identifier("c", "null_test_record"),
+  identifier: nullTestRecordIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1273,9 +1292,10 @@ const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   description: undefined,
   name: "uuidArray"
 });
+const edgeCaseIdentifier = sql.identifier("c", "edge_case");
 const edgeCaseCodec = recordCodec({
   name: "edgeCase",
-  identifier: sql.identifier("c", "edge_case"),
+  identifier: edgeCaseIdentifier,
   attributes: Object.assign(Object.create(null), {
     not_null_has_default: {
       description: undefined,
@@ -1323,9 +1343,10 @@ const edgeCaseCodec = recordCodec({
   },
   executor: executor
 });
+const leftArmIdentifier = sql.identifier("c", "left_arm");
 const spec_leftArm = {
   name: "leftArm",
-  identifier: sql.identifier("c", "left_arm"),
+  identifier: leftArmIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1381,9 +1402,10 @@ const spec_leftArm = {
   executor: executor
 };
 const leftArmCodec = recordCodec(spec_leftArm);
+const jwtTokenIdentifier = sql.identifier("b", "jwt_token");
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: sql.identifier("b", "jwt_token"),
+  identifier: jwtTokenIdentifier,
   attributes: Object.assign(Object.create(null), {
     role: {
       description: undefined,
@@ -1453,6 +1475,7 @@ const jwtTokenCodec = recordCodec({
   },
   executor: executor
 });
+const issue756Identifier = sql.identifier("c", "issue756");
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
   extensions: {
@@ -1467,7 +1490,7 @@ const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp
 });
 const spec_issue756 = {
   name: "issue756",
-  identifier: sql.identifier("c", "issue756"),
+  identifier: issue756Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1503,9 +1526,10 @@ const spec_issue756 = {
   executor: executor
 };
 const issue756Codec = recordCodec(spec_issue756);
+const authPayloadIdentifier = sql.identifier("b", "auth_payload");
 const authPayloadCodec = recordCodec({
   name: "authPayload",
-  identifier: sql.identifier("b", "auth_payload"),
+  identifier: authPayloadIdentifier,
   attributes: Object.assign(Object.create(null), {
     jwt: {
       description: undefined,
@@ -1555,6 +1579,7 @@ const authPayloadCodec = recordCodec({
   },
   executor: executor
 });
+const compoundTypeIdentifier = sql.identifier("c", "compound_type");
 const colorCodec = enumCodec({
   name: "color",
   identifier: sql.identifier("b", "color"),
@@ -1599,7 +1624,7 @@ const enumWithEmptyStringCodec = enumCodec({
 });
 const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: sql.identifier("c", "compound_type"),
+  identifier: compoundTypeIdentifier,
   attributes: Object.assign(Object.create(null), {
     a: {
       description: undefined,
@@ -1762,6 +1787,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor,
   isAnonymous: true
 });
+const postIdentifier = sql.identifier("a", "post");
 const anEnumCodec = enumCodec({
   name: "anEnum",
   identifier: sql.identifier("a", "an_enum"),
@@ -1843,7 +1869,7 @@ const comptypeArrayCodec = listOfCodec(comptypeCodec, {
 });
 const spec_post = {
   name: "post",
-  identifier: sql.identifier("a", "post"),
+  identifier: postIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -2019,6 +2045,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor,
   isAnonymous: true
 });
+const personIdentifier = sql.identifier("c", "person");
 const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
   description: undefined,
   extensions: {
@@ -2073,7 +2100,7 @@ const wrappedUrlCodec = recordCodec({
 });
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("c", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: "The primary unique identifier for the person",
@@ -2428,6 +2455,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor,
   isAnonymous: true
 });
+const typesIdentifier = sql.identifier("b", "types");
 const colorArrayCodec = listOfCodec(colorCodec, {
   extensions: {
     pg: {
@@ -2613,7 +2641,7 @@ const spec_types_attributes_ltree_codec_ltree = {
 const spec_types_attributes_ltree_array_codec_ltree_ = listOfCodec(spec_types_attributes_ltree_codec_ltree);
 const spec_types = {
   name: "types",
-  identifier: sql.identifier("b", "types"),
+  identifier: typesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -3317,10 +3345,10 @@ const default_valueUniques = [{
   }
 }];
 const registryConfig_pgResources_foreign_key_foreign_key = {
-  executor,
+  executor: executor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
-  from: foreignKeyCodec.sqlType,
+  from: foreignKeyIdentifier,
   codec: foreignKeyCodec,
   uniques: [],
   isVirtual: false,
@@ -3336,10 +3364,10 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   }
 };
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
-  executor,
+  executor: executor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
-  from: uniqueForeignKeyCodec.sqlType,
+  from: uniqueForeignKeyIdentifier,
   codec: uniqueForeignKeyCodec,
   uniques: [{
     isPrimary: false,
@@ -3381,10 +3409,10 @@ const person_secretUniques = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor,
+  executor: executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: personSecretCodec.sqlType,
+  from: personSecretIdentifier,
   codec: personSecretCodec,
   uniques: person_secretUniques,
   isVirtual: false,
@@ -3418,10 +3446,10 @@ const compound_keyUniques = [{
   }
 }];
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor,
+  executor: executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: compoundKeyCodec.sqlType,
+  from: compoundKeyIdentifier,
   codec: compoundKeyCodec,
   uniques: compound_keyUniques,
   isVirtual: false,
@@ -3479,10 +3507,10 @@ const left_armUniques = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor,
+  executor: executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: leftArmCodec.sqlType,
+  from: leftArmIdentifier,
   codec: leftArmCodec,
   uniques: left_armUniques,
   isVirtual: false,
@@ -3499,10 +3527,10 @@ const registryConfig_pgResources_left_arm_left_arm = {
 };
 const authenticate_failFunctionIdentifer = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
-  executor,
+  executor: executor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
-  from: jwtTokenCodec.sqlType,
+  from: jwtTokenIdentifier,
   codec: jwtTokenCodec,
   uniques: [],
   isVirtual: true,
@@ -3529,10 +3557,10 @@ const issue756Uniques = [{
   }
 }];
 const registryConfig_pgResources_issue756_issue756 = {
-  executor,
+  executor: executor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: issue756Codec.sqlType,
+  from: issue756Identifier,
   codec: issue756Codec,
   uniques: issue756Uniques,
   isVirtual: false,
@@ -3575,10 +3603,10 @@ const postUniques = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor,
+  executor: executor,
   name: "post",
   identifier: "main.a.post",
-  from: postCodec.sqlType,
+  from: postIdentifier,
   codec: postCodec,
   uniques: postUniques,
   isVirtual: false,
@@ -3595,10 +3623,10 @@ const registryConfig_pgResources_post_post = {
 };
 const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_compound_type = {
-  executor,
+  executor: executor,
   name: "compound_type",
   identifier: "main.c.compound_type",
-  from: compoundTypeCodec.sqlType,
+  from: compoundTypeIdentifier,
   codec: compoundTypeCodec,
   uniques: [],
   isVirtual: true,
@@ -3656,10 +3684,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.c.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -3693,10 +3721,10 @@ const typesUniques = [{
   }
 }];
 const registryConfig_pgResources_types_types = {
-  executor,
+  executor: executor,
   name: "types",
   identifier: "main.b.types",
-  from: typesCodec.sqlType,
+  from: typesIdentifier,
   codec: typesCodec,
   uniques: typesUniques,
   isVirtual: false,
@@ -5918,10 +5946,10 @@ const registry = makeRegistry({
       description: undefined
     },
     non_updatable_view: {
-      executor,
+      executor: executor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
-      from: nonUpdatableViewCodec.sqlType,
+      from: nonUpdatableViewIdentifier,
       codec: nonUpdatableViewCodec,
       uniques: [],
       isVirtual: false,
@@ -5939,10 +5967,10 @@ const registry = makeRegistry({
       }
     },
     inputs: {
-      executor,
+      executor: executor,
       name: "inputs",
       identifier: "main.a.inputs",
-      from: inputsCodec.sqlType,
+      from: inputsIdentifier,
       codec: inputsCodec,
       uniques: inputsUniques,
       isVirtual: false,
@@ -5958,10 +5986,10 @@ const registry = makeRegistry({
       }
     },
     patchs: {
-      executor,
+      executor: executor,
       name: "patchs",
       identifier: "main.a.patchs",
-      from: patchsCodec.sqlType,
+      from: patchsIdentifier,
       codec: patchsCodec,
       uniques: patchsUniques,
       isVirtual: false,
@@ -5977,10 +6005,10 @@ const registry = makeRegistry({
       }
     },
     reserved: {
-      executor,
+      executor: executor,
       name: "reserved",
       identifier: "main.a.reserved",
-      from: reservedCodec.sqlType,
+      from: reservedIdentifier,
       codec: reservedCodec,
       uniques: reservedUniques,
       isVirtual: false,
@@ -5996,10 +6024,10 @@ const registry = makeRegistry({
       }
     },
     reservedPatchs: {
-      executor,
+      executor: executor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
-      from: reservedPatchsCodec.sqlType,
+      from: reservedPatchsIdentifier,
       codec: reservedPatchsCodec,
       uniques: reservedPatchsUniques,
       isVirtual: false,
@@ -6015,10 +6043,10 @@ const registry = makeRegistry({
       }
     },
     reserved_input: {
-      executor,
+      executor: executor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
-      from: reservedInputCodec.sqlType,
+      from: reservedInputIdentifier,
       codec: reservedInputCodec,
       uniques: reserved_inputUniques,
       isVirtual: false,
@@ -6034,10 +6062,10 @@ const registry = makeRegistry({
       }
     },
     default_value: {
-      executor,
+      executor: executor,
       name: "default_value",
       identifier: "main.a.default_value",
-      from: defaultValueCodec.sqlType,
+      from: defaultValueIdentifier,
       codec: defaultValueCodec,
       uniques: default_valueUniques,
       isVirtual: false,
@@ -6054,10 +6082,10 @@ const registry = makeRegistry({
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
-      executor,
+      executor: executor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
-      from: noPrimaryKeyCodec.sqlType,
+      from: noPrimaryKeyIdentifier,
       codec: noPrimaryKeyCodec,
       uniques: [{
         isPrimary: false,
@@ -6080,10 +6108,10 @@ const registry = makeRegistry({
       }
     },
     testview: {
-      executor,
+      executor: executor,
       name: "testview",
       identifier: "main.a.testview",
-      from: testviewCodec.sqlType,
+      from: testviewIdentifier,
       codec: testviewCodec,
       uniques: [],
       isVirtual: false,
@@ -6100,10 +6128,10 @@ const registry = makeRegistry({
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
-      executor,
+      executor: executor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: myTableCodec.sqlType,
+      from: myTableIdentifier,
       codec: myTableCodec,
       uniques: my_tableUniques,
       isVirtual: false,
@@ -6120,10 +6148,10 @@ const registry = makeRegistry({
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
-      executor,
+      executor: executor,
       name: "view_table",
       identifier: "main.a.view_table",
-      from: viewTableCodec.sqlType,
+      from: viewTableIdentifier,
       codec: viewTableCodec,
       uniques: view_tableUniques,
       isVirtual: false,
@@ -6140,10 +6168,10 @@ const registry = makeRegistry({
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
-      executor,
+      executor: executor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
-      from: similarTable1Codec.sqlType,
+      from: similarTable1Identifier,
       codec: similarTable1Codec,
       uniques: similar_table_1Uniques,
       isVirtual: false,
@@ -6159,10 +6187,10 @@ const registry = makeRegistry({
       }
     },
     similar_table_2: {
-      executor,
+      executor: executor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
-      from: similarTable2Codec.sqlType,
+      from: similarTable2Identifier,
       codec: similarTable2Codec,
       uniques: similar_table_2Uniques,
       isVirtual: false,
@@ -6178,10 +6206,10 @@ const registry = makeRegistry({
       }
     },
     updatable_view: {
-      executor,
+      executor: executor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
-      from: updatableViewCodec.sqlType,
+      from: updatableViewIdentifier,
       codec: updatableViewCodec,
       uniques: [{
         isPrimary: false,
@@ -6209,10 +6237,10 @@ const registry = makeRegistry({
       }
     },
     null_test_record: {
-      executor,
+      executor: executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: nullTestRecordCodec.sqlType,
+      from: nullTestRecordIdentifier,
       codec: nullTestRecordCodec,
       uniques: null_test_recordUniques,
       isVirtual: false,
@@ -6318,10 +6346,10 @@ const registry = makeRegistry({
       description: undefined
     },
     edge_case: {
-      executor,
+      executor: executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: edgeCaseCodec.sqlType,
+      from: edgeCaseIdentifier,
       codec: edgeCaseCodec,
       uniques: [],
       isVirtual: false,
@@ -6511,10 +6539,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     authenticate_payload: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "auth_payload",
       identifier: "main.b.auth_payload",
-      from: authPayloadCodec.sqlType,
+      from: authPayloadIdentifier,
       codec: authPayloadCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/indexes.index_expressions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/indexes.index_expressions.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const employeeIdentifier = sql.identifier("index_expressions", "employee");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const spec_employee = {
   name: "employee",
-  identifier: sql.identifier("index_expressions", "employee"),
+  identifier: employeeIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -138,10 +139,10 @@ const pgResource_employeePgResource = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     employee: {
-      executor,
+      executor: executor,
       name: "employee",
       identifier: "main.index_expressions.employee",
-      from: employeeCodec.sqlType,
+      from: employeeIdentifier,
       codec: employeeCodec,
       uniques: employeeUniques,
       isVirtual: false,

--- a/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.export.mjs
@@ -459,9 +459,10 @@ const textArrayCodec = listOfCodec(TYPES.text, {
   description: undefined,
   name: "textArray"
 });
+const nonUpdatableViewIdentifier = sql.identifier("a", "non_updatable_view");
 const spec_nonUpdatableView = {
   name: "nonUpdatableView",
-  identifier: sql.identifier("a", "non_updatable_view"),
+  identifier: nonUpdatableViewIdentifier,
   attributes: Object.assign(Object.create(null), {
     "?column?": {
       description: undefined,
@@ -486,9 +487,10 @@ const spec_nonUpdatableView = {
   executor: executor
 };
 const nonUpdatableViewCodec = recordCodec(spec_nonUpdatableView);
+const inputsIdentifier = sql.identifier("a", "inputs");
 const spec_inputs = {
   name: "inputs",
-  identifier: sql.identifier("a", "inputs"),
+  identifier: inputsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -513,9 +515,10 @@ const spec_inputs = {
   executor: executor
 };
 const inputsCodec = recordCodec(spec_inputs);
+const patchsIdentifier = sql.identifier("a", "patchs");
 const spec_patchs = {
   name: "patchs",
-  identifier: sql.identifier("a", "patchs"),
+  identifier: patchsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -540,9 +543,10 @@ const spec_patchs = {
   executor: executor
 };
 const patchsCodec = recordCodec(spec_patchs);
+const reservedIdentifier = sql.identifier("a", "reserved");
 const spec_reserved = {
   name: "reserved",
-  identifier: sql.identifier("a", "reserved"),
+  identifier: reservedIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -567,9 +571,10 @@ const spec_reserved = {
   executor: executor
 };
 const reservedCodec = recordCodec(spec_reserved);
+const reservedPatchsIdentifier = sql.identifier("a", "reservedPatchs");
 const spec_reservedPatchs = {
   name: "reservedPatchs",
-  identifier: sql.identifier("a", "reservedPatchs"),
+  identifier: reservedPatchsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -594,9 +599,10 @@ const spec_reservedPatchs = {
   executor: executor
 };
 const reservedPatchsCodec = recordCodec(spec_reservedPatchs);
+const reservedInputIdentifier = sql.identifier("a", "reserved_input");
 const spec_reservedInput = {
   name: "reservedInput",
-  identifier: sql.identifier("a", "reserved_input"),
+  identifier: reservedInputIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -621,9 +627,10 @@ const spec_reservedInput = {
   executor: executor
 };
 const reservedInputCodec = recordCodec(spec_reservedInput);
+const defaultValueIdentifier = sql.identifier("a", "default_value");
 const spec_defaultValue = {
   name: "defaultValue",
-  identifier: sql.identifier("a", "default_value"),
+  identifier: defaultValueIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -657,9 +664,10 @@ const spec_defaultValue = {
   executor: executor
 };
 const defaultValueCodec = recordCodec(spec_defaultValue);
+const foreignKeyIdentifier = sql.identifier("a", "foreign_key");
 const spec_foreignKey = {
   name: "foreignKey",
-  identifier: sql.identifier("a", "foreign_key"),
+  identifier: foreignKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id: {
       description: undefined,
@@ -702,9 +710,10 @@ const spec_foreignKey = {
   executor: executor
 };
 const foreignKeyCodec = recordCodec(spec_foreignKey);
+const noPrimaryKeyIdentifier = sql.identifier("a", "no_primary_key");
 const spec_noPrimaryKey = {
   name: "noPrimaryKey",
-  identifier: sql.identifier("a", "no_primary_key"),
+  identifier: noPrimaryKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -738,9 +747,10 @@ const spec_noPrimaryKey = {
   executor: executor
 };
 const noPrimaryKeyCodec = recordCodec(spec_noPrimaryKey);
+const testviewIdentifier = sql.identifier("a", "testview");
 const spec_testview = {
   name: "testview",
-  identifier: sql.identifier("a", "testview"),
+  identifier: testviewIdentifier,
   attributes: Object.assign(Object.create(null), {
     testviewid: {
       description: undefined,
@@ -783,9 +793,10 @@ const spec_testview = {
   executor: executor
 };
 const testviewCodec = recordCodec(spec_testview);
+const uniqueForeignKeyIdentifier = sql.identifier("a", "unique_foreign_key");
 const spec_uniqueForeignKey = {
   name: "uniqueForeignKey",
-  identifier: sql.identifier("a", "unique_foreign_key"),
+  identifier: uniqueForeignKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     compound_key_1: {
       description: undefined,
@@ -822,9 +833,10 @@ const spec_uniqueForeignKey = {
   executor: executor
 };
 const uniqueForeignKeyCodec = recordCodec(spec_uniqueForeignKey);
+const myTableIdentifier = sql.identifier("c", "my_table");
 const spec_myTable = {
   name: "myTable",
-  identifier: sql.identifier("c", "my_table"),
+  identifier: myTableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -858,9 +870,10 @@ const spec_myTable = {
   executor: executor
 };
 const myTableCodec = recordCodec(spec_myTable);
+const personSecretIdentifier = sql.identifier("c", "person_secret");
 const spec_personSecret = {
   name: "personSecret",
-  identifier: sql.identifier("c", "person_secret"),
+  identifier: personSecretIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id: {
       description: undefined,
@@ -898,9 +911,10 @@ const spec_personSecret = {
   executor: executor
 };
 const personSecretCodec = recordCodec(spec_personSecret);
+const viewTableIdentifier = sql.identifier("a", "view_table");
 const spec_viewTable = {
   name: "viewTable",
-  identifier: sql.identifier("a", "view_table"),
+  identifier: viewTableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -943,9 +957,10 @@ const spec_viewTable = {
   executor: executor
 };
 const viewTableCodec = recordCodec(spec_viewTable);
+const compoundKeyIdentifier = sql.identifier("c", "compound_key");
 const spec_compoundKey = {
   name: "compoundKey",
-  identifier: sql.identifier("c", "compound_key"),
+  identifier: compoundKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id_2: {
       description: undefined,
@@ -988,9 +1003,10 @@ const spec_compoundKey = {
   executor: executor
 };
 const compoundKeyCodec = recordCodec(spec_compoundKey);
+const similarTable1Identifier = sql.identifier("a", "similar_table_1");
 const spec_similarTable1 = {
   name: "similarTable1",
-  identifier: sql.identifier("a", "similar_table_1"),
+  identifier: similarTable1Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1042,9 +1058,10 @@ const spec_similarTable1 = {
   executor: executor
 };
 const similarTable1Codec = recordCodec(spec_similarTable1);
+const similarTable2Identifier = sql.identifier("a", "similar_table_2");
 const spec_similarTable2 = {
   name: "similarTable2",
-  identifier: sql.identifier("a", "similar_table_2"),
+  identifier: similarTable2Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1096,9 +1113,10 @@ const spec_similarTable2 = {
   executor: executor
 };
 const similarTable2Codec = recordCodec(spec_similarTable2);
+const updatableViewIdentifier = sql.identifier("b", "updatable_view");
 const spec_updatableView = {
   name: "updatableView",
-  identifier: sql.identifier("b", "updatable_view"),
+  identifier: updatableViewIdentifier,
   attributes: Object.assign(Object.create(null), {
     x: {
       description: undefined,
@@ -1153,9 +1171,10 @@ const spec_updatableView = {
   executor: executor
 };
 const updatableViewCodec = recordCodec(spec_updatableView);
+const nullTestRecordIdentifier = sql.identifier("c", "null_test_record");
 const spec_nullTestRecord = {
   name: "nullTestRecord",
-  identifier: sql.identifier("c", "null_test_record"),
+  identifier: nullTestRecordIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1220,9 +1239,10 @@ const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   description: undefined,
   name: "uuidArray"
 });
+const edgeCaseIdentifier = sql.identifier("c", "edge_case");
 const spec_edgeCase = {
   name: "edgeCase",
-  identifier: sql.identifier("c", "edge_case"),
+  identifier: edgeCaseIdentifier,
   attributes: Object.assign(Object.create(null), {
     not_null_has_default: {
       description: undefined,
@@ -1265,9 +1285,10 @@ const spec_edgeCase = {
   executor: executor
 };
 const edgeCaseCodec = recordCodec(spec_edgeCase);
+const leftArmIdentifier = sql.identifier("c", "left_arm");
 const spec_leftArm = {
   name: "leftArm",
-  identifier: sql.identifier("c", "left_arm"),
+  identifier: leftArmIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1319,9 +1340,10 @@ const spec_leftArm = {
   executor: executor
 };
 const leftArmCodec = recordCodec(spec_leftArm);
+const jwtTokenIdentifier = sql.identifier("b", "jwt_token");
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: sql.identifier("b", "jwt_token"),
+  identifier: jwtTokenIdentifier,
   attributes: Object.assign(Object.create(null), {
     role: {
       description: undefined,
@@ -1381,6 +1403,7 @@ const jwtTokenCodec = recordCodec({
   },
   executor: executor
 });
+const issue756Identifier = sql.identifier("c", "issue756");
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
   extensions: {
@@ -1395,7 +1418,7 @@ const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp
 });
 const spec_issue756 = {
   name: "issue756",
-  identifier: sql.identifier("c", "issue756"),
+  identifier: issue756Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1429,9 +1452,10 @@ const spec_issue756 = {
   executor: executor
 };
 const issue756Codec = recordCodec(spec_issue756);
+const authPayloadIdentifier = sql.identifier("b", "auth_payload");
 const authPayloadCodec = recordCodec({
   name: "authPayload",
-  identifier: sql.identifier("b", "auth_payload"),
+  identifier: authPayloadIdentifier,
   attributes: Object.assign(Object.create(null), {
     jwt: {
       description: undefined,
@@ -1475,6 +1499,7 @@ const authPayloadCodec = recordCodec({
   },
   executor: executor
 });
+const compoundTypeIdentifier = sql.identifier("c", "compound_type");
 const colorCodec = enumCodec({
   name: "color",
   identifier: sql.identifier("b", "color"),
@@ -1519,7 +1544,7 @@ const enumWithEmptyStringCodec = enumCodec({
 });
 const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: sql.identifier("c", "compound_type"),
+  identifier: compoundTypeIdentifier,
   attributes: Object.assign(Object.create(null), {
     a: {
       description: undefined,
@@ -1666,6 +1691,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor,
   isAnonymous: true
 });
+const postIdentifier = sql.identifier("a", "post");
 const anEnumCodec = enumCodec({
   name: "anEnum",
   identifier: sql.identifier("a", "an_enum"),
@@ -1743,7 +1769,7 @@ const comptypeArrayCodec = listOfCodec(comptypeCodec, {
 });
 const spec_post = {
   name: "post",
-  identifier: sql.identifier("a", "post"),
+  identifier: postIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1911,6 +1937,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor,
   isAnonymous: true
 });
+const personIdentifier = sql.identifier("c", "person");
 const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
   description: undefined,
   extensions: {
@@ -1963,7 +1990,7 @@ const wrappedUrlCodec = recordCodec({
 });
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("c", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: "The primary unique identifier for the person",
@@ -2302,6 +2329,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor,
   isAnonymous: true
 });
+const typesIdentifier = sql.identifier("b", "types");
 const colorArrayCodec = listOfCodec(colorCodec, {
   extensions: {
     pg: {
@@ -2481,7 +2509,7 @@ const spec_types_attributes_ltree_codec_ltree = {
 const spec_types_attributes_ltree_array_codec_ltree_ = listOfCodec(spec_types_attributes_ltree_codec_ltree);
 const spec_types = {
   name: "types",
-  identifier: sql.identifier("b", "types"),
+  identifier: typesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -3089,10 +3117,10 @@ const default_valueUniques = [{
   }
 }];
 const registryConfig_pgResources_foreign_key_foreign_key = {
-  executor,
+  executor: executor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
-  from: foreignKeyCodec.sqlType,
+  from: foreignKeyIdentifier,
   codec: foreignKeyCodec,
   uniques: [],
   isVirtual: false,
@@ -3108,10 +3136,10 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   }
 };
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
-  executor,
+  executor: executor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
-  from: uniqueForeignKeyCodec.sqlType,
+  from: uniqueForeignKeyIdentifier,
   codec: uniqueForeignKeyCodec,
   uniques: [{
     isPrimary: false,
@@ -3153,10 +3181,10 @@ const person_secretUniques = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor,
+  executor: executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: personSecretCodec.sqlType,
+  from: personSecretIdentifier,
   codec: personSecretCodec,
   uniques: person_secretUniques,
   isVirtual: false,
@@ -3190,10 +3218,10 @@ const compound_keyUniques = [{
   }
 }];
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor,
+  executor: executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: compoundKeyCodec.sqlType,
+  from: compoundKeyIdentifier,
   codec: compoundKeyCodec,
   uniques: compound_keyUniques,
   isVirtual: false,
@@ -3251,10 +3279,10 @@ const left_armUniques = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor,
+  executor: executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: leftArmCodec.sqlType,
+  from: leftArmIdentifier,
   codec: leftArmCodec,
   uniques: left_armUniques,
   isVirtual: false,
@@ -3271,10 +3299,10 @@ const registryConfig_pgResources_left_arm_left_arm = {
 };
 const authenticate_failFunctionIdentifer = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
-  executor,
+  executor: executor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
-  from: jwtTokenCodec.sqlType,
+  from: jwtTokenIdentifier,
   codec: jwtTokenCodec,
   uniques: [],
   isVirtual: true,
@@ -3301,10 +3329,10 @@ const issue756Uniques = [{
   }
 }];
 const registryConfig_pgResources_issue756_issue756 = {
-  executor,
+  executor: executor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: issue756Codec.sqlType,
+  from: issue756Identifier,
   codec: issue756Codec,
   uniques: issue756Uniques,
   isVirtual: false,
@@ -3347,10 +3375,10 @@ const postUniques = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor,
+  executor: executor,
   name: "post",
   identifier: "main.a.post",
-  from: postCodec.sqlType,
+  from: postIdentifier,
   codec: postCodec,
   uniques: postUniques,
   isVirtual: false,
@@ -3367,10 +3395,10 @@ const registryConfig_pgResources_post_post = {
 };
 const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_compound_type = {
-  executor,
+  executor: executor,
   name: "compound_type",
   identifier: "main.c.compound_type",
-  from: compoundTypeCodec.sqlType,
+  from: compoundTypeIdentifier,
   codec: compoundTypeCodec,
   uniques: [],
   isVirtual: true,
@@ -3428,10 +3456,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.c.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -3465,10 +3493,10 @@ const typesUniques = [{
   }
 }];
 const registryConfig_pgResources_types_types = {
-  executor,
+  executor: executor,
   name: "types",
   identifier: "main.b.types",
-  from: typesCodec.sqlType,
+  from: typesIdentifier,
   codec: typesCodec,
   uniques: typesUniques,
   isVirtual: false,
@@ -5666,10 +5694,10 @@ const registry = makeRegistry({
       description: undefined
     },
     non_updatable_view: {
-      executor,
+      executor: executor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
-      from: nonUpdatableViewCodec.sqlType,
+      from: nonUpdatableViewIdentifier,
       codec: nonUpdatableViewCodec,
       uniques: [],
       isVirtual: false,
@@ -5687,10 +5715,10 @@ const registry = makeRegistry({
       }
     },
     inputs: {
-      executor,
+      executor: executor,
       name: "inputs",
       identifier: "main.a.inputs",
-      from: inputsCodec.sqlType,
+      from: inputsIdentifier,
       codec: inputsCodec,
       uniques: inputsUniques,
       isVirtual: false,
@@ -5706,10 +5734,10 @@ const registry = makeRegistry({
       }
     },
     patchs: {
-      executor,
+      executor: executor,
       name: "patchs",
       identifier: "main.a.patchs",
-      from: patchsCodec.sqlType,
+      from: patchsIdentifier,
       codec: patchsCodec,
       uniques: patchsUniques,
       isVirtual: false,
@@ -5725,10 +5753,10 @@ const registry = makeRegistry({
       }
     },
     reserved: {
-      executor,
+      executor: executor,
       name: "reserved",
       identifier: "main.a.reserved",
-      from: reservedCodec.sqlType,
+      from: reservedIdentifier,
       codec: reservedCodec,
       uniques: reservedUniques,
       isVirtual: false,
@@ -5744,10 +5772,10 @@ const registry = makeRegistry({
       }
     },
     reservedPatchs: {
-      executor,
+      executor: executor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
-      from: reservedPatchsCodec.sqlType,
+      from: reservedPatchsIdentifier,
       codec: reservedPatchsCodec,
       uniques: reservedPatchsUniques,
       isVirtual: false,
@@ -5763,10 +5791,10 @@ const registry = makeRegistry({
       }
     },
     reserved_input: {
-      executor,
+      executor: executor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
-      from: reservedInputCodec.sqlType,
+      from: reservedInputIdentifier,
       codec: reservedInputCodec,
       uniques: reserved_inputUniques,
       isVirtual: false,
@@ -5782,10 +5810,10 @@ const registry = makeRegistry({
       }
     },
     default_value: {
-      executor,
+      executor: executor,
       name: "default_value",
       identifier: "main.a.default_value",
-      from: defaultValueCodec.sqlType,
+      from: defaultValueIdentifier,
       codec: defaultValueCodec,
       uniques: default_valueUniques,
       isVirtual: false,
@@ -5802,10 +5830,10 @@ const registry = makeRegistry({
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
-      executor,
+      executor: executor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
-      from: noPrimaryKeyCodec.sqlType,
+      from: noPrimaryKeyIdentifier,
       codec: noPrimaryKeyCodec,
       uniques: [{
         isPrimary: false,
@@ -5828,10 +5856,10 @@ const registry = makeRegistry({
       }
     },
     testview: {
-      executor,
+      executor: executor,
       name: "testview",
       identifier: "main.a.testview",
-      from: testviewCodec.sqlType,
+      from: testviewIdentifier,
       codec: testviewCodec,
       uniques: [],
       isVirtual: false,
@@ -5848,10 +5876,10 @@ const registry = makeRegistry({
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
-      executor,
+      executor: executor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: myTableCodec.sqlType,
+      from: myTableIdentifier,
       codec: myTableCodec,
       uniques: my_tableUniques,
       isVirtual: false,
@@ -5868,10 +5896,10 @@ const registry = makeRegistry({
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
-      executor,
+      executor: executor,
       name: "view_table",
       identifier: "main.a.view_table",
-      from: viewTableCodec.sqlType,
+      from: viewTableIdentifier,
       codec: viewTableCodec,
       uniques: view_tableUniques,
       isVirtual: false,
@@ -5888,10 +5916,10 @@ const registry = makeRegistry({
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
-      executor,
+      executor: executor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
-      from: similarTable1Codec.sqlType,
+      from: similarTable1Identifier,
       codec: similarTable1Codec,
       uniques: similar_table_1Uniques,
       isVirtual: false,
@@ -5907,10 +5935,10 @@ const registry = makeRegistry({
       }
     },
     similar_table_2: {
-      executor,
+      executor: executor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
-      from: similarTable2Codec.sqlType,
+      from: similarTable2Identifier,
       codec: similarTable2Codec,
       uniques: similar_table_2Uniques,
       isVirtual: false,
@@ -5926,10 +5954,10 @@ const registry = makeRegistry({
       }
     },
     updatable_view: {
-      executor,
+      executor: executor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
-      from: updatableViewCodec.sqlType,
+      from: updatableViewIdentifier,
       codec: updatableViewCodec,
       uniques: [{
         isPrimary: false,
@@ -5957,10 +5985,10 @@ const registry = makeRegistry({
       }
     },
     null_test_record: {
-      executor,
+      executor: executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: nullTestRecordCodec.sqlType,
+      from: nullTestRecordIdentifier,
       codec: nullTestRecordCodec,
       uniques: null_test_recordUniques,
       isVirtual: false,
@@ -6066,10 +6094,10 @@ const registry = makeRegistry({
       description: undefined
     },
     edge_case: {
-      executor,
+      executor: executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: edgeCaseCodec.sqlType,
+      from: edgeCaseIdentifier,
       codec: edgeCaseCodec,
       uniques: [],
       isVirtual: false,
@@ -6259,10 +6287,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     authenticate_payload: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "auth_payload",
       identifier: "main.b.auth_payload",
-      from: authPayloadCodec.sqlType,
+      from: authPayloadIdentifier,
       codec: authPayloadCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/js-reserved.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/js-reserved.1.export.mjs
@@ -20,6 +20,7 @@ const handler_codec_base64JSON = {
     return base64JSONDecode;
   })()
 };
+const relationalTopicsIdentifier = sql.identifier("js_reserved", "relational_topics");
 const itemTypeCodec = enumCodec({
   name: "itemType",
   identifier: sql.identifier("js_reserved", "item_type"),
@@ -46,7 +47,7 @@ const executor = new PgExecutor({
 });
 const spec_relationalTopics = {
   name: "relationalTopics",
-  identifier: sql.identifier("js_reserved", "relational_topics"),
+  identifier: relationalTopicsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -104,9 +105,10 @@ const spec_relationalTopics = {
   executor: executor
 };
 const relationalTopicsCodec = recordCodec(spec_relationalTopics);
+const __proto__Identifier = sql.identifier("js_reserved", "__proto__");
 const spec___proto__ = {
   name: "__proto__",
-  identifier: sql.identifier("js_reserved", "__proto__"),
+  identifier: __proto__Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -149,9 +151,10 @@ const spec___proto__ = {
   executor: executor
 };
 const __proto__Codec = recordCodec(spec___proto__);
+const buildingIdentifier = sql.identifier("js_reserved", "building");
 const spec_building = {
   name: "building",
-  identifier: sql.identifier("js_reserved", "building"),
+  identifier: buildingIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -194,9 +197,10 @@ const spec_building = {
   executor: executor
 };
 const buildingCodec = recordCodec(spec_building);
+const constructorIdentifier = sql.identifier("js_reserved", "constructor");
 const spec_constructor = {
   name: "constructor",
-  identifier: sql.identifier("js_reserved", "constructor"),
+  identifier: constructorIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -239,9 +243,10 @@ const spec_constructor = {
   executor: executor
 };
 const constructorCodec = recordCodec(spec_constructor);
+const cropIdentifier = sql.identifier("js_reserved", "crop");
 const spec_crop = {
   name: "crop",
-  identifier: sql.identifier("js_reserved", "crop"),
+  identifier: cropIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -284,9 +289,10 @@ const spec_crop = {
   executor: executor
 };
 const cropCodec = recordCodec(spec_crop);
+const machineIdentifier = sql.identifier("js_reserved", "machine");
 const spec_machine = {
   name: "machine",
-  identifier: sql.identifier("js_reserved", "machine"),
+  identifier: machineIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -329,9 +335,10 @@ const spec_machine = {
   executor: executor
 };
 const machineCodec = recordCodec(spec_machine);
+const materialIdentifier = sql.identifier("js_reserved", "material");
 const spec_material = {
   name: "material",
-  identifier: sql.identifier("js_reserved", "material"),
+  identifier: materialIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -374,9 +381,10 @@ const spec_material = {
   executor: executor
 };
 const materialCodec = recordCodec(spec_material);
+const nullIdentifier = sql.identifier("js_reserved", "null");
 const spec_null = {
   name: "null",
-  identifier: sql.identifier("js_reserved", "null"),
+  identifier: nullIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -419,9 +427,10 @@ const spec_null = {
   executor: executor
 };
 const nullCodec = recordCodec(spec_null);
+const projectIdentifier = sql.identifier("js_reserved", "project");
 const spec_project = {
   name: "project",
-  identifier: sql.identifier("js_reserved", "project"),
+  identifier: projectIdentifier,
   attributes: Object.fromEntries([["id", {
     description: undefined,
     codec: TYPES.int,
@@ -460,9 +469,10 @@ const spec_project = {
   executor: executor
 };
 const projectCodec = recordCodec(spec_project);
+const relationalStatusIdentifier = sql.identifier("js_reserved", "relational_status");
 const spec_relationalStatus = {
   name: "relationalStatus",
-  identifier: sql.identifier("js_reserved", "relational_status"),
+  identifier: relationalStatusIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -529,9 +539,10 @@ const spec_relationalStatus = {
   executor: executor
 };
 const relationalStatusCodec = recordCodec(spec_relationalStatus);
+const yieldIdentifier = sql.identifier("js_reserved", "yield");
 const spec_yield = {
   name: "yield",
-  identifier: sql.identifier("js_reserved", "yield"),
+  identifier: yieldIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -574,9 +585,10 @@ const spec_yield = {
   executor: executor
 };
 const yieldCodec = recordCodec(spec_yield);
+const reservedIdentifier = sql.identifier("js_reserved", "reserved");
 const spec_reserved = {
   name: "reserved",
-  identifier: sql.identifier("js_reserved", "reserved"),
+  identifier: reservedIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -628,9 +640,10 @@ const spec_reserved = {
   executor: executor
 };
 const reservedCodec = recordCodec(spec_reserved);
+const relationalItemsIdentifier = sql.identifier("js_reserved", "relational_items");
 const spec_relationalItems = {
   name: "relationalItems",
-  identifier: sql.identifier("js_reserved", "relational_items"),
+  identifier: relationalItemsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -705,10 +718,10 @@ const relational_topicsUniques = [{
   }
 }];
 const registryConfig_pgResources_relational_topics_relational_topics = {
-  executor,
+  executor: executor,
   name: "relational_topics",
   identifier: "main.js_reserved.relational_topics",
-  from: relationalTopicsCodec.sqlType,
+  from: relationalTopicsIdentifier,
   codec: relationalTopicsCodec,
   uniques: relational_topicsUniques,
   isVirtual: false,
@@ -754,10 +767,10 @@ const buildingUniques = [{
   }
 }];
 const registryConfig_pgResources_building_building = {
-  executor,
+  executor: executor,
   name: "building",
   identifier: "main.js_reserved.building",
-  from: buildingCodec.sqlType,
+  from: buildingIdentifier,
   codec: buildingCodec,
   uniques: buildingUniques,
   isVirtual: false,
@@ -818,10 +831,10 @@ const machineUniques = [{
   }
 }];
 const registryConfig_pgResources_machine_machine = {
-  executor,
+  executor: executor,
   name: "machine",
   identifier: "main.js_reserved.machine",
-  from: machineCodec.sqlType,
+  from: machineIdentifier,
   codec: machineCodec,
   uniques: machineUniques,
   isVirtual: false,
@@ -904,10 +917,10 @@ const relational_statusUniques = [{
   }
 }];
 const registryConfig_pgResources_relational_status_relational_status = {
-  executor,
+  executor: executor,
   name: "relational_status",
   identifier: "main.js_reserved.relational_status",
-  from: relationalStatusCodec.sqlType,
+  from: relationalStatusIdentifier,
   codec: relationalStatusCodec,
   uniques: relational_statusUniques,
   isVirtual: false,
@@ -975,10 +988,10 @@ const relational_itemsUniques = [{
   }
 }];
 const registryConfig_pgResources_relational_items_relational_items = {
-  executor,
+  executor: executor,
   name: "relational_items",
   identifier: "main.js_reserved.relational_items",
-  from: relationalItemsCodec.sqlType,
+  from: relationalItemsIdentifier,
   codec: relationalItemsCodec,
   uniques: relational_itemsUniques,
   isVirtual: false,
@@ -1176,10 +1189,10 @@ const registryConfig = {
     },
     description: undefined
   }], ["relational_topics", registryConfig_pgResources_relational_topics_relational_topics], ["__proto__", {
-    executor,
+    executor: executor,
     name: "__proto__",
     identifier: "main.js_reserved.__proto__",
-    from: __proto__Codec.sqlType,
+    from: __proto__Identifier,
     codec: __proto__Codec,
     uniques: __proto__Uniques,
     isVirtual: false,
@@ -1194,10 +1207,10 @@ const registryConfig = {
       tags: {}
     }
   }], ["building", registryConfig_pgResources_building_building], ["constructor", {
-    executor,
+    executor: executor,
     name: "constructor",
     identifier: "main.js_reserved.constructor",
-    from: constructorCodec.sqlType,
+    from: constructorIdentifier,
     codec: constructorCodec,
     uniques: constructorUniques,
     isVirtual: false,
@@ -1212,10 +1225,10 @@ const registryConfig = {
       tags: {}
     }
   }], ["crop", {
-    executor,
+    executor: executor,
     name: "crop",
     identifier: "main.js_reserved.crop",
-    from: cropCodec.sqlType,
+    from: cropIdentifier,
     codec: cropCodec,
     uniques: cropUniques,
     isVirtual: false,
@@ -1230,10 +1243,10 @@ const registryConfig = {
       tags: {}
     }
   }], ["machine", registryConfig_pgResources_machine_machine], ["material", {
-    executor,
+    executor: executor,
     name: "material",
     identifier: "main.js_reserved.material",
-    from: materialCodec.sqlType,
+    from: materialIdentifier,
     codec: materialCodec,
     uniques: materialUniques,
     isVirtual: false,
@@ -1248,10 +1261,10 @@ const registryConfig = {
       tags: {}
     }
   }], ["null", {
-    executor,
+    executor: executor,
     name: "null",
     identifier: "main.js_reserved.null",
-    from: nullCodec.sqlType,
+    from: nullIdentifier,
     codec: nullCodec,
     uniques: nullUniques,
     isVirtual: false,
@@ -1266,10 +1279,10 @@ const registryConfig = {
       tags: {}
     }
   }], ["project", {
-    executor,
+    executor: executor,
     name: "project",
     identifier: "main.js_reserved.project",
-    from: projectCodec.sqlType,
+    from: projectIdentifier,
     codec: projectCodec,
     uniques: projectUniques,
     isVirtual: false,
@@ -1284,10 +1297,10 @@ const registryConfig = {
       tags: {}
     }
   }], ["relational_status", registryConfig_pgResources_relational_status_relational_status], ["yield", {
-    executor,
+    executor: executor,
     name: "yield",
     identifier: "main.js_reserved.yield",
-    from: yieldCodec.sqlType,
+    from: yieldIdentifier,
     codec: yieldCodec,
     uniques: yieldUniques,
     isVirtual: false,
@@ -1302,10 +1315,10 @@ const registryConfig = {
       tags: {}
     }
   }], ["reserved", {
-    executor,
+    executor: executor,
     name: "reserved",
     identifier: "main.js_reserved.reserved",
-    from: reservedCodec.sqlType,
+    from: reservedIdentifier,
     codec: reservedCodec,
     uniques: reservedUniques,
     isVirtual: false,

--- a/postgraphile/postgraphile/__tests__/schema/v4/jwt.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/jwt.1.export.mjs
@@ -78,6 +78,7 @@ const guidCodec = domainOfCodec(TYPES.varchar, "guid", sql.identifier("b", "guid
   },
   notNull: false
 });
+const updatableViewIdentifier = sql.identifier("b", "updatable_view");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -90,7 +91,7 @@ const executor = new PgExecutor({
 });
 const spec_updatableView = {
   name: "updatableView",
-  identifier: sql.identifier("b", "updatable_view"),
+  identifier: updatableViewIdentifier,
   attributes: Object.assign(Object.create(null), {
     x: {
       description: undefined,
@@ -145,9 +146,10 @@ const spec_updatableView = {
   executor: executor
 };
 const updatableViewCodec = recordCodec(spec_updatableView);
+const jwtTokenIdentifier = sql.identifier("b", "jwt_token");
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: sql.identifier("b", "jwt_token"),
+  identifier: jwtTokenIdentifier,
   attributes: Object.assign(Object.create(null), {
     role: {
       description: undefined,
@@ -222,9 +224,10 @@ const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   description: undefined,
   name: "uuidArray"
 });
+const authPayloadIdentifier = sql.identifier("b", "auth_payload");
 const authPayloadCodec = recordCodec({
   name: "authPayload",
-  identifier: sql.identifier("b", "auth_payload"),
+  identifier: authPayloadIdentifier,
   attributes: Object.assign(Object.create(null), {
     jwt: {
       description: undefined,
@@ -399,6 +402,7 @@ const compoundTypeCodec = recordCodec({
   },
   executor: executor
 });
+const typesIdentifier = sql.identifier("b", "types");
 const colorArrayCodec = listOfCodec(colorCodec, {
   extensions: {
     pg: {
@@ -604,7 +608,7 @@ const spec_types_attributes_ltree_codec_ltree = {
 const spec_types_attributes_ltree_array_codec_ltree_ = listOfCodec(spec_types_attributes_ltree_codec_ltree);
 const spec_types = {
   name: "types",
-  identifier: sql.identifier("b", "types"),
+  identifier: typesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1082,10 +1086,10 @@ const mult_4FunctionIdentifer = sql.identifier("b", "mult_4");
 const guid_fnFunctionIdentifer = sql.identifier("b", "guid_fn");
 const authenticate_failFunctionIdentifer = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
-  executor,
+  executor: executor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
-  from: jwtTokenCodec.sqlType,
+  from: jwtTokenIdentifier,
   codec: jwtTokenCodec,
   uniques: [],
   isVirtual: true,
@@ -1120,10 +1124,10 @@ const typesUniques = [{
   }
 }];
 const registryConfig_pgResources_types_types = {
-  executor,
+  executor: executor,
   name: "types",
   identifier: "main.b.types",
-  from: typesCodec.sqlType,
+  from: typesIdentifier,
   codec: typesCodec,
   uniques: typesUniques,
   isVirtual: false,
@@ -1438,10 +1442,10 @@ const registry = makeRegistry({
       description: undefined
     },
     updatable_view: {
-      executor,
+      executor: executor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
-      from: updatableViewCodec.sqlType,
+      from: updatableViewIdentifier,
       codec: updatableViewCodec,
       uniques: [{
         isPrimary: false,
@@ -1604,10 +1608,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     authenticate_payload: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "auth_payload",
       identifier: "main.b.auth_payload",
-      from: authPayloadCodec.sqlType,
+      from: authPayloadIdentifier,
       codec: authPayloadCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/network_types.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/network_types.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const networkIdentifier = sql.identifier("network_types", "network");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const spec_network = {
   name: "network",
-  identifier: sql.identifier("network_types", "network"),
+  identifier: networkIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -150,10 +151,10 @@ const pgResource_networkPgResource = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     network: {
-      executor,
+      executor: executor,
       name: "network",
       identifier: "main.network_types.network",
-      from: networkCodec.sqlType,
+      from: networkIdentifier,
       codec: networkCodec,
       uniques: networkUniques,
       isVirtual: false,

--- a/postgraphile/postgraphile/__tests__/schema/v4/network_types.custom.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/network_types.custom.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const networkIdentifier = sql.identifier("network_types", "network");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const spec_network = {
   name: "network",
-  identifier: sql.identifier("network_types", "network"),
+  identifier: networkIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -150,10 +151,10 @@ const pgResource_networkPgResource = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     network: {
-      executor,
+      executor: executor,
       name: "network",
       identifier: "main.network_types.network",
-      from: networkCodec.sqlType,
+      from: networkIdentifier,
       codec: networkCodec,
       uniques: networkUniques,
       isVirtual: false,

--- a/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.export.mjs
@@ -421,9 +421,10 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
   executor,
   isAnonymous: true
 });
+const myTableIdentifier = sql.identifier("c", "my_table");
 const spec_myTable = {
   name: "myTable",
-  identifier: sql.identifier("c", "my_table"),
+  identifier: myTableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -457,9 +458,10 @@ const spec_myTable = {
   executor: executor
 };
 const myTableCodec = recordCodec(spec_myTable);
+const personSecretIdentifier = sql.identifier("c", "person_secret");
 const spec_personSecret = {
   name: "personSecret",
-  identifier: sql.identifier("c", "person_secret"),
+  identifier: personSecretIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id: {
       description: undefined,
@@ -497,9 +499,10 @@ const spec_personSecret = {
   executor: executor
 };
 const personSecretCodec = recordCodec(spec_personSecret);
+const compoundKeyIdentifier = sql.identifier("c", "compound_key");
 const spec_compoundKey = {
   name: "compoundKey",
-  identifier: sql.identifier("c", "compound_key"),
+  identifier: compoundKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id_2: {
       description: undefined,
@@ -542,9 +545,10 @@ const spec_compoundKey = {
   executor: executor
 };
 const compoundKeyCodec = recordCodec(spec_compoundKey);
+const nullTestRecordIdentifier = sql.identifier("c", "null_test_record");
 const spec_nullTestRecord = {
   name: "nullTestRecord",
-  identifier: sql.identifier("c", "null_test_record"),
+  identifier: nullTestRecordIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -596,9 +600,10 @@ const spec_nullTestRecord = {
   executor: executor
 };
 const nullTestRecordCodec = recordCodec(spec_nullTestRecord);
+const edgeCaseIdentifier = sql.identifier("c", "edge_case");
 const spec_edgeCase = {
   name: "edgeCase",
-  identifier: sql.identifier("c", "edge_case"),
+  identifier: edgeCaseIdentifier,
   attributes: Object.assign(Object.create(null), {
     not_null_has_default: {
       description: undefined,
@@ -641,9 +646,10 @@ const spec_edgeCase = {
   executor: executor
 };
 const edgeCaseCodec = recordCodec(spec_edgeCase);
+const leftArmIdentifier = sql.identifier("c", "left_arm");
 const spec_leftArm = {
   name: "leftArm",
-  identifier: sql.identifier("c", "left_arm"),
+  identifier: leftArmIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -695,6 +701,7 @@ const spec_leftArm = {
   executor: executor
 };
 const leftArmCodec = recordCodec(spec_leftArm);
+const issue756Identifier = sql.identifier("c", "issue756");
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
   extensions: {
@@ -709,7 +716,7 @@ const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp
 });
 const spec_issue756 = {
   name: "issue756",
-  identifier: sql.identifier("c", "issue756"),
+  identifier: issue756Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -743,6 +750,7 @@ const spec_issue756 = {
   executor: executor
 };
 const issue756Codec = recordCodec(spec_issue756);
+const compoundTypeIdentifier = sql.identifier("c", "compound_type");
 const colorCodec = enumCodec({
   name: "color",
   identifier: sql.identifier("b", "color"),
@@ -787,7 +795,7 @@ const enumWithEmptyStringCodec = enumCodec({
 });
 const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: sql.identifier("c", "compound_type"),
+  identifier: compoundTypeIdentifier,
   attributes: Object.assign(Object.create(null), {
     a: {
       description: undefined,
@@ -1178,6 +1186,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor,
   isAnonymous: true
 });
+const personIdentifier = sql.identifier("c", "person");
 const textArrayCodec = listOfCodec(TYPES.text, {
   extensions: {
     pg: {
@@ -1243,7 +1252,7 @@ const wrappedUrlCodec = recordCodec({
 });
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("c", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: "The primary unique identifier for the person",
@@ -2307,10 +2316,10 @@ const person_secretUniques = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor,
+  executor: executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: personSecretCodec.sqlType,
+  from: personSecretIdentifier,
   codec: personSecretCodec,
   uniques: person_secretUniques,
   isVirtual: false,
@@ -2336,10 +2345,10 @@ const compound_keyUniques = [{
   }
 }];
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor,
+  executor: executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: compoundKeyCodec.sqlType,
+  from: compoundKeyIdentifier,
   codec: compoundKeyCodec,
   uniques: compound_keyUniques,
   isVirtual: false,
@@ -2380,10 +2389,10 @@ const left_armUniques = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor,
+  executor: executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: leftArmCodec.sqlType,
+  from: leftArmIdentifier,
   codec: leftArmCodec,
   uniques: left_armUniques,
   isVirtual: false,
@@ -2408,10 +2417,10 @@ const issue756Uniques = [{
   }
 }];
 const registryConfig_pgResources_issue756_issue756 = {
-  executor,
+  executor: executor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: issue756Codec.sqlType,
+  from: issue756Identifier,
   codec: issue756Codec,
   uniques: issue756Uniques,
   isVirtual: false,
@@ -2465,10 +2474,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.c.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -3546,10 +3555,10 @@ const registry = makeRegistry({
       description: undefined
     },
     my_table: {
-      executor,
+      executor: executor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: myTableCodec.sqlType,
+      from: myTableIdentifier,
       codec: myTableCodec,
       uniques: my_tableUniques,
       isVirtual: false,
@@ -3567,10 +3576,10 @@ const registry = makeRegistry({
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     null_test_record: {
-      executor,
+      executor: executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: nullTestRecordCodec.sqlType,
+      from: nullTestRecordIdentifier,
       codec: nullTestRecordCodec,
       uniques: null_test_recordUniques,
       isVirtual: false,
@@ -3637,10 +3646,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     edge_case: {
-      executor,
+      executor: executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: edgeCaseCodec.sqlType,
+      from: edgeCaseIdentifier,
       codec: edgeCaseCodec,
       uniques: [],
       isVirtual: false,
@@ -3968,10 +3977,10 @@ const registry = makeRegistry({
       description: undefined
     },
     compound_type_set_query: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "compound_type",
       identifier: "main.c.compound_type",
-      from: compoundTypeCodec.sqlType,
+      from: compoundTypeIdentifier,
       codec: compoundTypeCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const flambleIdentifier = sql.identifier("d", "flibble");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: sql.identifier("d", "flibble"),
+  identifier: flambleIdentifier,
   attributes: Object.assign(Object.create(null), {
     f: {
       description: undefined,
@@ -103,9 +104,10 @@ const flambleCodec = recordCodec({
   },
   executor: executor
 });
+const renamed_tableIdentifier = sql.identifier("d", "original_table");
 const spec_renamed_table = {
   name: "renamed_table",
-  identifier: sql.identifier("d", "original_table"),
+  identifier: renamed_tableIdentifier,
   attributes: Object.assign(Object.create(null), {
     col1: {
       description: undefined,
@@ -134,9 +136,10 @@ const spec_renamed_table = {
   executor: executor
 };
 const renamed_tableCodec = recordCodec(spec_renamed_table);
+const filmsIdentifier = sql.identifier("d", "films");
 const spec_films = {
   name: "films",
-  identifier: sql.identifier("d", "films"),
+  identifier: filmsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -170,9 +173,10 @@ const spec_films = {
   executor: executor
 };
 const filmsCodec = recordCodec(spec_films);
+const studiosIdentifier = sql.identifier("d", "studios");
 const spec_studios = {
   name: "studios",
-  identifier: sql.identifier("d", "studios"),
+  identifier: studiosIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -206,9 +210,10 @@ const spec_studios = {
   executor: executor
 };
 const studiosCodec = recordCodec(spec_studios);
+const postIdentifier = sql.identifier("d", "post");
 const spec_post = {
   name: "post",
-  identifier: sql.identifier("d", "post"),
+  identifier: postIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -251,9 +256,10 @@ const spec_post = {
   executor: executor
 };
 const postCodec = recordCodec(spec_post);
+const tvEpisodesIdentifier = sql.identifier("d", "tv_episodes");
 const spec_tvEpisodes = {
   name: "tvEpisodes",
-  identifier: sql.identifier("d", "tv_episodes"),
+  identifier: tvEpisodesIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -296,9 +302,10 @@ const spec_tvEpisodes = {
   executor: executor
 };
 const tvEpisodesCodec = recordCodec(spec_tvEpisodes);
+const tvShowsIdentifier = sql.identifier("d", "tv_shows");
 const spec_tvShows = {
   name: "tvShows",
-  identifier: sql.identifier("d", "tv_shows"),
+  identifier: tvShowsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -341,9 +348,10 @@ const spec_tvShows = {
   executor: executor
 };
 const tvShowsCodec = recordCodec(spec_tvShows);
+const jwtTokenIdentifier = sql.identifier("d", "jwt_token");
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: sql.identifier("d", "jwt_token"),
+  identifier: jwtTokenIdentifier,
   attributes: Object.assign(Object.create(null), {
     role: {
       description: undefined,
@@ -385,9 +393,10 @@ const jwtTokenCodec = recordCodec({
   },
   executor: executor
 });
+const personIdentifier = sql.identifier("d", "person");
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("d", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -533,10 +542,10 @@ const studiosUniques = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor,
+  executor: executor,
   name: "studios",
   identifier: "main.d.studios",
-  from: studiosCodec.sqlType,
+  from: studiosIdentifier,
   codec: studiosCodec,
   uniques: studiosUniques,
   isVirtual: false,
@@ -560,10 +569,10 @@ const postUniques = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor,
+  executor: executor,
   name: "post",
   identifier: "main.d.post",
-  from: postCodec.sqlType,
+  from: postIdentifier,
   codec: postCodec,
   uniques: postUniques,
   isVirtual: false,
@@ -587,10 +596,10 @@ const tv_episodesUniques = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor,
+  executor: executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: tvEpisodesCodec.sqlType,
+  from: tvEpisodesIdentifier,
   codec: tvEpisodesCodec,
   uniques: tv_episodesUniques,
   isVirtual: false,
@@ -614,10 +623,10 @@ const tv_showsUniques = [{
   }
 }];
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor,
+  executor: executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: tvShowsCodec.sqlType,
+  from: tvShowsIdentifier,
   codec: tvShowsCodec,
   uniques: tv_showsUniques,
   isVirtual: false,
@@ -646,10 +655,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.d.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -707,10 +716,10 @@ const registry = makeRegistry({
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "flamble",
       identifier: "main.d.flibble",
-      from: flambleCodec.sqlType,
+      from: flambleIdentifier,
       codec: flambleCodec,
       uniques: [],
       isVirtual: true,
@@ -750,10 +759,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     renamed_table: {
-      executor,
+      executor: executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: renamed_tableCodec.sqlType,
+      from: renamed_tableIdentifier,
       codec: renamed_tableCodec,
       uniques: [],
       isVirtual: false,
@@ -771,10 +780,10 @@ const registry = makeRegistry({
       }
     },
     films: {
-      executor,
+      executor: executor,
       name: "films",
       identifier: "main.d.films",
-      from: filmsCodec.sqlType,
+      from: filmsIdentifier,
       codec: filmsCodec,
       uniques: filmsUniques,
       isVirtual: false,
@@ -794,10 +803,10 @@ const registry = makeRegistry({
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
-      from: jwtTokenCodec.sqlType,
+      from: jwtTokenIdentifier,
       codec: jwtTokenCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const flambleIdentifier = sql.identifier("d", "flibble");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: sql.identifier("d", "flibble"),
+  identifier: flambleIdentifier,
   attributes: Object.assign(Object.create(null), {
     f: {
       description: undefined,
@@ -103,9 +104,10 @@ const flambleCodec = recordCodec({
   },
   executor: executor
 });
+const renamed_tableIdentifier = sql.identifier("d", "original_table");
 const spec_renamed_table = {
   name: "renamed_table",
-  identifier: sql.identifier("d", "original_table"),
+  identifier: renamed_tableIdentifier,
   attributes: Object.assign(Object.create(null), {
     col1: {
       description: undefined,
@@ -134,9 +136,10 @@ const spec_renamed_table = {
   executor: executor
 };
 const renamed_tableCodec = recordCodec(spec_renamed_table);
+const filmsIdentifier = sql.identifier("d", "films");
 const spec_films = {
   name: "films",
-  identifier: sql.identifier("d", "films"),
+  identifier: filmsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -170,9 +173,10 @@ const spec_films = {
   executor: executor
 };
 const filmsCodec = recordCodec(spec_films);
+const studiosIdentifier = sql.identifier("d", "studios");
 const spec_studios = {
   name: "studios",
-  identifier: sql.identifier("d", "studios"),
+  identifier: studiosIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -206,9 +210,10 @@ const spec_studios = {
   executor: executor
 };
 const studiosCodec = recordCodec(spec_studios);
+const postIdentifier = sql.identifier("d", "post");
 const spec_post = {
   name: "post",
-  identifier: sql.identifier("d", "post"),
+  identifier: postIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -251,9 +256,10 @@ const spec_post = {
   executor: executor
 };
 const postCodec = recordCodec(spec_post);
+const tvEpisodesIdentifier = sql.identifier("d", "tv_episodes");
 const spec_tvEpisodes = {
   name: "tvEpisodes",
-  identifier: sql.identifier("d", "tv_episodes"),
+  identifier: tvEpisodesIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -296,9 +302,10 @@ const spec_tvEpisodes = {
   executor: executor
 };
 const tvEpisodesCodec = recordCodec(spec_tvEpisodes);
+const tvShowsIdentifier = sql.identifier("d", "tv_shows");
 const spec_tvShows = {
   name: "tvShows",
-  identifier: sql.identifier("d", "tv_shows"),
+  identifier: tvShowsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -344,9 +351,10 @@ const spec_tvShows = {
   executor: executor
 };
 const tvShowsCodec = recordCodec(spec_tvShows);
+const jwtTokenIdentifier = sql.identifier("d", "jwt_token");
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: sql.identifier("d", "jwt_token"),
+  identifier: jwtTokenIdentifier,
   attributes: Object.assign(Object.create(null), {
     role: {
       description: undefined,
@@ -388,9 +396,10 @@ const jwtTokenCodec = recordCodec({
   },
   executor: executor
 });
+const personIdentifier = sql.identifier("d", "person");
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("d", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -536,10 +545,10 @@ const studiosUniques = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor,
+  executor: executor,
   name: "studios",
   identifier: "main.d.studios",
-  from: studiosCodec.sqlType,
+  from: studiosIdentifier,
   codec: studiosCodec,
   uniques: studiosUniques,
   isVirtual: false,
@@ -563,10 +572,10 @@ const postUniques = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor,
+  executor: executor,
   name: "post",
   identifier: "main.d.post",
-  from: postCodec.sqlType,
+  from: postIdentifier,
   codec: postCodec,
   uniques: postUniques,
   isVirtual: false,
@@ -590,10 +599,10 @@ const tv_episodesUniques = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor,
+  executor: executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: tvEpisodesCodec.sqlType,
+  from: tvEpisodesIdentifier,
   codec: tvEpisodesCodec,
   uniques: tv_episodesUniques,
   isVirtual: false,
@@ -617,10 +626,10 @@ const tv_showsUniques = [{
   }
 }];
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor,
+  executor: executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: tvShowsCodec.sqlType,
+  from: tvShowsIdentifier,
   codec: tvShowsCodec,
   uniques: tv_showsUniques,
   isVirtual: false,
@@ -649,10 +658,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.d.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -710,10 +719,10 @@ const registry = makeRegistry({
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "flamble",
       identifier: "main.d.flibble",
-      from: flambleCodec.sqlType,
+      from: flambleIdentifier,
       codec: flambleCodec,
       uniques: [],
       isVirtual: true,
@@ -753,10 +762,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     renamed_table: {
-      executor,
+      executor: executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: renamed_tableCodec.sqlType,
+      from: renamed_tableIdentifier,
       codec: renamed_tableCodec,
       uniques: [],
       isVirtual: false,
@@ -774,10 +783,10 @@ const registry = makeRegistry({
       }
     },
     films: {
-      executor,
+      executor: executor,
       name: "films",
       identifier: "main.d.films",
-      from: filmsCodec.sqlType,
+      from: filmsIdentifier,
       codec: filmsCodec,
       uniques: filmsUniques,
       isVirtual: false,
@@ -797,10 +806,10 @@ const registry = makeRegistry({
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
-      from: jwtTokenCodec.sqlType,
+      from: jwtTokenIdentifier,
       codec: jwtTokenCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.execute.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.execute.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const flambleIdentifier = sql.identifier("d", "flibble");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: sql.identifier("d", "flibble"),
+  identifier: flambleIdentifier,
   attributes: Object.assign(Object.create(null), {
     f: {
       description: undefined,
@@ -103,9 +104,10 @@ const flambleCodec = recordCodec({
   },
   executor: executor
 });
+const renamed_tableIdentifier = sql.identifier("d", "original_table");
 const spec_renamed_table = {
   name: "renamed_table",
-  identifier: sql.identifier("d", "original_table"),
+  identifier: renamed_tableIdentifier,
   attributes: Object.assign(Object.create(null), {
     col1: {
       description: undefined,
@@ -134,9 +136,10 @@ const spec_renamed_table = {
   executor: executor
 };
 const renamed_tableCodec = recordCodec(spec_renamed_table);
+const filmsIdentifier = sql.identifier("d", "films");
 const spec_films = {
   name: "films",
-  identifier: sql.identifier("d", "films"),
+  identifier: filmsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -170,9 +173,10 @@ const spec_films = {
   executor: executor
 };
 const filmsCodec = recordCodec(spec_films);
+const studiosIdentifier = sql.identifier("d", "studios");
 const spec_studios = {
   name: "studios",
-  identifier: sql.identifier("d", "studios"),
+  identifier: studiosIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -206,9 +210,10 @@ const spec_studios = {
   executor: executor
 };
 const studiosCodec = recordCodec(spec_studios);
+const postIdentifier = sql.identifier("d", "post");
 const spec_post = {
   name: "post",
-  identifier: sql.identifier("d", "post"),
+  identifier: postIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -251,9 +256,10 @@ const spec_post = {
   executor: executor
 };
 const postCodec = recordCodec(spec_post);
+const tvEpisodesIdentifier = sql.identifier("d", "tv_episodes");
 const spec_tvEpisodes = {
   name: "tvEpisodes",
-  identifier: sql.identifier("d", "tv_episodes"),
+  identifier: tvEpisodesIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -296,9 +302,10 @@ const spec_tvEpisodes = {
   executor: executor
 };
 const tvEpisodesCodec = recordCodec(spec_tvEpisodes);
+const tvShowsIdentifier = sql.identifier("d", "tv_shows");
 const spec_tvShows = {
   name: "tvShows",
-  identifier: sql.identifier("d", "tv_shows"),
+  identifier: tvShowsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -341,9 +348,10 @@ const spec_tvShows = {
   executor: executor
 };
 const tvShowsCodec = recordCodec(spec_tvShows);
+const jwtTokenIdentifier = sql.identifier("d", "jwt_token");
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: sql.identifier("d", "jwt_token"),
+  identifier: jwtTokenIdentifier,
   attributes: Object.assign(Object.create(null), {
     role: {
       description: undefined,
@@ -385,9 +393,10 @@ const jwtTokenCodec = recordCodec({
   },
   executor: executor
 });
+const personIdentifier = sql.identifier("d", "person");
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("d", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -533,10 +542,10 @@ const studiosUniques = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor,
+  executor: executor,
   name: "studios",
   identifier: "main.d.studios",
-  from: studiosCodec.sqlType,
+  from: studiosIdentifier,
   codec: studiosCodec,
   uniques: studiosUniques,
   isVirtual: false,
@@ -560,10 +569,10 @@ const postUniques = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor,
+  executor: executor,
   name: "post",
   identifier: "main.d.post",
-  from: postCodec.sqlType,
+  from: postIdentifier,
   codec: postCodec,
   uniques: postUniques,
   isVirtual: false,
@@ -587,10 +596,10 @@ const tv_episodesUniques = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor,
+  executor: executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: tvEpisodesCodec.sqlType,
+  from: tvEpisodesIdentifier,
   codec: tvEpisodesCodec,
   uniques: tv_episodesUniques,
   isVirtual: false,
@@ -614,10 +623,10 @@ const tv_showsUniques = [{
   }
 }];
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor,
+  executor: executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: tvShowsCodec.sqlType,
+  from: tvShowsIdentifier,
   codec: tvShowsCodec,
   uniques: tv_showsUniques,
   isVirtual: false,
@@ -646,10 +655,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.d.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -707,10 +716,10 @@ const registry = makeRegistry({
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "flamble",
       identifier: "main.d.flibble",
-      from: flambleCodec.sqlType,
+      from: flambleIdentifier,
       codec: flambleCodec,
       uniques: [],
       isVirtual: true,
@@ -750,10 +759,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     renamed_table: {
-      executor,
+      executor: executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: renamed_tableCodec.sqlType,
+      from: renamed_tableIdentifier,
       codec: renamed_tableCodec,
       uniques: [],
       isVirtual: false,
@@ -771,10 +780,10 @@ const registry = makeRegistry({
       }
     },
     films: {
-      executor,
+      executor: executor,
       name: "films",
       identifier: "main.d.films",
-      from: filmsCodec.sqlType,
+      from: filmsIdentifier,
       codec: filmsCodec,
       uniques: filmsUniques,
       isVirtual: false,
@@ -794,10 +803,10 @@ const registry = makeRegistry({
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
-      from: jwtTokenCodec.sqlType,
+      from: jwtTokenIdentifier,
       codec: jwtTokenCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.loads-title.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.loads-title.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const flambleIdentifier = sql.identifier("d", "flibble");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: sql.identifier("d", "flibble"),
+  identifier: flambleIdentifier,
   attributes: Object.assign(Object.create(null), {
     f: {
       description: undefined,
@@ -103,9 +104,10 @@ const flambleCodec = recordCodec({
   },
   executor: executor
 });
+const renamed_tableIdentifier = sql.identifier("d", "original_table");
 const spec_renamed_table = {
   name: "renamed_table",
-  identifier: sql.identifier("d", "original_table"),
+  identifier: renamed_tableIdentifier,
   attributes: Object.assign(Object.create(null), {
     col1: {
       description: undefined,
@@ -134,9 +136,10 @@ const spec_renamed_table = {
   executor: executor
 };
 const renamed_tableCodec = recordCodec(spec_renamed_table);
+const filmsIdentifier = sql.identifier("d", "films");
 const spec_films = {
   name: "films",
-  identifier: sql.identifier("d", "films"),
+  identifier: filmsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -170,9 +173,10 @@ const spec_films = {
   executor: executor
 };
 const filmsCodec = recordCodec(spec_films);
+const studiosIdentifier = sql.identifier("d", "studios");
 const spec_studios = {
   name: "studios",
-  identifier: sql.identifier("d", "studios"),
+  identifier: studiosIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -206,9 +210,10 @@ const spec_studios = {
   executor: executor
 };
 const studiosCodec = recordCodec(spec_studios);
+const postIdentifier = sql.identifier("d", "post");
 const spec_post = {
   name: "post",
-  identifier: sql.identifier("d", "post"),
+  identifier: postIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -251,9 +256,10 @@ const spec_post = {
   executor: executor
 };
 const postCodec = recordCodec(spec_post);
+const tvEpisodesIdentifier = sql.identifier("d", "tv_episodes");
 const spec_tvEpisodes = {
   name: "tvEpisodes",
-  identifier: sql.identifier("d", "tv_episodes"),
+  identifier: tvEpisodesIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -296,9 +302,10 @@ const spec_tvEpisodes = {
   executor: executor
 };
 const tvEpisodesCodec = recordCodec(spec_tvEpisodes);
+const tvShowsIdentifier = sql.identifier("d", "tv_shows");
 const spec_tvShows = {
   name: "tvShows",
-  identifier: sql.identifier("d", "tv_shows"),
+  identifier: tvShowsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -344,9 +351,10 @@ const spec_tvShows = {
   executor: executor
 };
 const tvShowsCodec = recordCodec(spec_tvShows);
+const jwtTokenIdentifier = sql.identifier("d", "jwt_token");
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: sql.identifier("d", "jwt_token"),
+  identifier: jwtTokenIdentifier,
   attributes: Object.assign(Object.create(null), {
     role: {
       description: undefined,
@@ -388,9 +396,10 @@ const jwtTokenCodec = recordCodec({
   },
   executor: executor
 });
+const personIdentifier = sql.identifier("d", "person");
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("d", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -536,10 +545,10 @@ const studiosUniques = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor,
+  executor: executor,
   name: "studios",
   identifier: "main.d.studios",
-  from: studiosCodec.sqlType,
+  from: studiosIdentifier,
   codec: studiosCodec,
   uniques: studiosUniques,
   isVirtual: false,
@@ -563,10 +572,10 @@ const postUniques = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor,
+  executor: executor,
   name: "post",
   identifier: "main.d.post",
-  from: postCodec.sqlType,
+  from: postIdentifier,
   codec: postCodec,
   uniques: postUniques,
   isVirtual: false,
@@ -590,10 +599,10 @@ const tv_episodesUniques = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor,
+  executor: executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: tvEpisodesCodec.sqlType,
+  from: tvEpisodesIdentifier,
   codec: tvEpisodesCodec,
   uniques: tv_episodesUniques,
   isVirtual: false,
@@ -617,10 +626,10 @@ const tv_showsUniques = [{
   }
 }];
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor,
+  executor: executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: tvShowsCodec.sqlType,
+  from: tvShowsIdentifier,
   codec: tvShowsCodec,
   uniques: tv_showsUniques,
   isVirtual: false,
@@ -649,10 +658,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.d.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -710,10 +719,10 @@ const registry = makeRegistry({
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "flamble",
       identifier: "main.d.flibble",
-      from: flambleCodec.sqlType,
+      from: flambleIdentifier,
       codec: flambleCodec,
       uniques: [],
       isVirtual: true,
@@ -753,10 +762,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     renamed_table: {
-      executor,
+      executor: executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: renamed_tableCodec.sqlType,
+      from: renamed_tableIdentifier,
       codec: renamed_tableCodec,
       uniques: [],
       isVirtual: false,
@@ -774,10 +783,10 @@ const registry = makeRegistry({
       }
     },
     films: {
-      executor,
+      executor: executor,
       name: "films",
       identifier: "main.d.films",
-      from: filmsCodec.sqlType,
+      from: filmsIdentifier,
       codec: filmsCodec,
       uniques: filmsUniques,
       isVirtual: false,
@@ -797,10 +806,10 @@ const registry = makeRegistry({
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
-      from: jwtTokenCodec.sqlType,
+      from: jwtTokenIdentifier,
       codec: jwtTokenCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.shows-title-asterisk.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.shows-title-asterisk.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const flambleIdentifier = sql.identifier("d", "flibble");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: sql.identifier("d", "flibble"),
+  identifier: flambleIdentifier,
   attributes: Object.assign(Object.create(null), {
     f: {
       description: undefined,
@@ -103,9 +104,10 @@ const flambleCodec = recordCodec({
   },
   executor: executor
 });
+const renamed_tableIdentifier = sql.identifier("d", "original_table");
 const spec_renamed_table = {
   name: "renamed_table",
-  identifier: sql.identifier("d", "original_table"),
+  identifier: renamed_tableIdentifier,
   attributes: Object.assign(Object.create(null), {
     col1: {
       description: undefined,
@@ -134,9 +136,10 @@ const spec_renamed_table = {
   executor: executor
 };
 const renamed_tableCodec = recordCodec(spec_renamed_table);
+const filmsIdentifier = sql.identifier("d", "films");
 const spec_films = {
   name: "films",
-  identifier: sql.identifier("d", "films"),
+  identifier: filmsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -170,9 +173,10 @@ const spec_films = {
   executor: executor
 };
 const filmsCodec = recordCodec(spec_films);
+const studiosIdentifier = sql.identifier("d", "studios");
 const spec_studios = {
   name: "studios",
-  identifier: sql.identifier("d", "studios"),
+  identifier: studiosIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -206,9 +210,10 @@ const spec_studios = {
   executor: executor
 };
 const studiosCodec = recordCodec(spec_studios);
+const postIdentifier = sql.identifier("d", "post");
 const spec_post = {
   name: "post",
-  identifier: sql.identifier("d", "post"),
+  identifier: postIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -251,9 +256,10 @@ const spec_post = {
   executor: executor
 };
 const postCodec = recordCodec(spec_post);
+const tvEpisodesIdentifier = sql.identifier("d", "tv_episodes");
 const spec_tvEpisodes = {
   name: "tvEpisodes",
-  identifier: sql.identifier("d", "tv_episodes"),
+  identifier: tvEpisodesIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -299,9 +305,10 @@ const spec_tvEpisodes = {
   executor: executor
 };
 const tvEpisodesCodec = recordCodec(spec_tvEpisodes);
+const tvShowsIdentifier = sql.identifier("d", "tv_shows");
 const spec_tvShows = {
   name: "tvShows",
-  identifier: sql.identifier("d", "tv_shows"),
+  identifier: tvShowsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -347,9 +354,10 @@ const spec_tvShows = {
   executor: executor
 };
 const tvShowsCodec = recordCodec(spec_tvShows);
+const jwtTokenIdentifier = sql.identifier("d", "jwt_token");
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: sql.identifier("d", "jwt_token"),
+  identifier: jwtTokenIdentifier,
   attributes: Object.assign(Object.create(null), {
     role: {
       description: undefined,
@@ -391,9 +399,10 @@ const jwtTokenCodec = recordCodec({
   },
   executor: executor
 });
+const personIdentifier = sql.identifier("d", "person");
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("d", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -539,10 +548,10 @@ const studiosUniques = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor,
+  executor: executor,
   name: "studios",
   identifier: "main.d.studios",
-  from: studiosCodec.sqlType,
+  from: studiosIdentifier,
   codec: studiosCodec,
   uniques: studiosUniques,
   isVirtual: false,
@@ -566,10 +575,10 @@ const postUniques = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor,
+  executor: executor,
   name: "post",
   identifier: "main.d.post",
-  from: postCodec.sqlType,
+  from: postIdentifier,
   codec: postCodec,
   uniques: postUniques,
   isVirtual: false,
@@ -593,10 +602,10 @@ const tv_episodesUniques = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor,
+  executor: executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: tvEpisodesCodec.sqlType,
+  from: tvEpisodesIdentifier,
   codec: tvEpisodesCodec,
   uniques: tv_episodesUniques,
   isVirtual: false,
@@ -620,10 +629,10 @@ const tv_showsUniques = [{
   }
 }];
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor,
+  executor: executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: tvShowsCodec.sqlType,
+  from: tvShowsIdentifier,
   codec: tvShowsCodec,
   uniques: tv_showsUniques,
   isVirtual: false,
@@ -652,10 +661,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.d.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -713,10 +722,10 @@ const registry = makeRegistry({
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "flamble",
       identifier: "main.d.flibble",
-      from: flambleCodec.sqlType,
+      from: flambleIdentifier,
       codec: flambleCodec,
       uniques: [],
       isVirtual: true,
@@ -756,10 +765,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     renamed_table: {
-      executor,
+      executor: executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: renamed_tableCodec.sqlType,
+      from: renamed_tableIdentifier,
       codec: renamed_tableCodec,
       uniques: [],
       isVirtual: false,
@@ -777,10 +786,10 @@ const registry = makeRegistry({
       }
     },
     films: {
-      executor,
+      executor: executor,
       name: "films",
       identifier: "main.d.films",
-      from: filmsCodec.sqlType,
+      from: filmsIdentifier,
       codec: filmsCodec,
       uniques: filmsUniques,
       isVirtual: false,
@@ -800,10 +809,10 @@ const registry = makeRegistry({
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
-      from: jwtTokenCodec.sqlType,
+      from: jwtTokenIdentifier,
       codec: jwtTokenCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.title-order.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.title-order.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const flambleIdentifier = sql.identifier("d", "flibble");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: sql.identifier("d", "flibble"),
+  identifier: flambleIdentifier,
   attributes: Object.assign(Object.create(null), {
     f: {
       description: undefined,
@@ -103,9 +104,10 @@ const flambleCodec = recordCodec({
   },
   executor: executor
 });
+const renamed_tableIdentifier = sql.identifier("d", "original_table");
 const spec_renamed_table = {
   name: "renamed_table",
-  identifier: sql.identifier("d", "original_table"),
+  identifier: renamed_tableIdentifier,
   attributes: Object.assign(Object.create(null), {
     col1: {
       description: undefined,
@@ -134,9 +136,10 @@ const spec_renamed_table = {
   executor: executor
 };
 const renamed_tableCodec = recordCodec(spec_renamed_table);
+const filmsIdentifier = sql.identifier("d", "films");
 const spec_films = {
   name: "films",
-  identifier: sql.identifier("d", "films"),
+  identifier: filmsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -170,9 +173,10 @@ const spec_films = {
   executor: executor
 };
 const filmsCodec = recordCodec(spec_films);
+const studiosIdentifier = sql.identifier("d", "studios");
 const spec_studios = {
   name: "studios",
-  identifier: sql.identifier("d", "studios"),
+  identifier: studiosIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -206,9 +210,10 @@ const spec_studios = {
   executor: executor
 };
 const studiosCodec = recordCodec(spec_studios);
+const postIdentifier = sql.identifier("d", "post");
 const spec_post = {
   name: "post",
-  identifier: sql.identifier("d", "post"),
+  identifier: postIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -251,9 +256,10 @@ const spec_post = {
   executor: executor
 };
 const postCodec = recordCodec(spec_post);
+const tvEpisodesIdentifier = sql.identifier("d", "tv_episodes");
 const spec_tvEpisodes = {
   name: "tvEpisodes",
-  identifier: sql.identifier("d", "tv_episodes"),
+  identifier: tvEpisodesIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -299,9 +305,10 @@ const spec_tvEpisodes = {
   executor: executor
 };
 const tvEpisodesCodec = recordCodec(spec_tvEpisodes);
+const tvShowsIdentifier = sql.identifier("d", "tv_shows");
 const spec_tvShows = {
   name: "tvShows",
-  identifier: sql.identifier("d", "tv_shows"),
+  identifier: tvShowsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -344,9 +351,10 @@ const spec_tvShows = {
   executor: executor
 };
 const tvShowsCodec = recordCodec(spec_tvShows);
+const jwtTokenIdentifier = sql.identifier("d", "jwt_token");
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: sql.identifier("d", "jwt_token"),
+  identifier: jwtTokenIdentifier,
   attributes: Object.assign(Object.create(null), {
     role: {
       description: undefined,
@@ -388,9 +396,10 @@ const jwtTokenCodec = recordCodec({
   },
   executor: executor
 });
+const personIdentifier = sql.identifier("d", "person");
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("d", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -536,10 +545,10 @@ const studiosUniques = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor,
+  executor: executor,
   name: "studios",
   identifier: "main.d.studios",
-  from: studiosCodec.sqlType,
+  from: studiosIdentifier,
   codec: studiosCodec,
   uniques: studiosUniques,
   isVirtual: false,
@@ -563,10 +572,10 @@ const postUniques = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor,
+  executor: executor,
   name: "post",
   identifier: "main.d.post",
-  from: postCodec.sqlType,
+  from: postIdentifier,
   codec: postCodec,
   uniques: postUniques,
   isVirtual: false,
@@ -590,10 +599,10 @@ const tv_episodesUniques = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor,
+  executor: executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: tvEpisodesCodec.sqlType,
+  from: tvEpisodesIdentifier,
   codec: tvEpisodesCodec,
   uniques: tv_episodesUniques,
   isVirtual: false,
@@ -617,10 +626,10 @@ const tv_showsUniques = [{
   }
 }];
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor,
+  executor: executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: tvShowsCodec.sqlType,
+  from: tvShowsIdentifier,
   codec: tvShowsCodec,
   uniques: tv_showsUniques,
   isVirtual: false,
@@ -649,10 +658,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.d.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -710,10 +719,10 @@ const registry = makeRegistry({
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "flamble",
       identifier: "main.d.flibble",
-      from: flambleCodec.sqlType,
+      from: flambleIdentifier,
       codec: flambleCodec,
       uniques: [],
       isVirtual: true,
@@ -753,10 +762,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     renamed_table: {
-      executor,
+      executor: executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: renamed_tableCodec.sqlType,
+      from: renamed_tableIdentifier,
       codec: renamed_tableCodec,
       uniques: [],
       isVirtual: false,
@@ -774,10 +783,10 @@ const registry = makeRegistry({
       }
     },
     films: {
-      executor,
+      executor: executor,
       name: "films",
       identifier: "main.d.films",
-      from: filmsCodec.sqlType,
+      from: filmsIdentifier,
       codec: filmsCodec,
       uniques: filmsUniques,
       isVirtual: false,
@@ -797,10 +806,10 @@ const registry = makeRegistry({
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
-      from: jwtTokenCodec.sqlType,
+      from: jwtTokenIdentifier,
       codec: jwtTokenCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.update-title.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.update-title.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const flambleIdentifier = sql.identifier("d", "flibble");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: sql.identifier("d", "flibble"),
+  identifier: flambleIdentifier,
   attributes: Object.assign(Object.create(null), {
     f: {
       description: undefined,
@@ -103,9 +104,10 @@ const flambleCodec = recordCodec({
   },
   executor: executor
 });
+const renamed_tableIdentifier = sql.identifier("d", "original_table");
 const spec_renamed_table = {
   name: "renamed_table",
-  identifier: sql.identifier("d", "original_table"),
+  identifier: renamed_tableIdentifier,
   attributes: Object.assign(Object.create(null), {
     col1: {
       description: undefined,
@@ -134,9 +136,10 @@ const spec_renamed_table = {
   executor: executor
 };
 const renamed_tableCodec = recordCodec(spec_renamed_table);
+const filmsIdentifier = sql.identifier("d", "films");
 const spec_films = {
   name: "films",
-  identifier: sql.identifier("d", "films"),
+  identifier: filmsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -170,9 +173,10 @@ const spec_films = {
   executor: executor
 };
 const filmsCodec = recordCodec(spec_films);
+const studiosIdentifier = sql.identifier("d", "studios");
 const spec_studios = {
   name: "studios",
-  identifier: sql.identifier("d", "studios"),
+  identifier: studiosIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -206,9 +210,10 @@ const spec_studios = {
   executor: executor
 };
 const studiosCodec = recordCodec(spec_studios);
+const postIdentifier = sql.identifier("d", "post");
 const spec_post = {
   name: "post",
-  identifier: sql.identifier("d", "post"),
+  identifier: postIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -251,9 +256,10 @@ const spec_post = {
   executor: executor
 };
 const postCodec = recordCodec(spec_post);
+const tvEpisodesIdentifier = sql.identifier("d", "tv_episodes");
 const spec_tvEpisodes = {
   name: "tvEpisodes",
-  identifier: sql.identifier("d", "tv_episodes"),
+  identifier: tvEpisodesIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -296,9 +302,10 @@ const spec_tvEpisodes = {
   executor: executor
 };
 const tvEpisodesCodec = recordCodec(spec_tvEpisodes);
+const tvShowsIdentifier = sql.identifier("d", "tv_shows");
 const spec_tvShows = {
   name: "tvShows",
-  identifier: sql.identifier("d", "tv_shows"),
+  identifier: tvShowsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -344,9 +351,10 @@ const spec_tvShows = {
   executor: executor
 };
 const tvShowsCodec = recordCodec(spec_tvShows);
+const jwtTokenIdentifier = sql.identifier("d", "jwt_token");
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: sql.identifier("d", "jwt_token"),
+  identifier: jwtTokenIdentifier,
   attributes: Object.assign(Object.create(null), {
     role: {
       description: undefined,
@@ -388,9 +396,10 @@ const jwtTokenCodec = recordCodec({
   },
   executor: executor
 });
+const personIdentifier = sql.identifier("d", "person");
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("d", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -536,10 +545,10 @@ const studiosUniques = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor,
+  executor: executor,
   name: "studios",
   identifier: "main.d.studios",
-  from: studiosCodec.sqlType,
+  from: studiosIdentifier,
   codec: studiosCodec,
   uniques: studiosUniques,
   isVirtual: false,
@@ -563,10 +572,10 @@ const postUniques = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor,
+  executor: executor,
   name: "post",
   identifier: "main.d.post",
-  from: postCodec.sqlType,
+  from: postIdentifier,
   codec: postCodec,
   uniques: postUniques,
   isVirtual: false,
@@ -590,10 +599,10 @@ const tv_episodesUniques = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor,
+  executor: executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: tvEpisodesCodec.sqlType,
+  from: tvEpisodesIdentifier,
   codec: tvEpisodesCodec,
   uniques: tv_episodesUniques,
   isVirtual: false,
@@ -617,10 +626,10 @@ const tv_showsUniques = [{
   }
 }];
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor,
+  executor: executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: tvShowsCodec.sqlType,
+  from: tvShowsIdentifier,
   codec: tvShowsCodec,
   uniques: tv_showsUniques,
   isVirtual: false,
@@ -649,10 +658,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.d.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -710,10 +719,10 @@ const registry = makeRegistry({
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "flamble",
       identifier: "main.d.flibble",
-      from: flambleCodec.sqlType,
+      from: flambleIdentifier,
       codec: flambleCodec,
       uniques: [],
       isVirtual: true,
@@ -753,10 +762,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     renamed_table: {
-      executor,
+      executor: executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: renamed_tableCodec.sqlType,
+      from: renamed_tableIdentifier,
       codec: renamed_tableCodec,
       uniques: [],
       isVirtual: false,
@@ -774,10 +783,10 @@ const registry = makeRegistry({
       }
     },
     films: {
-      executor,
+      executor: executor,
       name: "films",
       identifier: "main.d.films",
-      from: filmsCodec.sqlType,
+      from: filmsIdentifier,
       codec: filmsCodec,
       uniques: filmsUniques,
       isVirtual: false,
@@ -797,10 +806,10 @@ const registry = makeRegistry({
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
-      from: jwtTokenCodec.sqlType,
+      from: jwtTokenIdentifier,
       codec: jwtTokenCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const flambleIdentifier = sql.identifier("d", "flibble");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: sql.identifier("d", "flibble"),
+  identifier: flambleIdentifier,
   attributes: Object.assign(Object.create(null), {
     f: {
       description: undefined,
@@ -103,9 +104,10 @@ const flambleCodec = recordCodec({
   },
   executor: executor
 });
+const renamed_tableIdentifier = sql.identifier("d", "original_table");
 const spec_renamed_table = {
   name: "renamed_table",
-  identifier: sql.identifier("d", "original_table"),
+  identifier: renamed_tableIdentifier,
   attributes: Object.assign(Object.create(null), {
     col1: {
       description: undefined,
@@ -134,9 +136,10 @@ const spec_renamed_table = {
   executor: executor
 };
 const renamed_tableCodec = recordCodec(spec_renamed_table);
+const filmsIdentifier = sql.identifier("d", "films");
 const spec_films = {
   name: "films",
-  identifier: sql.identifier("d", "films"),
+  identifier: filmsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -173,9 +176,10 @@ const spec_films = {
   executor: executor
 };
 const filmsCodec = recordCodec(spec_films);
+const studiosIdentifier = sql.identifier("d", "studios");
 const spec_studios = {
   name: "studios",
-  identifier: sql.identifier("d", "studios"),
+  identifier: studiosIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -209,9 +213,10 @@ const spec_studios = {
   executor: executor
 };
 const studiosCodec = recordCodec(spec_studios);
+const postIdentifier = sql.identifier("d", "post");
 const spec_post = {
   name: "post",
-  identifier: sql.identifier("d", "post"),
+  identifier: postIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -254,9 +259,10 @@ const spec_post = {
   executor: executor
 };
 const postCodec = recordCodec(spec_post);
+const tvEpisodesIdentifier = sql.identifier("d", "tv_episodes");
 const spec_tvEpisodes = {
   name: "tvEpisodes",
-  identifier: sql.identifier("d", "tv_episodes"),
+  identifier: tvEpisodesIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -299,9 +305,10 @@ const spec_tvEpisodes = {
   executor: executor
 };
 const tvEpisodesCodec = recordCodec(spec_tvEpisodes);
+const tvShowsIdentifier = sql.identifier("d", "tv_shows");
 const spec_tvShows = {
   name: "tvShows",
-  identifier: sql.identifier("d", "tv_shows"),
+  identifier: tvShowsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -344,9 +351,10 @@ const spec_tvShows = {
   executor: executor
 };
 const tvShowsCodec = recordCodec(spec_tvShows);
+const jwtTokenIdentifier = sql.identifier("d", "jwt_token");
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: sql.identifier("d", "jwt_token"),
+  identifier: jwtTokenIdentifier,
   attributes: Object.assign(Object.create(null), {
     role: {
       description: undefined,
@@ -388,9 +396,10 @@ const jwtTokenCodec = recordCodec({
   },
   executor: executor
 });
+const personIdentifier = sql.identifier("d", "person");
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("d", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -536,10 +545,10 @@ const studiosUniques = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor,
+  executor: executor,
   name: "studios",
   identifier: "main.d.studios",
-  from: studiosCodec.sqlType,
+  from: studiosIdentifier,
   codec: studiosCodec,
   uniques: studiosUniques,
   isVirtual: false,
@@ -563,10 +572,10 @@ const postUniques = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor,
+  executor: executor,
   name: "post",
   identifier: "main.d.post",
-  from: postCodec.sqlType,
+  from: postIdentifier,
   codec: postCodec,
   uniques: postUniques,
   isVirtual: false,
@@ -590,10 +599,10 @@ const tv_episodesUniques = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor,
+  executor: executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: tvEpisodesCodec.sqlType,
+  from: tvEpisodesIdentifier,
   codec: tvEpisodesCodec,
   uniques: tv_episodesUniques,
   isVirtual: false,
@@ -617,10 +626,10 @@ const tv_showsUniques = [{
   }
 }];
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor,
+  executor: executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: tvShowsCodec.sqlType,
+  from: tvShowsIdentifier,
   codec: tvShowsCodec,
   uniques: tv_showsUniques,
   isVirtual: false,
@@ -649,10 +658,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.d.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -710,10 +719,10 @@ const registry = makeRegistry({
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "flamble",
       identifier: "main.d.flibble",
-      from: flambleCodec.sqlType,
+      from: flambleIdentifier,
       codec: flambleCodec,
       uniques: [],
       isVirtual: true,
@@ -753,10 +762,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     renamed_table: {
-      executor,
+      executor: executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: renamed_tableCodec.sqlType,
+      from: renamed_tableIdentifier,
       codec: renamed_tableCodec,
       uniques: [],
       isVirtual: false,
@@ -774,10 +783,10 @@ const registry = makeRegistry({
       }
     },
     films: {
-      executor,
+      executor: executor,
       name: "films",
       identifier: "main.d.films",
-      from: filmsCodec.sqlType,
+      from: filmsIdentifier,
       codec: filmsCodec,
       uniques: filmsUniques,
       isVirtual: false,
@@ -800,10 +809,10 @@ const registry = makeRegistry({
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
-      from: jwtTokenCodec.sqlType,
+      from: jwtTokenIdentifier,
       codec: jwtTokenCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.constraints.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.constraints.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const flambleIdentifier = sql.identifier("d", "flibble");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: sql.identifier("d", "flibble"),
+  identifier: flambleIdentifier,
   attributes: Object.assign(Object.create(null), {
     f: {
       description: undefined,
@@ -103,9 +104,10 @@ const flambleCodec = recordCodec({
   },
   executor: executor
 });
+const renamed_tableIdentifier = sql.identifier("d", "original_table");
 const spec_renamed_table = {
   name: "renamed_table",
-  identifier: sql.identifier("d", "original_table"),
+  identifier: renamed_tableIdentifier,
   attributes: Object.assign(Object.create(null), {
     col1: {
       description: undefined,
@@ -134,9 +136,10 @@ const spec_renamed_table = {
   executor: executor
 };
 const renamed_tableCodec = recordCodec(spec_renamed_table);
+const filmsIdentifier = sql.identifier("d", "films");
 const spec_films = {
   name: "films",
-  identifier: sql.identifier("d", "films"),
+  identifier: filmsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -170,9 +173,10 @@ const spec_films = {
   executor: executor
 };
 const filmsCodec = recordCodec(spec_films);
+const studiosIdentifier = sql.identifier("d", "studios");
 const spec_studios = {
   name: "studios",
-  identifier: sql.identifier("d", "studios"),
+  identifier: studiosIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -206,9 +210,10 @@ const spec_studios = {
   executor: executor
 };
 const studiosCodec = recordCodec(spec_studios);
+const postIdentifier = sql.identifier("d", "post");
 const spec_post = {
   name: "post",
-  identifier: sql.identifier("d", "post"),
+  identifier: postIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -251,9 +256,10 @@ const spec_post = {
   executor: executor
 };
 const postCodec = recordCodec(spec_post);
+const tvEpisodesIdentifier = sql.identifier("d", "tv_episodes");
 const spec_tvEpisodes = {
   name: "tvEpisodes",
-  identifier: sql.identifier("d", "tv_episodes"),
+  identifier: tvEpisodesIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -299,9 +305,10 @@ const spec_tvEpisodes = {
   executor: executor
 };
 const tvEpisodesCodec = recordCodec(spec_tvEpisodes);
+const tvShowsIdentifier = sql.identifier("d", "tv_shows");
 const spec_tvShows = {
   name: "tvShows",
-  identifier: sql.identifier("d", "tv_shows"),
+  identifier: tvShowsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -344,9 +351,10 @@ const spec_tvShows = {
   executor: executor
 };
 const tvShowsCodec = recordCodec(spec_tvShows);
+const jwtTokenIdentifier = sql.identifier("d", "jwt_token");
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: sql.identifier("d", "jwt_token"),
+  identifier: jwtTokenIdentifier,
   attributes: Object.assign(Object.create(null), {
     role: {
       description: undefined,
@@ -388,9 +396,10 @@ const jwtTokenCodec = recordCodec({
   },
   executor: executor
 });
+const personIdentifier = sql.identifier("d", "person");
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("d", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -536,10 +545,10 @@ const studiosUniques = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor,
+  executor: executor,
   name: "studios",
   identifier: "main.d.studios",
-  from: studiosCodec.sqlType,
+  from: studiosIdentifier,
   codec: studiosCodec,
   uniques: studiosUniques,
   isVirtual: false,
@@ -563,10 +572,10 @@ const postUniques = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor,
+  executor: executor,
   name: "post",
   identifier: "main.d.post",
-  from: postCodec.sqlType,
+  from: postIdentifier,
   codec: postCodec,
   uniques: postUniques,
   isVirtual: false,
@@ -590,10 +599,10 @@ const tv_episodesUniques = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor,
+  executor: executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: tvEpisodesCodec.sqlType,
+  from: tvEpisodesIdentifier,
   codec: tvEpisodesCodec,
   uniques: tv_episodesUniques,
   isVirtual: false,
@@ -620,10 +629,10 @@ const tv_showsUniques = [{
   }
 }];
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor,
+  executor: executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: tvShowsCodec.sqlType,
+  from: tvShowsIdentifier,
   codec: tvShowsCodec,
   uniques: tv_showsUniques,
   isVirtual: false,
@@ -652,10 +661,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.d.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -713,10 +722,10 @@ const registry = makeRegistry({
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "flamble",
       identifier: "main.d.flibble",
-      from: flambleCodec.sqlType,
+      from: flambleIdentifier,
       codec: flambleCodec,
       uniques: [],
       isVirtual: true,
@@ -756,10 +765,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     renamed_table: {
-      executor,
+      executor: executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: renamed_tableCodec.sqlType,
+      from: renamed_tableIdentifier,
       codec: renamed_tableCodec,
       uniques: [],
       isVirtual: false,
@@ -777,10 +786,10 @@ const registry = makeRegistry({
       }
     },
     films: {
-      executor,
+      executor: executor,
       name: "films",
       identifier: "main.d.films",
-      from: filmsCodec.sqlType,
+      from: filmsIdentifier,
       codec: filmsCodec,
       uniques: filmsUniques,
       isVirtual: false,
@@ -800,10 +809,10 @@ const registry = makeRegistry({
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
-      from: jwtTokenCodec.sqlType,
+      from: jwtTokenIdentifier,
       codec: jwtTokenCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-asterisk.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-asterisk.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const flambleIdentifier = sql.identifier("d", "flibble");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: sql.identifier("d", "flibble"),
+  identifier: flambleIdentifier,
   attributes: Object.assign(Object.create(null), {
     f: {
       description: undefined,
@@ -103,9 +104,10 @@ const flambleCodec = recordCodec({
   },
   executor: executor
 });
+const renamed_tableIdentifier = sql.identifier("d", "original_table");
 const spec_renamed_table = {
   name: "renamed_table",
-  identifier: sql.identifier("d", "original_table"),
+  identifier: renamed_tableIdentifier,
   attributes: Object.assign(Object.create(null), {
     col1: {
       description: undefined,
@@ -134,9 +136,10 @@ const spec_renamed_table = {
   executor: executor
 };
 const renamed_tableCodec = recordCodec(spec_renamed_table);
+const filmsIdentifier = sql.identifier("d", "films");
 const spec_films = {
   name: "films",
-  identifier: sql.identifier("d", "films"),
+  identifier: filmsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -173,9 +176,10 @@ const spec_films = {
   executor: executor
 };
 const filmsCodec = recordCodec(spec_films);
+const studiosIdentifier = sql.identifier("d", "studios");
 const spec_studios = {
   name: "studios",
-  identifier: sql.identifier("d", "studios"),
+  identifier: studiosIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -209,9 +213,10 @@ const spec_studios = {
   executor: executor
 };
 const studiosCodec = recordCodec(spec_studios);
+const postIdentifier = sql.identifier("d", "post");
 const spec_post = {
   name: "post",
-  identifier: sql.identifier("d", "post"),
+  identifier: postIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -254,9 +259,10 @@ const spec_post = {
   executor: executor
 };
 const postCodec = recordCodec(spec_post);
+const tvEpisodesIdentifier = sql.identifier("d", "tv_episodes");
 const spec_tvEpisodes = {
   name: "tvEpisodes",
-  identifier: sql.identifier("d", "tv_episodes"),
+  identifier: tvEpisodesIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -299,9 +305,10 @@ const spec_tvEpisodes = {
   executor: executor
 };
 const tvEpisodesCodec = recordCodec(spec_tvEpisodes);
+const tvShowsIdentifier = sql.identifier("d", "tv_shows");
 const spec_tvShows = {
   name: "tvShows",
-  identifier: sql.identifier("d", "tv_shows"),
+  identifier: tvShowsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -347,9 +354,10 @@ const spec_tvShows = {
   executor: executor
 };
 const tvShowsCodec = recordCodec(spec_tvShows);
+const jwtTokenIdentifier = sql.identifier("d", "jwt_token");
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: sql.identifier("d", "jwt_token"),
+  identifier: jwtTokenIdentifier,
   attributes: Object.assign(Object.create(null), {
     role: {
       description: undefined,
@@ -391,9 +399,10 @@ const jwtTokenCodec = recordCodec({
   },
   executor: executor
 });
+const personIdentifier = sql.identifier("d", "person");
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("d", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -531,10 +540,10 @@ const studiosUniques = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor,
+  executor: executor,
   name: "studios",
   identifier: "main.d.studios",
-  from: studiosCodec.sqlType,
+  from: studiosIdentifier,
   codec: studiosCodec,
   uniques: studiosUniques,
   isVirtual: false,
@@ -558,10 +567,10 @@ const postUniques = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor,
+  executor: executor,
   name: "post",
   identifier: "main.d.post",
-  from: postCodec.sqlType,
+  from: postIdentifier,
   codec: postCodec,
   uniques: postUniques,
   isVirtual: false,
@@ -585,10 +594,10 @@ const tv_episodesUniques = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor,
+  executor: executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: tvEpisodesCodec.sqlType,
+  from: tvEpisodesIdentifier,
   codec: tvEpisodesCodec,
   uniques: tv_episodesUniques,
   isVirtual: false,
@@ -604,10 +613,10 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   }
 };
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor,
+  executor: executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: tvShowsCodec.sqlType,
+  from: tvShowsIdentifier,
   codec: tvShowsCodec,
   uniques: [{
     isPrimary: true,
@@ -646,10 +655,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.d.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -707,10 +716,10 @@ const registry = makeRegistry({
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "flamble",
       identifier: "main.d.flibble",
-      from: flambleCodec.sqlType,
+      from: flambleIdentifier,
       codec: flambleCodec,
       uniques: [],
       isVirtual: true,
@@ -750,10 +759,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     renamed_table: {
-      executor,
+      executor: executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: renamed_tableCodec.sqlType,
+      from: renamed_tableIdentifier,
       codec: renamed_tableCodec,
       uniques: [],
       isVirtual: false,
@@ -771,10 +780,10 @@ const registry = makeRegistry({
       }
     },
     films: {
-      executor,
+      executor: executor,
       name: "films",
       identifier: "main.d.films",
-      from: filmsCodec.sqlType,
+      from: filmsIdentifier,
       codec: filmsCodec,
       uniques: [{
         isPrimary: true,
@@ -804,10 +813,10 @@ const registry = makeRegistry({
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
-      from: jwtTokenCodec.sqlType,
+      from: jwtTokenIdentifier,
       codec: jwtTokenCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-create.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-create.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const flambleIdentifier = sql.identifier("d", "flibble");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: sql.identifier("d", "flibble"),
+  identifier: flambleIdentifier,
   attributes: Object.assign(Object.create(null), {
     f: {
       description: undefined,
@@ -103,9 +104,10 @@ const flambleCodec = recordCodec({
   },
   executor: executor
 });
+const renamed_tableIdentifier = sql.identifier("d", "original_table");
 const spec_renamed_table = {
   name: "renamed_table",
-  identifier: sql.identifier("d", "original_table"),
+  identifier: renamed_tableIdentifier,
   attributes: Object.assign(Object.create(null), {
     col1: {
       description: undefined,
@@ -134,9 +136,10 @@ const spec_renamed_table = {
   executor: executor
 };
 const renamed_tableCodec = recordCodec(spec_renamed_table);
+const filmsIdentifier = sql.identifier("d", "films");
 const spec_films = {
   name: "films",
-  identifier: sql.identifier("d", "films"),
+  identifier: filmsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -173,9 +176,10 @@ const spec_films = {
   executor: executor
 };
 const filmsCodec = recordCodec(spec_films);
+const studiosIdentifier = sql.identifier("d", "studios");
 const spec_studios = {
   name: "studios",
-  identifier: sql.identifier("d", "studios"),
+  identifier: studiosIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -209,9 +213,10 @@ const spec_studios = {
   executor: executor
 };
 const studiosCodec = recordCodec(spec_studios);
+const postIdentifier = sql.identifier("d", "post");
 const spec_post = {
   name: "post",
-  identifier: sql.identifier("d", "post"),
+  identifier: postIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -254,9 +259,10 @@ const spec_post = {
   executor: executor
 };
 const postCodec = recordCodec(spec_post);
+const tvEpisodesIdentifier = sql.identifier("d", "tv_episodes");
 const spec_tvEpisodes = {
   name: "tvEpisodes",
-  identifier: sql.identifier("d", "tv_episodes"),
+  identifier: tvEpisodesIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -299,9 +305,10 @@ const spec_tvEpisodes = {
   executor: executor
 };
 const tvEpisodesCodec = recordCodec(spec_tvEpisodes);
+const tvShowsIdentifier = sql.identifier("d", "tv_shows");
 const spec_tvShows = {
   name: "tvShows",
-  identifier: sql.identifier("d", "tv_shows"),
+  identifier: tvShowsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -344,9 +351,10 @@ const spec_tvShows = {
   executor: executor
 };
 const tvShowsCodec = recordCodec(spec_tvShows);
+const jwtTokenIdentifier = sql.identifier("d", "jwt_token");
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: sql.identifier("d", "jwt_token"),
+  identifier: jwtTokenIdentifier,
   attributes: Object.assign(Object.create(null), {
     role: {
       description: undefined,
@@ -388,9 +396,10 @@ const jwtTokenCodec = recordCodec({
   },
   executor: executor
 });
+const personIdentifier = sql.identifier("d", "person");
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("d", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -536,10 +545,10 @@ const studiosUniques = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor,
+  executor: executor,
   name: "studios",
   identifier: "main.d.studios",
-  from: studiosCodec.sqlType,
+  from: studiosIdentifier,
   codec: studiosCodec,
   uniques: studiosUniques,
   isVirtual: false,
@@ -563,10 +572,10 @@ const postUniques = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor,
+  executor: executor,
   name: "post",
   identifier: "main.d.post",
-  from: postCodec.sqlType,
+  from: postIdentifier,
   codec: postCodec,
   uniques: postUniques,
   isVirtual: false,
@@ -590,10 +599,10 @@ const tv_episodesUniques = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor,
+  executor: executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: tvEpisodesCodec.sqlType,
+  from: tvEpisodesIdentifier,
   codec: tvEpisodesCodec,
   uniques: tv_episodesUniques,
   isVirtual: false,
@@ -617,10 +626,10 @@ const tv_showsUniques = [{
   }
 }];
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor,
+  executor: executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: tvShowsCodec.sqlType,
+  from: tvShowsIdentifier,
   codec: tvShowsCodec,
   uniques: tv_showsUniques,
   isVirtual: false,
@@ -649,10 +658,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.d.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -710,10 +719,10 @@ const registry = makeRegistry({
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "flamble",
       identifier: "main.d.flibble",
-      from: flambleCodec.sqlType,
+      from: flambleIdentifier,
       codec: flambleCodec,
       uniques: [],
       isVirtual: true,
@@ -753,10 +762,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     renamed_table: {
-      executor,
+      executor: executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: renamed_tableCodec.sqlType,
+      from: renamed_tableIdentifier,
       codec: renamed_tableCodec,
       uniques: [],
       isVirtual: false,
@@ -774,10 +783,10 @@ const registry = makeRegistry({
       }
     },
     films: {
-      executor,
+      executor: executor,
       name: "films",
       identifier: "main.d.films",
-      from: filmsCodec.sqlType,
+      from: filmsIdentifier,
       codec: filmsCodec,
       uniques: filmsUniques,
       isVirtual: false,
@@ -800,10 +809,10 @@ const registry = makeRegistry({
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
-      from: jwtTokenCodec.sqlType,
+      from: jwtTokenIdentifier,
       codec: jwtTokenCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-delete.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-delete.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const flambleIdentifier = sql.identifier("d", "flibble");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: sql.identifier("d", "flibble"),
+  identifier: flambleIdentifier,
   attributes: Object.assign(Object.create(null), {
     f: {
       description: undefined,
@@ -103,9 +104,10 @@ const flambleCodec = recordCodec({
   },
   executor: executor
 });
+const renamed_tableIdentifier = sql.identifier("d", "original_table");
 const spec_renamed_table = {
   name: "renamed_table",
-  identifier: sql.identifier("d", "original_table"),
+  identifier: renamed_tableIdentifier,
   attributes: Object.assign(Object.create(null), {
     col1: {
       description: undefined,
@@ -134,9 +136,10 @@ const spec_renamed_table = {
   executor: executor
 };
 const renamed_tableCodec = recordCodec(spec_renamed_table);
+const filmsIdentifier = sql.identifier("d", "films");
 const spec_films = {
   name: "films",
-  identifier: sql.identifier("d", "films"),
+  identifier: filmsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -173,9 +176,10 @@ const spec_films = {
   executor: executor
 };
 const filmsCodec = recordCodec(spec_films);
+const studiosIdentifier = sql.identifier("d", "studios");
 const spec_studios = {
   name: "studios",
-  identifier: sql.identifier("d", "studios"),
+  identifier: studiosIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -209,9 +213,10 @@ const spec_studios = {
   executor: executor
 };
 const studiosCodec = recordCodec(spec_studios);
+const postIdentifier = sql.identifier("d", "post");
 const spec_post = {
   name: "post",
-  identifier: sql.identifier("d", "post"),
+  identifier: postIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -254,9 +259,10 @@ const spec_post = {
   executor: executor
 };
 const postCodec = recordCodec(spec_post);
+const tvEpisodesIdentifier = sql.identifier("d", "tv_episodes");
 const spec_tvEpisodes = {
   name: "tvEpisodes",
-  identifier: sql.identifier("d", "tv_episodes"),
+  identifier: tvEpisodesIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -299,9 +305,10 @@ const spec_tvEpisodes = {
   executor: executor
 };
 const tvEpisodesCodec = recordCodec(spec_tvEpisodes);
+const tvShowsIdentifier = sql.identifier("d", "tv_shows");
 const spec_tvShows = {
   name: "tvShows",
-  identifier: sql.identifier("d", "tv_shows"),
+  identifier: tvShowsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -344,9 +351,10 @@ const spec_tvShows = {
   executor: executor
 };
 const tvShowsCodec = recordCodec(spec_tvShows);
+const jwtTokenIdentifier = sql.identifier("d", "jwt_token");
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: sql.identifier("d", "jwt_token"),
+  identifier: jwtTokenIdentifier,
   attributes: Object.assign(Object.create(null), {
     role: {
       description: undefined,
@@ -388,9 +396,10 @@ const jwtTokenCodec = recordCodec({
   },
   executor: executor
 });
+const personIdentifier = sql.identifier("d", "person");
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("d", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -536,10 +545,10 @@ const studiosUniques = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor,
+  executor: executor,
   name: "studios",
   identifier: "main.d.studios",
-  from: studiosCodec.sqlType,
+  from: studiosIdentifier,
   codec: studiosCodec,
   uniques: studiosUniques,
   isVirtual: false,
@@ -563,10 +572,10 @@ const postUniques = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor,
+  executor: executor,
   name: "post",
   identifier: "main.d.post",
-  from: postCodec.sqlType,
+  from: postIdentifier,
   codec: postCodec,
   uniques: postUniques,
   isVirtual: false,
@@ -590,10 +599,10 @@ const tv_episodesUniques = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor,
+  executor: executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: tvEpisodesCodec.sqlType,
+  from: tvEpisodesIdentifier,
   codec: tvEpisodesCodec,
   uniques: tv_episodesUniques,
   isVirtual: false,
@@ -617,10 +626,10 @@ const tv_showsUniques = [{
   }
 }];
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor,
+  executor: executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: tvShowsCodec.sqlType,
+  from: tvShowsIdentifier,
   codec: tvShowsCodec,
   uniques: tv_showsUniques,
   isVirtual: false,
@@ -649,10 +658,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.d.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -710,10 +719,10 @@ const registry = makeRegistry({
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "flamble",
       identifier: "main.d.flibble",
-      from: flambleCodec.sqlType,
+      from: flambleIdentifier,
       codec: flambleCodec,
       uniques: [],
       isVirtual: true,
@@ -753,10 +762,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     renamed_table: {
-      executor,
+      executor: executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: renamed_tableCodec.sqlType,
+      from: renamed_tableIdentifier,
       codec: renamed_tableCodec,
       uniques: [],
       isVirtual: false,
@@ -774,10 +783,10 @@ const registry = makeRegistry({
       }
     },
     films: {
-      executor,
+      executor: executor,
       name: "films",
       identifier: "main.d.films",
-      from: filmsCodec.sqlType,
+      from: filmsIdentifier,
       codec: filmsCodec,
       uniques: filmsUniques,
       isVirtual: false,
@@ -800,10 +809,10 @@ const registry = makeRegistry({
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
-      from: jwtTokenCodec.sqlType,
+      from: jwtTokenIdentifier,
       codec: jwtTokenCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-loads.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-loads.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const flambleIdentifier = sql.identifier("d", "flibble");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: sql.identifier("d", "flibble"),
+  identifier: flambleIdentifier,
   attributes: Object.assign(Object.create(null), {
     f: {
       description: undefined,
@@ -103,9 +104,10 @@ const flambleCodec = recordCodec({
   },
   executor: executor
 });
+const renamed_tableIdentifier = sql.identifier("d", "original_table");
 const spec_renamed_table = {
   name: "renamed_table",
-  identifier: sql.identifier("d", "original_table"),
+  identifier: renamed_tableIdentifier,
   attributes: Object.assign(Object.create(null), {
     col1: {
       description: undefined,
@@ -134,9 +136,10 @@ const spec_renamed_table = {
   executor: executor
 };
 const renamed_tableCodec = recordCodec(spec_renamed_table);
+const filmsIdentifier = sql.identifier("d", "films");
 const spec_films = {
   name: "films",
-  identifier: sql.identifier("d", "films"),
+  identifier: filmsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -173,9 +176,10 @@ const spec_films = {
   executor: executor
 };
 const filmsCodec = recordCodec(spec_films);
+const studiosIdentifier = sql.identifier("d", "studios");
 const spec_studios = {
   name: "studios",
-  identifier: sql.identifier("d", "studios"),
+  identifier: studiosIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -209,9 +213,10 @@ const spec_studios = {
   executor: executor
 };
 const studiosCodec = recordCodec(spec_studios);
+const postIdentifier = sql.identifier("d", "post");
 const spec_post = {
   name: "post",
-  identifier: sql.identifier("d", "post"),
+  identifier: postIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -254,9 +259,10 @@ const spec_post = {
   executor: executor
 };
 const postCodec = recordCodec(spec_post);
+const tvEpisodesIdentifier = sql.identifier("d", "tv_episodes");
 const spec_tvEpisodes = {
   name: "tvEpisodes",
-  identifier: sql.identifier("d", "tv_episodes"),
+  identifier: tvEpisodesIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -299,9 +305,10 @@ const spec_tvEpisodes = {
   executor: executor
 };
 const tvEpisodesCodec = recordCodec(spec_tvEpisodes);
+const tvShowsIdentifier = sql.identifier("d", "tv_shows");
 const spec_tvShows = {
   name: "tvShows",
-  identifier: sql.identifier("d", "tv_shows"),
+  identifier: tvShowsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -344,9 +351,10 @@ const spec_tvShows = {
   executor: executor
 };
 const tvShowsCodec = recordCodec(spec_tvShows);
+const jwtTokenIdentifier = sql.identifier("d", "jwt_token");
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: sql.identifier("d", "jwt_token"),
+  identifier: jwtTokenIdentifier,
   attributes: Object.assign(Object.create(null), {
     role: {
       description: undefined,
@@ -388,9 +396,10 @@ const jwtTokenCodec = recordCodec({
   },
   executor: executor
 });
+const personIdentifier = sql.identifier("d", "person");
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("d", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -528,10 +537,10 @@ const studiosUniques = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor,
+  executor: executor,
   name: "studios",
   identifier: "main.d.studios",
-  from: studiosCodec.sqlType,
+  from: studiosIdentifier,
   codec: studiosCodec,
   uniques: studiosUniques,
   isVirtual: false,
@@ -555,10 +564,10 @@ const postUniques = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor,
+  executor: executor,
   name: "post",
   identifier: "main.d.post",
-  from: postCodec.sqlType,
+  from: postIdentifier,
   codec: postCodec,
   uniques: postUniques,
   isVirtual: false,
@@ -582,10 +591,10 @@ const tv_episodesUniques = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor,
+  executor: executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: tvEpisodesCodec.sqlType,
+  from: tvEpisodesIdentifier,
   codec: tvEpisodesCodec,
   uniques: tv_episodesUniques,
   isVirtual: false,
@@ -609,10 +618,10 @@ const tv_showsUniques = [{
   }
 }];
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor,
+  executor: executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: tvShowsCodec.sqlType,
+  from: tvShowsIdentifier,
   codec: tvShowsCodec,
   uniques: tv_showsUniques,
   isVirtual: false,
@@ -641,10 +650,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.d.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -702,10 +711,10 @@ const registry = makeRegistry({
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "flamble",
       identifier: "main.d.flibble",
-      from: flambleCodec.sqlType,
+      from: flambleIdentifier,
       codec: flambleCodec,
       uniques: [],
       isVirtual: true,
@@ -745,10 +754,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     renamed_table: {
-      executor,
+      executor: executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: renamed_tableCodec.sqlType,
+      from: renamed_tableIdentifier,
       codec: renamed_tableCodec,
       uniques: [],
       isVirtual: false,
@@ -766,10 +775,10 @@ const registry = makeRegistry({
       }
     },
     films: {
-      executor,
+      executor: executor,
       name: "films",
       identifier: "main.d.films",
-      from: filmsCodec.sqlType,
+      from: filmsIdentifier,
       codec: filmsCodec,
       uniques: [{
         isPrimary: true,
@@ -799,10 +808,10 @@ const registry = makeRegistry({
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
-      from: jwtTokenCodec.sqlType,
+      from: jwtTokenIdentifier,
       codec: jwtTokenCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-update.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-update.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const flambleIdentifier = sql.identifier("d", "flibble");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: sql.identifier("d", "flibble"),
+  identifier: flambleIdentifier,
   attributes: Object.assign(Object.create(null), {
     f: {
       description: undefined,
@@ -103,9 +104,10 @@ const flambleCodec = recordCodec({
   },
   executor: executor
 });
+const renamed_tableIdentifier = sql.identifier("d", "original_table");
 const spec_renamed_table = {
   name: "renamed_table",
-  identifier: sql.identifier("d", "original_table"),
+  identifier: renamed_tableIdentifier,
   attributes: Object.assign(Object.create(null), {
     col1: {
       description: undefined,
@@ -134,9 +136,10 @@ const spec_renamed_table = {
   executor: executor
 };
 const renamed_tableCodec = recordCodec(spec_renamed_table);
+const filmsIdentifier = sql.identifier("d", "films");
 const spec_films = {
   name: "films",
-  identifier: sql.identifier("d", "films"),
+  identifier: filmsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -173,9 +176,10 @@ const spec_films = {
   executor: executor
 };
 const filmsCodec = recordCodec(spec_films);
+const studiosIdentifier = sql.identifier("d", "studios");
 const spec_studios = {
   name: "studios",
-  identifier: sql.identifier("d", "studios"),
+  identifier: studiosIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -209,9 +213,10 @@ const spec_studios = {
   executor: executor
 };
 const studiosCodec = recordCodec(spec_studios);
+const postIdentifier = sql.identifier("d", "post");
 const spec_post = {
   name: "post",
-  identifier: sql.identifier("d", "post"),
+  identifier: postIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -254,9 +259,10 @@ const spec_post = {
   executor: executor
 };
 const postCodec = recordCodec(spec_post);
+const tvEpisodesIdentifier = sql.identifier("d", "tv_episodes");
 const spec_tvEpisodes = {
   name: "tvEpisodes",
-  identifier: sql.identifier("d", "tv_episodes"),
+  identifier: tvEpisodesIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -299,9 +305,10 @@ const spec_tvEpisodes = {
   executor: executor
 };
 const tvEpisodesCodec = recordCodec(spec_tvEpisodes);
+const tvShowsIdentifier = sql.identifier("d", "tv_shows");
 const spec_tvShows = {
   name: "tvShows",
-  identifier: sql.identifier("d", "tv_shows"),
+  identifier: tvShowsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -344,9 +351,10 @@ const spec_tvShows = {
   executor: executor
 };
 const tvShowsCodec = recordCodec(spec_tvShows);
+const jwtTokenIdentifier = sql.identifier("d", "jwt_token");
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: sql.identifier("d", "jwt_token"),
+  identifier: jwtTokenIdentifier,
   attributes: Object.assign(Object.create(null), {
     role: {
       description: undefined,
@@ -388,9 +396,10 @@ const jwtTokenCodec = recordCodec({
   },
   executor: executor
 });
+const personIdentifier = sql.identifier("d", "person");
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("d", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -536,10 +545,10 @@ const studiosUniques = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor,
+  executor: executor,
   name: "studios",
   identifier: "main.d.studios",
-  from: studiosCodec.sqlType,
+  from: studiosIdentifier,
   codec: studiosCodec,
   uniques: studiosUniques,
   isVirtual: false,
@@ -563,10 +572,10 @@ const postUniques = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor,
+  executor: executor,
   name: "post",
   identifier: "main.d.post",
-  from: postCodec.sqlType,
+  from: postIdentifier,
   codec: postCodec,
   uniques: postUniques,
   isVirtual: false,
@@ -590,10 +599,10 @@ const tv_episodesUniques = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor,
+  executor: executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: tvEpisodesCodec.sqlType,
+  from: tvEpisodesIdentifier,
   codec: tvEpisodesCodec,
   uniques: tv_episodesUniques,
   isVirtual: false,
@@ -617,10 +626,10 @@ const tv_showsUniques = [{
   }
 }];
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor,
+  executor: executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: tvShowsCodec.sqlType,
+  from: tvShowsIdentifier,
   codec: tvShowsCodec,
   uniques: tv_showsUniques,
   isVirtual: false,
@@ -649,10 +658,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.d.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -710,10 +719,10 @@ const registry = makeRegistry({
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "flamble",
       identifier: "main.d.flibble",
-      from: flambleCodec.sqlType,
+      from: flambleIdentifier,
       codec: flambleCodec,
       uniques: [],
       isVirtual: true,
@@ -753,10 +762,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     renamed_table: {
-      executor,
+      executor: executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: renamed_tableCodec.sqlType,
+      from: renamed_tableIdentifier,
       codec: renamed_tableCodec,
       uniques: [],
       isVirtual: false,
@@ -774,10 +783,10 @@ const registry = makeRegistry({
       }
     },
     films: {
-      executor,
+      executor: executor,
       name: "films",
       identifier: "main.d.films",
-      from: filmsCodec.sqlType,
+      from: filmsIdentifier,
       codec: filmsCodec,
       uniques: filmsUniques,
       isVirtual: false,
@@ -800,10 +809,10 @@ const registry = makeRegistry({
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
-      from: jwtTokenCodec.sqlType,
+      from: jwtTokenIdentifier,
       codec: jwtTokenCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.shows-order.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.shows-order.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const flambleIdentifier = sql.identifier("d", "flibble");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: sql.identifier("d", "flibble"),
+  identifier: flambleIdentifier,
   attributes: Object.assign(Object.create(null), {
     f: {
       description: undefined,
@@ -103,9 +104,10 @@ const flambleCodec = recordCodec({
   },
   executor: executor
 });
+const renamed_tableIdentifier = sql.identifier("d", "original_table");
 const spec_renamed_table = {
   name: "renamed_table",
-  identifier: sql.identifier("d", "original_table"),
+  identifier: renamed_tableIdentifier,
   attributes: Object.assign(Object.create(null), {
     col1: {
       description: undefined,
@@ -134,9 +136,10 @@ const spec_renamed_table = {
   executor: executor
 };
 const renamed_tableCodec = recordCodec(spec_renamed_table);
+const filmsIdentifier = sql.identifier("d", "films");
 const spec_films = {
   name: "films",
-  identifier: sql.identifier("d", "films"),
+  identifier: filmsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -170,9 +173,10 @@ const spec_films = {
   executor: executor
 };
 const filmsCodec = recordCodec(spec_films);
+const studiosIdentifier = sql.identifier("d", "studios");
 const spec_studios = {
   name: "studios",
-  identifier: sql.identifier("d", "studios"),
+  identifier: studiosIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -206,9 +210,10 @@ const spec_studios = {
   executor: executor
 };
 const studiosCodec = recordCodec(spec_studios);
+const postIdentifier = sql.identifier("d", "post");
 const spec_post = {
   name: "post",
-  identifier: sql.identifier("d", "post"),
+  identifier: postIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -251,9 +256,10 @@ const spec_post = {
   executor: executor
 };
 const postCodec = recordCodec(spec_post);
+const tvEpisodesIdentifier = sql.identifier("d", "tv_episodes");
 const spec_tvEpisodes = {
   name: "tvEpisodes",
-  identifier: sql.identifier("d", "tv_episodes"),
+  identifier: tvEpisodesIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -296,9 +302,10 @@ const spec_tvEpisodes = {
   executor: executor
 };
 const tvEpisodesCodec = recordCodec(spec_tvEpisodes);
+const tvShowsIdentifier = sql.identifier("d", "tv_shows");
 const spec_tvShows = {
   name: "tvShows",
-  identifier: sql.identifier("d", "tv_shows"),
+  identifier: tvShowsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -344,9 +351,10 @@ const spec_tvShows = {
   executor: executor
 };
 const tvShowsCodec = recordCodec(spec_tvShows);
+const jwtTokenIdentifier = sql.identifier("d", "jwt_token");
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: sql.identifier("d", "jwt_token"),
+  identifier: jwtTokenIdentifier,
   attributes: Object.assign(Object.create(null), {
     role: {
       description: undefined,
@@ -388,9 +396,10 @@ const jwtTokenCodec = recordCodec({
   },
   executor: executor
 });
+const personIdentifier = sql.identifier("d", "person");
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("d", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -536,10 +545,10 @@ const studiosUniques = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor,
+  executor: executor,
   name: "studios",
   identifier: "main.d.studios",
-  from: studiosCodec.sqlType,
+  from: studiosIdentifier,
   codec: studiosCodec,
   uniques: studiosUniques,
   isVirtual: false,
@@ -563,10 +572,10 @@ const postUniques = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor,
+  executor: executor,
   name: "post",
   identifier: "main.d.post",
-  from: postCodec.sqlType,
+  from: postIdentifier,
   codec: postCodec,
   uniques: postUniques,
   isVirtual: false,
@@ -590,10 +599,10 @@ const tv_episodesUniques = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor,
+  executor: executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: tvEpisodesCodec.sqlType,
+  from: tvEpisodesIdentifier,
   codec: tvEpisodesCodec,
   uniques: tv_episodesUniques,
   isVirtual: false,
@@ -609,10 +618,10 @@ const registryConfig_pgResources_tv_episodes_tv_episodes = {
   }
 };
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor,
+  executor: executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: tvShowsCodec.sqlType,
+  from: tvShowsIdentifier,
   codec: tvShowsCodec,
   uniques: [{
     isPrimary: true,
@@ -651,10 +660,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.d.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -712,10 +721,10 @@ const registry = makeRegistry({
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "flamble",
       identifier: "main.d.flibble",
-      from: flambleCodec.sqlType,
+      from: flambleIdentifier,
       codec: flambleCodec,
       uniques: [],
       isVirtual: true,
@@ -755,10 +764,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     renamed_table: {
-      executor,
+      executor: executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: renamed_tableCodec.sqlType,
+      from: renamed_tableIdentifier,
       codec: renamed_tableCodec,
       uniques: [],
       isVirtual: false,
@@ -776,10 +785,10 @@ const registry = makeRegistry({
       }
     },
     films: {
-      executor,
+      executor: executor,
       name: "films",
       identifier: "main.d.films",
-      from: filmsCodec.sqlType,
+      from: filmsIdentifier,
       codec: filmsCodec,
       uniques: filmsUniques,
       isVirtual: false,
@@ -799,10 +808,10 @@ const registry = makeRegistry({
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
-      from: jwtTokenCodec.sqlType,
+      from: jwtTokenIdentifier,
       codec: jwtTokenCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/partitions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/partitions.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const usersIdentifier = sql.identifier("partitions", "users");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const spec_users = {
   name: "users",
-  identifier: sql.identifier("partitions", "users"),
+  identifier: usersIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -111,9 +112,10 @@ const spec_users = {
   executor: executor
 };
 const usersCodec = recordCodec(spec_users);
+const measurementsIdentifier = sql.identifier("partitions", "measurements");
 const spec_measurements = {
   name: "measurements",
-  identifier: sql.identifier("partitions", "measurements"),
+  identifier: measurementsIdentifier,
   attributes: Object.assign(Object.create(null), {
     timestamp: {
       description: undefined,
@@ -174,10 +176,10 @@ const usersUniques = [{
   }
 }];
 const registryConfig_pgResources_users_users = {
-  executor,
+  executor: executor,
   name: "users",
   identifier: "main.partitions.users",
-  from: usersCodec.sqlType,
+  from: usersIdentifier,
   codec: usersCodec,
   uniques: usersUniques,
   isVirtual: false,
@@ -201,10 +203,10 @@ const measurementsUniques = [{
   }
 }];
 const registryConfig_pgResources_measurements_measurements = {
-  executor,
+  executor: executor,
   name: "measurements",
   identifier: "main.partitions.measurements",
-  from: measurementsCodec.sqlType,
+  from: measurementsIdentifier,
   codec: measurementsCodec,
   uniques: measurementsUniques,
   isVirtual: false,

--- a/postgraphile/postgraphile/__tests__/schema/v4/pg11.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/pg11.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const alwaysAsIdentityIdentifier = sql.identifier("pg11", "always_as_identity");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const spec_alwaysAsIdentity = {
   name: "alwaysAsIdentity",
-  identifier: sql.identifier("pg11", "always_as_identity"),
+  identifier: alwaysAsIdentityIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -113,9 +114,10 @@ const spec_alwaysAsIdentity = {
   executor: executor
 };
 const alwaysAsIdentityCodec = recordCodec(spec_alwaysAsIdentity);
+const byDefaultAsIdentityIdentifier = sql.identifier("pg11", "by_default_as_identity");
 const spec_byDefaultAsIdentity = {
   name: "byDefaultAsIdentity",
-  identifier: sql.identifier("pg11", "by_default_as_identity"),
+  identifier: byDefaultAsIdentityIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -149,9 +151,10 @@ const spec_byDefaultAsIdentity = {
   executor: executor
 };
 const byDefaultAsIdentityCodec = recordCodec(spec_byDefaultAsIdentity);
+const networkIdentifier = sql.identifier("pg11", "network");
 const spec_network = {
   name: "network",
-  identifier: sql.identifier("pg11", "network"),
+  identifier: networkIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -392,9 +395,10 @@ const domainConstrainedCompoundTypeCodec = domainOfCodec(compoundTypeCodec, "dom
   },
   notNull: false
 });
+const typesIdentifier = sql.identifier("pg11", "types");
 const spec_types = {
   name: "types",
-  identifier: sql.identifier("pg11", "types"),
+  identifier: typesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -517,10 +521,10 @@ const registry = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     always_as_identity: {
-      executor,
+      executor: executor,
       name: "always_as_identity",
       identifier: "main.pg11.always_as_identity",
-      from: alwaysAsIdentityCodec.sqlType,
+      from: alwaysAsIdentityIdentifier,
       codec: alwaysAsIdentityCodec,
       uniques: always_as_identityUniques,
       isVirtual: false,
@@ -536,10 +540,10 @@ const registry = makeRegistry({
       }
     },
     by_default_as_identity: {
-      executor,
+      executor: executor,
       name: "by_default_as_identity",
       identifier: "main.pg11.by_default_as_identity",
-      from: byDefaultAsIdentityCodec.sqlType,
+      from: byDefaultAsIdentityIdentifier,
       codec: byDefaultAsIdentityCodec,
       uniques: by_default_as_identityUniques,
       isVirtual: false,
@@ -555,10 +559,10 @@ const registry = makeRegistry({
       }
     },
     network: {
-      executor,
+      executor: executor,
       name: "network",
       identifier: "main.pg11.network",
-      from: networkCodec.sqlType,
+      from: networkIdentifier,
       codec: networkCodec,
       uniques: networkUniques,
       isVirtual: false,
@@ -574,10 +578,10 @@ const registry = makeRegistry({
       }
     },
     types: {
-      executor,
+      executor: executor,
       name: "types",
       identifier: "main.pg11.types",
-      from: typesCodec.sqlType,
+      from: typesIdentifier,
       codec: typesCodec,
       uniques: typesUniques,
       isVirtual: false,

--- a/postgraphile/postgraphile/__tests__/schema/v4/pg11.custom.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/pg11.custom.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const alwaysAsIdentityIdentifier = sql.identifier("pg11", "always_as_identity");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const spec_alwaysAsIdentity = {
   name: "alwaysAsIdentity",
-  identifier: sql.identifier("pg11", "always_as_identity"),
+  identifier: alwaysAsIdentityIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -113,9 +114,10 @@ const spec_alwaysAsIdentity = {
   executor: executor
 };
 const alwaysAsIdentityCodec = recordCodec(spec_alwaysAsIdentity);
+const byDefaultAsIdentityIdentifier = sql.identifier("pg11", "by_default_as_identity");
 const spec_byDefaultAsIdentity = {
   name: "byDefaultAsIdentity",
-  identifier: sql.identifier("pg11", "by_default_as_identity"),
+  identifier: byDefaultAsIdentityIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -149,9 +151,10 @@ const spec_byDefaultAsIdentity = {
   executor: executor
 };
 const byDefaultAsIdentityCodec = recordCodec(spec_byDefaultAsIdentity);
+const networkIdentifier = sql.identifier("pg11", "network");
 const spec_network = {
   name: "network",
-  identifier: sql.identifier("pg11", "network"),
+  identifier: networkIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -392,9 +395,10 @@ const domainConstrainedCompoundTypeCodec = domainOfCodec(compoundTypeCodec, "dom
   },
   notNull: false
 });
+const typesIdentifier = sql.identifier("pg11", "types");
 const spec_types = {
   name: "types",
-  identifier: sql.identifier("pg11", "types"),
+  identifier: typesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -517,10 +521,10 @@ const registry = makeRegistry({
   }),
   pgResources: Object.assign(Object.create(null), {
     always_as_identity: {
-      executor,
+      executor: executor,
       name: "always_as_identity",
       identifier: "main.pg11.always_as_identity",
-      from: alwaysAsIdentityCodec.sqlType,
+      from: alwaysAsIdentityIdentifier,
       codec: alwaysAsIdentityCodec,
       uniques: always_as_identityUniques,
       isVirtual: false,
@@ -536,10 +540,10 @@ const registry = makeRegistry({
       }
     },
     by_default_as_identity: {
-      executor,
+      executor: executor,
       name: "by_default_as_identity",
       identifier: "main.pg11.by_default_as_identity",
-      from: byDefaultAsIdentityCodec.sqlType,
+      from: byDefaultAsIdentityIdentifier,
       codec: byDefaultAsIdentityCodec,
       uniques: by_default_as_identityUniques,
       isVirtual: false,
@@ -555,10 +559,10 @@ const registry = makeRegistry({
       }
     },
     network: {
-      executor,
+      executor: executor,
       name: "network",
       identifier: "main.pg11.network",
-      from: networkCodec.sqlType,
+      from: networkIdentifier,
       codec: networkCodec,
       uniques: networkUniques,
       isVirtual: false,
@@ -574,10 +578,10 @@ const registry = makeRegistry({
       }
     },
     types: {
-      executor,
+      executor: executor,
       name: "types",
       identifier: "main.pg11.types",
-      from: typesCodec.sqlType,
+      from: typesIdentifier,
       codec: typesCodec,
       uniques: typesUniques,
       isVirtual: false,

--- a/postgraphile/postgraphile/__tests__/schema/v4/polymorphic.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/polymorphic.1.export.mjs
@@ -20,6 +20,7 @@ const handler_codec_base64JSON = {
     return base64JSONDecode;
   })()
 };
+const awsApplicationFirstPartyVulnerabilitiesIdentifier = sql.identifier("polymorphic", "aws_application_first_party_vulnerabilities");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -32,7 +33,7 @@ const executor = new PgExecutor({
 });
 const spec_awsApplicationFirstPartyVulnerabilities = {
   name: "awsApplicationFirstPartyVulnerabilities",
-  identifier: sql.identifier("polymorphic", "aws_application_first_party_vulnerabilities"),
+  identifier: awsApplicationFirstPartyVulnerabilitiesIdentifier,
   attributes: Object.assign(Object.create(null), {
     aws_application_id: {
       description: undefined,
@@ -69,9 +70,10 @@ const spec_awsApplicationFirstPartyVulnerabilities = {
   executor: executor
 };
 const awsApplicationFirstPartyVulnerabilitiesCodec = recordCodec(spec_awsApplicationFirstPartyVulnerabilities);
+const awsApplicationThirdPartyVulnerabilitiesIdentifier = sql.identifier("polymorphic", "aws_application_third_party_vulnerabilities");
 const spec_awsApplicationThirdPartyVulnerabilities = {
   name: "awsApplicationThirdPartyVulnerabilities",
-  identifier: sql.identifier("polymorphic", "aws_application_third_party_vulnerabilities"),
+  identifier: awsApplicationThirdPartyVulnerabilitiesIdentifier,
   attributes: Object.assign(Object.create(null), {
     aws_application_id: {
       description: undefined,
@@ -108,9 +110,10 @@ const spec_awsApplicationThirdPartyVulnerabilities = {
   executor: executor
 };
 const awsApplicationThirdPartyVulnerabilitiesCodec = recordCodec(spec_awsApplicationThirdPartyVulnerabilities);
+const gcpApplicationFirstPartyVulnerabilitiesIdentifier = sql.identifier("polymorphic", "gcp_application_first_party_vulnerabilities");
 const spec_gcpApplicationFirstPartyVulnerabilities = {
   name: "gcpApplicationFirstPartyVulnerabilities",
-  identifier: sql.identifier("polymorphic", "gcp_application_first_party_vulnerabilities"),
+  identifier: gcpApplicationFirstPartyVulnerabilitiesIdentifier,
   attributes: Object.assign(Object.create(null), {
     gcp_application_id: {
       description: undefined,
@@ -147,9 +150,10 @@ const spec_gcpApplicationFirstPartyVulnerabilities = {
   executor: executor
 };
 const gcpApplicationFirstPartyVulnerabilitiesCodec = recordCodec(spec_gcpApplicationFirstPartyVulnerabilities);
+const gcpApplicationThirdPartyVulnerabilitiesIdentifier = sql.identifier("polymorphic", "gcp_application_third_party_vulnerabilities");
 const spec_gcpApplicationThirdPartyVulnerabilities = {
   name: "gcpApplicationThirdPartyVulnerabilities",
-  identifier: sql.identifier("polymorphic", "gcp_application_third_party_vulnerabilities"),
+  identifier: gcpApplicationThirdPartyVulnerabilitiesIdentifier,
   attributes: Object.assign(Object.create(null), {
     gcp_application_id: {
       description: undefined,
@@ -186,9 +190,10 @@ const spec_gcpApplicationThirdPartyVulnerabilities = {
   executor: executor
 };
 const gcpApplicationThirdPartyVulnerabilitiesCodec = recordCodec(spec_gcpApplicationThirdPartyVulnerabilities);
+const organizationsIdentifier = sql.identifier("polymorphic", "organizations");
 const spec_organizations = {
   name: "organizations",
-  identifier: sql.identifier("polymorphic", "organizations"),
+  identifier: organizationsIdentifier,
   attributes: Object.assign(Object.create(null), {
     organization_id: {
       description: undefined,
@@ -224,9 +229,10 @@ const spec_organizations = {
   executor: executor
 };
 const organizationsCodec = recordCodec(spec_organizations);
+const peopleIdentifier = sql.identifier("polymorphic", "people");
 const spec_people = {
   name: "people",
-  identifier: sql.identifier("polymorphic", "people"),
+  identifier: peopleIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id: {
       description: undefined,
@@ -277,9 +283,10 @@ const spec_people = {
   executor: executor
 };
 const peopleCodec = recordCodec(spec_people);
+const prioritiesIdentifier = sql.identifier("polymorphic", "priorities");
 const spec_priorities = {
   name: "priorities",
-  identifier: sql.identifier("polymorphic", "priorities"),
+  identifier: prioritiesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -316,6 +323,7 @@ const spec_priorities = {
   executor: executor
 };
 const prioritiesCodec = recordCodec(spec_priorities);
+const relationalChecklistsIdentifier = sql.identifier("polymorphic", "relational_checklists");
 const itemTypeCodec = enumCodec({
   name: "itemType",
   identifier: sql.identifier("polymorphic", "item_type"),
@@ -332,7 +340,7 @@ const itemTypeCodec = enumCodec({
 });
 const spec_relationalChecklists = {
   name: "relationalChecklists",
-  identifier: sql.identifier("polymorphic", "relational_checklists"),
+  identifier: relationalChecklistsIdentifier,
   attributes: Object.assign(Object.create(null), {
     checklist_item_id: {
       description: undefined,
@@ -477,9 +485,10 @@ const spec_relationalChecklists = {
   executor: executor
 };
 const relationalChecklistsCodec = recordCodec(spec_relationalChecklists);
+const relationalItemRelationCompositePksIdentifier = sql.identifier("polymorphic", "relational_item_relation_composite_pks");
 const spec_relationalItemRelationCompositePks = {
   name: "relationalItemRelationCompositePks",
-  identifier: sql.identifier("polymorphic", "relational_item_relation_composite_pks"),
+  identifier: relationalItemRelationCompositePksIdentifier,
   attributes: Object.assign(Object.create(null), {
     parent_id: {
       description: undefined,
@@ -513,9 +522,10 @@ const spec_relationalItemRelationCompositePks = {
   executor: executor
 };
 const relationalItemRelationCompositePksCodec = recordCodec(spec_relationalItemRelationCompositePks);
+const relationalTopicsIdentifier = sql.identifier("polymorphic", "relational_topics");
 const spec_relationalTopics = {
   name: "relationalTopics",
-  identifier: sql.identifier("polymorphic", "relational_topics"),
+  identifier: relationalTopicsIdentifier,
   attributes: Object.assign(Object.create(null), {
     topic_item_id: {
       description: undefined,
@@ -660,9 +670,10 @@ const spec_relationalTopics = {
   executor: executor
 };
 const relationalTopicsCodec = recordCodec(spec_relationalTopics);
+const singleTableItemRelationCompositePksIdentifier = sql.identifier("polymorphic", "single_table_item_relation_composite_pks");
 const spec_singleTableItemRelationCompositePks = {
   name: "singleTableItemRelationCompositePks",
-  identifier: sql.identifier("polymorphic", "single_table_item_relation_composite_pks"),
+  identifier: singleTableItemRelationCompositePksIdentifier,
   attributes: Object.assign(Object.create(null), {
     parent_id: {
       description: undefined,
@@ -696,9 +707,10 @@ const spec_singleTableItemRelationCompositePks = {
   executor: executor
 };
 const singleTableItemRelationCompositePksCodec = recordCodec(spec_singleTableItemRelationCompositePks);
+const relationalChecklistItemsIdentifier = sql.identifier("polymorphic", "relational_checklist_items");
 const spec_relationalChecklistItems = {
   name: "relationalChecklistItems",
-  identifier: sql.identifier("polymorphic", "relational_checklist_items"),
+  identifier: relationalChecklistItemsIdentifier,
   attributes: Object.assign(Object.create(null), {
     checklist_item_item_id: {
       description: undefined,
@@ -852,9 +864,10 @@ const spec_relationalChecklistItems = {
   executor: executor
 };
 const relationalChecklistItemsCodec = recordCodec(spec_relationalChecklistItems);
+const relationalDividersIdentifier = sql.identifier("polymorphic", "relational_dividers");
 const spec_relationalDividers = {
   name: "relationalDividers",
-  identifier: sql.identifier("polymorphic", "relational_dividers"),
+  identifier: relationalDividersIdentifier,
   attributes: Object.assign(Object.create(null), {
     divider_item_id: {
       description: undefined,
@@ -1008,9 +1021,10 @@ const spec_relationalDividers = {
   executor: executor
 };
 const relationalDividersCodec = recordCodec(spec_relationalDividers);
+const relationalItemRelationsIdentifier = sql.identifier("polymorphic", "relational_item_relations");
 const spec_relationalItemRelations = {
   name: "relationalItemRelations",
-  identifier: sql.identifier("polymorphic", "relational_item_relations"),
+  identifier: relationalItemRelationsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1053,9 +1067,10 @@ const spec_relationalItemRelations = {
   executor: executor
 };
 const relationalItemRelationsCodec = recordCodec(spec_relationalItemRelations);
+const singleTableItemRelationsIdentifier = sql.identifier("polymorphic", "single_table_item_relations");
 const spec_singleTableItemRelations = {
   name: "singleTableItemRelations",
-  identifier: sql.identifier("polymorphic", "single_table_item_relations"),
+  identifier: singleTableItemRelationsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1098,9 +1113,10 @@ const spec_singleTableItemRelations = {
   executor: executor
 };
 const singleTableItemRelationsCodec = recordCodec(spec_singleTableItemRelations);
+const logEntriesIdentifier = sql.identifier("polymorphic", "log_entries");
 const spec_logEntries = {
   name: "logEntries",
-  identifier: sql.identifier("polymorphic", "log_entries"),
+  identifier: logEntriesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1168,9 +1184,10 @@ const spec_logEntries = {
   executor: executor
 };
 const logEntriesCodec = recordCodec(spec_logEntries);
+const relationalPostsIdentifier = sql.identifier("polymorphic", "relational_posts");
 const spec_relationalPosts = {
   name: "relationalPosts",
-  identifier: sql.identifier("polymorphic", "relational_posts"),
+  identifier: relationalPostsIdentifier,
   attributes: Object.assign(Object.create(null), {
     post_item_id: {
       description: undefined,
@@ -1333,9 +1350,10 @@ const spec_relationalPosts = {
   executor: executor
 };
 const relationalPostsCodec = recordCodec(spec_relationalPosts);
+const firstPartyVulnerabilitiesIdentifier = sql.identifier("polymorphic", "first_party_vulnerabilities");
 const spec_firstPartyVulnerabilities = {
   name: "firstPartyVulnerabilities",
-  identifier: sql.identifier("polymorphic", "first_party_vulnerabilities"),
+  identifier: firstPartyVulnerabilitiesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1415,9 +1433,10 @@ const spec_firstPartyVulnerabilities = {
   executor: executor
 };
 const firstPartyVulnerabilitiesCodec = recordCodec(spec_firstPartyVulnerabilities);
+const thirdPartyVulnerabilitiesIdentifier = sql.identifier("polymorphic", "third_party_vulnerabilities");
 const spec_thirdPartyVulnerabilities = {
   name: "thirdPartyVulnerabilities",
-  identifier: sql.identifier("polymorphic", "third_party_vulnerabilities"),
+  identifier: thirdPartyVulnerabilitiesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1497,9 +1516,10 @@ const spec_thirdPartyVulnerabilities = {
   executor: executor
 };
 const thirdPartyVulnerabilitiesCodec = recordCodec(spec_thirdPartyVulnerabilities);
+const awsApplicationsIdentifier = sql.identifier("polymorphic", "aws_applications");
 const spec_awsApplications = {
   name: "awsApplications",
-  identifier: sql.identifier("polymorphic", "aws_applications"),
+  identifier: awsApplicationsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1597,9 +1617,10 @@ const spec_awsApplications = {
   executor: executor
 };
 const awsApplicationsCodec = recordCodec(spec_awsApplications);
+const gcpApplicationsIdentifier = sql.identifier("polymorphic", "gcp_applications");
 const spec_gcpApplications = {
   name: "gcpApplications",
-  identifier: sql.identifier("polymorphic", "gcp_applications"),
+  identifier: gcpApplicationsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1697,9 +1718,10 @@ const spec_gcpApplications = {
   executor: executor
 };
 const gcpApplicationsCodec = recordCodec(spec_gcpApplications);
+const singleTableItemsIdentifier = sql.identifier("polymorphic", "single_table_items");
 const spec_singleTableItems = {
   name: "singleTableItems",
-  identifier: sql.identifier("polymorphic", "single_table_items"),
+  identifier: singleTableItemsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1949,9 +1971,10 @@ const spec_singleTableItems = {
   }
 };
 const singleTableItemsCodec = recordCodec(spec_singleTableItems);
+const relationalItemsIdentifier = sql.identifier("polymorphic", "relational_items");
 const spec_relationalItems = {
   name: "relationalItems",
-  identifier: sql.identifier("polymorphic", "relational_items"),
+  identifier: relationalItemsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -2296,10 +2319,10 @@ const spec_ZeroImplementation = {
   }
 };
 const registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws_application_first_party_vulnerabilities = {
-  executor,
+  executor: executor,
   name: "aws_application_first_party_vulnerabilities",
   identifier: "main.polymorphic.aws_application_first_party_vulnerabilities",
-  from: awsApplicationFirstPartyVulnerabilitiesCodec.sqlType,
+  from: awsApplicationFirstPartyVulnerabilitiesIdentifier,
   codec: awsApplicationFirstPartyVulnerabilitiesCodec,
   uniques: [{
     isPrimary: true,
@@ -2325,10 +2348,10 @@ const registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws
   }
 };
 const registryConfig_pgResources_aws_application_third_party_vulnerabilities_aws_application_third_party_vulnerabilities = {
-  executor,
+  executor: executor,
   name: "aws_application_third_party_vulnerabilities",
   identifier: "main.polymorphic.aws_application_third_party_vulnerabilities",
-  from: awsApplicationThirdPartyVulnerabilitiesCodec.sqlType,
+  from: awsApplicationThirdPartyVulnerabilitiesIdentifier,
   codec: awsApplicationThirdPartyVulnerabilitiesCodec,
   uniques: [{
     isPrimary: true,
@@ -2354,10 +2377,10 @@ const registryConfig_pgResources_aws_application_third_party_vulnerabilities_aws
   }
 };
 const registryConfig_pgResources_gcp_application_first_party_vulnerabilities_gcp_application_first_party_vulnerabilities = {
-  executor,
+  executor: executor,
   name: "gcp_application_first_party_vulnerabilities",
   identifier: "main.polymorphic.gcp_application_first_party_vulnerabilities",
-  from: gcpApplicationFirstPartyVulnerabilitiesCodec.sqlType,
+  from: gcpApplicationFirstPartyVulnerabilitiesIdentifier,
   codec: gcpApplicationFirstPartyVulnerabilitiesCodec,
   uniques: [{
     isPrimary: true,
@@ -2383,10 +2406,10 @@ const registryConfig_pgResources_gcp_application_first_party_vulnerabilities_gcp
   }
 };
 const registryConfig_pgResources_gcp_application_third_party_vulnerabilities_gcp_application_third_party_vulnerabilities = {
-  executor,
+  executor: executor,
   name: "gcp_application_third_party_vulnerabilities",
   identifier: "main.polymorphic.gcp_application_third_party_vulnerabilities",
-  from: gcpApplicationThirdPartyVulnerabilitiesCodec.sqlType,
+  from: gcpApplicationThirdPartyVulnerabilitiesIdentifier,
   codec: gcpApplicationThirdPartyVulnerabilitiesCodec,
   uniques: [{
     isPrimary: true,
@@ -2427,10 +2450,10 @@ const organizationsUniques = [{
   }
 }];
 const registryConfig_pgResources_organizations_organizations = {
-  executor,
+  executor: executor,
   name: "organizations",
   identifier: "main.polymorphic.organizations",
-  from: organizationsCodec.sqlType,
+  from: organizationsIdentifier,
   codec: organizationsCodec,
   uniques: organizationsUniques,
   isVirtual: false,
@@ -2463,10 +2486,10 @@ const peopleUniques = [{
   }
 }];
 const registryConfig_pgResources_people_people = {
-  executor,
+  executor: executor,
   name: "people",
   identifier: "main.polymorphic.people",
-  from: peopleCodec.sqlType,
+  from: peopleIdentifier,
   codec: peopleCodec,
   uniques: peopleUniques,
   isVirtual: false,
@@ -2486,10 +2509,10 @@ const registryConfig_pgResources_people_people = {
   }
 };
 const registryConfig_pgResources_priorities_priorities = {
-  executor,
+  executor: executor,
   name: "priorities",
   identifier: "main.polymorphic.priorities",
-  from: prioritiesCodec.sqlType,
+  from: prioritiesIdentifier,
   codec: prioritiesCodec,
   uniques: [{
     isPrimary: true,
@@ -2523,10 +2546,10 @@ const relational_checklistsUniques = [{
   }
 }];
 const registryConfig_pgResources_relational_checklists_relational_checklists = {
-  executor,
+  executor: executor,
   name: "relational_checklists",
   identifier: "main.polymorphic.relational_checklists",
-  from: relationalChecklistsCodec.sqlType,
+  from: relationalChecklistsIdentifier,
   codec: relationalChecklistsCodec,
   uniques: relational_checklistsUniques,
   isVirtual: false,
@@ -2550,10 +2573,10 @@ const relational_item_relation_composite_pksUniques = [{
   }
 }];
 const registryConfig_pgResources_relational_item_relation_composite_pks_relational_item_relation_composite_pks = {
-  executor,
+  executor: executor,
   name: "relational_item_relation_composite_pks",
   identifier: "main.polymorphic.relational_item_relation_composite_pks",
-  from: relationalItemRelationCompositePksCodec.sqlType,
+  from: relationalItemRelationCompositePksIdentifier,
   codec: relationalItemRelationCompositePksCodec,
   uniques: relational_item_relation_composite_pksUniques,
   isVirtual: false,
@@ -2577,10 +2600,10 @@ const relational_topicsUniques = [{
   }
 }];
 const registryConfig_pgResources_relational_topics_relational_topics = {
-  executor,
+  executor: executor,
   name: "relational_topics",
   identifier: "main.polymorphic.relational_topics",
-  from: relationalTopicsCodec.sqlType,
+  from: relationalTopicsIdentifier,
   codec: relationalTopicsCodec,
   uniques: relational_topicsUniques,
   isVirtual: false,
@@ -2604,10 +2627,10 @@ const single_table_item_relation_composite_pksUniques = [{
   }
 }];
 const registryConfig_pgResources_single_table_item_relation_composite_pks_single_table_item_relation_composite_pks = {
-  executor,
+  executor: executor,
   name: "single_table_item_relation_composite_pks",
   identifier: "main.polymorphic.single_table_item_relation_composite_pks",
-  from: singleTableItemRelationCompositePksCodec.sqlType,
+  from: singleTableItemRelationCompositePksIdentifier,
   codec: singleTableItemRelationCompositePksCodec,
   uniques: single_table_item_relation_composite_pksUniques,
   isVirtual: false,
@@ -2631,10 +2654,10 @@ const relational_checklist_itemsUniques = [{
   }
 }];
 const registryConfig_pgResources_relational_checklist_items_relational_checklist_items = {
-  executor,
+  executor: executor,
   name: "relational_checklist_items",
   identifier: "main.polymorphic.relational_checklist_items",
-  from: relationalChecklistItemsCodec.sqlType,
+  from: relationalChecklistItemsIdentifier,
   codec: relationalChecklistItemsCodec,
   uniques: relational_checklist_itemsUniques,
   isVirtual: false,
@@ -2658,10 +2681,10 @@ const relational_dividersUniques = [{
   }
 }];
 const registryConfig_pgResources_relational_dividers_relational_dividers = {
-  executor,
+  executor: executor,
   name: "relational_dividers",
   identifier: "main.polymorphic.relational_dividers",
-  from: relationalDividersCodec.sqlType,
+  from: relationalDividersIdentifier,
   codec: relationalDividersCodec,
   uniques: relational_dividersUniques,
   isVirtual: false,
@@ -2692,10 +2715,10 @@ const relational_item_relationsUniques = [{
   }
 }];
 const registryConfig_pgResources_relational_item_relations_relational_item_relations = {
-  executor,
+  executor: executor,
   name: "relational_item_relations",
   identifier: "main.polymorphic.relational_item_relations",
-  from: relationalItemRelationsCodec.sqlType,
+  from: relationalItemRelationsIdentifier,
   codec: relationalItemRelationsCodec,
   uniques: relational_item_relationsUniques,
   isVirtual: false,
@@ -2726,10 +2749,10 @@ const single_table_item_relationsUniques = [{
   }
 }];
 const registryConfig_pgResources_single_table_item_relations_single_table_item_relations = {
-  executor,
+  executor: executor,
   name: "single_table_item_relations",
   identifier: "main.polymorphic.single_table_item_relations",
-  from: singleTableItemRelationsCodec.sqlType,
+  from: singleTableItemRelationsIdentifier,
   codec: singleTableItemRelationsCodec,
   uniques: single_table_item_relationsUniques,
   isVirtual: false,
@@ -2753,10 +2776,10 @@ const log_entriesUniques = [{
   }
 }];
 const registryConfig_pgResources_log_entries_log_entries = {
-  executor,
+  executor: executor,
   name: "log_entries",
   identifier: "main.polymorphic.log_entries",
-  from: logEntriesCodec.sqlType,
+  from: logEntriesIdentifier,
   codec: logEntriesCodec,
   uniques: log_entriesUniques,
   isVirtual: false,
@@ -2783,10 +2806,10 @@ const relational_postsUniques = [{
   }
 }];
 const registryConfig_pgResources_relational_posts_relational_posts = {
-  executor,
+  executor: executor,
   name: "relational_posts",
   identifier: "main.polymorphic.relational_posts",
-  from: relationalPostsCodec.sqlType,
+  from: relationalPostsIdentifier,
   codec: relationalPostsCodec,
   uniques: relational_postsUniques,
   isVirtual: false,
@@ -2810,10 +2833,10 @@ const first_party_vulnerabilitiesUniques = [{
   }
 }];
 const registryConfig_pgResources_first_party_vulnerabilities_first_party_vulnerabilities = {
-  executor,
+  executor: executor,
   name: "first_party_vulnerabilities",
   identifier: "main.polymorphic.first_party_vulnerabilities",
-  from: firstPartyVulnerabilitiesCodec.sqlType,
+  from: firstPartyVulnerabilitiesIdentifier,
   codec: firstPartyVulnerabilitiesCodec,
   uniques: first_party_vulnerabilitiesUniques,
   isVirtual: false,
@@ -2841,10 +2864,10 @@ const third_party_vulnerabilitiesUniques = [{
   }
 }];
 const registryConfig_pgResources_third_party_vulnerabilities_third_party_vulnerabilities = {
-  executor,
+  executor: executor,
   name: "third_party_vulnerabilities",
   identifier: "main.polymorphic.third_party_vulnerabilities",
-  from: thirdPartyVulnerabilitiesCodec.sqlType,
+  from: thirdPartyVulnerabilitiesIdentifier,
   codec: thirdPartyVulnerabilitiesCodec,
   uniques: third_party_vulnerabilitiesUniques,
   isVirtual: false,
@@ -2872,10 +2895,10 @@ const aws_applicationsUniques = [{
   }
 }];
 const registryConfig_pgResources_aws_applications_aws_applications = {
-  executor,
+  executor: executor,
   name: "aws_applications",
   identifier: "main.polymorphic.aws_applications",
-  from: awsApplicationsCodec.sqlType,
+  from: awsApplicationsIdentifier,
   codec: awsApplicationsCodec,
   uniques: aws_applicationsUniques,
   isVirtual: false,
@@ -2903,10 +2926,10 @@ const gcp_applicationsUniques = [{
   }
 }];
 const registryConfig_pgResources_gcp_applications_gcp_applications = {
-  executor,
+  executor: executor,
   name: "gcp_applications",
   identifier: "main.polymorphic.gcp_applications",
-  from: gcpApplicationsCodec.sqlType,
+  from: gcpApplicationsIdentifier,
   codec: gcpApplicationsCodec,
   uniques: gcp_applicationsUniques,
   isVirtual: false,
@@ -2935,10 +2958,10 @@ const single_table_itemsUniques = [{
   }
 }];
 const registryConfig_pgResources_single_table_items_single_table_items = {
-  executor,
+  executor: executor,
   name: "single_table_items",
   identifier: "main.polymorphic.single_table_items",
-  from: singleTableItemsCodec.sqlType,
+  from: singleTableItemsIdentifier,
   codec: singleTableItemsCodec,
   uniques: single_table_itemsUniques,
   isVirtual: false,
@@ -2968,10 +2991,10 @@ const relational_itemsUniques = [{
   }
 }];
 const registryConfig_pgResources_relational_items_relational_items = {
-  executor,
+  executor: executor,
   name: "relational_items",
   identifier: "main.polymorphic.relational_items",
-  from: relationalItemsCodec.sqlType,
+  from: relationalItemsIdentifier,
   codec: relationalItemsCodec,
   uniques: relational_itemsUniques,
   isVirtual: false,

--- a/postgraphile/postgraphile/__tests__/schema/v4/rbac.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/rbac.1.export.mjs
@@ -459,9 +459,10 @@ const textArrayCodec = listOfCodec(TYPES.text, {
   description: undefined,
   name: "textArray"
 });
+const nonUpdatableViewIdentifier = sql.identifier("a", "non_updatable_view");
 const nonUpdatableViewCodec = recordCodec({
   name: "nonUpdatableView",
-  identifier: sql.identifier("a", "non_updatable_view"),
+  identifier: nonUpdatableViewIdentifier,
   attributes: Object.assign(Object.create(null), {
     "?column?": {
       description: undefined,
@@ -487,9 +488,10 @@ const nonUpdatableViewCodec = recordCodec({
   },
   executor: executor
 });
+const inputsIdentifier = sql.identifier("a", "inputs");
 const inputsCodec = recordCodec({
   name: "inputs",
-  identifier: sql.identifier("a", "inputs"),
+  identifier: inputsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -515,9 +517,10 @@ const inputsCodec = recordCodec({
   },
   executor: executor
 });
+const patchsIdentifier = sql.identifier("a", "patchs");
 const patchsCodec = recordCodec({
   name: "patchs",
-  identifier: sql.identifier("a", "patchs"),
+  identifier: patchsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -543,9 +546,10 @@ const patchsCodec = recordCodec({
   },
   executor: executor
 });
+const reservedIdentifier = sql.identifier("a", "reserved");
 const reservedCodec = recordCodec({
   name: "reserved",
-  identifier: sql.identifier("a", "reserved"),
+  identifier: reservedIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -571,9 +575,10 @@ const reservedCodec = recordCodec({
   },
   executor: executor
 });
+const reservedPatchsIdentifier = sql.identifier("a", "reservedPatchs");
 const reservedPatchsCodec = recordCodec({
   name: "reservedPatchs",
-  identifier: sql.identifier("a", "reservedPatchs"),
+  identifier: reservedPatchsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -599,9 +604,10 @@ const reservedPatchsCodec = recordCodec({
   },
   executor: executor
 });
+const reservedInputIdentifier = sql.identifier("a", "reserved_input");
 const reservedInputCodec = recordCodec({
   name: "reservedInput",
-  identifier: sql.identifier("a", "reserved_input"),
+  identifier: reservedInputIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -627,9 +633,10 @@ const reservedInputCodec = recordCodec({
   },
   executor: executor
 });
+const defaultValueIdentifier = sql.identifier("a", "default_value");
 const defaultValueCodec = recordCodec({
   name: "defaultValue",
-  identifier: sql.identifier("a", "default_value"),
+  identifier: defaultValueIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -666,9 +673,10 @@ const defaultValueCodec = recordCodec({
   },
   executor: executor
 });
+const noPrimaryKeyIdentifier = sql.identifier("a", "no_primary_key");
 const noPrimaryKeyCodec = recordCodec({
   name: "noPrimaryKey",
-  identifier: sql.identifier("a", "no_primary_key"),
+  identifier: noPrimaryKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -705,9 +713,10 @@ const noPrimaryKeyCodec = recordCodec({
   },
   executor: executor
 });
+const uniqueForeignKeyIdentifier = sql.identifier("a", "unique_foreign_key");
 const uniqueForeignKeyCodec = recordCodec({
   name: "uniqueForeignKey",
-  identifier: sql.identifier("a", "unique_foreign_key"),
+  identifier: uniqueForeignKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     compound_key_1: {
       description: undefined,
@@ -747,9 +756,10 @@ const uniqueForeignKeyCodec = recordCodec({
   },
   executor: executor
 });
+const myTableIdentifier = sql.identifier("c", "my_table");
 const myTableCodec = recordCodec({
   name: "myTable",
-  identifier: sql.identifier("c", "my_table"),
+  identifier: myTableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -786,9 +796,10 @@ const myTableCodec = recordCodec({
   },
   executor: executor
 });
+const personSecretIdentifier = sql.identifier("c", "person_secret");
 const spec_personSecret = {
   name: "personSecret",
-  identifier: sql.identifier("c", "person_secret"),
+  identifier: personSecretIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id: {
       description: undefined,
@@ -829,9 +840,10 @@ const spec_personSecret = {
   executor: executor
 };
 const personSecretCodec = recordCodec(spec_personSecret);
+const foreignKeyIdentifier = sql.identifier("a", "foreign_key");
 const foreignKeyCodec = recordCodec({
   name: "foreignKey",
-  identifier: sql.identifier("a", "foreign_key"),
+  identifier: foreignKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id: {
       description: undefined,
@@ -879,9 +891,10 @@ const foreignKeyCodec = recordCodec({
   },
   executor: executor
 });
+const testviewIdentifier = sql.identifier("a", "testview");
 const testviewCodec = recordCodec({
   name: "testview",
-  identifier: sql.identifier("a", "testview"),
+  identifier: testviewIdentifier,
   attributes: Object.assign(Object.create(null), {
     testviewid: {
       description: undefined,
@@ -929,9 +942,10 @@ const testviewCodec = recordCodec({
   },
   executor: executor
 });
+const viewTableIdentifier = sql.identifier("a", "view_table");
 const viewTableCodec = recordCodec({
   name: "viewTable",
-  identifier: sql.identifier("a", "view_table"),
+  identifier: viewTableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -979,9 +993,10 @@ const viewTableCodec = recordCodec({
   },
   executor: executor
 });
+const compoundKeyIdentifier = sql.identifier("c", "compound_key");
 const compoundKeyCodec = recordCodec({
   name: "compoundKey",
-  identifier: sql.identifier("c", "compound_key"),
+  identifier: compoundKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id_2: {
       description: undefined,
@@ -1042,9 +1057,10 @@ const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   description: undefined,
   name: "uuidArray"
 });
+const similarTable1Identifier = sql.identifier("a", "similar_table_1");
 const similarTable1Codec = recordCodec({
   name: "similarTable1",
-  identifier: sql.identifier("a", "similar_table_1"),
+  identifier: similarTable1Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1103,9 +1119,10 @@ const similarTable1Codec = recordCodec({
   },
   executor: executor
 });
+const similarTable2Identifier = sql.identifier("a", "similar_table_2");
 const similarTable2Codec = recordCodec({
   name: "similarTable2",
-  identifier: sql.identifier("a", "similar_table_2"),
+  identifier: similarTable2Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1164,9 +1181,10 @@ const similarTable2Codec = recordCodec({
   },
   executor: executor
 });
+const updatableViewIdentifier = sql.identifier("b", "updatable_view");
 const updatableViewCodec = recordCodec({
   name: "updatableView",
-  identifier: sql.identifier("b", "updatable_view"),
+  identifier: updatableViewIdentifier,
   attributes: Object.assign(Object.create(null), {
     x: {
       description: undefined,
@@ -1228,9 +1246,10 @@ const updatableViewCodec = recordCodec({
   },
   executor: executor
 });
+const nullTestRecordIdentifier = sql.identifier("c", "null_test_record");
 const nullTestRecordCodec = recordCodec({
   name: "nullTestRecord",
-  identifier: sql.identifier("c", "null_test_record"),
+  identifier: nullTestRecordIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1289,9 +1308,10 @@ const nullTestRecordCodec = recordCodec({
   },
   executor: executor
 });
+const edgeCaseIdentifier = sql.identifier("c", "edge_case");
 const edgeCaseCodec = recordCodec({
   name: "edgeCase",
-  identifier: sql.identifier("c", "edge_case"),
+  identifier: edgeCaseIdentifier,
   attributes: Object.assign(Object.create(null), {
     not_null_has_default: {
       description: undefined,
@@ -1339,9 +1359,10 @@ const edgeCaseCodec = recordCodec({
   },
   executor: executor
 });
+const jwtTokenIdentifier = sql.identifier("b", "jwt_token");
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: sql.identifier("b", "jwt_token"),
+  identifier: jwtTokenIdentifier,
   attributes: Object.assign(Object.create(null), {
     role: {
       description: undefined,
@@ -1401,6 +1422,7 @@ const jwtTokenCodec = recordCodec({
   },
   executor: executor
 });
+const issue756Identifier = sql.identifier("c", "issue756");
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
   extensions: {
@@ -1415,7 +1437,7 @@ const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp
 });
 const issue756Codec = recordCodec({
   name: "issue756",
-  identifier: sql.identifier("c", "issue756"),
+  identifier: issue756Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1452,9 +1474,10 @@ const issue756Codec = recordCodec({
   },
   executor: executor
 });
+const leftArmIdentifier = sql.identifier("c", "left_arm");
 const spec_leftArm = {
   name: "leftArm",
-  identifier: sql.identifier("c", "left_arm"),
+  identifier: leftArmIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1514,9 +1537,10 @@ const spec_leftArm = {
   executor: executor
 };
 const leftArmCodec = recordCodec(spec_leftArm);
+const authPayloadIdentifier = sql.identifier("b", "auth_payload");
 const authPayloadCodec = recordCodec({
   name: "authPayload",
-  identifier: sql.identifier("b", "auth_payload"),
+  identifier: authPayloadIdentifier,
   attributes: Object.assign(Object.create(null), {
     jwt: {
       description: undefined,
@@ -1560,6 +1584,7 @@ const authPayloadCodec = recordCodec({
   },
   executor: executor
 });
+const compoundTypeIdentifier = sql.identifier("c", "compound_type");
 const colorCodec = enumCodec({
   name: "color",
   identifier: sql.identifier("b", "color"),
@@ -1604,7 +1629,7 @@ const enumWithEmptyStringCodec = enumCodec({
 });
 const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: sql.identifier("c", "compound_type"),
+  identifier: compoundTypeIdentifier,
   attributes: Object.assign(Object.create(null), {
     a: {
       description: undefined,
@@ -1751,6 +1776,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor,
   isAnonymous: true
 });
+const postIdentifier = sql.identifier("a", "post");
 const anEnumCodec = enumCodec({
   name: "anEnum",
   identifier: sql.identifier("a", "an_enum"),
@@ -1828,7 +1854,7 @@ const comptypeArrayCodec = listOfCodec(comptypeCodec, {
 });
 const spec_post = {
   name: "post",
-  identifier: sql.identifier("a", "post"),
+  identifier: postIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -2008,6 +2034,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor,
   isAnonymous: true
 });
+const personIdentifier = sql.identifier("c", "person");
 const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
   description: undefined,
   extensions: {
@@ -2060,7 +2087,7 @@ const wrappedUrlCodec = recordCodec({
 });
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("c", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: "The primary unique identifier for the person",
@@ -2411,6 +2438,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor,
   isAnonymous: true
 });
+const typesIdentifier = sql.identifier("b", "types");
 const colorArrayCodec = listOfCodec(colorCodec, {
   extensions: {
     pg: {
@@ -2590,7 +2618,7 @@ const spec_types_attributes_ltree_codec_ltree = {
 const spec_types_attributes_ltree_array_codec_ltree_ = listOfCodec(spec_types_attributes_ltree_codec_ltree);
 const spec_types = {
   name: "types",
-  identifier: sql.identifier("b", "types"),
+  identifier: typesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -3248,10 +3276,10 @@ const query_interval_arrayFunctionIdentifer = sql.identifier("a", "query_interva
 const mutation_text_arrayFunctionIdentifer = sql.identifier("a", "mutation_text_array");
 const query_text_arrayFunctionIdentifer = sql.identifier("a", "query_text_array");
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
-  executor,
+  executor: executor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
-  from: uniqueForeignKeyCodec.sqlType,
+  from: uniqueForeignKeyIdentifier,
   codec: uniqueForeignKeyCodec,
   uniques: [{
     isPrimary: false,
@@ -3285,10 +3313,10 @@ const person_secretUniques = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor,
+  executor: executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: personSecretCodec.sqlType,
+  from: personSecretIdentifier,
   codec: personSecretCodec,
   uniques: person_secretUniques,
   isVirtual: false,
@@ -3307,10 +3335,10 @@ const registryConfig_pgResources_person_secret_person_secret = {
   }
 };
 const registryConfig_pgResources_foreign_key_foreign_key = {
-  executor,
+  executor: executor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
-  from: foreignKeyCodec.sqlType,
+  from: foreignKeyIdentifier,
   codec: foreignKeyCodec,
   uniques: [],
   isVirtual: false,
@@ -3328,10 +3356,10 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   }
 };
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor,
+  executor: executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: compoundKeyCodec.sqlType,
+  from: compoundKeyIdentifier,
   codec: compoundKeyCodec,
   uniques: [{
     isPrimary: true,
@@ -3360,10 +3388,10 @@ const edge_case_computedFunctionIdentifer = sql.identifier("c", "edge_case_compu
 const return_table_without_grantsFunctionIdentifer = sql.identifier("c", "return_table_without_grants");
 const authenticate_failFunctionIdentifer = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
-  executor,
+  executor: executor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
-  from: jwtTokenCodec.sqlType,
+  from: jwtTokenIdentifier,
   codec: jwtTokenCodec,
   uniques: [],
   isVirtual: true,
@@ -3382,10 +3410,10 @@ const resourceConfig_jwt_token = {
 };
 const authenticateFunctionIdentifer = sql.identifier("b", "authenticate");
 const registryConfig_pgResources_issue756_issue756 = {
-  executor,
+  executor: executor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: issue756Codec.sqlType,
+  from: issue756Identifier,
   codec: issue756Codec,
   uniques: [{
     isPrimary: true,
@@ -3425,10 +3453,10 @@ const left_armUniques = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor,
+  executor: executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: leftArmCodec.sqlType,
+  from: leftArmIdentifier,
   codec: leftArmCodec,
   uniques: left_armUniques,
   isVirtual: false,
@@ -3463,10 +3491,10 @@ const post_headline_trimmed_no_defaultsFunctionIdentifer = sql.identifier("a", "
 const post_headline_trimmed_strictFunctionIdentifer = sql.identifier("a", "post_headline_trimmed_strict");
 const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_compound_type = {
-  executor,
+  executor: executor,
   name: "compound_type",
   identifier: "main.c.compound_type",
-  from: compoundTypeCodec.sqlType,
+  from: compoundTypeIdentifier,
   codec: compoundTypeCodec,
   uniques: [],
   isVirtual: true,
@@ -3500,10 +3528,10 @@ const postUniques = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor,
+  executor: executor,
   name: "post",
   identifier: "main.a.post",
-  from: postCodec.sqlType,
+  from: postIdentifier,
   codec: postCodec,
   uniques: postUniques,
   isVirtual: false,
@@ -3553,10 +3581,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.c.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -3583,10 +3611,10 @@ const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_
 const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
 const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
 const registryConfig_pgResources_types_types = {
-  executor,
+  executor: executor,
   name: "types",
   identifier: "main.b.types",
-  from: typesCodec.sqlType,
+  from: typesIdentifier,
   codec: typesCodec,
   uniques: [{
     isPrimary: true,
@@ -5792,10 +5820,10 @@ const registry = makeRegistry({
       description: undefined
     },
     non_updatable_view: {
-      executor,
+      executor: executor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
-      from: nonUpdatableViewCodec.sqlType,
+      from: nonUpdatableViewIdentifier,
       codec: nonUpdatableViewCodec,
       uniques: [],
       isVirtual: false,
@@ -5813,10 +5841,10 @@ const registry = makeRegistry({
       }
     },
     inputs: {
-      executor,
+      executor: executor,
       name: "inputs",
       identifier: "main.a.inputs",
-      from: inputsCodec.sqlType,
+      from: inputsIdentifier,
       codec: inputsCodec,
       uniques: [{
         isPrimary: true,
@@ -5841,10 +5869,10 @@ const registry = makeRegistry({
       }
     },
     patchs: {
-      executor,
+      executor: executor,
       name: "patchs",
       identifier: "main.a.patchs",
-      from: patchsCodec.sqlType,
+      from: patchsIdentifier,
       codec: patchsCodec,
       uniques: [{
         isPrimary: true,
@@ -5869,10 +5897,10 @@ const registry = makeRegistry({
       }
     },
     reserved: {
-      executor,
+      executor: executor,
       name: "reserved",
       identifier: "main.a.reserved",
-      from: reservedCodec.sqlType,
+      from: reservedIdentifier,
       codec: reservedCodec,
       uniques: [{
         isPrimary: true,
@@ -5897,10 +5925,10 @@ const registry = makeRegistry({
       }
     },
     reservedPatchs: {
-      executor,
+      executor: executor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
-      from: reservedPatchsCodec.sqlType,
+      from: reservedPatchsIdentifier,
       codec: reservedPatchsCodec,
       uniques: [{
         isPrimary: true,
@@ -5925,10 +5953,10 @@ const registry = makeRegistry({
       }
     },
     reserved_input: {
-      executor,
+      executor: executor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
-      from: reservedInputCodec.sqlType,
+      from: reservedInputIdentifier,
       codec: reservedInputCodec,
       uniques: [{
         isPrimary: true,
@@ -5953,10 +5981,10 @@ const registry = makeRegistry({
       }
     },
     default_value: {
-      executor,
+      executor: executor,
       name: "default_value",
       identifier: "main.a.default_value",
-      from: defaultValueCodec.sqlType,
+      from: defaultValueIdentifier,
       codec: defaultValueCodec,
       uniques: [{
         isPrimary: true,
@@ -5981,10 +6009,10 @@ const registry = makeRegistry({
       }
     },
     no_primary_key: {
-      executor,
+      executor: executor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
-      from: noPrimaryKeyCodec.sqlType,
+      from: noPrimaryKeyIdentifier,
       codec: noPrimaryKeyCodec,
       uniques: [{
         isPrimary: false,
@@ -6010,10 +6038,10 @@ const registry = makeRegistry({
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
-      executor,
+      executor: executor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: myTableCodec.sqlType,
+      from: myTableIdentifier,
       codec: myTableCodec,
       uniques: [{
         isPrimary: true,
@@ -6040,10 +6068,10 @@ const registry = makeRegistry({
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     testview: {
-      executor,
+      executor: executor,
       name: "testview",
       identifier: "main.a.testview",
-      from: testviewCodec.sqlType,
+      from: testviewIdentifier,
       codec: testviewCodec,
       uniques: [],
       isVirtual: false,
@@ -6061,10 +6089,10 @@ const registry = makeRegistry({
       }
     },
     view_table: {
-      executor,
+      executor: executor,
       name: "view_table",
       identifier: "main.a.view_table",
-      from: viewTableCodec.sqlType,
+      from: viewTableIdentifier,
       codec: viewTableCodec,
       uniques: [{
         isPrimary: true,
@@ -6129,10 +6157,10 @@ const registry = makeRegistry({
       description: undefined
     },
     similar_table_1: {
-      executor,
+      executor: executor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
-      from: similarTable1Codec.sqlType,
+      from: similarTable1Identifier,
       codec: similarTable1Codec,
       uniques: [{
         isPrimary: true,
@@ -6157,10 +6185,10 @@ const registry = makeRegistry({
       }
     },
     similar_table_2: {
-      executor,
+      executor: executor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
-      from: similarTable2Codec.sqlType,
+      from: similarTable2Identifier,
       codec: similarTable2Codec,
       uniques: [{
         isPrimary: true,
@@ -6214,10 +6242,10 @@ const registry = makeRegistry({
       description: undefined
     },
     updatable_view: {
-      executor,
+      executor: executor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
-      from: updatableViewCodec.sqlType,
+      from: updatableViewIdentifier,
       codec: updatableViewCodec,
       uniques: [{
         isPrimary: false,
@@ -6246,10 +6274,10 @@ const registry = makeRegistry({
       }
     },
     null_test_record: {
-      executor,
+      executor: executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: nullTestRecordCodec.sqlType,
+      from: nullTestRecordIdentifier,
       codec: nullTestRecordCodec,
       uniques: [{
         isPrimary: true,
@@ -6296,10 +6324,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     edge_case: {
-      executor,
+      executor: executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: edgeCaseCodec.sqlType,
+      from: edgeCaseIdentifier,
       codec: edgeCaseCodec,
       uniques: [],
       isVirtual: false,
@@ -6491,10 +6519,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     authenticate_payload: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "auth_payload",
       identifier: "main.b.auth_payload",
-      from: authPayloadCodec.sqlType,
+      from: authPayloadIdentifier,
       codec: authPayloadCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.export.mjs
@@ -459,9 +459,10 @@ const textArrayCodec = listOfCodec(TYPES.text, {
   description: undefined,
   name: "textArray"
 });
+const nonUpdatableViewIdentifier = sql.identifier("a", "non_updatable_view");
 const spec_nonUpdatableView = {
   name: "nonUpdatableView",
-  identifier: sql.identifier("a", "non_updatable_view"),
+  identifier: nonUpdatableViewIdentifier,
   attributes: Object.assign(Object.create(null), {
     "?column?": {
       description: undefined,
@@ -486,9 +487,10 @@ const spec_nonUpdatableView = {
   executor: executor
 };
 const nonUpdatableViewCodec = recordCodec(spec_nonUpdatableView);
+const inputsIdentifier = sql.identifier("a", "inputs");
 const spec_inputs = {
   name: "inputs",
-  identifier: sql.identifier("a", "inputs"),
+  identifier: inputsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -513,9 +515,10 @@ const spec_inputs = {
   executor: executor
 };
 const inputsCodec = recordCodec(spec_inputs);
+const patchsIdentifier = sql.identifier("a", "patchs");
 const spec_patchs = {
   name: "patchs",
-  identifier: sql.identifier("a", "patchs"),
+  identifier: patchsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -540,9 +543,10 @@ const spec_patchs = {
   executor: executor
 };
 const patchsCodec = recordCodec(spec_patchs);
+const reservedIdentifier = sql.identifier("a", "reserved");
 const spec_reserved = {
   name: "reserved",
-  identifier: sql.identifier("a", "reserved"),
+  identifier: reservedIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -567,9 +571,10 @@ const spec_reserved = {
   executor: executor
 };
 const reservedCodec = recordCodec(spec_reserved);
+const reservedPatchsIdentifier = sql.identifier("a", "reservedPatchs");
 const spec_reservedPatchs = {
   name: "reservedPatchs",
-  identifier: sql.identifier("a", "reservedPatchs"),
+  identifier: reservedPatchsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -594,9 +599,10 @@ const spec_reservedPatchs = {
   executor: executor
 };
 const reservedPatchsCodec = recordCodec(spec_reservedPatchs);
+const reservedInputIdentifier = sql.identifier("a", "reserved_input");
 const spec_reservedInput = {
   name: "reservedInput",
-  identifier: sql.identifier("a", "reserved_input"),
+  identifier: reservedInputIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -621,9 +627,10 @@ const spec_reservedInput = {
   executor: executor
 };
 const reservedInputCodec = recordCodec(spec_reservedInput);
+const defaultValueIdentifier = sql.identifier("a", "default_value");
 const spec_defaultValue = {
   name: "defaultValue",
-  identifier: sql.identifier("a", "default_value"),
+  identifier: defaultValueIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -657,9 +664,10 @@ const spec_defaultValue = {
   executor: executor
 };
 const defaultValueCodec = recordCodec(spec_defaultValue);
+const foreignKeyIdentifier = sql.identifier("a", "foreign_key");
 const spec_foreignKey = {
   name: "foreignKey",
-  identifier: sql.identifier("a", "foreign_key"),
+  identifier: foreignKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id: {
       description: undefined,
@@ -702,9 +710,10 @@ const spec_foreignKey = {
   executor: executor
 };
 const foreignKeyCodec = recordCodec(spec_foreignKey);
+const noPrimaryKeyIdentifier = sql.identifier("a", "no_primary_key");
 const spec_noPrimaryKey = {
   name: "noPrimaryKey",
-  identifier: sql.identifier("a", "no_primary_key"),
+  identifier: noPrimaryKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -738,9 +747,10 @@ const spec_noPrimaryKey = {
   executor: executor
 };
 const noPrimaryKeyCodec = recordCodec(spec_noPrimaryKey);
+const testviewIdentifier = sql.identifier("a", "testview");
 const spec_testview = {
   name: "testview",
-  identifier: sql.identifier("a", "testview"),
+  identifier: testviewIdentifier,
   attributes: Object.assign(Object.create(null), {
     testviewid: {
       description: undefined,
@@ -783,9 +793,10 @@ const spec_testview = {
   executor: executor
 };
 const testviewCodec = recordCodec(spec_testview);
+const uniqueForeignKeyIdentifier = sql.identifier("a", "unique_foreign_key");
 const spec_uniqueForeignKey = {
   name: "uniqueForeignKey",
-  identifier: sql.identifier("a", "unique_foreign_key"),
+  identifier: uniqueForeignKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     compound_key_1: {
       description: undefined,
@@ -822,9 +833,10 @@ const spec_uniqueForeignKey = {
   executor: executor
 };
 const uniqueForeignKeyCodec = recordCodec(spec_uniqueForeignKey);
+const myTableIdentifier = sql.identifier("c", "my_table");
 const spec_myTable = {
   name: "myTable",
-  identifier: sql.identifier("c", "my_table"),
+  identifier: myTableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -858,9 +870,10 @@ const spec_myTable = {
   executor: executor
 };
 const myTableCodec = recordCodec(spec_myTable);
+const personSecretIdentifier = sql.identifier("c", "person_secret");
 const spec_personSecret = {
   name: "personSecret",
-  identifier: sql.identifier("c", "person_secret"),
+  identifier: personSecretIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id: {
       description: undefined,
@@ -898,9 +911,10 @@ const spec_personSecret = {
   executor: executor
 };
 const personSecretCodec = recordCodec(spec_personSecret);
+const viewTableIdentifier = sql.identifier("a", "view_table");
 const spec_viewTable = {
   name: "viewTable",
-  identifier: sql.identifier("a", "view_table"),
+  identifier: viewTableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -943,9 +957,10 @@ const spec_viewTable = {
   executor: executor
 };
 const viewTableCodec = recordCodec(spec_viewTable);
+const compoundKeyIdentifier = sql.identifier("c", "compound_key");
 const spec_compoundKey = {
   name: "compoundKey",
-  identifier: sql.identifier("c", "compound_key"),
+  identifier: compoundKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id_2: {
       description: undefined,
@@ -988,9 +1003,10 @@ const spec_compoundKey = {
   executor: executor
 };
 const compoundKeyCodec = recordCodec(spec_compoundKey);
+const similarTable1Identifier = sql.identifier("a", "similar_table_1");
 const spec_similarTable1 = {
   name: "similarTable1",
-  identifier: sql.identifier("a", "similar_table_1"),
+  identifier: similarTable1Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1042,9 +1058,10 @@ const spec_similarTable1 = {
   executor: executor
 };
 const similarTable1Codec = recordCodec(spec_similarTable1);
+const similarTable2Identifier = sql.identifier("a", "similar_table_2");
 const spec_similarTable2 = {
   name: "similarTable2",
-  identifier: sql.identifier("a", "similar_table_2"),
+  identifier: similarTable2Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1096,9 +1113,10 @@ const spec_similarTable2 = {
   executor: executor
 };
 const similarTable2Codec = recordCodec(spec_similarTable2);
+const updatableViewIdentifier = sql.identifier("b", "updatable_view");
 const spec_updatableView = {
   name: "updatableView",
-  identifier: sql.identifier("b", "updatable_view"),
+  identifier: updatableViewIdentifier,
   attributes: Object.assign(Object.create(null), {
     x: {
       description: undefined,
@@ -1153,9 +1171,10 @@ const spec_updatableView = {
   executor: executor
 };
 const updatableViewCodec = recordCodec(spec_updatableView);
+const nullTestRecordIdentifier = sql.identifier("c", "null_test_record");
 const spec_nullTestRecord = {
   name: "nullTestRecord",
-  identifier: sql.identifier("c", "null_test_record"),
+  identifier: nullTestRecordIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1220,9 +1239,10 @@ const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   description: undefined,
   name: "uuidArray"
 });
+const edgeCaseIdentifier = sql.identifier("c", "edge_case");
 const spec_edgeCase = {
   name: "edgeCase",
-  identifier: sql.identifier("c", "edge_case"),
+  identifier: edgeCaseIdentifier,
   attributes: Object.assign(Object.create(null), {
     not_null_has_default: {
       description: undefined,
@@ -1265,9 +1285,10 @@ const spec_edgeCase = {
   executor: executor
 };
 const edgeCaseCodec = recordCodec(spec_edgeCase);
+const leftArmIdentifier = sql.identifier("c", "left_arm");
 const spec_leftArm = {
   name: "leftArm",
-  identifier: sql.identifier("c", "left_arm"),
+  identifier: leftArmIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1319,9 +1340,10 @@ const spec_leftArm = {
   executor: executor
 };
 const leftArmCodec = recordCodec(spec_leftArm);
+const jwtTokenIdentifier = sql.identifier("b", "jwt_token");
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: sql.identifier("b", "jwt_token"),
+  identifier: jwtTokenIdentifier,
   attributes: Object.assign(Object.create(null), {
     role: {
       description: undefined,
@@ -1381,6 +1403,7 @@ const jwtTokenCodec = recordCodec({
   },
   executor: executor
 });
+const issue756Identifier = sql.identifier("c", "issue756");
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
   extensions: {
@@ -1395,7 +1418,7 @@ const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp
 });
 const spec_issue756 = {
   name: "issue756",
-  identifier: sql.identifier("c", "issue756"),
+  identifier: issue756Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1429,9 +1452,10 @@ const spec_issue756 = {
   executor: executor
 };
 const issue756Codec = recordCodec(spec_issue756);
+const authPayloadIdentifier = sql.identifier("b", "auth_payload");
 const authPayloadCodec = recordCodec({
   name: "authPayload",
-  identifier: sql.identifier("b", "auth_payload"),
+  identifier: authPayloadIdentifier,
   attributes: Object.assign(Object.create(null), {
     jwt: {
       description: undefined,
@@ -1475,6 +1499,7 @@ const authPayloadCodec = recordCodec({
   },
   executor: executor
 });
+const compoundTypeIdentifier = sql.identifier("c", "compound_type");
 const colorCodec = enumCodec({
   name: "color",
   identifier: sql.identifier("b", "color"),
@@ -1519,7 +1544,7 @@ const enumWithEmptyStringCodec = enumCodec({
 });
 const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: sql.identifier("c", "compound_type"),
+  identifier: compoundTypeIdentifier,
   attributes: Object.assign(Object.create(null), {
     a: {
       description: undefined,
@@ -1666,6 +1691,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor,
   isAnonymous: true
 });
+const postIdentifier = sql.identifier("a", "post");
 const anEnumCodec = enumCodec({
   name: "anEnum",
   identifier: sql.identifier("a", "an_enum"),
@@ -1743,7 +1769,7 @@ const comptypeArrayCodec = listOfCodec(comptypeCodec, {
 });
 const spec_post = {
   name: "post",
-  identifier: sql.identifier("a", "post"),
+  identifier: postIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1911,6 +1937,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor,
   isAnonymous: true
 });
+const personIdentifier = sql.identifier("c", "person");
 const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
   description: undefined,
   extensions: {
@@ -1963,7 +1990,7 @@ const wrappedUrlCodec = recordCodec({
 });
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("c", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: "The primary unique identifier for the person",
@@ -2302,6 +2329,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor,
   isAnonymous: true
 });
+const typesIdentifier = sql.identifier("b", "types");
 const colorArrayCodec = listOfCodec(colorCodec, {
   extensions: {
     pg: {
@@ -2481,7 +2509,7 @@ const spec_types_attributes_ltree_codec_ltree = {
 const spec_types_attributes_ltree_array_codec_ltree_ = listOfCodec(spec_types_attributes_ltree_codec_ltree);
 const spec_types = {
   name: "types",
-  identifier: sql.identifier("b", "types"),
+  identifier: typesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -3089,10 +3117,10 @@ const default_valueUniques = [{
   }
 }];
 const registryConfig_pgResources_foreign_key_foreign_key = {
-  executor,
+  executor: executor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
-  from: foreignKeyCodec.sqlType,
+  from: foreignKeyIdentifier,
   codec: foreignKeyCodec,
   uniques: [],
   isVirtual: false,
@@ -3108,10 +3136,10 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   }
 };
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
-  executor,
+  executor: executor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
-  from: uniqueForeignKeyCodec.sqlType,
+  from: uniqueForeignKeyIdentifier,
   codec: uniqueForeignKeyCodec,
   uniques: [{
     isPrimary: false,
@@ -3153,10 +3181,10 @@ const person_secretUniques = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor,
+  executor: executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: personSecretCodec.sqlType,
+  from: personSecretIdentifier,
   codec: personSecretCodec,
   uniques: person_secretUniques,
   isVirtual: false,
@@ -3190,10 +3218,10 @@ const compound_keyUniques = [{
   }
 }];
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor,
+  executor: executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: compoundKeyCodec.sqlType,
+  from: compoundKeyIdentifier,
   codec: compoundKeyCodec,
   uniques: compound_keyUniques,
   isVirtual: false,
@@ -3251,10 +3279,10 @@ const left_armUniques = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor,
+  executor: executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: leftArmCodec.sqlType,
+  from: leftArmIdentifier,
   codec: leftArmCodec,
   uniques: left_armUniques,
   isVirtual: false,
@@ -3271,10 +3299,10 @@ const registryConfig_pgResources_left_arm_left_arm = {
 };
 const authenticate_failFunctionIdentifer = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
-  executor,
+  executor: executor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
-  from: jwtTokenCodec.sqlType,
+  from: jwtTokenIdentifier,
   codec: jwtTokenCodec,
   uniques: [],
   isVirtual: true,
@@ -3301,10 +3329,10 @@ const issue756Uniques = [{
   }
 }];
 const registryConfig_pgResources_issue756_issue756 = {
-  executor,
+  executor: executor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: issue756Codec.sqlType,
+  from: issue756Identifier,
   codec: issue756Codec,
   uniques: issue756Uniques,
   isVirtual: false,
@@ -3347,10 +3375,10 @@ const postUniques = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor,
+  executor: executor,
   name: "post",
   identifier: "main.a.post",
-  from: postCodec.sqlType,
+  from: postIdentifier,
   codec: postCodec,
   uniques: postUniques,
   isVirtual: false,
@@ -3367,10 +3395,10 @@ const registryConfig_pgResources_post_post = {
 };
 const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_compound_type = {
-  executor,
+  executor: executor,
   name: "compound_type",
   identifier: "main.c.compound_type",
-  from: compoundTypeCodec.sqlType,
+  from: compoundTypeIdentifier,
   codec: compoundTypeCodec,
   uniques: [],
   isVirtual: true,
@@ -3428,10 +3456,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.c.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -3465,10 +3493,10 @@ const typesUniques = [{
   }
 }];
 const registryConfig_pgResources_types_types = {
-  executor,
+  executor: executor,
   name: "types",
   identifier: "main.b.types",
-  from: typesCodec.sqlType,
+  from: typesIdentifier,
   codec: typesCodec,
   uniques: typesUniques,
   isVirtual: false,
@@ -5666,10 +5694,10 @@ const registry = makeRegistry({
       description: undefined
     },
     non_updatable_view: {
-      executor,
+      executor: executor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
-      from: nonUpdatableViewCodec.sqlType,
+      from: nonUpdatableViewIdentifier,
       codec: nonUpdatableViewCodec,
       uniques: [],
       isVirtual: false,
@@ -5687,10 +5715,10 @@ const registry = makeRegistry({
       }
     },
     inputs: {
-      executor,
+      executor: executor,
       name: "inputs",
       identifier: "main.a.inputs",
-      from: inputsCodec.sqlType,
+      from: inputsIdentifier,
       codec: inputsCodec,
       uniques: inputsUniques,
       isVirtual: false,
@@ -5706,10 +5734,10 @@ const registry = makeRegistry({
       }
     },
     patchs: {
-      executor,
+      executor: executor,
       name: "patchs",
       identifier: "main.a.patchs",
-      from: patchsCodec.sqlType,
+      from: patchsIdentifier,
       codec: patchsCodec,
       uniques: patchsUniques,
       isVirtual: false,
@@ -5725,10 +5753,10 @@ const registry = makeRegistry({
       }
     },
     reserved: {
-      executor,
+      executor: executor,
       name: "reserved",
       identifier: "main.a.reserved",
-      from: reservedCodec.sqlType,
+      from: reservedIdentifier,
       codec: reservedCodec,
       uniques: reservedUniques,
       isVirtual: false,
@@ -5744,10 +5772,10 @@ const registry = makeRegistry({
       }
     },
     reservedPatchs: {
-      executor,
+      executor: executor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
-      from: reservedPatchsCodec.sqlType,
+      from: reservedPatchsIdentifier,
       codec: reservedPatchsCodec,
       uniques: reservedPatchsUniques,
       isVirtual: false,
@@ -5763,10 +5791,10 @@ const registry = makeRegistry({
       }
     },
     reserved_input: {
-      executor,
+      executor: executor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
-      from: reservedInputCodec.sqlType,
+      from: reservedInputIdentifier,
       codec: reservedInputCodec,
       uniques: reserved_inputUniques,
       isVirtual: false,
@@ -5782,10 +5810,10 @@ const registry = makeRegistry({
       }
     },
     default_value: {
-      executor,
+      executor: executor,
       name: "default_value",
       identifier: "main.a.default_value",
-      from: defaultValueCodec.sqlType,
+      from: defaultValueIdentifier,
       codec: defaultValueCodec,
       uniques: default_valueUniques,
       isVirtual: false,
@@ -5802,10 +5830,10 @@ const registry = makeRegistry({
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
-      executor,
+      executor: executor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
-      from: noPrimaryKeyCodec.sqlType,
+      from: noPrimaryKeyIdentifier,
       codec: noPrimaryKeyCodec,
       uniques: [{
         isPrimary: false,
@@ -5828,10 +5856,10 @@ const registry = makeRegistry({
       }
     },
     testview: {
-      executor,
+      executor: executor,
       name: "testview",
       identifier: "main.a.testview",
-      from: testviewCodec.sqlType,
+      from: testviewIdentifier,
       codec: testviewCodec,
       uniques: [],
       isVirtual: false,
@@ -5848,10 +5876,10 @@ const registry = makeRegistry({
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
-      executor,
+      executor: executor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: myTableCodec.sqlType,
+      from: myTableIdentifier,
       codec: myTableCodec,
       uniques: my_tableUniques,
       isVirtual: false,
@@ -5868,10 +5896,10 @@ const registry = makeRegistry({
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
-      executor,
+      executor: executor,
       name: "view_table",
       identifier: "main.a.view_table",
-      from: viewTableCodec.sqlType,
+      from: viewTableIdentifier,
       codec: viewTableCodec,
       uniques: view_tableUniques,
       isVirtual: false,
@@ -5888,10 +5916,10 @@ const registry = makeRegistry({
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
-      executor,
+      executor: executor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
-      from: similarTable1Codec.sqlType,
+      from: similarTable1Identifier,
       codec: similarTable1Codec,
       uniques: similar_table_1Uniques,
       isVirtual: false,
@@ -5907,10 +5935,10 @@ const registry = makeRegistry({
       }
     },
     similar_table_2: {
-      executor,
+      executor: executor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
-      from: similarTable2Codec.sqlType,
+      from: similarTable2Identifier,
       codec: similarTable2Codec,
       uniques: similar_table_2Uniques,
       isVirtual: false,
@@ -5926,10 +5954,10 @@ const registry = makeRegistry({
       }
     },
     updatable_view: {
-      executor,
+      executor: executor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
-      from: updatableViewCodec.sqlType,
+      from: updatableViewIdentifier,
       codec: updatableViewCodec,
       uniques: [{
         isPrimary: false,
@@ -5957,10 +5985,10 @@ const registry = makeRegistry({
       }
     },
     null_test_record: {
-      executor,
+      executor: executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: nullTestRecordCodec.sqlType,
+      from: nullTestRecordIdentifier,
       codec: nullTestRecordCodec,
       uniques: null_test_recordUniques,
       isVirtual: false,
@@ -6066,10 +6094,10 @@ const registry = makeRegistry({
       description: undefined
     },
     edge_case: {
-      executor,
+      executor: executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: edgeCaseCodec.sqlType,
+      from: edgeCaseIdentifier,
       codec: edgeCaseCodec,
       uniques: [],
       isVirtual: false,
@@ -6259,10 +6287,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     authenticate_payload: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "auth_payload",
       identifier: "main.b.auth_payload",
-      from: authPayloadCodec.sqlType,
+      from: authPayloadIdentifier,
       codec: authPayloadCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/refs.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/refs.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const peopleIdentifier = sql.identifier("refs", "people");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const spec_people = {
   name: "people",
-  identifier: sql.identifier("refs", "people"),
+  identifier: peopleIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -111,9 +112,10 @@ const spec_people = {
   executor: executor
 };
 const peopleCodec = recordCodec(spec_people);
+const postsIdentifier = sql.identifier("refs", "posts");
 const spec_posts = {
   name: "posts",
-  identifier: sql.identifier("refs", "posts"),
+  identifier: postsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -174,10 +176,10 @@ const peopleUniques = [{
   }
 }];
 const registryConfig_pgResources_people_people = {
-  executor,
+  executor: executor,
   name: "people",
   identifier: "main.refs.people",
-  from: peopleCodec.sqlType,
+  from: peopleIdentifier,
   codec: peopleCodec,
   uniques: peopleUniques,
   isVirtual: false,
@@ -201,10 +203,10 @@ const postsUniques = [{
   }
 }];
 const registryConfig_pgResources_posts_posts = {
-  executor,
+  executor: executor,
   name: "posts",
   identifier: "main.refs.posts",
-  from: postsCodec.sqlType,
+  from: postsIdentifier,
   codec: postsCodec,
   uniques: postsUniques,
   isVirtual: false,

--- a/postgraphile/postgraphile/__tests__/schema/v4/relay.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/relay.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const flambleIdentifier = sql.identifier("d", "flibble");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const flambleCodec = recordCodec({
   name: "flamble",
-  identifier: sql.identifier("d", "flibble"),
+  identifier: flambleIdentifier,
   attributes: Object.assign(Object.create(null), {
     f: {
       description: undefined,
@@ -103,9 +104,10 @@ const flambleCodec = recordCodec({
   },
   executor: executor
 });
+const renamed_tableIdentifier = sql.identifier("d", "original_table");
 const spec_renamed_table = {
   name: "renamed_table",
-  identifier: sql.identifier("d", "original_table"),
+  identifier: renamed_tableIdentifier,
   attributes: Object.assign(Object.create(null), {
     col1: {
       description: undefined,
@@ -134,9 +136,10 @@ const spec_renamed_table = {
   executor: executor
 };
 const renamed_tableCodec = recordCodec(spec_renamed_table);
+const filmsIdentifier = sql.identifier("d", "films");
 const spec_films = {
   name: "films",
-  identifier: sql.identifier("d", "films"),
+  identifier: filmsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -170,9 +173,10 @@ const spec_films = {
   executor: executor
 };
 const filmsCodec = recordCodec(spec_films);
+const studiosIdentifier = sql.identifier("d", "studios");
 const spec_studios = {
   name: "studios",
-  identifier: sql.identifier("d", "studios"),
+  identifier: studiosIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -206,9 +210,10 @@ const spec_studios = {
   executor: executor
 };
 const studiosCodec = recordCodec(spec_studios);
+const postIdentifier = sql.identifier("d", "post");
 const spec_post = {
   name: "post",
-  identifier: sql.identifier("d", "post"),
+  identifier: postIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -251,9 +256,10 @@ const spec_post = {
   executor: executor
 };
 const postCodec = recordCodec(spec_post);
+const tvEpisodesIdentifier = sql.identifier("d", "tv_episodes");
 const spec_tvEpisodes = {
   name: "tvEpisodes",
-  identifier: sql.identifier("d", "tv_episodes"),
+  identifier: tvEpisodesIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -296,9 +302,10 @@ const spec_tvEpisodes = {
   executor: executor
 };
 const tvEpisodesCodec = recordCodec(spec_tvEpisodes);
+const tvShowsIdentifier = sql.identifier("d", "tv_shows");
 const spec_tvShows = {
   name: "tvShows",
-  identifier: sql.identifier("d", "tv_shows"),
+  identifier: tvShowsIdentifier,
   attributes: Object.assign(Object.create(null), {
     code: {
       description: undefined,
@@ -341,9 +348,10 @@ const spec_tvShows = {
   executor: executor
 };
 const tvShowsCodec = recordCodec(spec_tvShows);
+const jwtTokenIdentifier = sql.identifier("d", "jwt_token");
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: sql.identifier("d", "jwt_token"),
+  identifier: jwtTokenIdentifier,
   attributes: Object.assign(Object.create(null), {
     role: {
       description: undefined,
@@ -385,9 +393,10 @@ const jwtTokenCodec = recordCodec({
   },
   executor: executor
 });
+const personIdentifier = sql.identifier("d", "person");
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("d", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -533,10 +542,10 @@ const studiosUniques = [{
   }
 }];
 const registryConfig_pgResources_studios_studios = {
-  executor,
+  executor: executor,
   name: "studios",
   identifier: "main.d.studios",
-  from: studiosCodec.sqlType,
+  from: studiosIdentifier,
   codec: studiosCodec,
   uniques: studiosUniques,
   isVirtual: false,
@@ -560,10 +569,10 @@ const postUniques = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor,
+  executor: executor,
   name: "post",
   identifier: "main.d.post",
-  from: postCodec.sqlType,
+  from: postIdentifier,
   codec: postCodec,
   uniques: postUniques,
   isVirtual: false,
@@ -587,10 +596,10 @@ const tv_episodesUniques = [{
   }
 }];
 const registryConfig_pgResources_tv_episodes_tv_episodes = {
-  executor,
+  executor: executor,
   name: "tv_episodes",
   identifier: "main.d.tv_episodes",
-  from: tvEpisodesCodec.sqlType,
+  from: tvEpisodesIdentifier,
   codec: tvEpisodesCodec,
   uniques: tv_episodesUniques,
   isVirtual: false,
@@ -614,10 +623,10 @@ const tv_showsUniques = [{
   }
 }];
 const registryConfig_pgResources_tv_shows_tv_shows = {
-  executor,
+  executor: executor,
   name: "tv_shows",
   identifier: "main.d.tv_shows",
-  from: tvShowsCodec.sqlType,
+  from: tvShowsIdentifier,
   codec: tvShowsCodec,
   uniques: tv_showsUniques,
   isVirtual: false,
@@ -646,10 +655,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.d.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -707,10 +716,10 @@ const registryConfig = {
       description: undefined
     },
     getflamble: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "flamble",
       identifier: "main.d.flibble",
-      from: flambleCodec.sqlType,
+      from: flambleIdentifier,
       codec: flambleCodec,
       uniques: [],
       isVirtual: true,
@@ -750,10 +759,10 @@ const registryConfig = {
       description: undefined
     }),
     renamed_table: {
-      executor,
+      executor: executor,
       name: "renamed_table",
       identifier: "main.d.original_table",
-      from: renamed_tableCodec.sqlType,
+      from: renamed_tableIdentifier,
       codec: renamed_tableCodec,
       uniques: [],
       isVirtual: false,
@@ -771,10 +780,10 @@ const registryConfig = {
       }
     },
     films: {
-      executor,
+      executor: executor,
       name: "films",
       identifier: "main.d.films",
-      from: filmsCodec.sqlType,
+      from: filmsIdentifier,
       codec: filmsCodec,
       uniques: filmsUniques,
       isVirtual: false,
@@ -794,10 +803,10 @@ const registryConfig = {
     tv_episodes: registryConfig_pgResources_tv_episodes_tv_episodes,
     tv_shows: registryConfig_pgResources_tv_shows_tv_shows,
     login: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "jwt_token",
       identifier: "main.d.jwt_token",
-      from: jwtTokenCodec.sqlType,
+      from: jwtTokenIdentifier,
       codec: jwtTokenCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.export.mjs
@@ -421,9 +421,10 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
   executor,
   isAnonymous: true
 });
+const myTableIdentifier = sql.identifier("c", "my_table");
 const spec_myTable = {
   name: "myTable",
-  identifier: sql.identifier("c", "my_table"),
+  identifier: myTableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -457,9 +458,10 @@ const spec_myTable = {
   executor: executor
 };
 const myTableCodec = recordCodec(spec_myTable);
+const personSecretIdentifier = sql.identifier("c", "person_secret");
 const spec_personSecret = {
   name: "personSecret",
-  identifier: sql.identifier("c", "person_secret"),
+  identifier: personSecretIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id: {
       description: undefined,
@@ -497,9 +499,10 @@ const spec_personSecret = {
   executor: executor
 };
 const personSecretCodec = recordCodec(spec_personSecret);
+const compoundKeyIdentifier = sql.identifier("c", "compound_key");
 const spec_compoundKey = {
   name: "compoundKey",
-  identifier: sql.identifier("c", "compound_key"),
+  identifier: compoundKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id_2: {
       description: undefined,
@@ -542,9 +545,10 @@ const spec_compoundKey = {
   executor: executor
 };
 const compoundKeyCodec = recordCodec(spec_compoundKey);
+const nullTestRecordIdentifier = sql.identifier("c", "null_test_record");
 const spec_nullTestRecord = {
   name: "nullTestRecord",
-  identifier: sql.identifier("c", "null_test_record"),
+  identifier: nullTestRecordIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -596,9 +600,10 @@ const spec_nullTestRecord = {
   executor: executor
 };
 const nullTestRecordCodec = recordCodec(spec_nullTestRecord);
+const edgeCaseIdentifier = sql.identifier("c", "edge_case");
 const spec_edgeCase = {
   name: "edgeCase",
-  identifier: sql.identifier("c", "edge_case"),
+  identifier: edgeCaseIdentifier,
   attributes: Object.assign(Object.create(null), {
     not_null_has_default: {
       description: undefined,
@@ -641,9 +646,10 @@ const spec_edgeCase = {
   executor: executor
 };
 const edgeCaseCodec = recordCodec(spec_edgeCase);
+const leftArmIdentifier = sql.identifier("c", "left_arm");
 const spec_leftArm = {
   name: "leftArm",
-  identifier: sql.identifier("c", "left_arm"),
+  identifier: leftArmIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -695,6 +701,7 @@ const spec_leftArm = {
   executor: executor
 };
 const leftArmCodec = recordCodec(spec_leftArm);
+const issue756Identifier = sql.identifier("c", "issue756");
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
   extensions: {
@@ -709,7 +716,7 @@ const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp
 });
 const spec_issue756 = {
   name: "issue756",
-  identifier: sql.identifier("c", "issue756"),
+  identifier: issue756Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -743,6 +750,7 @@ const spec_issue756 = {
   executor: executor
 };
 const issue756Codec = recordCodec(spec_issue756);
+const compoundTypeIdentifier = sql.identifier("c", "compound_type");
 const colorCodec = enumCodec({
   name: "color",
   identifier: sql.identifier("b", "color"),
@@ -787,7 +795,7 @@ const enumWithEmptyStringCodec = enumCodec({
 });
 const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: sql.identifier("c", "compound_type"),
+  identifier: compoundTypeIdentifier,
   attributes: Object.assign(Object.create(null), {
     a: {
       description: undefined,
@@ -1178,6 +1186,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor,
   isAnonymous: true
 });
+const personIdentifier = sql.identifier("c", "person");
 const textArrayCodec = listOfCodec(TYPES.text, {
   extensions: {
     pg: {
@@ -1243,7 +1252,7 @@ const wrappedUrlCodec = recordCodec({
 });
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("c", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: "The primary unique identifier for the person",
@@ -2307,10 +2316,10 @@ const person_secretUniques = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor,
+  executor: executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: personSecretCodec.sqlType,
+  from: personSecretIdentifier,
   codec: personSecretCodec,
   uniques: person_secretUniques,
   isVirtual: false,
@@ -2336,10 +2345,10 @@ const compound_keyUniques = [{
   }
 }];
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor,
+  executor: executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: compoundKeyCodec.sqlType,
+  from: compoundKeyIdentifier,
   codec: compoundKeyCodec,
   uniques: compound_keyUniques,
   isVirtual: false,
@@ -2380,10 +2389,10 @@ const left_armUniques = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor,
+  executor: executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: leftArmCodec.sqlType,
+  from: leftArmIdentifier,
   codec: leftArmCodec,
   uniques: left_armUniques,
   isVirtual: false,
@@ -2408,10 +2417,10 @@ const issue756Uniques = [{
   }
 }];
 const registryConfig_pgResources_issue756_issue756 = {
-  executor,
+  executor: executor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: issue756Codec.sqlType,
+  from: issue756Identifier,
   codec: issue756Codec,
   uniques: issue756Uniques,
   isVirtual: false,
@@ -2465,10 +2474,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.c.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -3546,10 +3555,10 @@ const registry = makeRegistry({
       description: undefined
     },
     my_table: {
-      executor,
+      executor: executor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: myTableCodec.sqlType,
+      from: myTableIdentifier,
       codec: myTableCodec,
       uniques: my_tableUniques,
       isVirtual: false,
@@ -3567,10 +3576,10 @@ const registry = makeRegistry({
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     null_test_record: {
-      executor,
+      executor: executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: nullTestRecordCodec.sqlType,
+      from: nullTestRecordIdentifier,
       codec: nullTestRecordCodec,
       uniques: null_test_recordUniques,
       isVirtual: false,
@@ -3637,10 +3646,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     edge_case: {
-      executor,
+      executor: executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: edgeCaseCodec.sqlType,
+      from: edgeCaseIdentifier,
       codec: edgeCaseCodec,
       uniques: [],
       isVirtual: false,
@@ -3968,10 +3977,10 @@ const registry = makeRegistry({
       description: undefined
     },
     compound_type_set_query: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "compound_type",
       identifier: "main.c.compound_type",
-      from: compoundTypeCodec.sqlType,
+      from: compoundTypeIdentifier,
       codec: compoundTypeCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.export.mjs
@@ -421,9 +421,10 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
   executor,
   isAnonymous: true
 });
+const myTableIdentifier = sql.identifier("c", "my_table");
 const spec_myTable = {
   name: "myTable",
-  identifier: sql.identifier("c", "my_table"),
+  identifier: myTableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -457,9 +458,10 @@ const spec_myTable = {
   executor: executor
 };
 const myTableCodec = recordCodec(spec_myTable);
+const personSecretIdentifier = sql.identifier("c", "person_secret");
 const spec_personSecret = {
   name: "personSecret",
-  identifier: sql.identifier("c", "person_secret"),
+  identifier: personSecretIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id: {
       description: undefined,
@@ -497,9 +499,10 @@ const spec_personSecret = {
   executor: executor
 };
 const personSecretCodec = recordCodec(spec_personSecret);
+const compoundKeyIdentifier = sql.identifier("c", "compound_key");
 const spec_compoundKey = {
   name: "compoundKey",
-  identifier: sql.identifier("c", "compound_key"),
+  identifier: compoundKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id_2: {
       description: undefined,
@@ -542,9 +545,10 @@ const spec_compoundKey = {
   executor: executor
 };
 const compoundKeyCodec = recordCodec(spec_compoundKey);
+const nullTestRecordIdentifier = sql.identifier("c", "null_test_record");
 const spec_nullTestRecord = {
   name: "nullTestRecord",
-  identifier: sql.identifier("c", "null_test_record"),
+  identifier: nullTestRecordIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -596,9 +600,10 @@ const spec_nullTestRecord = {
   executor: executor
 };
 const nullTestRecordCodec = recordCodec(spec_nullTestRecord);
+const edgeCaseIdentifier = sql.identifier("c", "edge_case");
 const spec_edgeCase = {
   name: "edgeCase",
-  identifier: sql.identifier("c", "edge_case"),
+  identifier: edgeCaseIdentifier,
   attributes: Object.assign(Object.create(null), {
     not_null_has_default: {
       description: undefined,
@@ -641,9 +646,10 @@ const spec_edgeCase = {
   executor: executor
 };
 const edgeCaseCodec = recordCodec(spec_edgeCase);
+const leftArmIdentifier = sql.identifier("c", "left_arm");
 const spec_leftArm = {
   name: "leftArm",
-  identifier: sql.identifier("c", "left_arm"),
+  identifier: leftArmIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -695,6 +701,7 @@ const spec_leftArm = {
   executor: executor
 };
 const leftArmCodec = recordCodec(spec_leftArm);
+const issue756Identifier = sql.identifier("c", "issue756");
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
   extensions: {
@@ -709,7 +716,7 @@ const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp
 });
 const spec_issue756 = {
   name: "issue756",
-  identifier: sql.identifier("c", "issue756"),
+  identifier: issue756Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -743,6 +750,7 @@ const spec_issue756 = {
   executor: executor
 };
 const issue756Codec = recordCodec(spec_issue756);
+const compoundTypeIdentifier = sql.identifier("c", "compound_type");
 const colorCodec = enumCodec({
   name: "color",
   identifier: sql.identifier("b", "color"),
@@ -787,7 +795,7 @@ const enumWithEmptyStringCodec = enumCodec({
 });
 const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: sql.identifier("c", "compound_type"),
+  identifier: compoundTypeIdentifier,
   attributes: Object.assign(Object.create(null), {
     a: {
       description: undefined,
@@ -1178,6 +1186,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor,
   isAnonymous: true
 });
+const personIdentifier = sql.identifier("c", "person");
 const textArrayCodec = listOfCodec(TYPES.text, {
   extensions: {
     pg: {
@@ -1243,7 +1252,7 @@ const wrappedUrlCodec = recordCodec({
 });
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("c", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: "The primary unique identifier for the person",
@@ -2307,10 +2316,10 @@ const person_secretUniques = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor,
+  executor: executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: personSecretCodec.sqlType,
+  from: personSecretIdentifier,
   codec: personSecretCodec,
   uniques: person_secretUniques,
   isVirtual: false,
@@ -2336,10 +2345,10 @@ const compound_keyUniques = [{
   }
 }];
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor,
+  executor: executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: compoundKeyCodec.sqlType,
+  from: compoundKeyIdentifier,
   codec: compoundKeyCodec,
   uniques: compound_keyUniques,
   isVirtual: false,
@@ -2380,10 +2389,10 @@ const left_armUniques = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor,
+  executor: executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: leftArmCodec.sqlType,
+  from: leftArmIdentifier,
   codec: leftArmCodec,
   uniques: left_armUniques,
   isVirtual: false,
@@ -2408,10 +2417,10 @@ const issue756Uniques = [{
   }
 }];
 const registryConfig_pgResources_issue756_issue756 = {
-  executor,
+  executor: executor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: issue756Codec.sqlType,
+  from: issue756Identifier,
   codec: issue756Codec,
   uniques: issue756Uniques,
   isVirtual: false,
@@ -2465,10 +2474,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.c.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -3546,10 +3555,10 @@ const registry = makeRegistry({
       description: undefined
     },
     my_table: {
-      executor,
+      executor: executor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: myTableCodec.sqlType,
+      from: myTableIdentifier,
       codec: myTableCodec,
       uniques: my_tableUniques,
       isVirtual: false,
@@ -3567,10 +3576,10 @@ const registry = makeRegistry({
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     null_test_record: {
-      executor,
+      executor: executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: nullTestRecordCodec.sqlType,
+      from: nullTestRecordIdentifier,
       codec: nullTestRecordCodec,
       uniques: null_test_recordUniques,
       isVirtual: false,
@@ -3637,10 +3646,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     edge_case: {
-      executor,
+      executor: executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: edgeCaseCodec.sqlType,
+      from: edgeCaseIdentifier,
       codec: edgeCaseCodec,
       uniques: [],
       isVirtual: false,
@@ -3968,10 +3977,10 @@ const registry = makeRegistry({
       description: undefined
     },
     compound_type_set_query: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "compound_type",
       identifier: "main.c.compound_type",
-      from: compoundTypeCodec.sqlType,
+      from: compoundTypeIdentifier,
       codec: compoundTypeCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.omit-pets-simple.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.omit-pets-simple.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const peopleIdentifier = sql.identifier("simple_collections", "people");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const spec_people = {
   name: "people",
-  identifier: sql.identifier("simple_collections", "people"),
+  identifier: peopleIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -111,9 +112,10 @@ const spec_people = {
   executor: executor
 };
 const peopleCodec = recordCodec(spec_people);
+const petsIdentifier = sql.identifier("simple_collections", "pets");
 const spec_pets = {
   name: "pets",
-  identifier: sql.identifier("simple_collections", "pets"),
+  identifier: petsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -165,10 +167,10 @@ const peopleUniques = [{
   }
 }];
 const registryConfig_pgResources_people_people = {
-  executor,
+  executor: executor,
   name: "people",
   identifier: "main.simple_collections.people",
-  from: peopleCodec.sqlType,
+  from: peopleIdentifier,
   codec: peopleCodec,
   uniques: peopleUniques,
   isVirtual: false,
@@ -192,10 +194,10 @@ const petsUniques = [{
   }
 }];
 const registryConfig_pgResources_pets_pets = {
-  executor,
+  executor: executor,
   name: "pets",
   identifier: "main.simple_collections.pets",
-  from: petsCodec.sqlType,
+  from: petsIdentifier,
   codec: petsCodec,
   uniques: petsUniques,
   isVirtual: false,

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only-people-omit.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only-people-omit.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const peopleIdentifier = sql.identifier("simple_collections", "people");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const spec_people = {
   name: "people",
-  identifier: sql.identifier("simple_collections", "people"),
+  identifier: peopleIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -114,9 +115,10 @@ const spec_people = {
   executor: executor
 };
 const peopleCodec = recordCodec(spec_people);
+const petsIdentifier = sql.identifier("simple_collections", "pets");
 const spec_pets = {
   name: "pets",
-  identifier: sql.identifier("simple_collections", "pets"),
+  identifier: petsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -168,10 +170,10 @@ const peopleUniques = [{
   }
 }];
 const registryConfig_pgResources_people_people = {
-  executor,
+  executor: executor,
   name: "people",
   identifier: "main.simple_collections.people",
-  from: peopleCodec.sqlType,
+  from: peopleIdentifier,
   codec: peopleCodec,
   uniques: peopleUniques,
   isVirtual: false,
@@ -198,10 +200,10 @@ const petsUniques = [{
   }
 }];
 const registryConfig_pgResources_pets_pets = {
-  executor,
+  executor: executor,
   name: "pets",
   identifier: "main.simple_collections.pets",
-  from: petsCodec.sqlType,
+  from: petsIdentifier,
   codec: petsCodec,
   uniques: petsUniques,
   isVirtual: false,

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only.1.export.mjs
@@ -421,9 +421,10 @@ const registryConfig_pgCodecs_SearchTestSummariesRecord_SearchTestSummariesRecor
   executor,
   isAnonymous: true
 });
+const myTableIdentifier = sql.identifier("c", "my_table");
 const spec_myTable = {
   name: "myTable",
-  identifier: sql.identifier("c", "my_table"),
+  identifier: myTableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -457,9 +458,10 @@ const spec_myTable = {
   executor: executor
 };
 const myTableCodec = recordCodec(spec_myTable);
+const personSecretIdentifier = sql.identifier("c", "person_secret");
 const spec_personSecret = {
   name: "personSecret",
-  identifier: sql.identifier("c", "person_secret"),
+  identifier: personSecretIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id: {
       description: undefined,
@@ -497,9 +499,10 @@ const spec_personSecret = {
   executor: executor
 };
 const personSecretCodec = recordCodec(spec_personSecret);
+const compoundKeyIdentifier = sql.identifier("c", "compound_key");
 const spec_compoundKey = {
   name: "compoundKey",
-  identifier: sql.identifier("c", "compound_key"),
+  identifier: compoundKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id_2: {
       description: undefined,
@@ -542,9 +545,10 @@ const spec_compoundKey = {
   executor: executor
 };
 const compoundKeyCodec = recordCodec(spec_compoundKey);
+const nullTestRecordIdentifier = sql.identifier("c", "null_test_record");
 const spec_nullTestRecord = {
   name: "nullTestRecord",
-  identifier: sql.identifier("c", "null_test_record"),
+  identifier: nullTestRecordIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -596,9 +600,10 @@ const spec_nullTestRecord = {
   executor: executor
 };
 const nullTestRecordCodec = recordCodec(spec_nullTestRecord);
+const edgeCaseIdentifier = sql.identifier("c", "edge_case");
 const spec_edgeCase = {
   name: "edgeCase",
-  identifier: sql.identifier("c", "edge_case"),
+  identifier: edgeCaseIdentifier,
   attributes: Object.assign(Object.create(null), {
     not_null_has_default: {
       description: undefined,
@@ -641,9 +646,10 @@ const spec_edgeCase = {
   executor: executor
 };
 const edgeCaseCodec = recordCodec(spec_edgeCase);
+const leftArmIdentifier = sql.identifier("c", "left_arm");
 const spec_leftArm = {
   name: "leftArm",
-  identifier: sql.identifier("c", "left_arm"),
+  identifier: leftArmIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -695,6 +701,7 @@ const spec_leftArm = {
   executor: executor
 };
 const leftArmCodec = recordCodec(spec_leftArm);
+const issue756Identifier = sql.identifier("c", "issue756");
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
   extensions: {
@@ -709,7 +716,7 @@ const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp
 });
 const spec_issue756 = {
   name: "issue756",
-  identifier: sql.identifier("c", "issue756"),
+  identifier: issue756Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -743,6 +750,7 @@ const spec_issue756 = {
   executor: executor
 };
 const issue756Codec = recordCodec(spec_issue756);
+const compoundTypeIdentifier = sql.identifier("c", "compound_type");
 const colorCodec = enumCodec({
   name: "color",
   identifier: sql.identifier("b", "color"),
@@ -787,7 +795,7 @@ const enumWithEmptyStringCodec = enumCodec({
 });
 const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: sql.identifier("c", "compound_type"),
+  identifier: compoundTypeIdentifier,
   attributes: Object.assign(Object.create(null), {
     a: {
       description: undefined,
@@ -1178,6 +1186,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor,
   isAnonymous: true
 });
+const personIdentifier = sql.identifier("c", "person");
 const textArrayCodec = listOfCodec(TYPES.text, {
   extensions: {
     pg: {
@@ -1243,7 +1252,7 @@ const wrappedUrlCodec = recordCodec({
 });
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("c", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: "The primary unique identifier for the person",
@@ -2307,10 +2316,10 @@ const person_secretUniques = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor,
+  executor: executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: personSecretCodec.sqlType,
+  from: personSecretIdentifier,
   codec: personSecretCodec,
   uniques: person_secretUniques,
   isVirtual: false,
@@ -2336,10 +2345,10 @@ const compound_keyUniques = [{
   }
 }];
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor,
+  executor: executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: compoundKeyCodec.sqlType,
+  from: compoundKeyIdentifier,
   codec: compoundKeyCodec,
   uniques: compound_keyUniques,
   isVirtual: false,
@@ -2380,10 +2389,10 @@ const left_armUniques = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor,
+  executor: executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: leftArmCodec.sqlType,
+  from: leftArmIdentifier,
   codec: leftArmCodec,
   uniques: left_armUniques,
   isVirtual: false,
@@ -2408,10 +2417,10 @@ const issue756Uniques = [{
   }
 }];
 const registryConfig_pgResources_issue756_issue756 = {
-  executor,
+  executor: executor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: issue756Codec.sqlType,
+  from: issue756Identifier,
   codec: issue756Codec,
   uniques: issue756Uniques,
   isVirtual: false,
@@ -2465,10 +2474,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.c.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -3546,10 +3555,10 @@ const registry = makeRegistry({
       description: undefined
     },
     my_table: {
-      executor,
+      executor: executor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: myTableCodec.sqlType,
+      from: myTableIdentifier,
       codec: myTableCodec,
       uniques: my_tableUniques,
       isVirtual: false,
@@ -3567,10 +3576,10 @@ const registry = makeRegistry({
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     null_test_record: {
-      executor,
+      executor: executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: nullTestRecordCodec.sqlType,
+      from: nullTestRecordIdentifier,
       codec: nullTestRecordCodec,
       uniques: null_test_recordUniques,
       isVirtual: false,
@@ -3637,10 +3646,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     edge_case: {
-      executor,
+      executor: executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: edgeCaseCodec.sqlType,
+      from: edgeCaseIdentifier,
       codec: edgeCaseCodec,
       uniques: [],
       isVirtual: false,
@@ -3968,10 +3977,10 @@ const registry = makeRegistry({
       description: undefined
     },
     compound_type_set_query: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "compound_type",
       identifier: "main.c.compound_type",
-      from: compoundTypeCodec.sqlType,
+      from: compoundTypeIdentifier,
       codec: compoundTypeCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.pets-simple.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.pets-simple.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const peopleIdentifier = sql.identifier("simple_collections", "people");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const spec_people = {
   name: "people",
-  identifier: sql.identifier("simple_collections", "people"),
+  identifier: peopleIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -111,9 +112,10 @@ const spec_people = {
   executor: executor
 };
 const peopleCodec = recordCodec(spec_people);
+const petsIdentifier = sql.identifier("simple_collections", "pets");
 const spec_pets = {
   name: "pets",
-  identifier: sql.identifier("simple_collections", "pets"),
+  identifier: petsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -165,10 +167,10 @@ const peopleUniques = [{
   }
 }];
 const registryConfig_pgResources_people_people = {
-  executor,
+  executor: executor,
   name: "people",
   identifier: "main.simple_collections.people",
-  from: peopleCodec.sqlType,
+  from: peopleIdentifier,
   codec: peopleCodec,
   uniques: peopleUniques,
   isVirtual: false,
@@ -192,10 +194,10 @@ const petsUniques = [{
   }
 }];
 const registryConfig_pgResources_pets_pets = {
-  executor,
+  executor: executor,
   name: "pets",
   identifier: "main.simple_collections.pets",
-  from: petsCodec.sqlType,
+  from: petsIdentifier,
   codec: petsCodec,
   uniques: petsUniques,
   isVirtual: false,

--- a/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.export.mjs
@@ -459,9 +459,10 @@ const textArrayCodec = listOfCodec(TYPES.text, {
   description: undefined,
   name: "textArray"
 });
+const nonUpdatableViewIdentifier = sql.identifier("a", "non_updatable_view");
 const spec_nonUpdatableView = {
   name: "nonUpdatableView",
-  identifier: sql.identifier("a", "non_updatable_view"),
+  identifier: nonUpdatableViewIdentifier,
   attributes: Object.assign(Object.create(null), {
     "?column?": {
       description: undefined,
@@ -486,9 +487,10 @@ const spec_nonUpdatableView = {
   executor: executor
 };
 const nonUpdatableViewCodec = recordCodec(spec_nonUpdatableView);
+const inputsIdentifier = sql.identifier("a", "inputs");
 const spec_inputs = {
   name: "inputs",
-  identifier: sql.identifier("a", "inputs"),
+  identifier: inputsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -513,9 +515,10 @@ const spec_inputs = {
   executor: executor
 };
 const inputsCodec = recordCodec(spec_inputs);
+const patchsIdentifier = sql.identifier("a", "patchs");
 const spec_patchs = {
   name: "patchs",
-  identifier: sql.identifier("a", "patchs"),
+  identifier: patchsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -540,9 +543,10 @@ const spec_patchs = {
   executor: executor
 };
 const patchsCodec = recordCodec(spec_patchs);
+const reservedIdentifier = sql.identifier("a", "reserved");
 const spec_reserved = {
   name: "reserved",
-  identifier: sql.identifier("a", "reserved"),
+  identifier: reservedIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -567,9 +571,10 @@ const spec_reserved = {
   executor: executor
 };
 const reservedCodec = recordCodec(spec_reserved);
+const reservedPatchsIdentifier = sql.identifier("a", "reservedPatchs");
 const spec_reservedPatchs = {
   name: "reservedPatchs",
-  identifier: sql.identifier("a", "reservedPatchs"),
+  identifier: reservedPatchsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -594,9 +599,10 @@ const spec_reservedPatchs = {
   executor: executor
 };
 const reservedPatchsCodec = recordCodec(spec_reservedPatchs);
+const reservedInputIdentifier = sql.identifier("a", "reserved_input");
 const spec_reservedInput = {
   name: "reservedInput",
-  identifier: sql.identifier("a", "reserved_input"),
+  identifier: reservedInputIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -621,9 +627,10 @@ const spec_reservedInput = {
   executor: executor
 };
 const reservedInputCodec = recordCodec(spec_reservedInput);
+const defaultValueIdentifier = sql.identifier("a", "default_value");
 const spec_defaultValue = {
   name: "defaultValue",
-  identifier: sql.identifier("a", "default_value"),
+  identifier: defaultValueIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -657,9 +664,10 @@ const spec_defaultValue = {
   executor: executor
 };
 const defaultValueCodec = recordCodec(spec_defaultValue);
+const foreignKeyIdentifier = sql.identifier("a", "foreign_key");
 const spec_foreignKey = {
   name: "foreignKey",
-  identifier: sql.identifier("a", "foreign_key"),
+  identifier: foreignKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id: {
       description: undefined,
@@ -702,9 +710,10 @@ const spec_foreignKey = {
   executor: executor
 };
 const foreignKeyCodec = recordCodec(spec_foreignKey);
+const noPrimaryKeyIdentifier = sql.identifier("a", "no_primary_key");
 const spec_noPrimaryKey = {
   name: "noPrimaryKey",
-  identifier: sql.identifier("a", "no_primary_key"),
+  identifier: noPrimaryKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -738,9 +747,10 @@ const spec_noPrimaryKey = {
   executor: executor
 };
 const noPrimaryKeyCodec = recordCodec(spec_noPrimaryKey);
+const testviewIdentifier = sql.identifier("a", "testview");
 const spec_testview = {
   name: "testview",
-  identifier: sql.identifier("a", "testview"),
+  identifier: testviewIdentifier,
   attributes: Object.assign(Object.create(null), {
     testviewid: {
       description: undefined,
@@ -783,9 +793,10 @@ const spec_testview = {
   executor: executor
 };
 const testviewCodec = recordCodec(spec_testview);
+const uniqueForeignKeyIdentifier = sql.identifier("a", "unique_foreign_key");
 const spec_uniqueForeignKey = {
   name: "uniqueForeignKey",
-  identifier: sql.identifier("a", "unique_foreign_key"),
+  identifier: uniqueForeignKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     compound_key_1: {
       description: undefined,
@@ -822,9 +833,10 @@ const spec_uniqueForeignKey = {
   executor: executor
 };
 const uniqueForeignKeyCodec = recordCodec(spec_uniqueForeignKey);
+const myTableIdentifier = sql.identifier("c", "my_table");
 const spec_myTable = {
   name: "myTable",
-  identifier: sql.identifier("c", "my_table"),
+  identifier: myTableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -858,9 +870,10 @@ const spec_myTable = {
   executor: executor
 };
 const myTableCodec = recordCodec(spec_myTable);
+const personSecretIdentifier = sql.identifier("c", "person_secret");
 const spec_personSecret = {
   name: "personSecret",
-  identifier: sql.identifier("c", "person_secret"),
+  identifier: personSecretIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id: {
       description: undefined,
@@ -898,9 +911,10 @@ const spec_personSecret = {
   executor: executor
 };
 const personSecretCodec = recordCodec(spec_personSecret);
+const viewTableIdentifier = sql.identifier("a", "view_table");
 const spec_viewTable = {
   name: "viewTable",
-  identifier: sql.identifier("a", "view_table"),
+  identifier: viewTableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -943,9 +957,10 @@ const spec_viewTable = {
   executor: executor
 };
 const viewTableCodec = recordCodec(spec_viewTable);
+const compoundKeyIdentifier = sql.identifier("c", "compound_key");
 const spec_compoundKey = {
   name: "compoundKey",
-  identifier: sql.identifier("c", "compound_key"),
+  identifier: compoundKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id_2: {
       description: undefined,
@@ -988,9 +1003,10 @@ const spec_compoundKey = {
   executor: executor
 };
 const compoundKeyCodec = recordCodec(spec_compoundKey);
+const similarTable1Identifier = sql.identifier("a", "similar_table_1");
 const spec_similarTable1 = {
   name: "similarTable1",
-  identifier: sql.identifier("a", "similar_table_1"),
+  identifier: similarTable1Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1042,9 +1058,10 @@ const spec_similarTable1 = {
   executor: executor
 };
 const similarTable1Codec = recordCodec(spec_similarTable1);
+const similarTable2Identifier = sql.identifier("a", "similar_table_2");
 const spec_similarTable2 = {
   name: "similarTable2",
-  identifier: sql.identifier("a", "similar_table_2"),
+  identifier: similarTable2Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1096,9 +1113,10 @@ const spec_similarTable2 = {
   executor: executor
 };
 const similarTable2Codec = recordCodec(spec_similarTable2);
+const updatableViewIdentifier = sql.identifier("b", "updatable_view");
 const spec_updatableView = {
   name: "updatableView",
-  identifier: sql.identifier("b", "updatable_view"),
+  identifier: updatableViewIdentifier,
   attributes: Object.assign(Object.create(null), {
     x: {
       description: undefined,
@@ -1153,9 +1171,10 @@ const spec_updatableView = {
   executor: executor
 };
 const updatableViewCodec = recordCodec(spec_updatableView);
+const nullTestRecordIdentifier = sql.identifier("c", "null_test_record");
 const spec_nullTestRecord = {
   name: "nullTestRecord",
-  identifier: sql.identifier("c", "null_test_record"),
+  identifier: nullTestRecordIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1220,9 +1239,10 @@ const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   description: undefined,
   name: "uuidArray"
 });
+const edgeCaseIdentifier = sql.identifier("c", "edge_case");
 const spec_edgeCase = {
   name: "edgeCase",
-  identifier: sql.identifier("c", "edge_case"),
+  identifier: edgeCaseIdentifier,
   attributes: Object.assign(Object.create(null), {
     not_null_has_default: {
       description: undefined,
@@ -1265,9 +1285,10 @@ const spec_edgeCase = {
   executor: executor
 };
 const edgeCaseCodec = recordCodec(spec_edgeCase);
+const leftArmIdentifier = sql.identifier("c", "left_arm");
 const spec_leftArm = {
   name: "leftArm",
-  identifier: sql.identifier("c", "left_arm"),
+  identifier: leftArmIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1319,9 +1340,10 @@ const spec_leftArm = {
   executor: executor
 };
 const leftArmCodec = recordCodec(spec_leftArm);
+const jwtTokenIdentifier = sql.identifier("b", "jwt_token");
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: sql.identifier("b", "jwt_token"),
+  identifier: jwtTokenIdentifier,
   attributes: Object.assign(Object.create(null), {
     role: {
       description: undefined,
@@ -1381,6 +1403,7 @@ const jwtTokenCodec = recordCodec({
   },
   executor: executor
 });
+const issue756Identifier = sql.identifier("c", "issue756");
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
   extensions: {
@@ -1395,7 +1418,7 @@ const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp
 });
 const spec_issue756 = {
   name: "issue756",
-  identifier: sql.identifier("c", "issue756"),
+  identifier: issue756Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1429,9 +1452,10 @@ const spec_issue756 = {
   executor: executor
 };
 const issue756Codec = recordCodec(spec_issue756);
+const authPayloadIdentifier = sql.identifier("b", "auth_payload");
 const authPayloadCodec = recordCodec({
   name: "authPayload",
-  identifier: sql.identifier("b", "auth_payload"),
+  identifier: authPayloadIdentifier,
   attributes: Object.assign(Object.create(null), {
     jwt: {
       description: undefined,
@@ -1475,6 +1499,7 @@ const authPayloadCodec = recordCodec({
   },
   executor: executor
 });
+const compoundTypeIdentifier = sql.identifier("c", "compound_type");
 const colorCodec = enumCodec({
   name: "color",
   identifier: sql.identifier("b", "color"),
@@ -1519,7 +1544,7 @@ const enumWithEmptyStringCodec = enumCodec({
 });
 const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: sql.identifier("c", "compound_type"),
+  identifier: compoundTypeIdentifier,
   attributes: Object.assign(Object.create(null), {
     a: {
       description: undefined,
@@ -1666,6 +1691,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor,
   isAnonymous: true
 });
+const postIdentifier = sql.identifier("a", "post");
 const anEnumCodec = enumCodec({
   name: "anEnum",
   identifier: sql.identifier("a", "an_enum"),
@@ -1743,7 +1769,7 @@ const comptypeArrayCodec = listOfCodec(comptypeCodec, {
 });
 const spec_post = {
   name: "post",
-  identifier: sql.identifier("a", "post"),
+  identifier: postIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1911,6 +1937,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor,
   isAnonymous: true
 });
+const personIdentifier = sql.identifier("c", "person");
 const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
   description: undefined,
   extensions: {
@@ -1963,7 +1990,7 @@ const wrappedUrlCodec = recordCodec({
 });
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("c", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: "The primary unique identifier for the person",
@@ -2302,6 +2329,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor,
   isAnonymous: true
 });
+const typesIdentifier = sql.identifier("b", "types");
 const colorArrayCodec = listOfCodec(colorCodec, {
   extensions: {
     pg: {
@@ -2481,7 +2509,7 @@ const spec_types_attributes_ltree_codec_ltree = {
 const spec_types_attributes_ltree_array_codec_ltree_ = listOfCodec(spec_types_attributes_ltree_codec_ltree);
 const spec_types = {
   name: "types",
-  identifier: sql.identifier("b", "types"),
+  identifier: typesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -3089,10 +3117,10 @@ const default_valueUniques = [{
   }
 }];
 const registryConfig_pgResources_foreign_key_foreign_key = {
-  executor,
+  executor: executor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
-  from: foreignKeyCodec.sqlType,
+  from: foreignKeyIdentifier,
   codec: foreignKeyCodec,
   uniques: [],
   isVirtual: false,
@@ -3108,10 +3136,10 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   }
 };
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
-  executor,
+  executor: executor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
-  from: uniqueForeignKeyCodec.sqlType,
+  from: uniqueForeignKeyIdentifier,
   codec: uniqueForeignKeyCodec,
   uniques: [{
     isPrimary: false,
@@ -3153,10 +3181,10 @@ const person_secretUniques = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor,
+  executor: executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: personSecretCodec.sqlType,
+  from: personSecretIdentifier,
   codec: personSecretCodec,
   uniques: person_secretUniques,
   isVirtual: false,
@@ -3190,10 +3218,10 @@ const compound_keyUniques = [{
   }
 }];
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor,
+  executor: executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: compoundKeyCodec.sqlType,
+  from: compoundKeyIdentifier,
   codec: compoundKeyCodec,
   uniques: compound_keyUniques,
   isVirtual: false,
@@ -3251,10 +3279,10 @@ const left_armUniques = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor,
+  executor: executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: leftArmCodec.sqlType,
+  from: leftArmIdentifier,
   codec: leftArmCodec,
   uniques: left_armUniques,
   isVirtual: false,
@@ -3271,10 +3299,10 @@ const registryConfig_pgResources_left_arm_left_arm = {
 };
 const authenticate_failFunctionIdentifer = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
-  executor,
+  executor: executor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
-  from: jwtTokenCodec.sqlType,
+  from: jwtTokenIdentifier,
   codec: jwtTokenCodec,
   uniques: [],
   isVirtual: true,
@@ -3301,10 +3329,10 @@ const issue756Uniques = [{
   }
 }];
 const registryConfig_pgResources_issue756_issue756 = {
-  executor,
+  executor: executor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: issue756Codec.sqlType,
+  from: issue756Identifier,
   codec: issue756Codec,
   uniques: issue756Uniques,
   isVirtual: false,
@@ -3347,10 +3375,10 @@ const postUniques = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor,
+  executor: executor,
   name: "post",
   identifier: "main.a.post",
-  from: postCodec.sqlType,
+  from: postIdentifier,
   codec: postCodec,
   uniques: postUniques,
   isVirtual: false,
@@ -3367,10 +3395,10 @@ const registryConfig_pgResources_post_post = {
 };
 const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_compound_type = {
-  executor,
+  executor: executor,
   name: "compound_type",
   identifier: "main.c.compound_type",
-  from: compoundTypeCodec.sqlType,
+  from: compoundTypeIdentifier,
   codec: compoundTypeCodec,
   uniques: [],
   isVirtual: true,
@@ -3428,10 +3456,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.c.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -3465,10 +3493,10 @@ const typesUniques = [{
   }
 }];
 const registryConfig_pgResources_types_types = {
-  executor,
+  executor: executor,
   name: "types",
   identifier: "main.b.types",
-  from: typesCodec.sqlType,
+  from: typesIdentifier,
   codec: typesCodec,
   uniques: typesUniques,
   isVirtual: false,
@@ -5666,10 +5694,10 @@ const registry = makeRegistry({
       description: undefined
     },
     non_updatable_view: {
-      executor,
+      executor: executor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
-      from: nonUpdatableViewCodec.sqlType,
+      from: nonUpdatableViewIdentifier,
       codec: nonUpdatableViewCodec,
       uniques: [],
       isVirtual: false,
@@ -5687,10 +5715,10 @@ const registry = makeRegistry({
       }
     },
     inputs: {
-      executor,
+      executor: executor,
       name: "inputs",
       identifier: "main.a.inputs",
-      from: inputsCodec.sqlType,
+      from: inputsIdentifier,
       codec: inputsCodec,
       uniques: inputsUniques,
       isVirtual: false,
@@ -5706,10 +5734,10 @@ const registry = makeRegistry({
       }
     },
     patchs: {
-      executor,
+      executor: executor,
       name: "patchs",
       identifier: "main.a.patchs",
-      from: patchsCodec.sqlType,
+      from: patchsIdentifier,
       codec: patchsCodec,
       uniques: patchsUniques,
       isVirtual: false,
@@ -5725,10 +5753,10 @@ const registry = makeRegistry({
       }
     },
     reserved: {
-      executor,
+      executor: executor,
       name: "reserved",
       identifier: "main.a.reserved",
-      from: reservedCodec.sqlType,
+      from: reservedIdentifier,
       codec: reservedCodec,
       uniques: reservedUniques,
       isVirtual: false,
@@ -5744,10 +5772,10 @@ const registry = makeRegistry({
       }
     },
     reservedPatchs: {
-      executor,
+      executor: executor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
-      from: reservedPatchsCodec.sqlType,
+      from: reservedPatchsIdentifier,
       codec: reservedPatchsCodec,
       uniques: reservedPatchsUniques,
       isVirtual: false,
@@ -5763,10 +5791,10 @@ const registry = makeRegistry({
       }
     },
     reserved_input: {
-      executor,
+      executor: executor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
-      from: reservedInputCodec.sqlType,
+      from: reservedInputIdentifier,
       codec: reservedInputCodec,
       uniques: reserved_inputUniques,
       isVirtual: false,
@@ -5782,10 +5810,10 @@ const registry = makeRegistry({
       }
     },
     default_value: {
-      executor,
+      executor: executor,
       name: "default_value",
       identifier: "main.a.default_value",
-      from: defaultValueCodec.sqlType,
+      from: defaultValueIdentifier,
       codec: defaultValueCodec,
       uniques: default_valueUniques,
       isVirtual: false,
@@ -5802,10 +5830,10 @@ const registry = makeRegistry({
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
-      executor,
+      executor: executor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
-      from: noPrimaryKeyCodec.sqlType,
+      from: noPrimaryKeyIdentifier,
       codec: noPrimaryKeyCodec,
       uniques: [{
         isPrimary: false,
@@ -5828,10 +5856,10 @@ const registry = makeRegistry({
       }
     },
     testview: {
-      executor,
+      executor: executor,
       name: "testview",
       identifier: "main.a.testview",
-      from: testviewCodec.sqlType,
+      from: testviewIdentifier,
       codec: testviewCodec,
       uniques: [],
       isVirtual: false,
@@ -5848,10 +5876,10 @@ const registry = makeRegistry({
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
-      executor,
+      executor: executor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: myTableCodec.sqlType,
+      from: myTableIdentifier,
       codec: myTableCodec,
       uniques: my_tableUniques,
       isVirtual: false,
@@ -5868,10 +5896,10 @@ const registry = makeRegistry({
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
-      executor,
+      executor: executor,
       name: "view_table",
       identifier: "main.a.view_table",
-      from: viewTableCodec.sqlType,
+      from: viewTableIdentifier,
       codec: viewTableCodec,
       uniques: view_tableUniques,
       isVirtual: false,
@@ -5888,10 +5916,10 @@ const registry = makeRegistry({
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
-      executor,
+      executor: executor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
-      from: similarTable1Codec.sqlType,
+      from: similarTable1Identifier,
       codec: similarTable1Codec,
       uniques: similar_table_1Uniques,
       isVirtual: false,
@@ -5907,10 +5935,10 @@ const registry = makeRegistry({
       }
     },
     similar_table_2: {
-      executor,
+      executor: executor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
-      from: similarTable2Codec.sqlType,
+      from: similarTable2Identifier,
       codec: similarTable2Codec,
       uniques: similar_table_2Uniques,
       isVirtual: false,
@@ -5926,10 +5954,10 @@ const registry = makeRegistry({
       }
     },
     updatable_view: {
-      executor,
+      executor: executor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
-      from: updatableViewCodec.sqlType,
+      from: updatableViewIdentifier,
       codec: updatableViewCodec,
       uniques: [{
         isPrimary: false,
@@ -5957,10 +5985,10 @@ const registry = makeRegistry({
       }
     },
     null_test_record: {
-      executor,
+      executor: executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: nullTestRecordCodec.sqlType,
+      from: nullTestRecordIdentifier,
       codec: nullTestRecordCodec,
       uniques: null_test_recordUniques,
       isVirtual: false,
@@ -6066,10 +6094,10 @@ const registry = makeRegistry({
       description: undefined
     },
     edge_case: {
-      executor,
+      executor: executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: edgeCaseCodec.sqlType,
+      from: edgeCaseIdentifier,
       codec: edgeCaseCodec,
       uniques: [],
       isVirtual: false,
@@ -6259,10 +6287,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     authenticate_payload: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "auth_payload",
       identifier: "main.b.auth_payload",
-      from: authPayloadCodec.sqlType,
+      from: authPayloadIdentifier,
       codec: authPayloadCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.1.export.mjs
@@ -397,9 +397,10 @@ const textArrayCodec = listOfCodec(TYPES.text, {
   description: undefined,
   name: "textArray"
 });
+const nonUpdatableViewIdentifier = sql.identifier("a", "non_updatable_view");
 const spec_nonUpdatableView = {
   name: "nonUpdatableView",
-  identifier: sql.identifier("a", "non_updatable_view"),
+  identifier: nonUpdatableViewIdentifier,
   attributes: Object.assign(Object.create(null), {
     "?column?": {
       description: undefined,
@@ -424,9 +425,10 @@ const spec_nonUpdatableView = {
   executor: executor
 };
 const nonUpdatableViewCodec = recordCodec(spec_nonUpdatableView);
+const inputsIdentifier = sql.identifier("a", "inputs");
 const spec_inputs = {
   name: "inputs",
-  identifier: sql.identifier("a", "inputs"),
+  identifier: inputsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -451,9 +453,10 @@ const spec_inputs = {
   executor: executor
 };
 const inputsCodec = recordCodec(spec_inputs);
+const patchsIdentifier = sql.identifier("a", "patchs");
 const spec_patchs = {
   name: "patchs",
-  identifier: sql.identifier("a", "patchs"),
+  identifier: patchsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -478,9 +481,10 @@ const spec_patchs = {
   executor: executor
 };
 const patchsCodec = recordCodec(spec_patchs);
+const reservedIdentifier = sql.identifier("a", "reserved");
 const spec_reserved = {
   name: "reserved",
-  identifier: sql.identifier("a", "reserved"),
+  identifier: reservedIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -505,9 +509,10 @@ const spec_reserved = {
   executor: executor
 };
 const reservedCodec = recordCodec(spec_reserved);
+const reservedPatchsIdentifier = sql.identifier("a", "reservedPatchs");
 const spec_reservedPatchs = {
   name: "reservedPatchs",
-  identifier: sql.identifier("a", "reservedPatchs"),
+  identifier: reservedPatchsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -532,9 +537,10 @@ const spec_reservedPatchs = {
   executor: executor
 };
 const reservedPatchsCodec = recordCodec(spec_reservedPatchs);
+const reservedInputIdentifier = sql.identifier("a", "reserved_input");
 const spec_reservedInput = {
   name: "reservedInput",
-  identifier: sql.identifier("a", "reserved_input"),
+  identifier: reservedInputIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -559,9 +565,10 @@ const spec_reservedInput = {
   executor: executor
 };
 const reservedInputCodec = recordCodec(spec_reservedInput);
+const defaultValueIdentifier = sql.identifier("a", "default_value");
 const spec_defaultValue = {
   name: "defaultValue",
-  identifier: sql.identifier("a", "default_value"),
+  identifier: defaultValueIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -595,9 +602,10 @@ const spec_defaultValue = {
   executor: executor
 };
 const defaultValueCodec = recordCodec(spec_defaultValue);
+const foreignKeyIdentifier = sql.identifier("a", "foreign_key");
 const spec_foreignKey = {
   name: "foreignKey",
-  identifier: sql.identifier("a", "foreign_key"),
+  identifier: foreignKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id: {
       description: undefined,
@@ -640,9 +648,10 @@ const spec_foreignKey = {
   executor: executor
 };
 const foreignKeyCodec = recordCodec(spec_foreignKey);
+const noPrimaryKeyIdentifier = sql.identifier("a", "no_primary_key");
 const spec_noPrimaryKey = {
   name: "noPrimaryKey",
-  identifier: sql.identifier("a", "no_primary_key"),
+  identifier: noPrimaryKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -676,9 +685,10 @@ const spec_noPrimaryKey = {
   executor: executor
 };
 const noPrimaryKeyCodec = recordCodec(spec_noPrimaryKey);
+const testviewIdentifier = sql.identifier("a", "testview");
 const spec_testview = {
   name: "testview",
-  identifier: sql.identifier("a", "testview"),
+  identifier: testviewIdentifier,
   attributes: Object.assign(Object.create(null), {
     testviewid: {
       description: undefined,
@@ -721,9 +731,10 @@ const spec_testview = {
   executor: executor
 };
 const testviewCodec = recordCodec(spec_testview);
+const uniqueForeignKeyIdentifier = sql.identifier("a", "unique_foreign_key");
 const spec_uniqueForeignKey = {
   name: "uniqueForeignKey",
-  identifier: sql.identifier("a", "unique_foreign_key"),
+  identifier: uniqueForeignKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     compound_key_1: {
       description: undefined,
@@ -760,9 +771,10 @@ const spec_uniqueForeignKey = {
   executor: executor
 };
 const uniqueForeignKeyCodec = recordCodec(spec_uniqueForeignKey);
+const myTableIdentifier = sql.identifier("c", "my_table");
 const spec_myTable = {
   name: "myTable",
-  identifier: sql.identifier("c", "my_table"),
+  identifier: myTableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -796,9 +808,10 @@ const spec_myTable = {
   executor: executor
 };
 const myTableCodec = recordCodec(spec_myTable);
+const personSecretIdentifier = sql.identifier("c", "person_secret");
 const spec_personSecret = {
   name: "personSecret",
-  identifier: sql.identifier("c", "person_secret"),
+  identifier: personSecretIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id: {
       description: undefined,
@@ -836,9 +849,10 @@ const spec_personSecret = {
   executor: executor
 };
 const personSecretCodec = recordCodec(spec_personSecret);
+const viewTableIdentifier = sql.identifier("a", "view_table");
 const spec_viewTable = {
   name: "viewTable",
-  identifier: sql.identifier("a", "view_table"),
+  identifier: viewTableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -881,9 +895,10 @@ const spec_viewTable = {
   executor: executor
 };
 const viewTableCodec = recordCodec(spec_viewTable);
+const compoundKeyIdentifier = sql.identifier("c", "compound_key");
 const spec_compoundKey = {
   name: "compoundKey",
-  identifier: sql.identifier("c", "compound_key"),
+  identifier: compoundKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id_2: {
       description: undefined,
@@ -926,9 +941,10 @@ const spec_compoundKey = {
   executor: executor
 };
 const compoundKeyCodec = recordCodec(spec_compoundKey);
+const similarTable1Identifier = sql.identifier("a", "similar_table_1");
 const spec_similarTable1 = {
   name: "similarTable1",
-  identifier: sql.identifier("a", "similar_table_1"),
+  identifier: similarTable1Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -980,9 +996,10 @@ const spec_similarTable1 = {
   executor: executor
 };
 const similarTable1Codec = recordCodec(spec_similarTable1);
+const similarTable2Identifier = sql.identifier("a", "similar_table_2");
 const spec_similarTable2 = {
   name: "similarTable2",
-  identifier: sql.identifier("a", "similar_table_2"),
+  identifier: similarTable2Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1034,9 +1051,10 @@ const spec_similarTable2 = {
   executor: executor
 };
 const similarTable2Codec = recordCodec(spec_similarTable2);
+const updatableViewIdentifier = sql.identifier("b", "updatable_view");
 const spec_updatableView = {
   name: "updatableView",
-  identifier: sql.identifier("b", "updatable_view"),
+  identifier: updatableViewIdentifier,
   attributes: Object.assign(Object.create(null), {
     x: {
       description: undefined,
@@ -1091,9 +1109,10 @@ const spec_updatableView = {
   executor: executor
 };
 const updatableViewCodec = recordCodec(spec_updatableView);
+const nullTestRecordIdentifier = sql.identifier("c", "null_test_record");
 const spec_nullTestRecord = {
   name: "nullTestRecord",
-  identifier: sql.identifier("c", "null_test_record"),
+  identifier: nullTestRecordIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1158,9 +1177,10 @@ const uuidArrayCodec = listOfCodec(TYPES.uuid, {
   description: undefined,
   name: "uuidArray"
 });
+const edgeCaseIdentifier = sql.identifier("c", "edge_case");
 const spec_edgeCase = {
   name: "edgeCase",
-  identifier: sql.identifier("c", "edge_case"),
+  identifier: edgeCaseIdentifier,
   attributes: Object.assign(Object.create(null), {
     not_null_has_default: {
       description: undefined,
@@ -1203,9 +1223,10 @@ const spec_edgeCase = {
   executor: executor
 };
 const edgeCaseCodec = recordCodec(spec_edgeCase);
+const leftArmIdentifier = sql.identifier("c", "left_arm");
 const spec_leftArm = {
   name: "leftArm",
-  identifier: sql.identifier("c", "left_arm"),
+  identifier: leftArmIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1257,9 +1278,10 @@ const spec_leftArm = {
   executor: executor
 };
 const leftArmCodec = recordCodec(spec_leftArm);
+const jwtTokenIdentifier = sql.identifier("b", "jwt_token");
 const jwtTokenCodec = recordCodec({
   name: "jwtToken",
-  identifier: sql.identifier("b", "jwt_token"),
+  identifier: jwtTokenIdentifier,
   attributes: Object.assign(Object.create(null), {
     role: {
       description: undefined,
@@ -1319,6 +1341,7 @@ const jwtTokenCodec = recordCodec({
   },
   executor: executor
 });
+const issue756Identifier = sql.identifier("c", "issue756");
 const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
   extensions: {
@@ -1333,7 +1356,7 @@ const notNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "notNullTimestamp
 });
 const spec_issue756 = {
   name: "issue756",
-  identifier: sql.identifier("c", "issue756"),
+  identifier: issue756Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1367,9 +1390,10 @@ const spec_issue756 = {
   executor: executor
 };
 const issue756Codec = recordCodec(spec_issue756);
+const authPayloadIdentifier = sql.identifier("b", "auth_payload");
 const authPayloadCodec = recordCodec({
   name: "authPayload",
-  identifier: sql.identifier("b", "auth_payload"),
+  identifier: authPayloadIdentifier,
   attributes: Object.assign(Object.create(null), {
     jwt: {
       description: undefined,
@@ -1413,6 +1437,7 @@ const authPayloadCodec = recordCodec({
   },
   executor: executor
 });
+const compoundTypeIdentifier = sql.identifier("c", "compound_type");
 const colorCodec = enumCodec({
   name: "color",
   identifier: sql.identifier("b", "color"),
@@ -1457,7 +1482,7 @@ const enumWithEmptyStringCodec = enumCodec({
 });
 const compoundTypeCodec = recordCodec({
   name: "compoundType",
-  identifier: sql.identifier("c", "compound_type"),
+  identifier: compoundTypeIdentifier,
   attributes: Object.assign(Object.create(null), {
     a: {
       description: undefined,
@@ -1604,6 +1629,7 @@ const registryConfig_pgCodecs_MutationOutOutCompoundTypeRecord_MutationOutOutCom
   executor,
   isAnonymous: true
 });
+const postIdentifier = sql.identifier("a", "post");
 const anEnumCodec = enumCodec({
   name: "anEnum",
   identifier: sql.identifier("a", "an_enum"),
@@ -1681,7 +1707,7 @@ const comptypeArrayCodec = listOfCodec(comptypeCodec, {
 });
 const spec_post = {
   name: "post",
-  identifier: sql.identifier("a", "post"),
+  identifier: postIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1849,6 +1875,7 @@ const registryConfig_pgCodecs_PersonComputedInoutOutRecord_PersonComputedInoutOu
   executor,
   isAnonymous: true
 });
+const personIdentifier = sql.identifier("c", "person");
 const emailCodec = domainOfCodec(TYPES.text, "email", sql.identifier("b", "email"), {
   description: undefined,
   extensions: {
@@ -1901,7 +1928,7 @@ const wrappedUrlCodec = recordCodec({
 });
 const spec_person = {
   name: "person",
-  identifier: sql.identifier("c", "person"),
+  identifier: personIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: "The primary unique identifier for the person",
@@ -2240,6 +2267,7 @@ const registryConfig_pgCodecs_PersonComputedComplexRecord_PersonComputedComplexR
   executor,
   isAnonymous: true
 });
+const typesIdentifier = sql.identifier("b", "types");
 const colorArrayCodec = listOfCodec(colorCodec, {
   extensions: {
     pg: {
@@ -2419,7 +2447,7 @@ const spec_types_attributes_ltree_codec_ltree = {
 const spec_types_attributes_ltree_array_codec_ltree_ = listOfCodec(spec_types_attributes_ltree_codec_ltree);
 const spec_types = {
   name: "types",
-  identifier: sql.identifier("b", "types"),
+  identifier: typesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -3027,10 +3055,10 @@ const default_valueUniques = [{
   }
 }];
 const registryConfig_pgResources_foreign_key_foreign_key = {
-  executor,
+  executor: executor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
-  from: foreignKeyCodec.sqlType,
+  from: foreignKeyIdentifier,
   codec: foreignKeyCodec,
   uniques: [],
   isVirtual: false,
@@ -3046,10 +3074,10 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   }
 };
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
-  executor,
+  executor: executor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
-  from: uniqueForeignKeyCodec.sqlType,
+  from: uniqueForeignKeyIdentifier,
   codec: uniqueForeignKeyCodec,
   uniques: [{
     isPrimary: false,
@@ -3091,10 +3119,10 @@ const person_secretUniques = [{
   }
 }];
 const registryConfig_pgResources_person_secret_person_secret = {
-  executor,
+  executor: executor,
   name: "person_secret",
   identifier: "main.c.person_secret",
-  from: personSecretCodec.sqlType,
+  from: personSecretIdentifier,
   codec: personSecretCodec,
   uniques: person_secretUniques,
   isVirtual: false,
@@ -3128,10 +3156,10 @@ const compound_keyUniques = [{
   }
 }];
 const registryConfig_pgResources_compound_key_compound_key = {
-  executor,
+  executor: executor,
   name: "compound_key",
   identifier: "main.c.compound_key",
-  from: compoundKeyCodec.sqlType,
+  from: compoundKeyIdentifier,
   codec: compoundKeyCodec,
   uniques: compound_keyUniques,
   isVirtual: false,
@@ -3189,10 +3217,10 @@ const left_armUniques = [{
   }
 }];
 const registryConfig_pgResources_left_arm_left_arm = {
-  executor,
+  executor: executor,
   name: "left_arm",
   identifier: "main.c.left_arm",
-  from: leftArmCodec.sqlType,
+  from: leftArmIdentifier,
   codec: leftArmCodec,
   uniques: left_armUniques,
   isVirtual: false,
@@ -3209,10 +3237,10 @@ const registryConfig_pgResources_left_arm_left_arm = {
 };
 const authenticate_failFunctionIdentifer = sql.identifier("b", "authenticate_fail");
 const resourceConfig_jwt_token = {
-  executor,
+  executor: executor,
   name: "jwt_token",
   identifier: "main.b.jwt_token",
-  from: jwtTokenCodec.sqlType,
+  from: jwtTokenIdentifier,
   codec: jwtTokenCodec,
   uniques: [],
   isVirtual: true,
@@ -3239,10 +3267,10 @@ const issue756Uniques = [{
   }
 }];
 const registryConfig_pgResources_issue756_issue756 = {
-  executor,
+  executor: executor,
   name: "issue756",
   identifier: "main.c.issue756",
-  from: issue756Codec.sqlType,
+  from: issue756Identifier,
   codec: issue756Codec,
   uniques: issue756Uniques,
   isVirtual: false,
@@ -3285,10 +3313,10 @@ const postUniques = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor,
+  executor: executor,
   name: "post",
   identifier: "main.a.post",
-  from: postCodec.sqlType,
+  from: postIdentifier,
   codec: postCodec,
   uniques: postUniques,
   isVirtual: false,
@@ -3305,10 +3333,10 @@ const registryConfig_pgResources_post_post = {
 };
 const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_compound_type = {
-  executor,
+  executor: executor,
   name: "compound_type",
   identifier: "main.c.compound_type",
-  from: compoundTypeCodec.sqlType,
+  from: compoundTypeIdentifier,
   codec: compoundTypeCodec,
   uniques: [],
   isVirtual: true,
@@ -3366,10 +3394,10 @@ const personUniques = [{
   }
 }];
 const registryConfig_pgResources_person_person = {
-  executor,
+  executor: executor,
   name: "person",
   identifier: "main.c.person",
-  from: personCodec.sqlType,
+  from: personIdentifier,
   codec: personCodec,
   uniques: personUniques,
   isVirtual: false,
@@ -3403,10 +3431,10 @@ const typesUniques = [{
   }
 }];
 const registryConfig_pgResources_types_types = {
-  executor,
+  executor: executor,
   name: "types",
   identifier: "main.b.types",
-  from: typesCodec.sqlType,
+  from: typesIdentifier,
   codec: typesCodec,
   uniques: typesUniques,
   isVirtual: false,
@@ -5604,10 +5632,10 @@ const registry = makeRegistry({
       description: undefined
     },
     non_updatable_view: {
-      executor,
+      executor: executor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
-      from: nonUpdatableViewCodec.sqlType,
+      from: nonUpdatableViewIdentifier,
       codec: nonUpdatableViewCodec,
       uniques: [],
       isVirtual: false,
@@ -5625,10 +5653,10 @@ const registry = makeRegistry({
       }
     },
     inputs: {
-      executor,
+      executor: executor,
       name: "inputs",
       identifier: "main.a.inputs",
-      from: inputsCodec.sqlType,
+      from: inputsIdentifier,
       codec: inputsCodec,
       uniques: inputsUniques,
       isVirtual: false,
@@ -5644,10 +5672,10 @@ const registry = makeRegistry({
       }
     },
     patchs: {
-      executor,
+      executor: executor,
       name: "patchs",
       identifier: "main.a.patchs",
-      from: patchsCodec.sqlType,
+      from: patchsIdentifier,
       codec: patchsCodec,
       uniques: patchsUniques,
       isVirtual: false,
@@ -5663,10 +5691,10 @@ const registry = makeRegistry({
       }
     },
     reserved: {
-      executor,
+      executor: executor,
       name: "reserved",
       identifier: "main.a.reserved",
-      from: reservedCodec.sqlType,
+      from: reservedIdentifier,
       codec: reservedCodec,
       uniques: reservedUniques,
       isVirtual: false,
@@ -5682,10 +5710,10 @@ const registry = makeRegistry({
       }
     },
     reservedPatchs: {
-      executor,
+      executor: executor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
-      from: reservedPatchsCodec.sqlType,
+      from: reservedPatchsIdentifier,
       codec: reservedPatchsCodec,
       uniques: reservedPatchsUniques,
       isVirtual: false,
@@ -5701,10 +5729,10 @@ const registry = makeRegistry({
       }
     },
     reserved_input: {
-      executor,
+      executor: executor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
-      from: reservedInputCodec.sqlType,
+      from: reservedInputIdentifier,
       codec: reservedInputCodec,
       uniques: reserved_inputUniques,
       isVirtual: false,
@@ -5720,10 +5748,10 @@ const registry = makeRegistry({
       }
     },
     default_value: {
-      executor,
+      executor: executor,
       name: "default_value",
       identifier: "main.a.default_value",
-      from: defaultValueCodec.sqlType,
+      from: defaultValueIdentifier,
       codec: defaultValueCodec,
       uniques: default_valueUniques,
       isVirtual: false,
@@ -5740,10 +5768,10 @@ const registry = makeRegistry({
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
-      executor,
+      executor: executor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
-      from: noPrimaryKeyCodec.sqlType,
+      from: noPrimaryKeyIdentifier,
       codec: noPrimaryKeyCodec,
       uniques: [{
         isPrimary: false,
@@ -5766,10 +5794,10 @@ const registry = makeRegistry({
       }
     },
     testview: {
-      executor,
+      executor: executor,
       name: "testview",
       identifier: "main.a.testview",
-      from: testviewCodec.sqlType,
+      from: testviewIdentifier,
       codec: testviewCodec,
       uniques: [],
       isVirtual: false,
@@ -5786,10 +5814,10 @@ const registry = makeRegistry({
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     my_table: {
-      executor,
+      executor: executor,
       name: "my_table",
       identifier: "main.c.my_table",
-      from: myTableCodec.sqlType,
+      from: myTableIdentifier,
       codec: myTableCodec,
       uniques: my_tableUniques,
       isVirtual: false,
@@ -5806,10 +5834,10 @@ const registry = makeRegistry({
     },
     person_secret: registryConfig_pgResources_person_secret_person_secret,
     view_table: {
-      executor,
+      executor: executor,
       name: "view_table",
       identifier: "main.a.view_table",
-      from: viewTableCodec.sqlType,
+      from: viewTableIdentifier,
       codec: viewTableCodec,
       uniques: view_tableUniques,
       isVirtual: false,
@@ -5826,10 +5854,10 @@ const registry = makeRegistry({
     },
     compound_key: registryConfig_pgResources_compound_key_compound_key,
     similar_table_1: {
-      executor,
+      executor: executor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
-      from: similarTable1Codec.sqlType,
+      from: similarTable1Identifier,
       codec: similarTable1Codec,
       uniques: similar_table_1Uniques,
       isVirtual: false,
@@ -5845,10 +5873,10 @@ const registry = makeRegistry({
       }
     },
     similar_table_2: {
-      executor,
+      executor: executor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
-      from: similarTable2Codec.sqlType,
+      from: similarTable2Identifier,
       codec: similarTable2Codec,
       uniques: similar_table_2Uniques,
       isVirtual: false,
@@ -5864,10 +5892,10 @@ const registry = makeRegistry({
       }
     },
     updatable_view: {
-      executor,
+      executor: executor,
       name: "updatable_view",
       identifier: "main.b.updatable_view",
-      from: updatableViewCodec.sqlType,
+      from: updatableViewIdentifier,
       codec: updatableViewCodec,
       uniques: [{
         isPrimary: false,
@@ -5895,10 +5923,10 @@ const registry = makeRegistry({
       }
     },
     null_test_record: {
-      executor,
+      executor: executor,
       name: "null_test_record",
       identifier: "main.c.null_test_record",
-      from: nullTestRecordCodec.sqlType,
+      from: nullTestRecordIdentifier,
       codec: nullTestRecordCodec,
       uniques: null_test_recordUniques,
       isVirtual: false,
@@ -6004,10 +6032,10 @@ const registry = makeRegistry({
       description: undefined
     },
     edge_case: {
-      executor,
+      executor: executor,
       name: "edge_case",
       identifier: "main.c.edge_case",
-      from: edgeCaseCodec.sqlType,
+      from: edgeCaseIdentifier,
       codec: edgeCaseCodec,
       uniques: [],
       isVirtual: false,
@@ -6197,10 +6225,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     authenticate_payload: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "auth_payload",
       identifier: "main.b.auth_payload",
-      from: authPayloadCodec.sqlType,
+      from: authPayloadIdentifier,
       codec: authPayloadCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.polymorphic.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.polymorphic.1.export.mjs
@@ -3,6 +3,7 @@ import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, assertEdg
 import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
+const awsApplicationFirstPartyVulnerabilitiesIdentifier = sql.identifier("polymorphic", "aws_application_first_party_vulnerabilities");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -15,7 +16,7 @@ const executor = new PgExecutor({
 });
 const spec_awsApplicationFirstPartyVulnerabilities = {
   name: "awsApplicationFirstPartyVulnerabilities",
-  identifier: sql.identifier("polymorphic", "aws_application_first_party_vulnerabilities"),
+  identifier: awsApplicationFirstPartyVulnerabilitiesIdentifier,
   attributes: Object.assign(Object.create(null), {
     aws_application_id: {
       description: undefined,
@@ -52,9 +53,10 @@ const spec_awsApplicationFirstPartyVulnerabilities = {
   executor: executor
 };
 const awsApplicationFirstPartyVulnerabilitiesCodec = recordCodec(spec_awsApplicationFirstPartyVulnerabilities);
+const awsApplicationThirdPartyVulnerabilitiesIdentifier = sql.identifier("polymorphic", "aws_application_third_party_vulnerabilities");
 const spec_awsApplicationThirdPartyVulnerabilities = {
   name: "awsApplicationThirdPartyVulnerabilities",
-  identifier: sql.identifier("polymorphic", "aws_application_third_party_vulnerabilities"),
+  identifier: awsApplicationThirdPartyVulnerabilitiesIdentifier,
   attributes: Object.assign(Object.create(null), {
     aws_application_id: {
       description: undefined,
@@ -91,9 +93,10 @@ const spec_awsApplicationThirdPartyVulnerabilities = {
   executor: executor
 };
 const awsApplicationThirdPartyVulnerabilitiesCodec = recordCodec(spec_awsApplicationThirdPartyVulnerabilities);
+const gcpApplicationFirstPartyVulnerabilitiesIdentifier = sql.identifier("polymorphic", "gcp_application_first_party_vulnerabilities");
 const spec_gcpApplicationFirstPartyVulnerabilities = {
   name: "gcpApplicationFirstPartyVulnerabilities",
-  identifier: sql.identifier("polymorphic", "gcp_application_first_party_vulnerabilities"),
+  identifier: gcpApplicationFirstPartyVulnerabilitiesIdentifier,
   attributes: Object.assign(Object.create(null), {
     gcp_application_id: {
       description: undefined,
@@ -130,9 +133,10 @@ const spec_gcpApplicationFirstPartyVulnerabilities = {
   executor: executor
 };
 const gcpApplicationFirstPartyVulnerabilitiesCodec = recordCodec(spec_gcpApplicationFirstPartyVulnerabilities);
+const gcpApplicationThirdPartyVulnerabilitiesIdentifier = sql.identifier("polymorphic", "gcp_application_third_party_vulnerabilities");
 const spec_gcpApplicationThirdPartyVulnerabilities = {
   name: "gcpApplicationThirdPartyVulnerabilities",
-  identifier: sql.identifier("polymorphic", "gcp_application_third_party_vulnerabilities"),
+  identifier: gcpApplicationThirdPartyVulnerabilitiesIdentifier,
   attributes: Object.assign(Object.create(null), {
     gcp_application_id: {
       description: undefined,
@@ -169,9 +173,10 @@ const spec_gcpApplicationThirdPartyVulnerabilities = {
   executor: executor
 };
 const gcpApplicationThirdPartyVulnerabilitiesCodec = recordCodec(spec_gcpApplicationThirdPartyVulnerabilities);
+const organizationsIdentifier = sql.identifier("polymorphic", "organizations");
 const spec_organizations = {
   name: "organizations",
-  identifier: sql.identifier("polymorphic", "organizations"),
+  identifier: organizationsIdentifier,
   attributes: Object.assign(Object.create(null), {
     organization_id: {
       description: undefined,
@@ -207,9 +212,10 @@ const spec_organizations = {
   executor: executor
 };
 const organizationsCodec = recordCodec(spec_organizations);
+const peopleIdentifier = sql.identifier("polymorphic", "people");
 const spec_people = {
   name: "people",
-  identifier: sql.identifier("polymorphic", "people"),
+  identifier: peopleIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id: {
       description: undefined,
@@ -260,9 +266,10 @@ const spec_people = {
   executor: executor
 };
 const peopleCodec = recordCodec(spec_people);
+const prioritiesIdentifier = sql.identifier("polymorphic", "priorities");
 const spec_priorities = {
   name: "priorities",
-  identifier: sql.identifier("polymorphic", "priorities"),
+  identifier: prioritiesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -299,6 +306,7 @@ const spec_priorities = {
   executor: executor
 };
 const prioritiesCodec = recordCodec(spec_priorities);
+const relationalChecklistsIdentifier = sql.identifier("polymorphic", "relational_checklists");
 const itemTypeCodec = enumCodec({
   name: "itemType",
   identifier: sql.identifier("polymorphic", "item_type"),
@@ -315,7 +323,7 @@ const itemTypeCodec = enumCodec({
 });
 const spec_relationalChecklists = {
   name: "relationalChecklists",
-  identifier: sql.identifier("polymorphic", "relational_checklists"),
+  identifier: relationalChecklistsIdentifier,
   attributes: Object.assign(Object.create(null), {
     checklist_item_id: {
       description: undefined,
@@ -460,9 +468,10 @@ const spec_relationalChecklists = {
   executor: executor
 };
 const relationalChecklistsCodec = recordCodec(spec_relationalChecklists);
+const relationalItemRelationCompositePksIdentifier = sql.identifier("polymorphic", "relational_item_relation_composite_pks");
 const spec_relationalItemRelationCompositePks = {
   name: "relationalItemRelationCompositePks",
-  identifier: sql.identifier("polymorphic", "relational_item_relation_composite_pks"),
+  identifier: relationalItemRelationCompositePksIdentifier,
   attributes: Object.assign(Object.create(null), {
     parent_id: {
       description: undefined,
@@ -496,9 +505,10 @@ const spec_relationalItemRelationCompositePks = {
   executor: executor
 };
 const relationalItemRelationCompositePksCodec = recordCodec(spec_relationalItemRelationCompositePks);
+const relationalTopicsIdentifier = sql.identifier("polymorphic", "relational_topics");
 const spec_relationalTopics = {
   name: "relationalTopics",
-  identifier: sql.identifier("polymorphic", "relational_topics"),
+  identifier: relationalTopicsIdentifier,
   attributes: Object.assign(Object.create(null), {
     topic_item_id: {
       description: undefined,
@@ -643,9 +653,10 @@ const spec_relationalTopics = {
   executor: executor
 };
 const relationalTopicsCodec = recordCodec(spec_relationalTopics);
+const singleTableItemRelationCompositePksIdentifier = sql.identifier("polymorphic", "single_table_item_relation_composite_pks");
 const spec_singleTableItemRelationCompositePks = {
   name: "singleTableItemRelationCompositePks",
-  identifier: sql.identifier("polymorphic", "single_table_item_relation_composite_pks"),
+  identifier: singleTableItemRelationCompositePksIdentifier,
   attributes: Object.assign(Object.create(null), {
     parent_id: {
       description: undefined,
@@ -679,9 +690,10 @@ const spec_singleTableItemRelationCompositePks = {
   executor: executor
 };
 const singleTableItemRelationCompositePksCodec = recordCodec(spec_singleTableItemRelationCompositePks);
+const relationalChecklistItemsIdentifier = sql.identifier("polymorphic", "relational_checklist_items");
 const spec_relationalChecklistItems = {
   name: "relationalChecklistItems",
-  identifier: sql.identifier("polymorphic", "relational_checklist_items"),
+  identifier: relationalChecklistItemsIdentifier,
   attributes: Object.assign(Object.create(null), {
     checklist_item_item_id: {
       description: undefined,
@@ -835,9 +847,10 @@ const spec_relationalChecklistItems = {
   executor: executor
 };
 const relationalChecklistItemsCodec = recordCodec(spec_relationalChecklistItems);
+const relationalDividersIdentifier = sql.identifier("polymorphic", "relational_dividers");
 const spec_relationalDividers = {
   name: "relationalDividers",
-  identifier: sql.identifier("polymorphic", "relational_dividers"),
+  identifier: relationalDividersIdentifier,
   attributes: Object.assign(Object.create(null), {
     divider_item_id: {
       description: undefined,
@@ -991,9 +1004,10 @@ const spec_relationalDividers = {
   executor: executor
 };
 const relationalDividersCodec = recordCodec(spec_relationalDividers);
+const relationalItemRelationsIdentifier = sql.identifier("polymorphic", "relational_item_relations");
 const spec_relationalItemRelations = {
   name: "relationalItemRelations",
-  identifier: sql.identifier("polymorphic", "relational_item_relations"),
+  identifier: relationalItemRelationsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1036,9 +1050,10 @@ const spec_relationalItemRelations = {
   executor: executor
 };
 const relationalItemRelationsCodec = recordCodec(spec_relationalItemRelations);
+const singleTableItemRelationsIdentifier = sql.identifier("polymorphic", "single_table_item_relations");
 const spec_singleTableItemRelations = {
   name: "singleTableItemRelations",
-  identifier: sql.identifier("polymorphic", "single_table_item_relations"),
+  identifier: singleTableItemRelationsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1081,9 +1096,10 @@ const spec_singleTableItemRelations = {
   executor: executor
 };
 const singleTableItemRelationsCodec = recordCodec(spec_singleTableItemRelations);
+const logEntriesIdentifier = sql.identifier("polymorphic", "log_entries");
 const spec_logEntries = {
   name: "logEntries",
-  identifier: sql.identifier("polymorphic", "log_entries"),
+  identifier: logEntriesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1151,9 +1167,10 @@ const spec_logEntries = {
   executor: executor
 };
 const logEntriesCodec = recordCodec(spec_logEntries);
+const relationalPostsIdentifier = sql.identifier("polymorphic", "relational_posts");
 const spec_relationalPosts = {
   name: "relationalPosts",
-  identifier: sql.identifier("polymorphic", "relational_posts"),
+  identifier: relationalPostsIdentifier,
   attributes: Object.assign(Object.create(null), {
     post_item_id: {
       description: undefined,
@@ -1316,9 +1333,10 @@ const spec_relationalPosts = {
   executor: executor
 };
 const relationalPostsCodec = recordCodec(spec_relationalPosts);
+const firstPartyVulnerabilitiesIdentifier = sql.identifier("polymorphic", "first_party_vulnerabilities");
 const spec_firstPartyVulnerabilities = {
   name: "firstPartyVulnerabilities",
-  identifier: sql.identifier("polymorphic", "first_party_vulnerabilities"),
+  identifier: firstPartyVulnerabilitiesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1398,9 +1416,10 @@ const spec_firstPartyVulnerabilities = {
   executor: executor
 };
 const firstPartyVulnerabilitiesCodec = recordCodec(spec_firstPartyVulnerabilities);
+const thirdPartyVulnerabilitiesIdentifier = sql.identifier("polymorphic", "third_party_vulnerabilities");
 const spec_thirdPartyVulnerabilities = {
   name: "thirdPartyVulnerabilities",
-  identifier: sql.identifier("polymorphic", "third_party_vulnerabilities"),
+  identifier: thirdPartyVulnerabilitiesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1480,9 +1499,10 @@ const spec_thirdPartyVulnerabilities = {
   executor: executor
 };
 const thirdPartyVulnerabilitiesCodec = recordCodec(spec_thirdPartyVulnerabilities);
+const awsApplicationsIdentifier = sql.identifier("polymorphic", "aws_applications");
 const spec_awsApplications = {
   name: "awsApplications",
-  identifier: sql.identifier("polymorphic", "aws_applications"),
+  identifier: awsApplicationsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1580,9 +1600,10 @@ const spec_awsApplications = {
   executor: executor
 };
 const awsApplicationsCodec = recordCodec(spec_awsApplications);
+const gcpApplicationsIdentifier = sql.identifier("polymorphic", "gcp_applications");
 const spec_gcpApplications = {
   name: "gcpApplications",
-  identifier: sql.identifier("polymorphic", "gcp_applications"),
+  identifier: gcpApplicationsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1680,9 +1701,10 @@ const spec_gcpApplications = {
   executor: executor
 };
 const gcpApplicationsCodec = recordCodec(spec_gcpApplications);
+const singleTableItemsIdentifier = sql.identifier("polymorphic", "single_table_items");
 const spec_singleTableItems = {
   name: "singleTableItems",
-  identifier: sql.identifier("polymorphic", "single_table_items"),
+  identifier: singleTableItemsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1932,9 +1954,10 @@ const spec_singleTableItems = {
   }
 };
 const singleTableItemsCodec = recordCodec(spec_singleTableItems);
+const relationalItemsIdentifier = sql.identifier("polymorphic", "relational_items");
 const spec_relationalItems = {
   name: "relationalItems",
-  identifier: sql.identifier("polymorphic", "relational_items"),
+  identifier: relationalItemsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -2279,10 +2302,10 @@ const spec_ZeroImplementation = {
   }
 };
 const registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws_application_first_party_vulnerabilities = {
-  executor,
+  executor: executor,
   name: "aws_application_first_party_vulnerabilities",
   identifier: "main.polymorphic.aws_application_first_party_vulnerabilities",
-  from: awsApplicationFirstPartyVulnerabilitiesCodec.sqlType,
+  from: awsApplicationFirstPartyVulnerabilitiesIdentifier,
   codec: awsApplicationFirstPartyVulnerabilitiesCodec,
   uniques: [{
     isPrimary: true,
@@ -2308,10 +2331,10 @@ const registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws
   }
 };
 const registryConfig_pgResources_aws_application_third_party_vulnerabilities_aws_application_third_party_vulnerabilities = {
-  executor,
+  executor: executor,
   name: "aws_application_third_party_vulnerabilities",
   identifier: "main.polymorphic.aws_application_third_party_vulnerabilities",
-  from: awsApplicationThirdPartyVulnerabilitiesCodec.sqlType,
+  from: awsApplicationThirdPartyVulnerabilitiesIdentifier,
   codec: awsApplicationThirdPartyVulnerabilitiesCodec,
   uniques: [{
     isPrimary: true,
@@ -2337,10 +2360,10 @@ const registryConfig_pgResources_aws_application_third_party_vulnerabilities_aws
   }
 };
 const registryConfig_pgResources_gcp_application_first_party_vulnerabilities_gcp_application_first_party_vulnerabilities = {
-  executor,
+  executor: executor,
   name: "gcp_application_first_party_vulnerabilities",
   identifier: "main.polymorphic.gcp_application_first_party_vulnerabilities",
-  from: gcpApplicationFirstPartyVulnerabilitiesCodec.sqlType,
+  from: gcpApplicationFirstPartyVulnerabilitiesIdentifier,
   codec: gcpApplicationFirstPartyVulnerabilitiesCodec,
   uniques: [{
     isPrimary: true,
@@ -2366,10 +2389,10 @@ const registryConfig_pgResources_gcp_application_first_party_vulnerabilities_gcp
   }
 };
 const registryConfig_pgResources_gcp_application_third_party_vulnerabilities_gcp_application_third_party_vulnerabilities = {
-  executor,
+  executor: executor,
   name: "gcp_application_third_party_vulnerabilities",
   identifier: "main.polymorphic.gcp_application_third_party_vulnerabilities",
-  from: gcpApplicationThirdPartyVulnerabilitiesCodec.sqlType,
+  from: gcpApplicationThirdPartyVulnerabilitiesIdentifier,
   codec: gcpApplicationThirdPartyVulnerabilitiesCodec,
   uniques: [{
     isPrimary: true,
@@ -2410,10 +2433,10 @@ const organizationsUniques = [{
   }
 }];
 const registryConfig_pgResources_organizations_organizations = {
-  executor,
+  executor: executor,
   name: "organizations",
   identifier: "main.polymorphic.organizations",
-  from: organizationsCodec.sqlType,
+  from: organizationsIdentifier,
   codec: organizationsCodec,
   uniques: organizationsUniques,
   isVirtual: false,
@@ -2446,10 +2469,10 @@ const peopleUniques = [{
   }
 }];
 const registryConfig_pgResources_people_people = {
-  executor,
+  executor: executor,
   name: "people",
   identifier: "main.polymorphic.people",
-  from: peopleCodec.sqlType,
+  from: peopleIdentifier,
   codec: peopleCodec,
   uniques: peopleUniques,
   isVirtual: false,
@@ -2469,10 +2492,10 @@ const registryConfig_pgResources_people_people = {
   }
 };
 const registryConfig_pgResources_priorities_priorities = {
-  executor,
+  executor: executor,
   name: "priorities",
   identifier: "main.polymorphic.priorities",
-  from: prioritiesCodec.sqlType,
+  from: prioritiesIdentifier,
   codec: prioritiesCodec,
   uniques: [{
     isPrimary: true,
@@ -2506,10 +2529,10 @@ const relational_checklistsUniques = [{
   }
 }];
 const registryConfig_pgResources_relational_checklists_relational_checklists = {
-  executor,
+  executor: executor,
   name: "relational_checklists",
   identifier: "main.polymorphic.relational_checklists",
-  from: relationalChecklistsCodec.sqlType,
+  from: relationalChecklistsIdentifier,
   codec: relationalChecklistsCodec,
   uniques: relational_checklistsUniques,
   isVirtual: false,
@@ -2533,10 +2556,10 @@ const relational_item_relation_composite_pksUniques = [{
   }
 }];
 const registryConfig_pgResources_relational_item_relation_composite_pks_relational_item_relation_composite_pks = {
-  executor,
+  executor: executor,
   name: "relational_item_relation_composite_pks",
   identifier: "main.polymorphic.relational_item_relation_composite_pks",
-  from: relationalItemRelationCompositePksCodec.sqlType,
+  from: relationalItemRelationCompositePksIdentifier,
   codec: relationalItemRelationCompositePksCodec,
   uniques: relational_item_relation_composite_pksUniques,
   isVirtual: false,
@@ -2560,10 +2583,10 @@ const relational_topicsUniques = [{
   }
 }];
 const registryConfig_pgResources_relational_topics_relational_topics = {
-  executor,
+  executor: executor,
   name: "relational_topics",
   identifier: "main.polymorphic.relational_topics",
-  from: relationalTopicsCodec.sqlType,
+  from: relationalTopicsIdentifier,
   codec: relationalTopicsCodec,
   uniques: relational_topicsUniques,
   isVirtual: false,
@@ -2587,10 +2610,10 @@ const single_table_item_relation_composite_pksUniques = [{
   }
 }];
 const registryConfig_pgResources_single_table_item_relation_composite_pks_single_table_item_relation_composite_pks = {
-  executor,
+  executor: executor,
   name: "single_table_item_relation_composite_pks",
   identifier: "main.polymorphic.single_table_item_relation_composite_pks",
-  from: singleTableItemRelationCompositePksCodec.sqlType,
+  from: singleTableItemRelationCompositePksIdentifier,
   codec: singleTableItemRelationCompositePksCodec,
   uniques: single_table_item_relation_composite_pksUniques,
   isVirtual: false,
@@ -2614,10 +2637,10 @@ const relational_checklist_itemsUniques = [{
   }
 }];
 const registryConfig_pgResources_relational_checklist_items_relational_checklist_items = {
-  executor,
+  executor: executor,
   name: "relational_checklist_items",
   identifier: "main.polymorphic.relational_checklist_items",
-  from: relationalChecklistItemsCodec.sqlType,
+  from: relationalChecklistItemsIdentifier,
   codec: relationalChecklistItemsCodec,
   uniques: relational_checklist_itemsUniques,
   isVirtual: false,
@@ -2641,10 +2664,10 @@ const relational_dividersUniques = [{
   }
 }];
 const registryConfig_pgResources_relational_dividers_relational_dividers = {
-  executor,
+  executor: executor,
   name: "relational_dividers",
   identifier: "main.polymorphic.relational_dividers",
-  from: relationalDividersCodec.sqlType,
+  from: relationalDividersIdentifier,
   codec: relationalDividersCodec,
   uniques: relational_dividersUniques,
   isVirtual: false,
@@ -2675,10 +2698,10 @@ const relational_item_relationsUniques = [{
   }
 }];
 const registryConfig_pgResources_relational_item_relations_relational_item_relations = {
-  executor,
+  executor: executor,
   name: "relational_item_relations",
   identifier: "main.polymorphic.relational_item_relations",
-  from: relationalItemRelationsCodec.sqlType,
+  from: relationalItemRelationsIdentifier,
   codec: relationalItemRelationsCodec,
   uniques: relational_item_relationsUniques,
   isVirtual: false,
@@ -2709,10 +2732,10 @@ const single_table_item_relationsUniques = [{
   }
 }];
 const registryConfig_pgResources_single_table_item_relations_single_table_item_relations = {
-  executor,
+  executor: executor,
   name: "single_table_item_relations",
   identifier: "main.polymorphic.single_table_item_relations",
-  from: singleTableItemRelationsCodec.sqlType,
+  from: singleTableItemRelationsIdentifier,
   codec: singleTableItemRelationsCodec,
   uniques: single_table_item_relationsUniques,
   isVirtual: false,
@@ -2736,10 +2759,10 @@ const log_entriesUniques = [{
   }
 }];
 const registryConfig_pgResources_log_entries_log_entries = {
-  executor,
+  executor: executor,
   name: "log_entries",
   identifier: "main.polymorphic.log_entries",
-  from: logEntriesCodec.sqlType,
+  from: logEntriesIdentifier,
   codec: logEntriesCodec,
   uniques: log_entriesUniques,
   isVirtual: false,
@@ -2766,10 +2789,10 @@ const relational_postsUniques = [{
   }
 }];
 const registryConfig_pgResources_relational_posts_relational_posts = {
-  executor,
+  executor: executor,
   name: "relational_posts",
   identifier: "main.polymorphic.relational_posts",
-  from: relationalPostsCodec.sqlType,
+  from: relationalPostsIdentifier,
   codec: relationalPostsCodec,
   uniques: relational_postsUniques,
   isVirtual: false,
@@ -2793,10 +2816,10 @@ const first_party_vulnerabilitiesUniques = [{
   }
 }];
 const registryConfig_pgResources_first_party_vulnerabilities_first_party_vulnerabilities = {
-  executor,
+  executor: executor,
   name: "first_party_vulnerabilities",
   identifier: "main.polymorphic.first_party_vulnerabilities",
-  from: firstPartyVulnerabilitiesCodec.sqlType,
+  from: firstPartyVulnerabilitiesIdentifier,
   codec: firstPartyVulnerabilitiesCodec,
   uniques: first_party_vulnerabilitiesUniques,
   isVirtual: false,
@@ -2824,10 +2847,10 @@ const third_party_vulnerabilitiesUniques = [{
   }
 }];
 const registryConfig_pgResources_third_party_vulnerabilities_third_party_vulnerabilities = {
-  executor,
+  executor: executor,
   name: "third_party_vulnerabilities",
   identifier: "main.polymorphic.third_party_vulnerabilities",
-  from: thirdPartyVulnerabilitiesCodec.sqlType,
+  from: thirdPartyVulnerabilitiesIdentifier,
   codec: thirdPartyVulnerabilitiesCodec,
   uniques: third_party_vulnerabilitiesUniques,
   isVirtual: false,
@@ -2855,10 +2878,10 @@ const aws_applicationsUniques = [{
   }
 }];
 const registryConfig_pgResources_aws_applications_aws_applications = {
-  executor,
+  executor: executor,
   name: "aws_applications",
   identifier: "main.polymorphic.aws_applications",
-  from: awsApplicationsCodec.sqlType,
+  from: awsApplicationsIdentifier,
   codec: awsApplicationsCodec,
   uniques: aws_applicationsUniques,
   isVirtual: false,
@@ -2886,10 +2909,10 @@ const gcp_applicationsUniques = [{
   }
 }];
 const registryConfig_pgResources_gcp_applications_gcp_applications = {
-  executor,
+  executor: executor,
   name: "gcp_applications",
   identifier: "main.polymorphic.gcp_applications",
-  from: gcpApplicationsCodec.sqlType,
+  from: gcpApplicationsIdentifier,
   codec: gcpApplicationsCodec,
   uniques: gcp_applicationsUniques,
   isVirtual: false,
@@ -2918,10 +2941,10 @@ const single_table_itemsUniques = [{
   }
 }];
 const registryConfig_pgResources_single_table_items_single_table_items = {
-  executor,
+  executor: executor,
   name: "single_table_items",
   identifier: "main.polymorphic.single_table_items",
-  from: singleTableItemsCodec.sqlType,
+  from: singleTableItemsIdentifier,
   codec: singleTableItemsCodec,
   uniques: single_table_itemsUniques,
   isVirtual: false,
@@ -2951,10 +2974,10 @@ const relational_itemsUniques = [{
   }
 }];
 const registryConfig_pgResources_relational_items_relational_items = {
-  executor,
+  executor: executor,
   name: "relational_items",
   identifier: "main.polymorphic.relational_items",
-  from: relationalItemsCodec.sqlType,
+  from: relationalItemsIdentifier,
   codec: relationalItemsCodec,
   uniques: relational_itemsUniques,
   isVirtual: false,

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const post_tableIdentifier = sql.identifier("smart_comment_relations", "post");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const spec_post_table = {
   name: "post_table",
-  identifier: sql.identifier("smart_comment_relations", "post"),
+  identifier: post_tableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -106,9 +107,10 @@ const spec_post_table = {
   executor: executor
 };
 const post_tableCodec = recordCodec(spec_post_table);
+const postsIdentifier = sql.identifier("smart_comment_relations", "post_view");
 const spec_posts = {
   name: "posts",
-  identifier: sql.identifier("smart_comment_relations", "post_view"),
+  identifier: postsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -136,9 +138,10 @@ const spec_posts = {
   executor: executor
 };
 const postsCodec = recordCodec(spec_posts);
+const offer_tableIdentifier = sql.identifier("smart_comment_relations", "offer");
 const spec_offer_table = {
   name: "offer_table",
-  identifier: sql.identifier("smart_comment_relations", "offer"),
+  identifier: offer_tableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -176,9 +179,10 @@ const spec_offer_table = {
   executor: executor
 };
 const offer_tableCodec = recordCodec(spec_offer_table);
+const offersIdentifier = sql.identifier("smart_comment_relations", "offer_view");
 const spec_offers = {
   name: "offers",
-  identifier: sql.identifier("smart_comment_relations", "offer_view"),
+  identifier: offersIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -216,9 +220,10 @@ const spec_offers = {
   executor: executor
 };
 const offersCodec = recordCodec(spec_offers);
+const streetsIdentifier = sql.identifier("smart_comment_relations", "streets");
 const spec_streets = {
   name: "streets",
-  identifier: sql.identifier("smart_comment_relations", "streets"),
+  identifier: streetsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -254,9 +259,10 @@ const spec_streets = {
   executor: executor
 };
 const streetsCodec = recordCodec(spec_streets);
+const propertiesIdentifier = sql.identifier("smart_comment_relations", "properties");
 const spec_properties = {
   name: "properties",
-  identifier: sql.identifier("smart_comment_relations", "properties"),
+  identifier: propertiesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -299,9 +305,10 @@ const spec_properties = {
   executor: executor
 };
 const propertiesCodec = recordCodec(spec_properties);
+const streetPropertyIdentifier = sql.identifier("smart_comment_relations", "street_property");
 const spec_streetProperty = {
   name: "streetProperty",
-  identifier: sql.identifier("smart_comment_relations", "street_property"),
+  identifier: streetPropertyIdentifier,
   attributes: Object.assign(Object.create(null), {
     str_id: {
       description: undefined,
@@ -344,9 +351,10 @@ const spec_streetProperty = {
   executor: executor
 };
 const streetPropertyCodec = recordCodec(spec_streetProperty);
+const housesIdentifier = sql.identifier("smart_comment_relations", "houses");
 const spec_houses = {
   name: "houses",
-  identifier: sql.identifier("smart_comment_relations", "houses"),
+  identifier: housesIdentifier,
   attributes: Object.assign(Object.create(null), {
     building_name: {
       description: undefined,
@@ -432,9 +440,10 @@ const spec_houses = {
   executor: executor
 };
 const housesCodec = recordCodec(spec_houses);
+const buildingsIdentifier = sql.identifier("smart_comment_relations", "buildings");
 const spec_buildings = {
   name: "buildings",
-  identifier: sql.identifier("smart_comment_relations", "buildings"),
+  identifier: buildingsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -498,10 +507,10 @@ const spec_buildings = {
 };
 const buildingsCodec = recordCodec(spec_buildings);
 const registryConfig_pgResources_post_table_post_table = {
-  executor,
+  executor: executor,
   name: "post_table",
   identifier: "main.smart_comment_relations.post",
-  from: post_tableCodec.sqlType,
+  from: post_tableIdentifier,
   codec: post_tableCodec,
   uniques: [{
     isPrimary: true,
@@ -536,10 +545,10 @@ const postsUniques = [{
   }
 }];
 const registryConfig_pgResources_posts_posts = {
-  executor,
+  executor: executor,
   name: "posts",
   identifier: "main.smart_comment_relations.post_view",
-  from: postsCodec.sqlType,
+  from: postsIdentifier,
   codec: postsCodec,
   uniques: postsUniques,
   isVirtual: false,
@@ -558,10 +567,10 @@ const registryConfig_pgResources_posts_posts = {
   }
 };
 const registryConfig_pgResources_offer_table_offer_table = {
-  executor,
+  executor: executor,
   name: "offer_table",
   identifier: "main.smart_comment_relations.offer",
-  from: offer_tableCodec.sqlType,
+  from: offer_tableIdentifier,
   codec: offer_tableCodec,
   uniques: [{
     isPrimary: true,
@@ -596,10 +605,10 @@ const offersUniques = [{
   }
 }];
 const registryConfig_pgResources_offers_offers = {
-  executor,
+  executor: executor,
   name: "offers",
   identifier: "main.smart_comment_relations.offer_view",
-  from: offersCodec.sqlType,
+  from: offersIdentifier,
   codec: offersCodec,
   uniques: offersUniques,
   isVirtual: false,
@@ -634,10 +643,10 @@ const streetsUniques = [{
   }
 }];
 const registryConfig_pgResources_streets_streets = {
-  executor,
+  executor: executor,
   name: "streets",
   identifier: "main.smart_comment_relations.streets",
-  from: streetsCodec.sqlType,
+  from: streetsIdentifier,
   codec: streetsCodec,
   uniques: streetsUniques,
   isVirtual: false,
@@ -663,10 +672,10 @@ const propertiesUniques = [{
   }
 }];
 const registryConfig_pgResources_properties_properties = {
-  executor,
+  executor: executor,
   name: "properties",
   identifier: "main.smart_comment_relations.properties",
-  from: propertiesCodec.sqlType,
+  from: propertiesIdentifier,
   codec: propertiesCodec,
   uniques: propertiesUniques,
   isVirtual: false,
@@ -690,10 +699,10 @@ const street_propertyUniques = [{
   }
 }];
 const registryConfig_pgResources_street_property_street_property = {
-  executor,
+  executor: executor,
   name: "street_property",
   identifier: "main.smart_comment_relations.street_property",
-  from: streetPropertyCodec.sqlType,
+  from: streetPropertyIdentifier,
   codec: streetPropertyCodec,
   uniques: street_propertyUniques,
   isVirtual: false,
@@ -717,10 +726,10 @@ const housesUniques = [{
   }
 }];
 const registryConfig_pgResources_houses_houses = {
-  executor,
+  executor: executor,
   name: "houses",
   identifier: "main.smart_comment_relations.houses",
-  from: housesCodec.sqlType,
+  from: housesIdentifier,
   codec: housesCodec,
   uniques: housesUniques,
   isVirtual: false,
@@ -748,10 +757,10 @@ const buildingsUniques = [{
   }
 }];
 const registryConfig_pgResources_buildings_buildings = {
-  executor,
+  executor: executor,
   name: "buildings",
   identifier: "main.smart_comment_relations.buildings",
-  from: buildingsCodec.sqlType,
+  from: buildingsIdentifier,
   codec: buildingsCodec,
   uniques: buildingsUniques,
   isVirtual: false,

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const post_tableIdentifier = sql.identifier("smart_comment_relations", "post");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const spec_post_table = {
   name: "post_table",
-  identifier: sql.identifier("smart_comment_relations", "post"),
+  identifier: post_tableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -106,9 +107,10 @@ const spec_post_table = {
   executor: executor
 };
 const post_tableCodec = recordCodec(spec_post_table);
+const postsIdentifier = sql.identifier("smart_comment_relations", "post_view");
 const spec_posts = {
   name: "posts",
-  identifier: sql.identifier("smart_comment_relations", "post_view"),
+  identifier: postsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -136,9 +138,10 @@ const spec_posts = {
   executor: executor
 };
 const postsCodec = recordCodec(spec_posts);
+const offer_tableIdentifier = sql.identifier("smart_comment_relations", "offer");
 const spec_offer_table = {
   name: "offer_table",
-  identifier: sql.identifier("smart_comment_relations", "offer"),
+  identifier: offer_tableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -176,9 +179,10 @@ const spec_offer_table = {
   executor: executor
 };
 const offer_tableCodec = recordCodec(spec_offer_table);
+const offersIdentifier = sql.identifier("smart_comment_relations", "offer_view");
 const spec_offers = {
   name: "offers",
-  identifier: sql.identifier("smart_comment_relations", "offer_view"),
+  identifier: offersIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -216,9 +220,10 @@ const spec_offers = {
   executor: executor
 };
 const offersCodec = recordCodec(spec_offers);
+const streetsIdentifier = sql.identifier("smart_comment_relations", "streets");
 const spec_streets = {
   name: "streets",
-  identifier: sql.identifier("smart_comment_relations", "streets"),
+  identifier: streetsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -254,9 +259,10 @@ const spec_streets = {
   executor: executor
 };
 const streetsCodec = recordCodec(spec_streets);
+const propertiesIdentifier = sql.identifier("smart_comment_relations", "properties");
 const spec_properties = {
   name: "properties",
-  identifier: sql.identifier("smart_comment_relations", "properties"),
+  identifier: propertiesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -299,9 +305,10 @@ const spec_properties = {
   executor: executor
 };
 const propertiesCodec = recordCodec(spec_properties);
+const streetPropertyIdentifier = sql.identifier("smart_comment_relations", "street_property");
 const spec_streetProperty = {
   name: "streetProperty",
-  identifier: sql.identifier("smart_comment_relations", "street_property"),
+  identifier: streetPropertyIdentifier,
   attributes: Object.assign(Object.create(null), {
     str_id: {
       description: undefined,
@@ -344,9 +351,10 @@ const spec_streetProperty = {
   executor: executor
 };
 const streetPropertyCodec = recordCodec(spec_streetProperty);
+const housesIdentifier = sql.identifier("smart_comment_relations", "houses");
 const spec_houses = {
   name: "houses",
-  identifier: sql.identifier("smart_comment_relations", "houses"),
+  identifier: housesIdentifier,
   attributes: Object.assign(Object.create(null), {
     building_name: {
       description: undefined,
@@ -432,9 +440,10 @@ const spec_houses = {
   executor: executor
 };
 const housesCodec = recordCodec(spec_houses);
+const buildingsIdentifier = sql.identifier("smart_comment_relations", "buildings");
 const spec_buildings = {
   name: "buildings",
-  identifier: sql.identifier("smart_comment_relations", "buildings"),
+  identifier: buildingsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -498,10 +507,10 @@ const spec_buildings = {
 };
 const buildingsCodec = recordCodec(spec_buildings);
 const registryConfig_pgResources_post_table_post_table = {
-  executor,
+  executor: executor,
   name: "post_table",
   identifier: "main.smart_comment_relations.post",
-  from: post_tableCodec.sqlType,
+  from: post_tableIdentifier,
   codec: post_tableCodec,
   uniques: [{
     isPrimary: true,
@@ -536,10 +545,10 @@ const postsUniques = [{
   }
 }];
 const registryConfig_pgResources_offer_table_offer_table = {
-  executor,
+  executor: executor,
   name: "offer_table",
   identifier: "main.smart_comment_relations.offer",
-  from: offer_tableCodec.sqlType,
+  from: offer_tableIdentifier,
   codec: offer_tableCodec,
   uniques: [{
     isPrimary: true,
@@ -574,10 +583,10 @@ const offersUniques = [{
   }
 }];
 const registryConfig_pgResources_offers_offers = {
-  executor,
+  executor: executor,
   name: "offers",
   identifier: "main.smart_comment_relations.offer_view",
-  from: offersCodec.sqlType,
+  from: offersIdentifier,
   codec: offersCodec,
   uniques: offersUniques,
   isVirtual: false,
@@ -612,10 +621,10 @@ const streetsUniques = [{
   }
 }];
 const registryConfig_pgResources_streets_streets = {
-  executor,
+  executor: executor,
   name: "streets",
   identifier: "main.smart_comment_relations.streets",
-  from: streetsCodec.sqlType,
+  from: streetsIdentifier,
   codec: streetsCodec,
   uniques: streetsUniques,
   isVirtual: false,
@@ -641,10 +650,10 @@ const propertiesUniques = [{
   }
 }];
 const registryConfig_pgResources_properties_properties = {
-  executor,
+  executor: executor,
   name: "properties",
   identifier: "main.smart_comment_relations.properties",
-  from: propertiesCodec.sqlType,
+  from: propertiesIdentifier,
   codec: propertiesCodec,
   uniques: propertiesUniques,
   isVirtual: false,
@@ -668,10 +677,10 @@ const street_propertyUniques = [{
   }
 }];
 const registryConfig_pgResources_street_property_street_property = {
-  executor,
+  executor: executor,
   name: "street_property",
   identifier: "main.smart_comment_relations.street_property",
-  from: streetPropertyCodec.sqlType,
+  from: streetPropertyIdentifier,
   codec: streetPropertyCodec,
   uniques: street_propertyUniques,
   isVirtual: false,
@@ -695,10 +704,10 @@ const housesUniques = [{
   }
 }];
 const registryConfig_pgResources_houses_houses = {
-  executor,
+  executor: executor,
   name: "houses",
   identifier: "main.smart_comment_relations.houses",
-  from: housesCodec.sqlType,
+  from: housesIdentifier,
   codec: housesCodec,
   uniques: housesUniques,
   isVirtual: false,
@@ -726,10 +735,10 @@ const buildingsUniques = [{
   }
 }];
 const registryConfig_pgResources_buildings_buildings = {
-  executor,
+  executor: executor,
   name: "buildings",
   identifier: "main.smart_comment_relations.buildings",
-  from: buildingsCodec.sqlType,
+  from: buildingsIdentifier,
   codec: buildingsCodec,
   uniques: buildingsUniques,
   isVirtual: false,
@@ -766,10 +775,10 @@ const registry = makeRegistry({
   pgResources: Object.assign(Object.create(null), {
     post_table: registryConfig_pgResources_post_table_post_table,
     posts: {
-      executor,
+      executor: executor,
       name: "posts",
       identifier: "main.smart_comment_relations.post_view",
-      from: postsCodec.sqlType,
+      from: postsIdentifier,
       codec: postsCodec,
       uniques: postsUniques,
       isVirtual: false,

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post_view.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post_view.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const post_tableIdentifier = sql.identifier("smart_comment_relations", "post");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const spec_post_table = {
   name: "post_table",
-  identifier: sql.identifier("smart_comment_relations", "post"),
+  identifier: post_tableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -106,9 +107,10 @@ const spec_post_table = {
   executor: executor
 };
 const post_tableCodec = recordCodec(spec_post_table);
+const postsIdentifier = sql.identifier("smart_comment_relations", "post_view");
 const spec_posts = {
   name: "posts",
-  identifier: sql.identifier("smart_comment_relations", "post_view"),
+  identifier: postsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -136,9 +138,10 @@ const spec_posts = {
   executor: executor
 };
 const postsCodec = recordCodec(spec_posts);
+const offer_tableIdentifier = sql.identifier("smart_comment_relations", "offer");
 const spec_offer_table = {
   name: "offer_table",
-  identifier: sql.identifier("smart_comment_relations", "offer"),
+  identifier: offer_tableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -176,9 +179,10 @@ const spec_offer_table = {
   executor: executor
 };
 const offer_tableCodec = recordCodec(spec_offer_table);
+const offersIdentifier = sql.identifier("smart_comment_relations", "offer_view");
 const spec_offers = {
   name: "offers",
-  identifier: sql.identifier("smart_comment_relations", "offer_view"),
+  identifier: offersIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -216,9 +220,10 @@ const spec_offers = {
   executor: executor
 };
 const offersCodec = recordCodec(spec_offers);
+const streetsIdentifier = sql.identifier("smart_comment_relations", "streets");
 const spec_streets = {
   name: "streets",
-  identifier: sql.identifier("smart_comment_relations", "streets"),
+  identifier: streetsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -254,9 +259,10 @@ const spec_streets = {
   executor: executor
 };
 const streetsCodec = recordCodec(spec_streets);
+const propertiesIdentifier = sql.identifier("smart_comment_relations", "properties");
 const spec_properties = {
   name: "properties",
-  identifier: sql.identifier("smart_comment_relations", "properties"),
+  identifier: propertiesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -299,9 +305,10 @@ const spec_properties = {
   executor: executor
 };
 const propertiesCodec = recordCodec(spec_properties);
+const streetPropertyIdentifier = sql.identifier("smart_comment_relations", "street_property");
 const spec_streetProperty = {
   name: "streetProperty",
-  identifier: sql.identifier("smart_comment_relations", "street_property"),
+  identifier: streetPropertyIdentifier,
   attributes: Object.assign(Object.create(null), {
     str_id: {
       description: undefined,
@@ -344,9 +351,10 @@ const spec_streetProperty = {
   executor: executor
 };
 const streetPropertyCodec = recordCodec(spec_streetProperty);
+const housesIdentifier = sql.identifier("smart_comment_relations", "houses");
 const spec_houses = {
   name: "houses",
-  identifier: sql.identifier("smart_comment_relations", "houses"),
+  identifier: housesIdentifier,
   attributes: Object.assign(Object.create(null), {
     building_name: {
       description: undefined,
@@ -432,9 +440,10 @@ const spec_houses = {
   executor: executor
 };
 const housesCodec = recordCodec(spec_houses);
+const buildingsIdentifier = sql.identifier("smart_comment_relations", "buildings");
 const spec_buildings = {
   name: "buildings",
-  identifier: sql.identifier("smart_comment_relations", "buildings"),
+  identifier: buildingsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -498,10 +507,10 @@ const spec_buildings = {
 };
 const buildingsCodec = recordCodec(spec_buildings);
 const registryConfig_pgResources_post_table_post_table = {
-  executor,
+  executor: executor,
   name: "post_table",
   identifier: "main.smart_comment_relations.post",
-  from: post_tableCodec.sqlType,
+  from: post_tableIdentifier,
   codec: post_tableCodec,
   uniques: [{
     isPrimary: true,
@@ -536,10 +545,10 @@ const postsUniques = [{
   }
 }];
 const registryConfig_pgResources_posts_posts = {
-  executor,
+  executor: executor,
   name: "posts",
   identifier: "main.smart_comment_relations.post_view",
-  from: postsCodec.sqlType,
+  from: postsIdentifier,
   codec: postsCodec,
   uniques: postsUniques,
   isVirtual: false,
@@ -558,10 +567,10 @@ const registryConfig_pgResources_posts_posts = {
   }
 };
 const registryConfig_pgResources_offer_table_offer_table = {
-  executor,
+  executor: executor,
   name: "offer_table",
   identifier: "main.smart_comment_relations.offer",
-  from: offer_tableCodec.sqlType,
+  from: offer_tableIdentifier,
   codec: offer_tableCodec,
   uniques: [{
     isPrimary: true,
@@ -596,10 +605,10 @@ const offersUniques = [{
   }
 }];
 const registryConfig_pgResources_offers_offers = {
-  executor,
+  executor: executor,
   name: "offers",
   identifier: "main.smart_comment_relations.offer_view",
-  from: offersCodec.sqlType,
+  from: offersIdentifier,
   codec: offersCodec,
   uniques: offersUniques,
   isVirtual: false,
@@ -634,10 +643,10 @@ const streetsUniques = [{
   }
 }];
 const registryConfig_pgResources_streets_streets = {
-  executor,
+  executor: executor,
   name: "streets",
   identifier: "main.smart_comment_relations.streets",
-  from: streetsCodec.sqlType,
+  from: streetsIdentifier,
   codec: streetsCodec,
   uniques: streetsUniques,
   isVirtual: false,
@@ -663,10 +672,10 @@ const propertiesUniques = [{
   }
 }];
 const registryConfig_pgResources_properties_properties = {
-  executor,
+  executor: executor,
   name: "properties",
   identifier: "main.smart_comment_relations.properties",
-  from: propertiesCodec.sqlType,
+  from: propertiesIdentifier,
   codec: propertiesCodec,
   uniques: propertiesUniques,
   isVirtual: false,
@@ -690,10 +699,10 @@ const street_propertyUniques = [{
   }
 }];
 const registryConfig_pgResources_street_property_street_property = {
-  executor,
+  executor: executor,
   name: "street_property",
   identifier: "main.smart_comment_relations.street_property",
-  from: streetPropertyCodec.sqlType,
+  from: streetPropertyIdentifier,
   codec: streetPropertyCodec,
   uniques: street_propertyUniques,
   isVirtual: false,
@@ -717,10 +726,10 @@ const housesUniques = [{
   }
 }];
 const registryConfig_pgResources_houses_houses = {
-  executor,
+  executor: executor,
   name: "houses",
   identifier: "main.smart_comment_relations.houses",
-  from: housesCodec.sqlType,
+  from: housesIdentifier,
   codec: housesCodec,
   uniques: housesUniques,
   isVirtual: false,
@@ -748,10 +757,10 @@ const buildingsUniques = [{
   }
 }];
 const registryConfig_pgResources_buildings_buildings = {
-  executor,
+  executor: executor,
   name: "buildings",
   identifier: "main.smart_comment_relations.buildings",
-  from: buildingsCodec.sqlType,
+  from: buildingsIdentifier,
   codec: buildingsCodec,
   uniques: buildingsUniques,
   isVirtual: false,

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post_view_no_pk.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post_view_no_pk.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const post_tableIdentifier = sql.identifier("smart_comment_relations", "post");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const spec_post_table = {
   name: "post_table",
-  identifier: sql.identifier("smart_comment_relations", "post"),
+  identifier: post_tableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -106,9 +107,10 @@ const spec_post_table = {
   executor: executor
 };
 const post_tableCodec = recordCodec(spec_post_table);
+const postsIdentifier = sql.identifier("smart_comment_relations", "post_view");
 const spec_posts = {
   name: "posts",
-  identifier: sql.identifier("smart_comment_relations", "post_view"),
+  identifier: postsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -137,9 +139,10 @@ const spec_posts = {
   executor: executor
 };
 const postsCodec = recordCodec(spec_posts);
+const offer_tableIdentifier = sql.identifier("smart_comment_relations", "offer");
 const spec_offer_table = {
   name: "offer_table",
-  identifier: sql.identifier("smart_comment_relations", "offer"),
+  identifier: offer_tableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -177,9 +180,10 @@ const spec_offer_table = {
   executor: executor
 };
 const offer_tableCodec = recordCodec(spec_offer_table);
+const offersIdentifier = sql.identifier("smart_comment_relations", "offer_view");
 const spec_offers = {
   name: "offers",
-  identifier: sql.identifier("smart_comment_relations", "offer_view"),
+  identifier: offersIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -217,9 +221,10 @@ const spec_offers = {
   executor: executor
 };
 const offersCodec = recordCodec(spec_offers);
+const streetsIdentifier = sql.identifier("smart_comment_relations", "streets");
 const spec_streets = {
   name: "streets",
-  identifier: sql.identifier("smart_comment_relations", "streets"),
+  identifier: streetsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -255,9 +260,10 @@ const spec_streets = {
   executor: executor
 };
 const streetsCodec = recordCodec(spec_streets);
+const propertiesIdentifier = sql.identifier("smart_comment_relations", "properties");
 const spec_properties = {
   name: "properties",
-  identifier: sql.identifier("smart_comment_relations", "properties"),
+  identifier: propertiesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -300,9 +306,10 @@ const spec_properties = {
   executor: executor
 };
 const propertiesCodec = recordCodec(spec_properties);
+const streetPropertyIdentifier = sql.identifier("smart_comment_relations", "street_property");
 const spec_streetProperty = {
   name: "streetProperty",
-  identifier: sql.identifier("smart_comment_relations", "street_property"),
+  identifier: streetPropertyIdentifier,
   attributes: Object.assign(Object.create(null), {
     str_id: {
       description: undefined,
@@ -345,9 +352,10 @@ const spec_streetProperty = {
   executor: executor
 };
 const streetPropertyCodec = recordCodec(spec_streetProperty);
+const housesIdentifier = sql.identifier("smart_comment_relations", "houses");
 const spec_houses = {
   name: "houses",
-  identifier: sql.identifier("smart_comment_relations", "houses"),
+  identifier: housesIdentifier,
   attributes: Object.assign(Object.create(null), {
     building_name: {
       description: undefined,
@@ -433,9 +441,10 @@ const spec_houses = {
   executor: executor
 };
 const housesCodec = recordCodec(spec_houses);
+const buildingsIdentifier = sql.identifier("smart_comment_relations", "buildings");
 const spec_buildings = {
   name: "buildings",
-  identifier: sql.identifier("smart_comment_relations", "buildings"),
+  identifier: buildingsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -499,10 +508,10 @@ const spec_buildings = {
 };
 const buildingsCodec = recordCodec(spec_buildings);
 const registryConfig_pgResources_post_table_post_table = {
-  executor,
+  executor: executor,
   name: "post_table",
   identifier: "main.smart_comment_relations.post",
-  from: post_tableCodec.sqlType,
+  from: post_tableIdentifier,
   codec: post_tableCodec,
   uniques: [{
     isPrimary: true,
@@ -529,10 +538,10 @@ const registryConfig_pgResources_post_table_post_table = {
   }
 };
 const registryConfig_pgResources_posts_posts = {
-  executor,
+  executor: executor,
   name: "posts",
   identifier: "main.smart_comment_relations.post_view",
-  from: postsCodec.sqlType,
+  from: postsIdentifier,
   codec: postsCodec,
   uniques: [{
     isPrimary: false,
@@ -561,10 +570,10 @@ const registryConfig_pgResources_posts_posts = {
   }
 };
 const registryConfig_pgResources_offer_table_offer_table = {
-  executor,
+  executor: executor,
   name: "offer_table",
   identifier: "main.smart_comment_relations.offer",
-  from: offer_tableCodec.sqlType,
+  from: offer_tableIdentifier,
   codec: offer_tableCodec,
   uniques: [{
     isPrimary: true,
@@ -599,10 +608,10 @@ const offersUniques = [{
   }
 }];
 const registryConfig_pgResources_offers_offers = {
-  executor,
+  executor: executor,
   name: "offers",
   identifier: "main.smart_comment_relations.offer_view",
-  from: offersCodec.sqlType,
+  from: offersIdentifier,
   codec: offersCodec,
   uniques: offersUniques,
   isVirtual: false,
@@ -637,10 +646,10 @@ const streetsUniques = [{
   }
 }];
 const registryConfig_pgResources_streets_streets = {
-  executor,
+  executor: executor,
   name: "streets",
   identifier: "main.smart_comment_relations.streets",
-  from: streetsCodec.sqlType,
+  from: streetsIdentifier,
   codec: streetsCodec,
   uniques: streetsUniques,
   isVirtual: false,
@@ -666,10 +675,10 @@ const propertiesUniques = [{
   }
 }];
 const registryConfig_pgResources_properties_properties = {
-  executor,
+  executor: executor,
   name: "properties",
   identifier: "main.smart_comment_relations.properties",
-  from: propertiesCodec.sqlType,
+  from: propertiesIdentifier,
   codec: propertiesCodec,
   uniques: propertiesUniques,
   isVirtual: false,
@@ -693,10 +702,10 @@ const street_propertyUniques = [{
   }
 }];
 const registryConfig_pgResources_street_property_street_property = {
-  executor,
+  executor: executor,
   name: "street_property",
   identifier: "main.smart_comment_relations.street_property",
-  from: streetPropertyCodec.sqlType,
+  from: streetPropertyIdentifier,
   codec: streetPropertyCodec,
   uniques: street_propertyUniques,
   isVirtual: false,
@@ -720,10 +729,10 @@ const housesUniques = [{
   }
 }];
 const registryConfig_pgResources_houses_houses = {
-  executor,
+  executor: executor,
   name: "houses",
   identifier: "main.smart_comment_relations.houses",
-  from: housesCodec.sqlType,
+  from: housesIdentifier,
   codec: housesCodec,
   uniques: housesUniques,
   isVirtual: false,
@@ -751,10 +760,10 @@ const buildingsUniques = [{
   }
 }];
 const registryConfig_pgResources_buildings_buildings = {
-  executor,
+  executor: executor,
   name: "buildings",
   identifier: "main.smart_comment_relations.buildings",
-  from: buildingsCodec.sqlType,
+  from: buildingsIdentifier,
   codec: buildingsCodec,
   uniques: buildingsUniques,
   isVirtual: false,

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.view_fake_unique.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.view_fake_unique.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const post_tableIdentifier = sql.identifier("smart_comment_relations", "post");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const spec_post_table = {
   name: "post_table",
-  identifier: sql.identifier("smart_comment_relations", "post"),
+  identifier: post_tableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -106,9 +107,10 @@ const spec_post_table = {
   executor: executor
 };
 const post_tableCodec = recordCodec(spec_post_table);
+const postsIdentifier = sql.identifier("smart_comment_relations", "post_view");
 const spec_posts = {
   name: "posts",
-  identifier: sql.identifier("smart_comment_relations", "post_view"),
+  identifier: postsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -136,9 +138,10 @@ const spec_posts = {
   executor: executor
 };
 const postsCodec = recordCodec(spec_posts);
+const offer_tableIdentifier = sql.identifier("smart_comment_relations", "offer");
 const spec_offer_table = {
   name: "offer_table",
-  identifier: sql.identifier("smart_comment_relations", "offer"),
+  identifier: offer_tableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -176,9 +179,10 @@ const spec_offer_table = {
   executor: executor
 };
 const offer_tableCodec = recordCodec(spec_offer_table);
+const offersIdentifier = sql.identifier("smart_comment_relations", "offer_view");
 const spec_offers = {
   name: "offers",
-  identifier: sql.identifier("smart_comment_relations", "offer_view"),
+  identifier: offersIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -216,9 +220,10 @@ const spec_offers = {
   executor: executor
 };
 const offersCodec = recordCodec(spec_offers);
+const streetsIdentifier = sql.identifier("smart_comment_relations", "streets");
 const spec_streets = {
   name: "streets",
-  identifier: sql.identifier("smart_comment_relations", "streets"),
+  identifier: streetsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -254,9 +259,10 @@ const spec_streets = {
   executor: executor
 };
 const streetsCodec = recordCodec(spec_streets);
+const propertiesIdentifier = sql.identifier("smart_comment_relations", "properties");
 const spec_properties = {
   name: "properties",
-  identifier: sql.identifier("smart_comment_relations", "properties"),
+  identifier: propertiesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -299,9 +305,10 @@ const spec_properties = {
   executor: executor
 };
 const propertiesCodec = recordCodec(spec_properties);
+const streetPropertyIdentifier = sql.identifier("smart_comment_relations", "street_property");
 const spec_streetProperty = {
   name: "streetProperty",
-  identifier: sql.identifier("smart_comment_relations", "street_property"),
+  identifier: streetPropertyIdentifier,
   attributes: Object.assign(Object.create(null), {
     str_id: {
       description: undefined,
@@ -344,9 +351,10 @@ const spec_streetProperty = {
   executor: executor
 };
 const streetPropertyCodec = recordCodec(spec_streetProperty);
+const housesIdentifier = sql.identifier("smart_comment_relations", "houses");
 const spec_houses = {
   name: "houses",
-  identifier: sql.identifier("smart_comment_relations", "houses"),
+  identifier: housesIdentifier,
   attributes: Object.assign(Object.create(null), {
     building_name: {
       description: undefined,
@@ -432,9 +440,10 @@ const spec_houses = {
   executor: executor
 };
 const housesCodec = recordCodec(spec_houses);
+const buildingsIdentifier = sql.identifier("smart_comment_relations", "buildings");
 const spec_buildings = {
   name: "buildings",
-  identifier: sql.identifier("smart_comment_relations", "buildings"),
+  identifier: buildingsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -498,10 +507,10 @@ const spec_buildings = {
 };
 const buildingsCodec = recordCodec(spec_buildings);
 const registryConfig_pgResources_post_table_post_table = {
-  executor,
+  executor: executor,
   name: "post_table",
   identifier: "main.smart_comment_relations.post",
-  from: post_tableCodec.sqlType,
+  from: post_tableIdentifier,
   codec: post_tableCodec,
   uniques: [{
     isPrimary: true,
@@ -528,10 +537,10 @@ const registryConfig_pgResources_post_table_post_table = {
   }
 };
 const registryConfig_pgResources_posts_posts = {
-  executor,
+  executor: executor,
   name: "posts",
   identifier: "main.smart_comment_relations.post_view",
-  from: postsCodec.sqlType,
+  from: postsIdentifier,
   codec: postsCodec,
   uniques: [{
     isPrimary: false,
@@ -557,10 +566,10 @@ const registryConfig_pgResources_posts_posts = {
   }
 };
 const registryConfig_pgResources_offer_table_offer_table = {
-  executor,
+  executor: executor,
   name: "offer_table",
   identifier: "main.smart_comment_relations.offer",
-  from: offer_tableCodec.sqlType,
+  from: offer_tableIdentifier,
   codec: offer_tableCodec,
   uniques: [{
     isPrimary: true,
@@ -595,10 +604,10 @@ const offersUniques = [{
   }
 }];
 const registryConfig_pgResources_offers_offers = {
-  executor,
+  executor: executor,
   name: "offers",
   identifier: "main.smart_comment_relations.offer_view",
-  from: offersCodec.sqlType,
+  from: offersIdentifier,
   codec: offersCodec,
   uniques: offersUniques,
   isVirtual: false,
@@ -633,10 +642,10 @@ const streetsUniques = [{
   }
 }];
 const registryConfig_pgResources_streets_streets = {
-  executor,
+  executor: executor,
   name: "streets",
   identifier: "main.smart_comment_relations.streets",
-  from: streetsCodec.sqlType,
+  from: streetsIdentifier,
   codec: streetsCodec,
   uniques: streetsUniques,
   isVirtual: false,
@@ -662,10 +671,10 @@ const propertiesUniques = [{
   }
 }];
 const registryConfig_pgResources_properties_properties = {
-  executor,
+  executor: executor,
   name: "properties",
   identifier: "main.smart_comment_relations.properties",
-  from: propertiesCodec.sqlType,
+  from: propertiesIdentifier,
   codec: propertiesCodec,
   uniques: propertiesUniques,
   isVirtual: false,
@@ -689,10 +698,10 @@ const street_propertyUniques = [{
   }
 }];
 const registryConfig_pgResources_street_property_street_property = {
-  executor,
+  executor: executor,
   name: "street_property",
   identifier: "main.smart_comment_relations.street_property",
-  from: streetPropertyCodec.sqlType,
+  from: streetPropertyIdentifier,
   codec: streetPropertyCodec,
   uniques: street_propertyUniques,
   isVirtual: false,
@@ -716,10 +725,10 @@ const housesUniques = [{
   }
 }];
 const registryConfig_pgResources_houses_houses = {
-  executor,
+  executor: executor,
   name: "houses",
   identifier: "main.smart_comment_relations.houses",
-  from: housesCodec.sqlType,
+  from: housesIdentifier,
   codec: housesCodec,
   uniques: housesUniques,
   isVirtual: false,
@@ -747,10 +756,10 @@ const buildingsUniques = [{
   }
 }];
 const registryConfig_pgResources_buildings_buildings = {
-  executor,
+  executor: executor,
   name: "buildings",
   identifier: "main.smart_comment_relations.buildings",
-  from: buildingsCodec.sqlType,
+  from: buildingsIdentifier,
   codec: buildingsCodec,
   uniques: buildingsUniques,
   isVirtual: false,

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.view_fake_unique_pk.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.view_fake_unique_pk.1.export.mjs
@@ -65,6 +65,7 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
     })
   }
 });
+const post_tableIdentifier = sql.identifier("smart_comment_relations", "post");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -77,7 +78,7 @@ const executor = new PgExecutor({
 });
 const spec_post_table = {
   name: "post_table",
-  identifier: sql.identifier("smart_comment_relations", "post"),
+  identifier: post_tableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -106,9 +107,10 @@ const spec_post_table = {
   executor: executor
 };
 const post_tableCodec = recordCodec(spec_post_table);
+const postsIdentifier = sql.identifier("smart_comment_relations", "post_view");
 const spec_posts = {
   name: "posts",
-  identifier: sql.identifier("smart_comment_relations", "post_view"),
+  identifier: postsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -136,9 +138,10 @@ const spec_posts = {
   executor: executor
 };
 const postsCodec = recordCodec(spec_posts);
+const offer_tableIdentifier = sql.identifier("smart_comment_relations", "offer");
 const spec_offer_table = {
   name: "offer_table",
-  identifier: sql.identifier("smart_comment_relations", "offer"),
+  identifier: offer_tableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -176,9 +179,10 @@ const spec_offer_table = {
   executor: executor
 };
 const offer_tableCodec = recordCodec(spec_offer_table);
+const offersIdentifier = sql.identifier("smart_comment_relations", "offer_view");
 const spec_offers = {
   name: "offers",
-  identifier: sql.identifier("smart_comment_relations", "offer_view"),
+  identifier: offersIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -216,9 +220,10 @@ const spec_offers = {
   executor: executor
 };
 const offersCodec = recordCodec(spec_offers);
+const streetsIdentifier = sql.identifier("smart_comment_relations", "streets");
 const spec_streets = {
   name: "streets",
-  identifier: sql.identifier("smart_comment_relations", "streets"),
+  identifier: streetsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -254,9 +259,10 @@ const spec_streets = {
   executor: executor
 };
 const streetsCodec = recordCodec(spec_streets);
+const propertiesIdentifier = sql.identifier("smart_comment_relations", "properties");
 const spec_properties = {
   name: "properties",
-  identifier: sql.identifier("smart_comment_relations", "properties"),
+  identifier: propertiesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -299,9 +305,10 @@ const spec_properties = {
   executor: executor
 };
 const propertiesCodec = recordCodec(spec_properties);
+const streetPropertyIdentifier = sql.identifier("smart_comment_relations", "street_property");
 const spec_streetProperty = {
   name: "streetProperty",
-  identifier: sql.identifier("smart_comment_relations", "street_property"),
+  identifier: streetPropertyIdentifier,
   attributes: Object.assign(Object.create(null), {
     str_id: {
       description: undefined,
@@ -344,9 +351,10 @@ const spec_streetProperty = {
   executor: executor
 };
 const streetPropertyCodec = recordCodec(spec_streetProperty);
+const housesIdentifier = sql.identifier("smart_comment_relations", "houses");
 const spec_houses = {
   name: "houses",
-  identifier: sql.identifier("smart_comment_relations", "houses"),
+  identifier: housesIdentifier,
   attributes: Object.assign(Object.create(null), {
     building_name: {
       description: undefined,
@@ -433,9 +441,10 @@ const spec_houses = {
   executor: executor
 };
 const housesCodec = recordCodec(spec_houses);
+const buildingsIdentifier = sql.identifier("smart_comment_relations", "buildings");
 const spec_buildings = {
   name: "buildings",
-  identifier: sql.identifier("smart_comment_relations", "buildings"),
+  identifier: buildingsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -499,10 +508,10 @@ const spec_buildings = {
 };
 const buildingsCodec = recordCodec(spec_buildings);
 const registryConfig_pgResources_post_table_post_table = {
-  executor,
+  executor: executor,
   name: "post_table",
   identifier: "main.smart_comment_relations.post",
-  from: post_tableCodec.sqlType,
+  from: post_tableIdentifier,
   codec: post_tableCodec,
   uniques: [{
     isPrimary: true,
@@ -537,10 +546,10 @@ const postsUniques = [{
   }
 }];
 const registryConfig_pgResources_posts_posts = {
-  executor,
+  executor: executor,
   name: "posts",
   identifier: "main.smart_comment_relations.post_view",
-  from: postsCodec.sqlType,
+  from: postsIdentifier,
   codec: postsCodec,
   uniques: postsUniques,
   isVirtual: false,
@@ -559,10 +568,10 @@ const registryConfig_pgResources_posts_posts = {
   }
 };
 const registryConfig_pgResources_offer_table_offer_table = {
-  executor,
+  executor: executor,
   name: "offer_table",
   identifier: "main.smart_comment_relations.offer",
-  from: offer_tableCodec.sqlType,
+  from: offer_tableIdentifier,
   codec: offer_tableCodec,
   uniques: [{
     isPrimary: true,
@@ -597,10 +606,10 @@ const offersUniques = [{
   }
 }];
 const registryConfig_pgResources_offers_offers = {
-  executor,
+  executor: executor,
   name: "offers",
   identifier: "main.smart_comment_relations.offer_view",
-  from: offersCodec.sqlType,
+  from: offersIdentifier,
   codec: offersCodec,
   uniques: offersUniques,
   isVirtual: false,
@@ -635,10 +644,10 @@ const streetsUniques = [{
   }
 }];
 const registryConfig_pgResources_streets_streets = {
-  executor,
+  executor: executor,
   name: "streets",
   identifier: "main.smart_comment_relations.streets",
-  from: streetsCodec.sqlType,
+  from: streetsIdentifier,
   codec: streetsCodec,
   uniques: streetsUniques,
   isVirtual: false,
@@ -664,10 +673,10 @@ const propertiesUniques = [{
   }
 }];
 const registryConfig_pgResources_properties_properties = {
-  executor,
+  executor: executor,
   name: "properties",
   identifier: "main.smart_comment_relations.properties",
-  from: propertiesCodec.sqlType,
+  from: propertiesIdentifier,
   codec: propertiesCodec,
   uniques: propertiesUniques,
   isVirtual: false,
@@ -691,10 +700,10 @@ const street_propertyUniques = [{
   }
 }];
 const registryConfig_pgResources_street_property_street_property = {
-  executor,
+  executor: executor,
   name: "street_property",
   identifier: "main.smart_comment_relations.street_property",
-  from: streetPropertyCodec.sqlType,
+  from: streetPropertyIdentifier,
   codec: streetPropertyCodec,
   uniques: street_propertyUniques,
   isVirtual: false,
@@ -747,10 +756,10 @@ const buildingsUniques = [{
   }
 }];
 const registryConfig_pgResources_buildings_buildings = {
-  executor,
+  executor: executor,
   name: "buildings",
   identifier: "main.smart_comment_relations.buildings",
-  from: buildingsCodec.sqlType,
+  from: buildingsIdentifier,
   codec: buildingsCodec,
   uniques: buildingsUniques,
   isVirtual: false,
@@ -793,10 +802,10 @@ const registry = makeRegistry({
     properties: registryConfig_pgResources_properties_properties,
     street_property: registryConfig_pgResources_street_property_street_property,
     houses: {
-      executor,
+      executor: executor,
       name: "houses",
       identifier: "main.smart_comment_relations.houses",
-      from: housesCodec.sqlType,
+      from: housesIdentifier,
       codec: housesCodec,
       uniques: housesUniques,
       isVirtual: false,

--- a/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.1.export.mjs
@@ -397,9 +397,10 @@ const pgCatalogTextArrayCodec = listOfCodec(TYPES.text, {
   description: undefined,
   name: "pgCatalogTextArray"
 });
+const nonUpdatableViewIdentifier = sql.identifier("a", "non_updatable_view");
 const spec_nonUpdatableView = {
   name: "nonUpdatableView",
-  identifier: sql.identifier("a", "non_updatable_view"),
+  identifier: nonUpdatableViewIdentifier,
   attributes: Object.assign(Object.create(null), {
     "?column?": {
       description: undefined,
@@ -424,9 +425,10 @@ const spec_nonUpdatableView = {
   executor: executor
 };
 const nonUpdatableViewCodec = recordCodec(spec_nonUpdatableView);
+const inputsIdentifier = sql.identifier("a", "inputs");
 const spec_inputs = {
   name: "inputs",
-  identifier: sql.identifier("a", "inputs"),
+  identifier: inputsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -451,9 +453,10 @@ const spec_inputs = {
   executor: executor
 };
 const inputsCodec = recordCodec(spec_inputs);
+const patchsIdentifier = sql.identifier("a", "patchs");
 const spec_patchs = {
   name: "patchs",
-  identifier: sql.identifier("a", "patchs"),
+  identifier: patchsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -478,9 +481,10 @@ const spec_patchs = {
   executor: executor
 };
 const patchsCodec = recordCodec(spec_patchs);
+const reservedIdentifier = sql.identifier("a", "reserved");
 const spec_reserved = {
   name: "reserved",
-  identifier: sql.identifier("a", "reserved"),
+  identifier: reservedIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -505,9 +509,10 @@ const spec_reserved = {
   executor: executor
 };
 const reservedCodec = recordCodec(spec_reserved);
+const reservedPatchsIdentifier = sql.identifier("a", "reservedPatchs");
 const spec_reservedPatchs = {
   name: "reservedPatchs",
-  identifier: sql.identifier("a", "reservedPatchs"),
+  identifier: reservedPatchsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -532,9 +537,10 @@ const spec_reservedPatchs = {
   executor: executor
 };
 const reservedPatchsCodec = recordCodec(spec_reservedPatchs);
+const reservedInputIdentifier = sql.identifier("a", "reserved_input");
 const spec_reservedInput = {
   name: "reservedInput",
-  identifier: sql.identifier("a", "reserved_input"),
+  identifier: reservedInputIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -559,9 +565,10 @@ const spec_reservedInput = {
   executor: executor
 };
 const reservedInputCodec = recordCodec(spec_reservedInput);
+const defaultValueIdentifier = sql.identifier("a", "default_value");
 const spec_defaultValue = {
   name: "defaultValue",
-  identifier: sql.identifier("a", "default_value"),
+  identifier: defaultValueIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -595,9 +602,10 @@ const spec_defaultValue = {
   executor: executor
 };
 const defaultValueCodec = recordCodec(spec_defaultValue);
+const foreignKeyIdentifier = sql.identifier("a", "foreign_key");
 const spec_foreignKey = {
   name: "foreignKey",
-  identifier: sql.identifier("a", "foreign_key"),
+  identifier: foreignKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id: {
       description: undefined,
@@ -640,9 +648,10 @@ const spec_foreignKey = {
   executor: executor
 };
 const foreignKeyCodec = recordCodec(spec_foreignKey);
+const noPrimaryKeyIdentifier = sql.identifier("a", "no_primary_key");
 const spec_noPrimaryKey = {
   name: "noPrimaryKey",
-  identifier: sql.identifier("a", "no_primary_key"),
+  identifier: noPrimaryKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -676,9 +685,10 @@ const spec_noPrimaryKey = {
   executor: executor
 };
 const noPrimaryKeyCodec = recordCodec(spec_noPrimaryKey);
+const testviewIdentifier = sql.identifier("a", "testview");
 const spec_testview = {
   name: "testview",
-  identifier: sql.identifier("a", "testview"),
+  identifier: testviewIdentifier,
   attributes: Object.assign(Object.create(null), {
     testviewid: {
       description: undefined,
@@ -721,9 +731,10 @@ const spec_testview = {
   executor: executor
 };
 const testviewCodec = recordCodec(spec_testview);
+const uniqueForeignKeyIdentifier = sql.identifier("a", "unique_foreign_key");
 const spec_uniqueForeignKey = {
   name: "uniqueForeignKey",
-  identifier: sql.identifier("a", "unique_foreign_key"),
+  identifier: uniqueForeignKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     compound_key_1: {
       description: undefined,
@@ -759,9 +770,10 @@ const spec_uniqueForeignKey = {
   executor: executor
 };
 const uniqueForeignKeyCodec = recordCodec(spec_uniqueForeignKey);
+const cMyTableIdentifier = sql.identifier("c", "my_table");
 const spec_cMyTable = {
   name: "cMyTable",
-  identifier: sql.identifier("c", "my_table"),
+  identifier: cMyTableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -795,9 +807,10 @@ const spec_cMyTable = {
   executor: executor
 };
 const cMyTableCodec = recordCodec(spec_cMyTable);
+const cPersonSecretIdentifier = sql.identifier("c", "person_secret");
 const spec_cPersonSecret = {
   name: "cPersonSecret",
-  identifier: sql.identifier("c", "person_secret"),
+  identifier: cPersonSecretIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id: {
       description: undefined,
@@ -835,9 +848,10 @@ const spec_cPersonSecret = {
   executor: executor
 };
 const cPersonSecretCodec = recordCodec(spec_cPersonSecret);
+const viewTableIdentifier = sql.identifier("a", "view_table");
 const spec_viewTable = {
   name: "viewTable",
-  identifier: sql.identifier("a", "view_table"),
+  identifier: viewTableIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -880,9 +894,10 @@ const spec_viewTable = {
   executor: executor
 };
 const viewTableCodec = recordCodec(spec_viewTable);
+const bUpdatableViewIdentifier = sql.identifier("b", "updatable_view");
 const spec_bUpdatableView = {
   name: "bUpdatableView",
-  identifier: sql.identifier("b", "updatable_view"),
+  identifier: bUpdatableViewIdentifier,
   attributes: Object.assign(Object.create(null), {
     x: {
       description: undefined,
@@ -936,9 +951,10 @@ const spec_bUpdatableView = {
   executor: executor
 };
 const bUpdatableViewCodec = recordCodec(spec_bUpdatableView);
+const cCompoundKeyIdentifier = sql.identifier("c", "compound_key");
 const spec_cCompoundKey = {
   name: "cCompoundKey",
-  identifier: sql.identifier("c", "compound_key"),
+  identifier: cCompoundKeyIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id_2: {
       description: undefined,
@@ -981,9 +997,10 @@ const spec_cCompoundKey = {
   executor: executor
 };
 const cCompoundKeyCodec = recordCodec(spec_cCompoundKey);
+const similarTable1Identifier = sql.identifier("a", "similar_table_1");
 const spec_similarTable1 = {
   name: "similarTable1",
-  identifier: sql.identifier("a", "similar_table_1"),
+  identifier: similarTable1Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1035,9 +1052,10 @@ const spec_similarTable1 = {
   executor: executor
 };
 const similarTable1Codec = recordCodec(spec_similarTable1);
+const similarTable2Identifier = sql.identifier("a", "similar_table_2");
 const spec_similarTable2 = {
   name: "similarTable2",
-  identifier: sql.identifier("a", "similar_table_2"),
+  identifier: similarTable2Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1089,9 +1107,10 @@ const spec_similarTable2 = {
   executor: executor
 };
 const similarTable2Codec = recordCodec(spec_similarTable2);
+const cNullTestRecordIdentifier = sql.identifier("c", "null_test_record");
 const spec_cNullTestRecord = {
   name: "cNullTestRecord",
-  identifier: sql.identifier("c", "null_test_record"),
+  identifier: cNullTestRecordIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1156,9 +1175,10 @@ const pgCatalogUuidArrayCodec = listOfCodec(TYPES.uuid, {
   description: undefined,
   name: "pgCatalogUuidArray"
 });
+const cEdgeCaseIdentifier = sql.identifier("c", "edge_case");
 const spec_cEdgeCase = {
   name: "cEdgeCase",
-  identifier: sql.identifier("c", "edge_case"),
+  identifier: cEdgeCaseIdentifier,
   attributes: Object.assign(Object.create(null), {
     not_null_has_default: {
       description: undefined,
@@ -1201,9 +1221,10 @@ const spec_cEdgeCase = {
   executor: executor
 };
 const cEdgeCaseCodec = recordCodec(spec_cEdgeCase);
+const cLeftArmIdentifier = sql.identifier("c", "left_arm");
 const spec_cLeftArm = {
   name: "cLeftArm",
-  identifier: sql.identifier("c", "left_arm"),
+  identifier: cLeftArmIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1255,9 +1276,10 @@ const spec_cLeftArm = {
   executor: executor
 };
 const cLeftArmCodec = recordCodec(spec_cLeftArm);
+const bJwtTokenIdentifier = sql.identifier("b", "jwt_token");
 const bJwtTokenCodec = recordCodec({
   name: "bJwtToken",
-  identifier: sql.identifier("b", "jwt_token"),
+  identifier: bJwtTokenIdentifier,
   attributes: Object.assign(Object.create(null), {
     role: {
       description: undefined,
@@ -1317,6 +1339,7 @@ const bJwtTokenCodec = recordCodec({
   },
   executor: executor
 });
+const cIssue756Identifier = sql.identifier("c", "issue756");
 const cNotNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "cNotNullTimestamp", sql.identifier("c", "not_null_timestamp"), {
   description: undefined,
   extensions: {
@@ -1331,7 +1354,7 @@ const cNotNullTimestampCodec = domainOfCodec(TYPES.timestamptz, "cNotNullTimesta
 });
 const spec_cIssue756 = {
   name: "cIssue756",
-  identifier: sql.identifier("c", "issue756"),
+  identifier: cIssue756Identifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1365,9 +1388,10 @@ const spec_cIssue756 = {
   executor: executor
 };
 const cIssue756Codec = recordCodec(spec_cIssue756);
+const bAuthPayloadIdentifier = sql.identifier("b", "auth_payload");
 const bAuthPayloadCodec = recordCodec({
   name: "bAuthPayload",
-  identifier: sql.identifier("b", "auth_payload"),
+  identifier: bAuthPayloadIdentifier,
   attributes: Object.assign(Object.create(null), {
     jwt: {
       description: undefined,
@@ -1411,6 +1435,7 @@ const bAuthPayloadCodec = recordCodec({
   },
   executor: executor
 });
+const cCompoundTypeIdentifier = sql.identifier("c", "compound_type");
 const bColorCodec = enumCodec({
   name: "bColor",
   identifier: sql.identifier("b", "color"),
@@ -1455,7 +1480,7 @@ const bEnumWithEmptyStringCodec = enumCodec({
 });
 const cCompoundTypeCodec = recordCodec({
   name: "cCompoundType",
-  identifier: sql.identifier("c", "compound_type"),
+  identifier: cCompoundTypeIdentifier,
   attributes: Object.assign(Object.create(null), {
     a: {
       description: undefined,
@@ -1602,6 +1627,7 @@ const registryConfig_pgCodecs_CMutationOutOutCompoundTypeRecord_CMutationOutOutC
   executor,
   isAnonymous: true
 });
+const postIdentifier = sql.identifier("a", "post");
 const anEnumCodec = enumCodec({
   name: "anEnum",
   identifier: sql.identifier("a", "an_enum"),
@@ -1679,7 +1705,7 @@ const comptypeArrayCodec = listOfCodec(comptypeCodec, {
 });
 const spec_post = {
   name: "post",
-  identifier: sql.identifier("a", "post"),
+  identifier: postIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1847,6 +1873,7 @@ const registryConfig_pgCodecs_CPersonComputedInoutOutRecord_CPersonComputedInout
   executor,
   isAnonymous: true
 });
+const cPersonIdentifier = sql.identifier("c", "person");
 const bEmailCodec = domainOfCodec(TYPES.text, "bEmail", sql.identifier("b", "email"), {
   description: undefined,
   extensions: {
@@ -1899,7 +1926,7 @@ const bWrappedUrlCodec = recordCodec({
 });
 const spec_cPerson = {
   name: "cPerson",
-  identifier: sql.identifier("c", "person"),
+  identifier: cPersonIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: "The primary unique identifier for the person",
@@ -2238,6 +2265,7 @@ const registryConfig_pgCodecs_CPersonComputedComplexRecord_CPersonComputedComple
   executor,
   isAnonymous: true
 });
+const bTypesIdentifier = sql.identifier("b", "types");
 const bColorArrayCodec = listOfCodec(bColorCodec, {
   extensions: {
     pg: {
@@ -2417,7 +2445,7 @@ const spec_bTypes_attributes_ltree_codec_ltree = {
 const spec_bTypes_attributes_ltree_array_codec_ltree_ = listOfCodec(spec_bTypes_attributes_ltree_codec_ltree);
 const spec_bTypes = {
   name: "bTypes",
-  identifier: sql.identifier("b", "types"),
+  identifier: bTypesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -3025,10 +3053,10 @@ const default_valueUniques = [{
   }
 }];
 const registryConfig_pgResources_foreign_key_foreign_key = {
-  executor,
+  executor: executor,
   name: "foreign_key",
   identifier: "main.a.foreign_key",
-  from: foreignKeyCodec.sqlType,
+  from: foreignKeyIdentifier,
   codec: foreignKeyCodec,
   uniques: [],
   isVirtual: false,
@@ -3044,10 +3072,10 @@ const registryConfig_pgResources_foreign_key_foreign_key = {
   }
 };
 const registryConfig_pgResources_unique_foreign_key_unique_foreign_key = {
-  executor,
+  executor: executor,
   name: "unique_foreign_key",
   identifier: "main.a.unique_foreign_key",
-  from: uniqueForeignKeyCodec.sqlType,
+  from: uniqueForeignKeyIdentifier,
   codec: uniqueForeignKeyCodec,
   uniques: [{
     isPrimary: false,
@@ -3088,10 +3116,10 @@ const c_person_secretUniques = [{
   }
 }];
 const registryConfig_pgResources_c_person_secret_c_person_secret = {
-  executor,
+  executor: executor,
   name: "c_person_secret",
   identifier: "main.c.person_secret",
-  from: cPersonSecretCodec.sqlType,
+  from: cPersonSecretIdentifier,
   codec: cPersonSecretCodec,
   uniques: c_person_secretUniques,
   isVirtual: false,
@@ -3125,10 +3153,10 @@ const c_compound_keyUniques = [{
   }
 }];
 const registryConfig_pgResources_c_compound_key_c_compound_key = {
-  executor,
+  executor: executor,
   name: "c_compound_key",
   identifier: "main.c.compound_key",
-  from: cCompoundKeyCodec.sqlType,
+  from: cCompoundKeyIdentifier,
   codec: cCompoundKeyCodec,
   uniques: c_compound_keyUniques,
   isVirtual: false,
@@ -3186,10 +3214,10 @@ const c_left_armUniques = [{
   }
 }];
 const registryConfig_pgResources_c_left_arm_c_left_arm = {
-  executor,
+  executor: executor,
   name: "c_left_arm",
   identifier: "main.c.left_arm",
-  from: cLeftArmCodec.sqlType,
+  from: cLeftArmIdentifier,
   codec: cLeftArmCodec,
   uniques: c_left_armUniques,
   isVirtual: false,
@@ -3206,10 +3234,10 @@ const registryConfig_pgResources_c_left_arm_c_left_arm = {
 };
 const authenticate_failFunctionIdentifer = sql.identifier("b", "authenticate_fail");
 const resourceConfig_b_jwt_token = {
-  executor,
+  executor: executor,
   name: "b_jwt_token",
   identifier: "main.b.jwt_token",
-  from: bJwtTokenCodec.sqlType,
+  from: bJwtTokenIdentifier,
   codec: bJwtTokenCodec,
   uniques: [],
   isVirtual: true,
@@ -3236,10 +3264,10 @@ const c_issue756Uniques = [{
   }
 }];
 const registryConfig_pgResources_c_issue756_c_issue756 = {
-  executor,
+  executor: executor,
   name: "c_issue756",
   identifier: "main.c.issue756",
-  from: cIssue756Codec.sqlType,
+  from: cIssue756Identifier,
   codec: cIssue756Codec,
   uniques: c_issue756Uniques,
   isVirtual: false,
@@ -3282,10 +3310,10 @@ const postUniques = [{
   }
 }];
 const registryConfig_pgResources_post_post = {
-  executor,
+  executor: executor,
   name: "post",
   identifier: "main.a.post",
-  from: postCodec.sqlType,
+  from: postIdentifier,
   codec: postCodec,
   uniques: postUniques,
   isVirtual: false,
@@ -3302,10 +3330,10 @@ const registryConfig_pgResources_post_post = {
 };
 const compound_type_set_queryFunctionIdentifer = sql.identifier("c", "compound_type_set_query");
 const resourceConfig_c_compound_type = {
-  executor,
+  executor: executor,
   name: "c_compound_type",
   identifier: "main.c.compound_type",
-  from: cCompoundTypeCodec.sqlType,
+  from: cCompoundTypeIdentifier,
   codec: cCompoundTypeCodec,
   uniques: [],
   isVirtual: true,
@@ -3363,10 +3391,10 @@ const c_personUniques = [{
   }
 }];
 const registryConfig_pgResources_c_person_c_person = {
-  executor,
+  executor: executor,
   name: "c_person",
   identifier: "main.c.person",
-  from: cPersonCodec.sqlType,
+  from: cPersonIdentifier,
   codec: cPersonCodec,
   uniques: c_personUniques,
   isVirtual: false,
@@ -3400,10 +3428,10 @@ const b_typesUniques = [{
   }
 }];
 const registryConfig_pgResources_b_types_b_types = {
-  executor,
+  executor: executor,
   name: "b_types",
   identifier: "main.b.types",
-  from: bTypesCodec.sqlType,
+  from: bTypesIdentifier,
   codec: bTypesCodec,
   uniques: b_typesUniques,
   isVirtual: false,
@@ -5601,10 +5629,10 @@ const registry = makeRegistry({
       description: undefined
     },
     non_updatable_view: {
-      executor,
+      executor: executor,
       name: "non_updatable_view",
       identifier: "main.a.non_updatable_view",
-      from: nonUpdatableViewCodec.sqlType,
+      from: nonUpdatableViewIdentifier,
       codec: nonUpdatableViewCodec,
       uniques: [],
       isVirtual: false,
@@ -5622,10 +5650,10 @@ const registry = makeRegistry({
       }
     },
     inputs: {
-      executor,
+      executor: executor,
       name: "inputs",
       identifier: "main.a.inputs",
-      from: inputsCodec.sqlType,
+      from: inputsIdentifier,
       codec: inputsCodec,
       uniques: inputsUniques,
       isVirtual: false,
@@ -5641,10 +5669,10 @@ const registry = makeRegistry({
       }
     },
     patchs: {
-      executor,
+      executor: executor,
       name: "patchs",
       identifier: "main.a.patchs",
-      from: patchsCodec.sqlType,
+      from: patchsIdentifier,
       codec: patchsCodec,
       uniques: patchsUniques,
       isVirtual: false,
@@ -5660,10 +5688,10 @@ const registry = makeRegistry({
       }
     },
     reserved: {
-      executor,
+      executor: executor,
       name: "reserved",
       identifier: "main.a.reserved",
-      from: reservedCodec.sqlType,
+      from: reservedIdentifier,
       codec: reservedCodec,
       uniques: reservedUniques,
       isVirtual: false,
@@ -5679,10 +5707,10 @@ const registry = makeRegistry({
       }
     },
     reservedPatchs: {
-      executor,
+      executor: executor,
       name: "reservedPatchs",
       identifier: "main.a.reservedPatchs",
-      from: reservedPatchsCodec.sqlType,
+      from: reservedPatchsIdentifier,
       codec: reservedPatchsCodec,
       uniques: reservedPatchsUniques,
       isVirtual: false,
@@ -5698,10 +5726,10 @@ const registry = makeRegistry({
       }
     },
     reserved_input: {
-      executor,
+      executor: executor,
       name: "reserved_input",
       identifier: "main.a.reserved_input",
-      from: reservedInputCodec.sqlType,
+      from: reservedInputIdentifier,
       codec: reservedInputCodec,
       uniques: reserved_inputUniques,
       isVirtual: false,
@@ -5717,10 +5745,10 @@ const registry = makeRegistry({
       }
     },
     default_value: {
-      executor,
+      executor: executor,
       name: "default_value",
       identifier: "main.a.default_value",
-      from: defaultValueCodec.sqlType,
+      from: defaultValueIdentifier,
       codec: defaultValueCodec,
       uniques: default_valueUniques,
       isVirtual: false,
@@ -5737,10 +5765,10 @@ const registry = makeRegistry({
     },
     foreign_key: registryConfig_pgResources_foreign_key_foreign_key,
     no_primary_key: {
-      executor,
+      executor: executor,
       name: "no_primary_key",
       identifier: "main.a.no_primary_key",
-      from: noPrimaryKeyCodec.sqlType,
+      from: noPrimaryKeyIdentifier,
       codec: noPrimaryKeyCodec,
       uniques: [{
         isPrimary: false,
@@ -5763,10 +5791,10 @@ const registry = makeRegistry({
       }
     },
     testview: {
-      executor,
+      executor: executor,
       name: "testview",
       identifier: "main.a.testview",
-      from: testviewCodec.sqlType,
+      from: testviewIdentifier,
       codec: testviewCodec,
       uniques: [],
       isVirtual: false,
@@ -5783,10 +5811,10 @@ const registry = makeRegistry({
     },
     unique_foreign_key: registryConfig_pgResources_unique_foreign_key_unique_foreign_key,
     c_my_table: {
-      executor,
+      executor: executor,
       name: "c_my_table",
       identifier: "main.c.my_table",
-      from: cMyTableCodec.sqlType,
+      from: cMyTableIdentifier,
       codec: cMyTableCodec,
       uniques: c_my_tableUniques,
       isVirtual: false,
@@ -5803,10 +5831,10 @@ const registry = makeRegistry({
     },
     c_person_secret: registryConfig_pgResources_c_person_secret_c_person_secret,
     view_table: {
-      executor,
+      executor: executor,
       name: "view_table",
       identifier: "main.a.view_table",
-      from: viewTableCodec.sqlType,
+      from: viewTableIdentifier,
       codec: viewTableCodec,
       uniques: view_tableUniques,
       isVirtual: false,
@@ -5822,10 +5850,10 @@ const registry = makeRegistry({
       }
     },
     b_updatable_view: {
-      executor,
+      executor: executor,
       name: "b_updatable_view",
       identifier: "main.b.updatable_view",
-      from: bUpdatableViewCodec.sqlType,
+      from: bUpdatableViewIdentifier,
       codec: bUpdatableViewCodec,
       uniques: [],
       isVirtual: false,
@@ -5844,10 +5872,10 @@ const registry = makeRegistry({
     },
     c_compound_key: registryConfig_pgResources_c_compound_key_c_compound_key,
     similar_table_1: {
-      executor,
+      executor: executor,
       name: "similar_table_1",
       identifier: "main.a.similar_table_1",
-      from: similarTable1Codec.sqlType,
+      from: similarTable1Identifier,
       codec: similarTable1Codec,
       uniques: similar_table_1Uniques,
       isVirtual: false,
@@ -5863,10 +5891,10 @@ const registry = makeRegistry({
       }
     },
     similar_table_2: {
-      executor,
+      executor: executor,
       name: "similar_table_2",
       identifier: "main.a.similar_table_2",
-      from: similarTable2Codec.sqlType,
+      from: similarTable2Identifier,
       codec: similarTable2Codec,
       uniques: similar_table_2Uniques,
       isVirtual: false,
@@ -5882,10 +5910,10 @@ const registry = makeRegistry({
       }
     },
     c_null_test_record: {
-      executor,
+      executor: executor,
       name: "c_null_test_record",
       identifier: "main.c.null_test_record",
-      from: cNullTestRecordCodec.sqlType,
+      from: cNullTestRecordIdentifier,
       codec: cNullTestRecordCodec,
       uniques: c_null_test_recordUniques,
       isVirtual: false,
@@ -5991,10 +6019,10 @@ const registry = makeRegistry({
       description: undefined
     },
     c_edge_case: {
-      executor,
+      executor: executor,
       name: "c_edge_case",
       identifier: "main.c.edge_case",
-      from: cEdgeCaseCodec.sqlType,
+      from: cEdgeCaseIdentifier,
       codec: cEdgeCaseCodec,
       uniques: [],
       isVirtual: false,
@@ -6184,10 +6212,10 @@ const registry = makeRegistry({
       description: undefined
     }),
     b_authenticate_payload: PgResource.functionResourceOptions({
-      executor,
+      executor: executor,
       name: "b_auth_payload",
       identifier: "main.b.auth_payload",
-      from: bAuthPayloadCodec.sqlType,
+      from: bAuthPayloadIdentifier,
       codec: bAuthPayloadCodec,
       uniques: [],
       isVirtual: true,

--- a/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.polymorphic.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.polymorphic.1.export.mjs
@@ -3,6 +3,7 @@ import { ConnectionStep, EdgeStep, ObjectStep, SafeError, __ValueStep, assertEdg
 import { GraphQLError, Kind } from "graphql";
 import { sql } from "pg-sql2";
 import { inspect } from "util";
+const awsApplicationFirstPartyVulnerabilitiesIdentifier = sql.identifier("polymorphic", "aws_application_first_party_vulnerabilities");
 const executor = new PgExecutor({
   name: "main",
   context() {
@@ -15,7 +16,7 @@ const executor = new PgExecutor({
 });
 const spec_awsApplicationFirstPartyVulnerabilities = {
   name: "awsApplicationFirstPartyVulnerabilities",
-  identifier: sql.identifier("polymorphic", "aws_application_first_party_vulnerabilities"),
+  identifier: awsApplicationFirstPartyVulnerabilitiesIdentifier,
   attributes: Object.assign(Object.create(null), {
     aws_application_id: {
       description: undefined,
@@ -51,9 +52,10 @@ const spec_awsApplicationFirstPartyVulnerabilities = {
   executor: executor
 };
 const awsApplicationFirstPartyVulnerabilitiesCodec = recordCodec(spec_awsApplicationFirstPartyVulnerabilities);
+const awsApplicationThirdPartyVulnerabilitiesIdentifier = sql.identifier("polymorphic", "aws_application_third_party_vulnerabilities");
 const spec_awsApplicationThirdPartyVulnerabilities = {
   name: "awsApplicationThirdPartyVulnerabilities",
-  identifier: sql.identifier("polymorphic", "aws_application_third_party_vulnerabilities"),
+  identifier: awsApplicationThirdPartyVulnerabilitiesIdentifier,
   attributes: Object.assign(Object.create(null), {
     aws_application_id: {
       description: undefined,
@@ -89,9 +91,10 @@ const spec_awsApplicationThirdPartyVulnerabilities = {
   executor: executor
 };
 const awsApplicationThirdPartyVulnerabilitiesCodec = recordCodec(spec_awsApplicationThirdPartyVulnerabilities);
+const gcpApplicationFirstPartyVulnerabilitiesIdentifier = sql.identifier("polymorphic", "gcp_application_first_party_vulnerabilities");
 const spec_gcpApplicationFirstPartyVulnerabilities = {
   name: "gcpApplicationFirstPartyVulnerabilities",
-  identifier: sql.identifier("polymorphic", "gcp_application_first_party_vulnerabilities"),
+  identifier: gcpApplicationFirstPartyVulnerabilitiesIdentifier,
   attributes: Object.assign(Object.create(null), {
     gcp_application_id: {
       description: undefined,
@@ -127,9 +130,10 @@ const spec_gcpApplicationFirstPartyVulnerabilities = {
   executor: executor
 };
 const gcpApplicationFirstPartyVulnerabilitiesCodec = recordCodec(spec_gcpApplicationFirstPartyVulnerabilities);
+const gcpApplicationThirdPartyVulnerabilitiesIdentifier = sql.identifier("polymorphic", "gcp_application_third_party_vulnerabilities");
 const spec_gcpApplicationThirdPartyVulnerabilities = {
   name: "gcpApplicationThirdPartyVulnerabilities",
-  identifier: sql.identifier("polymorphic", "gcp_application_third_party_vulnerabilities"),
+  identifier: gcpApplicationThirdPartyVulnerabilitiesIdentifier,
   attributes: Object.assign(Object.create(null), {
     gcp_application_id: {
       description: undefined,
@@ -165,9 +169,10 @@ const spec_gcpApplicationThirdPartyVulnerabilities = {
   executor: executor
 };
 const gcpApplicationThirdPartyVulnerabilitiesCodec = recordCodec(spec_gcpApplicationThirdPartyVulnerabilities);
+const organizationsIdentifier = sql.identifier("polymorphic", "organizations");
 const spec_organizations = {
   name: "organizations",
-  identifier: sql.identifier("polymorphic", "organizations"),
+  identifier: organizationsIdentifier,
   attributes: Object.assign(Object.create(null), {
     organization_id: {
       description: undefined,
@@ -203,9 +208,10 @@ const spec_organizations = {
   executor: executor
 };
 const organizationsCodec = recordCodec(spec_organizations);
+const peopleIdentifier = sql.identifier("polymorphic", "people");
 const spec_people = {
   name: "people",
-  identifier: sql.identifier("polymorphic", "people"),
+  identifier: peopleIdentifier,
   attributes: Object.assign(Object.create(null), {
     person_id: {
       description: undefined,
@@ -256,9 +262,10 @@ const spec_people = {
   executor: executor
 };
 const peopleCodec = recordCodec(spec_people);
+const prioritiesIdentifier = sql.identifier("polymorphic", "priorities");
 const spec_priorities = {
   name: "priorities",
-  identifier: sql.identifier("polymorphic", "priorities"),
+  identifier: prioritiesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -294,6 +301,7 @@ const spec_priorities = {
   executor: executor
 };
 const prioritiesCodec = recordCodec(spec_priorities);
+const relationalChecklistsIdentifier = sql.identifier("polymorphic", "relational_checklists");
 const itemTypeCodec = enumCodec({
   name: "itemType",
   identifier: sql.identifier("polymorphic", "item_type"),
@@ -310,7 +318,7 @@ const itemTypeCodec = enumCodec({
 });
 const spec_relationalChecklists = {
   name: "relationalChecklists",
-  identifier: sql.identifier("polymorphic", "relational_checklists"),
+  identifier: relationalChecklistsIdentifier,
   attributes: Object.assign(Object.create(null), {
     checklist_item_id: {
       description: undefined,
@@ -455,9 +463,10 @@ const spec_relationalChecklists = {
   executor: executor
 };
 const relationalChecklistsCodec = recordCodec(spec_relationalChecklists);
+const relationalItemRelationCompositePksIdentifier = sql.identifier("polymorphic", "relational_item_relation_composite_pks");
 const spec_relationalItemRelationCompositePks = {
   name: "relationalItemRelationCompositePks",
-  identifier: sql.identifier("polymorphic", "relational_item_relation_composite_pks"),
+  identifier: relationalItemRelationCompositePksIdentifier,
   attributes: Object.assign(Object.create(null), {
     parent_id: {
       description: undefined,
@@ -491,9 +500,10 @@ const spec_relationalItemRelationCompositePks = {
   executor: executor
 };
 const relationalItemRelationCompositePksCodec = recordCodec(spec_relationalItemRelationCompositePks);
+const relationalTopicsIdentifier = sql.identifier("polymorphic", "relational_topics");
 const spec_relationalTopics = {
   name: "relationalTopics",
-  identifier: sql.identifier("polymorphic", "relational_topics"),
+  identifier: relationalTopicsIdentifier,
   attributes: Object.assign(Object.create(null), {
     topic_item_id: {
       description: undefined,
@@ -638,9 +648,10 @@ const spec_relationalTopics = {
   executor: executor
 };
 const relationalTopicsCodec = recordCodec(spec_relationalTopics);
+const singleTableItemRelationCompositePksIdentifier = sql.identifier("polymorphic", "single_table_item_relation_composite_pks");
 const spec_singleTableItemRelationCompositePks = {
   name: "singleTableItemRelationCompositePks",
-  identifier: sql.identifier("polymorphic", "single_table_item_relation_composite_pks"),
+  identifier: singleTableItemRelationCompositePksIdentifier,
   attributes: Object.assign(Object.create(null), {
     parent_id: {
       description: undefined,
@@ -674,9 +685,10 @@ const spec_singleTableItemRelationCompositePks = {
   executor: executor
 };
 const singleTableItemRelationCompositePksCodec = recordCodec(spec_singleTableItemRelationCompositePks);
+const relationalChecklistItemsIdentifier = sql.identifier("polymorphic", "relational_checklist_items");
 const spec_relationalChecklistItems = {
   name: "relationalChecklistItems",
-  identifier: sql.identifier("polymorphic", "relational_checklist_items"),
+  identifier: relationalChecklistItemsIdentifier,
   attributes: Object.assign(Object.create(null), {
     checklist_item_item_id: {
       description: undefined,
@@ -830,9 +842,10 @@ const spec_relationalChecklistItems = {
   executor: executor
 };
 const relationalChecklistItemsCodec = recordCodec(spec_relationalChecklistItems);
+const relationalDividersIdentifier = sql.identifier("polymorphic", "relational_dividers");
 const spec_relationalDividers = {
   name: "relationalDividers",
-  identifier: sql.identifier("polymorphic", "relational_dividers"),
+  identifier: relationalDividersIdentifier,
   attributes: Object.assign(Object.create(null), {
     divider_item_id: {
       description: undefined,
@@ -986,9 +999,10 @@ const spec_relationalDividers = {
   executor: executor
 };
 const relationalDividersCodec = recordCodec(spec_relationalDividers);
+const relationalItemRelationsIdentifier = sql.identifier("polymorphic", "relational_item_relations");
 const spec_relationalItemRelations = {
   name: "relationalItemRelations",
-  identifier: sql.identifier("polymorphic", "relational_item_relations"),
+  identifier: relationalItemRelationsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1031,9 +1045,10 @@ const spec_relationalItemRelations = {
   executor: executor
 };
 const relationalItemRelationsCodec = recordCodec(spec_relationalItemRelations);
+const singleTableItemRelationsIdentifier = sql.identifier("polymorphic", "single_table_item_relations");
 const spec_singleTableItemRelations = {
   name: "singleTableItemRelations",
-  identifier: sql.identifier("polymorphic", "single_table_item_relations"),
+  identifier: singleTableItemRelationsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1076,9 +1091,10 @@ const spec_singleTableItemRelations = {
   executor: executor
 };
 const singleTableItemRelationsCodec = recordCodec(spec_singleTableItemRelations);
+const logEntriesIdentifier = sql.identifier("polymorphic", "log_entries");
 const spec_logEntries = {
   name: "logEntries",
-  identifier: sql.identifier("polymorphic", "log_entries"),
+  identifier: logEntriesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1146,9 +1162,10 @@ const spec_logEntries = {
   executor: executor
 };
 const logEntriesCodec = recordCodec(spec_logEntries);
+const relationalPostsIdentifier = sql.identifier("polymorphic", "relational_posts");
 const spec_relationalPosts = {
   name: "relationalPosts",
-  identifier: sql.identifier("polymorphic", "relational_posts"),
+  identifier: relationalPostsIdentifier,
   attributes: Object.assign(Object.create(null), {
     post_item_id: {
       description: undefined,
@@ -1311,9 +1328,10 @@ const spec_relationalPosts = {
   executor: executor
 };
 const relationalPostsCodec = recordCodec(spec_relationalPosts);
+const firstPartyVulnerabilitiesIdentifier = sql.identifier("polymorphic", "first_party_vulnerabilities");
 const spec_firstPartyVulnerabilities = {
   name: "firstPartyVulnerabilities",
-  identifier: sql.identifier("polymorphic", "first_party_vulnerabilities"),
+  identifier: firstPartyVulnerabilitiesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1393,9 +1411,10 @@ const spec_firstPartyVulnerabilities = {
   executor: executor
 };
 const firstPartyVulnerabilitiesCodec = recordCodec(spec_firstPartyVulnerabilities);
+const thirdPartyVulnerabilitiesIdentifier = sql.identifier("polymorphic", "third_party_vulnerabilities");
 const spec_thirdPartyVulnerabilities = {
   name: "thirdPartyVulnerabilities",
-  identifier: sql.identifier("polymorphic", "third_party_vulnerabilities"),
+  identifier: thirdPartyVulnerabilitiesIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1475,9 +1494,10 @@ const spec_thirdPartyVulnerabilities = {
   executor: executor
 };
 const thirdPartyVulnerabilitiesCodec = recordCodec(spec_thirdPartyVulnerabilities);
+const awsApplicationsIdentifier = sql.identifier("polymorphic", "aws_applications");
 const spec_awsApplications = {
   name: "awsApplications",
-  identifier: sql.identifier("polymorphic", "aws_applications"),
+  identifier: awsApplicationsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1575,9 +1595,10 @@ const spec_awsApplications = {
   executor: executor
 };
 const awsApplicationsCodec = recordCodec(spec_awsApplications);
+const gcpApplicationsIdentifier = sql.identifier("polymorphic", "gcp_applications");
 const spec_gcpApplications = {
   name: "gcpApplications",
-  identifier: sql.identifier("polymorphic", "gcp_applications"),
+  identifier: gcpApplicationsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1675,9 +1696,10 @@ const spec_gcpApplications = {
   executor: executor
 };
 const gcpApplicationsCodec = recordCodec(spec_gcpApplications);
+const singleTableItemsIdentifier = sql.identifier("polymorphic", "single_table_items");
 const spec_singleTableItems = {
   name: "singleTableItems",
-  identifier: sql.identifier("polymorphic", "single_table_items"),
+  identifier: singleTableItemsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -1927,9 +1949,10 @@ const spec_singleTableItems = {
   }
 };
 const singleTableItemsCodec = recordCodec(spec_singleTableItems);
+const relationalItemsIdentifier = sql.identifier("polymorphic", "relational_items");
 const spec_relationalItems = {
   name: "relationalItems",
-  identifier: sql.identifier("polymorphic", "relational_items"),
+  identifier: relationalItemsIdentifier,
   attributes: Object.assign(Object.create(null), {
     id: {
       description: undefined,
@@ -2282,10 +2305,10 @@ const aws_application_first_party_vulnerabilitiesUniques = [{
   }
 }];
 const registryConfig_pgResources_aws_application_first_party_vulnerabilities_aws_application_first_party_vulnerabilities = {
-  executor,
+  executor: executor,
   name: "aws_application_first_party_vulnerabilities",
   identifier: "main.polymorphic.aws_application_first_party_vulnerabilities",
-  from: awsApplicationFirstPartyVulnerabilitiesCodec.sqlType,
+  from: awsApplicationFirstPartyVulnerabilitiesIdentifier,
   codec: awsApplicationFirstPartyVulnerabilitiesCodec,
   uniques: aws_application_first_party_vulnerabilitiesUniques,
   isVirtual: false,
@@ -2311,10 +2334,10 @@ const aws_application_third_party_vulnerabilitiesUniques = [{
   }
 }];
 const registryConfig_pgResources_aws_application_third_party_vulnerabilities_aws_application_third_party_vulnerabilities = {
-  executor,
+  executor: executor,
   name: "aws_application_third_party_vulnerabilities",
   identifier: "main.polymorphic.aws_application_third_party_vulnerabilities",
-  from: awsApplicationThirdPartyVulnerabilitiesCodec.sqlType,
+  from: awsApplicationThirdPartyVulnerabilitiesIdentifier,
   codec: awsApplicationThirdPartyVulnerabilitiesCodec,
   uniques: aws_application_third_party_vulnerabilitiesUniques,
   isVirtual: false,
@@ -2340,10 +2363,10 @@ const gcp_application_first_party_vulnerabilitiesUniques = [{
   }
 }];
 const registryConfig_pgResources_gcp_application_first_party_vulnerabilities_gcp_application_first_party_vulnerabilities = {
-  executor,
+  executor: executor,
   name: "gcp_application_first_party_vulnerabilities",
   identifier: "main.polymorphic.gcp_application_first_party_vulnerabilities",
-  from: gcpApplicationFirstPartyVulnerabilitiesCodec.sqlType,
+  from: gcpApplicationFirstPartyVulnerabilitiesIdentifier,
   codec: gcpApplicationFirstPartyVulnerabilitiesCodec,
   uniques: gcp_application_first_party_vulnerabilitiesUniques,
   isVirtual: false,
@@ -2369,10 +2392,10 @@ const gcp_application_third_party_vulnerabilitiesUniques = [{
   }
 }];
 const registryConfig_pgResources_gcp_application_third_party_vulnerabilities_gcp_application_third_party_vulnerabilities = {
-  executor,
+  executor: executor,
   name: "gcp_application_third_party_vulnerabilities",
   identifier: "main.polymorphic.gcp_application_third_party_vulnerabilities",
-  from: gcpApplicationThirdPartyVulnerabilitiesCodec.sqlType,
+  from: gcpApplicationThirdPartyVulnerabilitiesIdentifier,
   codec: gcpApplicationThirdPartyVulnerabilitiesCodec,
   uniques: gcp_application_third_party_vulnerabilitiesUniques,
   isVirtual: false,
@@ -2405,10 +2428,10 @@ const organizationsUniques = [{
   }
 }];
 const registryConfig_pgResources_organizations_organizations = {
-  executor,
+  executor: executor,
   name: "organizations",
   identifier: "main.polymorphic.organizations",
-  from: organizationsCodec.sqlType,
+  from: organizationsIdentifier,
   codec: organizationsCodec,
   uniques: organizationsUniques,
   isVirtual: false,
@@ -2441,10 +2464,10 @@ const peopleUniques = [{
   }
 }];
 const registryConfig_pgResources_people_people = {
-  executor,
+  executor: executor,
   name: "people",
   identifier: "main.polymorphic.people",
-  from: peopleCodec.sqlType,
+  from: peopleIdentifier,
   codec: peopleCodec,
   uniques: peopleUniques,
   isVirtual: false,
@@ -2472,10 +2495,10 @@ const prioritiesUniques = [{
   }
 }];
 const registryConfig_pgResources_priorities_priorities = {
-  executor,
+  executor: executor,
   name: "priorities",
   identifier: "main.polymorphic.priorities",
-  from: prioritiesCodec.sqlType,
+  from: prioritiesIdentifier,
   codec: prioritiesCodec,
   uniques: prioritiesUniques,
   isVirtual: false,
@@ -2501,10 +2524,10 @@ const relational_checklistsUniques = [{
   }
 }];
 const registryConfig_pgResources_relational_checklists_relational_checklists = {
-  executor,
+  executor: executor,
   name: "relational_checklists",
   identifier: "main.polymorphic.relational_checklists",
-  from: relationalChecklistsCodec.sqlType,
+  from: relationalChecklistsIdentifier,
   codec: relationalChecklistsCodec,
   uniques: relational_checklistsUniques,
   isVirtual: false,
@@ -2528,10 +2551,10 @@ const relational_item_relation_composite_pksUniques = [{
   }
 }];
 const registryConfig_pgResources_relational_item_relation_composite_pks_relational_item_relation_composite_pks = {
-  executor,
+  executor: executor,
   name: "relational_item_relation_composite_pks",
   identifier: "main.polymorphic.relational_item_relation_composite_pks",
-  from: relationalItemRelationCompositePksCodec.sqlType,
+  from: relationalItemRelationCompositePksIdentifier,
   codec: relationalItemRelationCompositePksCodec,
   uniques: relational_item_relation_composite_pksUniques,
   isVirtual: false,
@@ -2555,10 +2578,10 @@ const relational_topicsUniques = [{
   }
 }];
 const registryConfig_pgResources_relational_topics_relational_topics = {
-  executor,
+  executor: executor,
   name: "relational_topics",
   identifier: "main.polymorphic.relational_topics",
-  from: relationalTopicsCodec.sqlType,
+  from: relationalTopicsIdentifier,
   codec: relationalTopicsCodec,
   uniques: relational_topicsUniques,
   isVirtual: false,
@@ -2582,10 +2605,10 @@ const single_table_item_relation_composite_pksUniques = [{
   }
 }];
 const registryConfig_pgResources_single_table_item_relation_composite_pks_single_table_item_relation_composite_pks = {
-  executor,
+  executor: executor,
   name: "single_table_item_relation_composite_pks",
   identifier: "main.polymorphic.single_table_item_relation_composite_pks",
-  from: singleTableItemRelationCompositePksCodec.sqlType,
+  from: singleTableItemRelationCompositePksIdentifier,
   codec: singleTableItemRelationCompositePksCodec,
   uniques: single_table_item_relation_composite_pksUniques,
   isVirtual: false,
@@ -2609,10 +2632,10 @@ const relational_checklist_itemsUniques = [{
   }
 }];
 const registryConfig_pgResources_relational_checklist_items_relational_checklist_items = {
-  executor,
+  executor: executor,
   name: "relational_checklist_items",
   identifier: "main.polymorphic.relational_checklist_items",
-  from: relationalChecklistItemsCodec.sqlType,
+  from: relationalChecklistItemsIdentifier,
   codec: relationalChecklistItemsCodec,
   uniques: relational_checklist_itemsUniques,
   isVirtual: false,
@@ -2636,10 +2659,10 @@ const relational_dividersUniques = [{
   }
 }];
 const registryConfig_pgResources_relational_dividers_relational_dividers = {
-  executor,
+  executor: executor,
   name: "relational_dividers",
   identifier: "main.polymorphic.relational_dividers",
-  from: relationalDividersCodec.sqlType,
+  from: relationalDividersIdentifier,
   codec: relationalDividersCodec,
   uniques: relational_dividersUniques,
   isVirtual: false,
@@ -2670,10 +2693,10 @@ const relational_item_relationsUniques = [{
   }
 }];
 const registryConfig_pgResources_relational_item_relations_relational_item_relations = {
-  executor,
+  executor: executor,
   name: "relational_item_relations",
   identifier: "main.polymorphic.relational_item_relations",
-  from: relationalItemRelationsCodec.sqlType,
+  from: relationalItemRelationsIdentifier,
   codec: relationalItemRelationsCodec,
   uniques: relational_item_relationsUniques,
   isVirtual: false,
@@ -2704,10 +2727,10 @@ const single_table_item_relationsUniques = [{
   }
 }];
 const registryConfig_pgResources_single_table_item_relations_single_table_item_relations = {
-  executor,
+  executor: executor,
   name: "single_table_item_relations",
   identifier: "main.polymorphic.single_table_item_relations",
-  from: singleTableItemRelationsCodec.sqlType,
+  from: singleTableItemRelationsIdentifier,
   codec: singleTableItemRelationsCodec,
   uniques: single_table_item_relationsUniques,
   isVirtual: false,
@@ -2731,10 +2754,10 @@ const log_entriesUniques = [{
   }
 }];
 const registryConfig_pgResources_log_entries_log_entries = {
-  executor,
+  executor: executor,
   name: "log_entries",
   identifier: "main.polymorphic.log_entries",
-  from: logEntriesCodec.sqlType,
+  from: logEntriesIdentifier,
   codec: logEntriesCodec,
   uniques: log_entriesUniques,
   isVirtual: false,
@@ -2761,10 +2784,10 @@ const relational_postsUniques = [{
   }
 }];
 const registryConfig_pgResources_relational_posts_relational_posts = {
-  executor,
+  executor: executor,
   name: "relational_posts",
   identifier: "main.polymorphic.relational_posts",
-  from: relationalPostsCodec.sqlType,
+  from: relationalPostsIdentifier,
   codec: relationalPostsCodec,
   uniques: relational_postsUniques,
   isVirtual: false,
@@ -2788,10 +2811,10 @@ const first_party_vulnerabilitiesUniques = [{
   }
 }];
 const registryConfig_pgResources_first_party_vulnerabilities_first_party_vulnerabilities = {
-  executor,
+  executor: executor,
   name: "first_party_vulnerabilities",
   identifier: "main.polymorphic.first_party_vulnerabilities",
-  from: firstPartyVulnerabilitiesCodec.sqlType,
+  from: firstPartyVulnerabilitiesIdentifier,
   codec: firstPartyVulnerabilitiesCodec,
   uniques: first_party_vulnerabilitiesUniques,
   isVirtual: false,
@@ -2819,10 +2842,10 @@ const third_party_vulnerabilitiesUniques = [{
   }
 }];
 const registryConfig_pgResources_third_party_vulnerabilities_third_party_vulnerabilities = {
-  executor,
+  executor: executor,
   name: "third_party_vulnerabilities",
   identifier: "main.polymorphic.third_party_vulnerabilities",
-  from: thirdPartyVulnerabilitiesCodec.sqlType,
+  from: thirdPartyVulnerabilitiesIdentifier,
   codec: thirdPartyVulnerabilitiesCodec,
   uniques: third_party_vulnerabilitiesUniques,
   isVirtual: false,
@@ -2850,10 +2873,10 @@ const aws_applicationsUniques = [{
   }
 }];
 const registryConfig_pgResources_aws_applications_aws_applications = {
-  executor,
+  executor: executor,
   name: "aws_applications",
   identifier: "main.polymorphic.aws_applications",
-  from: awsApplicationsCodec.sqlType,
+  from: awsApplicationsIdentifier,
   codec: awsApplicationsCodec,
   uniques: aws_applicationsUniques,
   isVirtual: false,
@@ -2881,10 +2904,10 @@ const gcp_applicationsUniques = [{
   }
 }];
 const registryConfig_pgResources_gcp_applications_gcp_applications = {
-  executor,
+  executor: executor,
   name: "gcp_applications",
   identifier: "main.polymorphic.gcp_applications",
-  from: gcpApplicationsCodec.sqlType,
+  from: gcpApplicationsIdentifier,
   codec: gcpApplicationsCodec,
   uniques: gcp_applicationsUniques,
   isVirtual: false,
@@ -2913,10 +2936,10 @@ const single_table_itemsUniques = [{
   }
 }];
 const registryConfig_pgResources_single_table_items_single_table_items = {
-  executor,
+  executor: executor,
   name: "single_table_items",
   identifier: "main.polymorphic.single_table_items",
-  from: singleTableItemsCodec.sqlType,
+  from: singleTableItemsIdentifier,
   codec: singleTableItemsCodec,
   uniques: single_table_itemsUniques,
   isVirtual: false,
@@ -2946,10 +2969,10 @@ const relational_itemsUniques = [{
   }
 }];
 const registryConfig_pgResources_relational_items_relational_items = {
-  executor,
+  executor: executor,
   name: "relational_items",
   identifier: "main.polymorphic.relational_items",
-  from: relationalItemsCodec.sqlType,
+  from: relationalItemsIdentifier,
   codec: relationalItemsCodec,
   uniques: relational_itemsUniques,
   isVirtual: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12197,6 +12197,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     pluralize: "npm:^7.0.0"
     semver: "npm:^7.5.4"
+    tamedevil: "workspace:^"
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.6.2"
     typescript: "npm:^5.2.2"


### PR DESCRIPTION
## Description

Noticed that the `Object.fromEntries()` was making the exports pretty gross, so I've fixed that.

## Performance impact

Marginal, schema build only.

## Security impact

Dynamic function, but protected via `tamedevil`.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
