### PR TITLE
Fix updateByNodeId bug

### DIFF
--- a/.changeset/plenty-dingos-flow.md
+++ b/.changeset/plenty-dingos-flow.md
@@ -1,0 +1,8 @@
+---
+"graphile-build-pg": patch
+"postgraphile": patch
+"grafast": patch
+---
+
+Fix a bug relating to Global Object Identifiers (specifically in update
+mutations, but probably elsewhere too) related to early exit.

--- a/grafast/grafast/src/steps/__flag.ts
+++ b/grafast/grafast/src/steps/__flag.ts
@@ -312,6 +312,7 @@ export function trap<T>(
   options?: {
     valueForInhibited?: FlagStepOptions["valueForInhibited"];
     valueForError?: FlagStepOptions["valueForError"];
+    if?: FlagStepOptions["if"];
   },
 ) {
   return new __FlagStep<T>($step, {

--- a/graphile-build/graphile-build-pg/src/plugins/PgNodeIdAttributesPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgNodeIdAttributesPlugin.ts
@@ -237,7 +237,17 @@ export const PgNodeIdAttributesPlugin: GraphileConfig.Plugin = {
                             ],
                           )
                         : EXPORTABLE(
-                            (TRAP_INHIBITED, assertNotNull, condition, getSpec, localAttributes, remoteAttributes, trap, typeName) => function plan(
+                            (
+                              TRAP_INHIBITED,
+                              assertNotNull,
+                              condition,
+                              getSpec,
+                              localAttributes,
+                              remoteAttributes,
+                              trap,
+                              typeName,
+                            ) =>
+                              function plan(
                                 $insert: SetterStep<any, any>,
                                 val,
                               ) {
@@ -268,7 +278,16 @@ export const PgNodeIdAttributesPlugin: GraphileConfig.Plugin = {
                                   $insert.set(localName, $value);
                                 }
                               },
-                            [TRAP_INHIBITED, assertNotNull, condition, getSpec, localAttributes, remoteAttributes, trap, typeName],
+                            [
+                              TRAP_INHIBITED,
+                              assertNotNull,
+                              condition,
+                              getSpec,
+                              localAttributes,
+                              remoteAttributes,
+                              trap,
+                              typeName,
+                            ],
                           ),
                     },
                   ),

--- a/graphile-build/graphile-build-pg/src/plugins/PgNodeIdAttributesPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgNodeIdAttributesPlugin.ts
@@ -187,6 +187,10 @@ export const PgNodeIdAttributesPlugin: GraphileConfig.Plugin = {
                                 val,
                               ) {
                                 const $nodeId = val.get();
+                                const $nodeIdExists = condition(
+                                  "exists",
+                                  $nodeId,
+                                );
                                 const spec = getSpec($nodeId);
                                 for (
                                   let i = 0, l = localAttributes.length;
@@ -196,15 +200,19 @@ export const PgNodeIdAttributesPlugin: GraphileConfig.Plugin = {
                                   const localName = localAttributes[i];
                                   const codec = localAttributeCodecs[i];
                                   const remoteName = remoteAttributes[i];
-                                  const $rawCol = spec[remoteName];
-                                  // const $col = nodeIdentifierColumnOrNull($nodeId, spec, 'id')
-                                  const $col = assertNotNull(
-                                    trap($rawCol, TRAP_INHIBITED),
+                                  // Set `null` if invalid
+                                  const $rawValue = trap(
+                                    spec[remoteName],
+                                    TRAP_INHIBITED,
+                                  );
+                                  // If `null` but `$nodeId` wasn't null, throw an error: invalid Node ID!
+                                  const $value = assertNotNull(
+                                    $rawValue,
                                     `Invalid node identifier for '${typeName}'`,
-                                    { if: condition("exists", $nodeId) },
+                                    { if: $nodeIdExists },
                                   );
                                   const sqlRemoteValue = $condition.placeholder(
-                                    $col,
+                                    $value,
                                     codec,
                                   );
                                   $condition.where({
@@ -229,12 +237,16 @@ export const PgNodeIdAttributesPlugin: GraphileConfig.Plugin = {
                             ],
                           )
                         : EXPORTABLE(
-                            (getSpec, localAttributes, remoteAttributes) =>
-                              function plan(
+                            (TRAP_INHIBITED, assertNotNull, condition, getSpec, localAttributes, remoteAttributes, trap, typeName) => function plan(
                                 $insert: SetterStep<any, any>,
                                 val,
                               ) {
-                                const spec = getSpec(val.get());
+                                const $nodeId = val.get();
+                                const $nodeIdExists = condition(
+                                  "exists",
+                                  $nodeId,
+                                );
+                                const spec = getSpec($nodeId);
                                 for (
                                   let i = 0, l = localAttributes.length;
                                   i < l;
@@ -242,11 +254,21 @@ export const PgNodeIdAttributesPlugin: GraphileConfig.Plugin = {
                                 ) {
                                   const localName = localAttributes[i];
                                   const remoteName = remoteAttributes[i];
-                                  const $val = spec[remoteName];
-                                  $insert.set(localName, $val);
+                                  // Set `null` if invalid
+                                  const $rawValue = trap(
+                                    spec[remoteName],
+                                    TRAP_INHIBITED,
+                                  );
+                                  // If `null` but `$nodeId` wasn't null, throw an error: invalid Node ID!
+                                  const $value = assertNotNull(
+                                    $rawValue,
+                                    `Invalid node identifier for '${typeName}'`,
+                                    { if: $nodeIdExists },
+                                  );
+                                  $insert.set(localName, $value);
                                 }
                               },
-                            [getSpec, localAttributes, remoteAttributes],
+                            [TRAP_INHIBITED, assertNotNull, condition, getSpec, localAttributes, remoteAttributes, trap, typeName],
                           ),
                     },
                   ),

--- a/postgraphile/postgraphile/__tests__/kitchen-sink-schema.sql
+++ b/postgraphile/postgraphile/__tests__/kitchen-sink-schema.sql
@@ -103,7 +103,7 @@ comment on table c.person_secret is E'@deprecated This is deprecated (comment on
 -- This is to test that "one-to-one" relationships also work on unique keys
 create table c.left_arm (
   id serial primary key,
-  person_id int not null default c.current_user_id() unique references c.person on delete cascade,
+  person_id int default c.current_user_id() unique references c.person on delete cascade,
   length_in_metres float,
   mood text not null default 'neutral'
 );

--- a/postgraphile/postgraphile/__tests__/mutations/v4/d.updatePersonByNodeId.json5
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/d.updatePersonByNodeId.json5
@@ -1,0 +1,16 @@
+{
+  updatePerson: {
+    person: {
+      id: 1,
+      nodeId: "WyJwZW9wbGUiLDFd",
+      firstName: "John",
+      lastName: "Doe",
+      colNoCreate: "update2",
+      colNoUpdate: "col_no_update1",
+      colNoOrder: "update1",
+      colNoFilter: "update3",
+      colNoCreateUpdate: "col_no_create_update1",
+      colNoCreateUpdateOrderFilter: "col_no_create_update_order_filter1",
+    },
+  },
+}

--- a/postgraphile/postgraphile/__tests__/mutations/v4/d.updatePersonByNodeId.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/d.updatePersonByNodeId.mermaid
@@ -1,0 +1,79 @@
+%%{init: {'themeVariables': { 'fontSize': '12px'}}}%%
+graph TD
+    classDef path fill:#eee,stroke:#000,color:#000
+    classDef plan fill:#fff,stroke-width:1px,color:#000
+    classDef itemplan fill:#fff,stroke-width:2px,color:#000
+    classDef unbatchedplan fill:#dff,stroke-width:1px,color:#000
+    classDef sideeffectplan fill:#fcc,stroke-width:2px,color:#000
+    classDef bucket fill:#f6f6f6,color:#000,stroke-width:2px,text-align:left
+
+
+    %% plan dependencies
+    Object23{{"Object[23∈0]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access21{{"Access[21∈0]<br />ᐸ3.pgSettingsᐳ"}}:::plan
+    Access22{{"Access[22∈0]<br />ᐸ3.withPgClientᐳ"}}:::plan
+    Access21 & Access22 --> Object23
+    Lambda17{{"Lambda[17∈0]<br />ᐸdecode_Person_base64JSONᐳ"}}:::plan
+    Constant38{{"Constant[38∈0]<br />ᐸ'WyJwZW9wbGUiLDFd'ᐳ"}}:::plan
+    Constant38 --> Lambda17
+    Access18{{"Access[18∈0]<br />ᐸ17.1ᐳ"}}:::plan
+    Lambda17 --> Access18
+    __Value3["__Value[3∈0]<br />ᐸcontextᐳ"]:::plan
+    __Value3 --> Access21
+    __Value3 --> Access22
+    __Value0["__Value[0∈0]"]:::plan
+    __Value5["__Value[5∈0]<br />ᐸrootValueᐳ"]:::plan
+    Constant39{{"Constant[39∈0]<br />ᐸ'Doe'ᐳ"}}:::plan
+    Constant40{{"Constant[40∈0]<br />ᐸ'update2'ᐳ"}}:::plan
+    Constant41{{"Constant[41∈0]<br />ᐸ'update1'ᐳ"}}:::plan
+    Constant42{{"Constant[42∈0]<br />ᐸ'update3'ᐳ"}}:::plan
+    PgUpdateSingle20[["PgUpdateSingle[20∈1]<br />ᐸperson(id;last_name,col_no_create,col_no_order,col_no_filter)ᐳ"]]:::sideeffectplan
+    Object23 -->|rejectNull| PgUpdateSingle20
+    Access18 & Constant39 & Constant40 & Constant41 & Constant42 --> PgUpdateSingle20
+    Object24{{"Object[24∈1]<br />ᐸ{result}ᐳ"}}:::plan
+    PgUpdateSingle20 --> Object24
+    List28{{"List[28∈3]<br />ᐸ26,25ᐳ"}}:::plan
+    Constant26{{"Constant[26∈3]<br />ᐸ'people'ᐳ"}}:::plan
+    PgClassExpression25{{"PgClassExpression[25∈3]<br />ᐸ__person__.”id”ᐳ"}}:::plan
+    Constant26 & PgClassExpression25 --> List28
+    PgUpdateSingle20 --> PgClassExpression25
+    Lambda29{{"Lambda[29∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List28 --> Lambda29
+    PgClassExpression30{{"PgClassExpression[30∈3]<br />ᐸ__person__.”first_name”ᐳ"}}:::plan
+    PgUpdateSingle20 --> PgClassExpression30
+    PgClassExpression31{{"PgClassExpression[31∈3]<br />ᐸ__person__.”last_name”ᐳ"}}:::plan
+    PgUpdateSingle20 --> PgClassExpression31
+    PgClassExpression32{{"PgClassExpression[32∈3]<br />ᐸ__person__...no_create”ᐳ"}}:::plan
+    PgUpdateSingle20 --> PgClassExpression32
+    PgClassExpression33{{"PgClassExpression[33∈3]<br />ᐸ__person__...no_update”ᐳ"}}:::plan
+    PgUpdateSingle20 --> PgClassExpression33
+    PgClassExpression34{{"PgClassExpression[34∈3]<br />ᐸ__person__..._no_order”ᐳ"}}:::plan
+    PgUpdateSingle20 --> PgClassExpression34
+    PgClassExpression35{{"PgClassExpression[35∈3]<br />ᐸ__person__...no_filter”ᐳ"}}:::plan
+    PgUpdateSingle20 --> PgClassExpression35
+    PgClassExpression36{{"PgClassExpression[36∈3]<br />ᐸ__person__...te_update”ᐳ"}}:::plan
+    PgUpdateSingle20 --> PgClassExpression36
+    PgClassExpression37{{"PgClassExpression[37∈3]<br />ᐸ__person__...er_filter”ᐳ"}}:::plan
+    PgUpdateSingle20 --> PgClassExpression37
+
+    %% define steps
+
+    subgraph "Buckets for mutations/v4/d.updatePersonByNodeId"
+    Bucket0("Bucket 0 (root)"):::bucket
+    classDef bucket0 stroke:#696969
+    class Bucket0,__Value0,__Value3,__Value5,Lambda17,Access18,Access21,Access22,Object23,Constant38,Constant39,Constant40,Constant41,Constant42 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 23, 18, 39, 40, 41, 42<br /><br />1: PgUpdateSingle[20]<br />2: <br />ᐳ: Object[24]"):::bucket
+    classDef bucket1 stroke:#00bfff
+    class Bucket1,PgUpdateSingle20,Object24 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 24, 20<br /><br />ROOT Object{1}ᐸ{result}ᐳ[24]"):::bucket
+    classDef bucket2 stroke:#7f007f
+    class Bucket2 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 20<br /><br />ROOT PgUpdateSingle{1}ᐸperson(id;last_name,col_no_create,col_no_order,col_no_filter)ᐳ[20]"):::bucket
+    classDef bucket3 stroke:#ffa500
+    class Bucket3,PgClassExpression25,Constant26,List28,Lambda29,PgClassExpression30,PgClassExpression31,PgClassExpression32,PgClassExpression33,PgClassExpression34,PgClassExpression35,PgClassExpression36,PgClassExpression37 bucket3
+    Bucket0 --> Bucket1
+    Bucket1 --> Bucket2
+    Bucket2 --> Bucket3
+    classDef unary fill:#fafffa,borderWidth:8px
+    class Object23,Lambda17,Access18,Access21,Access22,__Value0,__Value3,__Value5,Constant38,Constant39,Constant40,Constant41,Constant42,PgUpdateSingle20,Object24,List28,PgClassExpression25,Lambda29,PgClassExpression30,PgClassExpression31,PgClassExpression32,PgClassExpression33,PgClassExpression34,PgClassExpression35,PgClassExpression36,PgClassExpression37,Constant26 unary
+    end

--- a/postgraphile/postgraphile/__tests__/mutations/v4/d.updatePersonByNodeId.sql
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/d.updatePersonByNodeId.sql
@@ -1,0 +1,10 @@
+update "d"."person" as __person__ set "last_name" = $1::"varchar", "col_no_create" = $2::"text", "col_no_order" = $3::"text", "col_no_filter" = $4::"text" where (__person__."id" = $5::"int4") returning
+  __person__."id"::text as "0",
+  __person__."first_name" as "1",
+  __person__."last_name" as "2",
+  __person__."col_no_create" as "3",
+  __person__."col_no_update" as "4",
+  __person__."col_no_order" as "5",
+  __person__."col_no_filter" as "6",
+  __person__."col_no_create_update" as "7",
+  __person__."col_no_create_update_order_filter" as "8";

--- a/postgraphile/postgraphile/__tests__/mutations/v4/d.updatePersonByNodeId.test.graphql
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/d.updatePersonByNodeId.test.graphql
@@ -1,0 +1,28 @@
+## expect(errors).toBeFalsy();
+#> schema: ["d"]
+mutation {
+  updatePerson(
+    input: {
+      nodeId: "WyJwZW9wbGUiLDFd"
+      personPatch: {
+        lastName: "Doe"
+        colNoOrder: "update1"
+        colNoCreate: "update2"
+        colNoFilter: "update3"
+      }
+    }
+  ) {
+    person {
+      id
+      nodeId
+      firstName
+      lastName
+      colNoCreate
+      colNoUpdate
+      colNoOrder
+      colNoFilter
+      colNoCreateUpdate
+      colNoCreateUpdateOrderFilter
+    }
+  }
+}

--- a/postgraphile/postgraphile/__tests__/mutations/v4/polymorphic.relay.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/polymorphic.relay.mermaid
@@ -16,849 +16,897 @@ graph TD
     __Value3["__Value[3∈0]<br />ᐸcontextᐳ"]:::plan
     __Value3 --> Access14
     __Value3 --> Access15
-    Lambda18{{"Lambda[18∈0]<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
-    Constant736{{"Constant[736∈0]<br />ᐸ'WyJyZWxhdGlvbmFsX3RvcGljcyIsMV0='ᐳ"}}:::plan
-    Constant736 --> Lambda18
-    List23{{"List[23∈0]<br />ᐸ735ᐳ"}}:::plan
-    Access735{{"Access[735∈0]<br />ᐸ18.base64JSON.1ᐳ"}}:::plan
-    Access735 --> List23
-    Lambda52{{"Lambda[52∈0]<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
-    Constant738{{"Constant[738∈0]<br />ᐸ'WyJyZWxhdGlvbmFsX3RvcGljcyIsMl0='ᐳ"}}:::plan
-    Constant738 --> Lambda52
-    List57{{"List[57∈0]<br />ᐸ737ᐳ"}}:::plan
-    Access737{{"Access[737∈0]<br />ᐸ52.base64JSON.1ᐳ"}}:::plan
-    Access737 --> List57
-    Lambda18 --> Access735
-    Lambda52 --> Access737
+    Condition18{{"Condition[18∈0]<br />ᐸexistsᐳ"}}:::plan
+    Constant760{{"Constant[760∈0]<br />ᐸ'WyJyZWxhdGlvbmFsX3RvcGljcyIsMV0='ᐳ"}}:::plan
+    Constant760 --> Condition18
+    Lambda19{{"Lambda[19∈0]<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
+    Constant760 --> Lambda19
+    List24{{"List[24∈0]<br />ᐸ759ᐳ"}}:::plan
+    Access759{{"Access[759∈0]<br />ᐸ19.base64JSON.1ᐳ"}}:::plan
+    Access759 --> List24
+    Condition55{{"Condition[55∈0]<br />ᐸexistsᐳ"}}:::plan
+    Constant762{{"Constant[762∈0]<br />ᐸ'WyJyZWxhdGlvbmFsX3RvcGljcyIsMl0='ᐳ"}}:::plan
+    Constant762 --> Condition55
+    Lambda56{{"Lambda[56∈0]<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
+    Constant762 --> Lambda56
+    List61{{"List[61∈0]<br />ᐸ761ᐳ"}}:::plan
+    Access761{{"Access[761∈0]<br />ᐸ56.base64JSON.1ᐳ"}}:::plan
+    Access761 --> List61
+    Lambda19 --> Access759
+    Lambda56 --> Access761
     __Value0["__Value[0∈0]"]:::plan
     __Value5["__Value[5∈0]<br />ᐸrootValueᐳ"]:::plan
-    Constant744{{"Constant[744∈0]<br />ᐸ'WyJTaW5nbGVUYWJsZVRvcGljIiwxXQ=='ᐳ"}}:::plan
-    Constant746{{"Constant[746∈0]<br />ᐸ'WyJTaW5nbGVUYWJsZVRvcGljIiwyXQ=='ᐳ"}}:::plan
-    List49{{"List[49∈1]<br />ᐸ24,30,36,42,48ᐳ"}}:::plan
-    Object24{{"Object[24∈1]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object30{{"Object[30∈1]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object36{{"Object[36∈1]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object42{{"Object[42∈1]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object48{{"Object[48∈1]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object24 & Object30 & Object36 & Object42 & Object48 --> List49
-    List83{{"List[83∈1]<br />ᐸ58,64,70,76,82ᐳ"}}:::plan
-    Object58{{"Object[58∈1]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object64{{"Object[64∈1]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object70{{"Object[70∈1]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object76{{"Object[76∈1]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object82{{"Object[82∈1]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object58 & Object64 & Object70 & Object76 & Object82 --> List83
+    Constant768{{"Constant[768∈0]<br />ᐸ'WyJTaW5nbGVUYWJsZVRvcGljIiwxXQ=='ᐳ"}}:::plan
+    Constant770{{"Constant[770∈0]<br />ᐸ'WyJTaW5nbGVUYWJsZVRvcGljIiwyXQ=='ᐳ"}}:::plan
+    List50{{"List[50∈1]<br />ᐸ25,31,37,43,49ᐳ"}}:::plan
+    Object25{{"Object[25∈1]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object31{{"Object[31∈1]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object37{{"Object[37∈1]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object43{{"Object[43∈1]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object49{{"Object[49∈1]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object25 & Object31 & Object37 & Object43 & Object49 --> List50
+    List87{{"List[87∈1]<br />ᐸ62,68,74,80,86ᐳ"}}:::plan
+    Object62{{"Object[62∈1]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object68{{"Object[68∈1]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object74{{"Object[74∈1]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object80{{"Object[80∈1]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object86{{"Object[86∈1]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object62 & Object68 & Object74 & Object80 & Object86 --> List87
     PgInsertSingle13[["PgInsertSingle[13∈1]<br />ᐸrelational_item_relations(child_id,parent_id)ᐳ"]]:::sideeffectplan
-    Access51{{"Access[51∈1]<br />ᐸ50.0ᐳ"}}:::plan
-    Access85{{"Access[85∈1]<br />ᐸ84.0ᐳ"}}:::plan
-    Object16 & Access51 & Access85 --> PgInsertSingle13
-    Lambda22[["Lambda[22∈1]"]]:::unbatchedplan
-    Lambda22 & List23 --> Object24
-    Lambda28[["Lambda[28∈1]"]]:::unbatchedplan
-    Lambda28 & List23 --> Object30
-    Lambda34[["Lambda[34∈1]"]]:::unbatchedplan
-    Lambda34 & List23 --> Object36
-    Lambda40[["Lambda[40∈1]"]]:::unbatchedplan
-    Lambda40 & List23 --> Object42
-    Lambda46[["Lambda[46∈1]"]]:::unbatchedplan
-    Lambda46 & List23 --> Object48
-    Lambda56[["Lambda[56∈1]"]]:::unbatchedplan
-    Lambda56 & List57 --> Object58
-    Lambda62[["Lambda[62∈1]"]]:::unbatchedplan
-    Lambda62 & List57 --> Object64
-    Lambda68[["Lambda[68∈1]"]]:::unbatchedplan
-    Lambda68 & List57 --> Object70
-    Lambda74[["Lambda[74∈1]"]]:::unbatchedplan
-    Lambda74 & List57 --> Object76
-    Lambda80[["Lambda[80∈1]"]]:::unbatchedplan
-    Lambda80 & List57 --> Object82
+    __Flag54[["__Flag[54∈1]<br />ᐸ53, if(18), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
+    __Flag91[["__Flag[91∈1]<br />ᐸ90, if(55), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
+    Object16 & __Flag54 & __Flag91 --> PgInsertSingle13
+    Lambda23[["Lambda[23∈1]"]]:::unbatchedplan
+    Lambda23 & List24 --> Object25
+    Lambda29[["Lambda[29∈1]"]]:::unbatchedplan
+    Lambda29 & List24 --> Object31
+    Lambda35[["Lambda[35∈1]"]]:::unbatchedplan
+    Lambda35 & List24 --> Object37
+    Lambda41[["Lambda[41∈1]"]]:::unbatchedplan
+    Lambda41 & List24 --> Object43
+    Lambda47[["Lambda[47∈1]"]]:::unbatchedplan
+    Lambda47 & List24 --> Object49
+    __Flag53[["__Flag[53∈1]<br />ᐸ52, trapInhibited, onReject: INHIBITᐳ"]]:::plan
+    __Flag53 & Condition18 --> __Flag54
+    Lambda60[["Lambda[60∈1]"]]:::unbatchedplan
+    Lambda60 & List61 --> Object62
+    Lambda66[["Lambda[66∈1]"]]:::unbatchedplan
+    Lambda66 & List61 --> Object68
+    Lambda72[["Lambda[72∈1]"]]:::unbatchedplan
+    Lambda72 & List61 --> Object74
+    Lambda78[["Lambda[78∈1]"]]:::unbatchedplan
+    Lambda78 & List61 --> Object80
+    Lambda84[["Lambda[84∈1]"]]:::unbatchedplan
+    Lambda84 & List61 --> Object86
+    __Flag90[["__Flag[90∈1]<br />ᐸ89, trapInhibited, onReject: INHIBITᐳ"]]:::plan
+    __Flag90 & Condition55 --> __Flag91
     Object17{{"Object[17∈1]<br />ᐸ{result}ᐳ"}}:::plan
     PgInsertSingle13 --> Object17
-    Lambda18 --> Lambda22
-    Lambda18 --> Lambda28
-    Lambda18 --> Lambda34
-    Lambda18 --> Lambda40
-    Lambda18 --> Lambda46
-    Lambda50{{"Lambda[50∈1]"}}:::plan
-    List49 --> Lambda50
-    Lambda50 --> Access51
-    Lambda52 --> Lambda56
-    Lambda52 --> Lambda62
-    Lambda52 --> Lambda68
-    Lambda52 --> Lambda74
-    Lambda52 --> Lambda80
-    Lambda84{{"Lambda[84∈1]"}}:::plan
-    List83 --> Lambda84
-    Lambda84 --> Access85
-    List88{{"List[88∈3]<br />ᐸ86,87ᐳ"}}:::plan
-    Constant86{{"Constant[86∈3]<br />ᐸ'relational_item_relations'ᐳ"}}:::plan
-    PgClassExpression87{{"PgClassExpression[87∈3]<br />ᐸ__relation...ons__.”id”ᐳ"}}:::plan
-    Constant86 & PgClassExpression87 --> List88
-    PgSelect91[["PgSelect[91∈3]<br />ᐸrelational_itemsᐳ"]]:::plan
-    PgClassExpression90{{"PgClassExpression[90∈3]<br />ᐸ__relation...”child_id”ᐳ"}}:::plan
-    Object16 & PgClassExpression90 --> PgSelect91
-    PgSelect158[["PgSelect[158∈3]<br />ᐸrelational_itemsᐳ"]]:::plan
-    PgClassExpression157{{"PgClassExpression[157∈3]<br />ᐸ__relation...parent_id”ᐳ"}}:::plan
-    Object16 & PgClassExpression157 --> PgSelect158
-    PgInsertSingle13 --> PgClassExpression87
-    Lambda89{{"Lambda[89∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List88 --> Lambda89
-    PgInsertSingle13 --> PgClassExpression90
-    First95{{"First[95∈3]"}}:::plan
-    PgSelect91 --> First95
-    PgSelectSingle96{{"PgSelectSingle[96∈3]<br />ᐸrelational_itemsᐳ"}}:::plan
-    First95 --> PgSelectSingle96
-    PgClassExpression97{{"PgClassExpression[97∈3]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
-    PgSelectSingle96 --> PgClassExpression97
-    PgClassExpression108{{"PgClassExpression[108∈3]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle96 --> PgClassExpression108
-    PgInsertSingle13 --> PgClassExpression157
-    First162{{"First[162∈3]"}}:::plan
-    PgSelect158 --> First162
-    PgSelectSingle163{{"PgSelectSingle[163∈3]<br />ᐸrelational_itemsᐳ"}}:::plan
-    First162 --> PgSelectSingle163
-    PgClassExpression164{{"PgClassExpression[164∈3]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
-    PgSelectSingle163 --> PgClassExpression164
-    PgClassExpression175{{"PgClassExpression[175∈3]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle163 --> PgClassExpression175
-    PgSelect98[["PgSelect[98∈4]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    Object16 & PgClassExpression97 --> PgSelect98
-    List106{{"List[106∈4]<br />ᐸ104,105ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Constant104{{"Constant[104∈4]<br />ᐸ'relational_topics'ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgClassExpression105{{"PgClassExpression[105∈4]<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
-    Constant104 & PgClassExpression105 --> List106
-    PgSelect110[["PgSelect[110∈4]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object16 & PgClassExpression97 --> PgSelect110
-    List118{{"List[118∈4]<br />ᐸ116,117ᐳ<br />ᐳRelationalPost"}}:::plan
-    Constant116{{"Constant[116∈4]<br />ᐸ'relational_posts'ᐳ<br />ᐳRelationalPost"}}:::plan
-    PgClassExpression117{{"PgClassExpression[117∈4]<br />ᐸ__relation...t_item_id”ᐳ"}}:::plan
-    Constant116 & PgClassExpression117 --> List118
-    PgSelect122[["PgSelect[122∈4]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object16 & PgClassExpression97 --> PgSelect122
-    List130{{"List[130∈4]<br />ᐸ128,129ᐳ<br />ᐳRelationalDivider"}}:::plan
-    Constant128{{"Constant[128∈4]<br />ᐸ'relational_dividers'ᐳ<br />ᐳRelationalDivider"}}:::plan
-    PgClassExpression129{{"PgClassExpression[129∈4]<br />ᐸ__relation...r_item_id”ᐳ"}}:::plan
-    Constant128 & PgClassExpression129 --> List130
-    PgSelect134[["PgSelect[134∈4]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object16 & PgClassExpression97 --> PgSelect134
-    List142{{"List[142∈4]<br />ᐸ140,141ᐳ<br />ᐳRelationalChecklist"}}:::plan
-    Constant140{{"Constant[140∈4]<br />ᐸ'relational_checklists'ᐳ<br />ᐳRelationalChecklist"}}:::plan
-    PgClassExpression141{{"PgClassExpression[141∈4]<br />ᐸ__relation...t_item_id”ᐳ"}}:::plan
-    Constant140 & PgClassExpression141 --> List142
-    PgSelect146[["PgSelect[146∈4]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object16 & PgClassExpression97 --> PgSelect146
-    List154{{"List[154∈4]<br />ᐸ152,153ᐳ<br />ᐳRelationalChecklistItem"}}:::plan
-    Constant152{{"Constant[152∈4]<br />ᐸ'relational_checklist_items'ᐳ<br />ᐳRelationalChecklistItem"}}:::plan
-    PgClassExpression153{{"PgClassExpression[153∈4]<br />ᐸ__relation...m_item_id”ᐳ"}}:::plan
-    Constant152 & PgClassExpression153 --> List154
-    First102{{"First[102∈4]"}}:::plan
-    PgSelect98 --> First102
-    PgSelectSingle103{{"PgSelectSingle[103∈4]<br />ᐸrelational_topicsᐳ"}}:::plan
-    First102 --> PgSelectSingle103
-    PgSelectSingle103 --> PgClassExpression105
-    Lambda107{{"Lambda[107∈4]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List106 --> Lambda107
-    First114{{"First[114∈4]"}}:::plan
-    PgSelect110 --> First114
-    PgSelectSingle115{{"PgSelectSingle[115∈4]<br />ᐸrelational_postsᐳ"}}:::plan
-    First114 --> PgSelectSingle115
-    PgSelectSingle115 --> PgClassExpression117
-    Lambda119{{"Lambda[119∈4]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List118 --> Lambda119
-    First126{{"First[126∈4]"}}:::plan
-    PgSelect122 --> First126
-    PgSelectSingle127{{"PgSelectSingle[127∈4]<br />ᐸrelational_dividersᐳ"}}:::plan
-    First126 --> PgSelectSingle127
-    PgSelectSingle127 --> PgClassExpression129
-    Lambda131{{"Lambda[131∈4]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List130 --> Lambda131
-    First138{{"First[138∈4]"}}:::plan
-    PgSelect134 --> First138
-    PgSelectSingle139{{"PgSelectSingle[139∈4]<br />ᐸrelational_checklistsᐳ"}}:::plan
-    First138 --> PgSelectSingle139
-    PgSelectSingle139 --> PgClassExpression141
-    Lambda143{{"Lambda[143∈4]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List142 --> Lambda143
-    First150{{"First[150∈4]"}}:::plan
-    PgSelect146 --> First150
-    PgSelectSingle151{{"PgSelectSingle[151∈4]<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
-    First150 --> PgSelectSingle151
-    PgSelectSingle151 --> PgClassExpression153
-    Lambda155{{"Lambda[155∈4]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List154 --> Lambda155
-    PgSelect165[["PgSelect[165∈5]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    Object16 & PgClassExpression164 --> PgSelect165
-    List173{{"List[173∈5]<br />ᐸ171,172ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Constant171{{"Constant[171∈5]<br />ᐸ'relational_topics'ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgClassExpression172{{"PgClassExpression[172∈5]<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
-    Constant171 & PgClassExpression172 --> List173
-    PgSelect177[["PgSelect[177∈5]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object16 & PgClassExpression164 --> PgSelect177
-    List185{{"List[185∈5]<br />ᐸ183,184ᐳ<br />ᐳRelationalPost"}}:::plan
-    Constant183{{"Constant[183∈5]<br />ᐸ'relational_posts'ᐳ<br />ᐳRelationalPost"}}:::plan
-    PgClassExpression184{{"PgClassExpression[184∈5]<br />ᐸ__relation...t_item_id”ᐳ"}}:::plan
-    Constant183 & PgClassExpression184 --> List185
-    PgSelect189[["PgSelect[189∈5]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object16 & PgClassExpression164 --> PgSelect189
-    List197{{"List[197∈5]<br />ᐸ195,196ᐳ<br />ᐳRelationalDivider"}}:::plan
-    Constant195{{"Constant[195∈5]<br />ᐸ'relational_dividers'ᐳ<br />ᐳRelationalDivider"}}:::plan
-    PgClassExpression196{{"PgClassExpression[196∈5]<br />ᐸ__relation...r_item_id”ᐳ"}}:::plan
-    Constant195 & PgClassExpression196 --> List197
-    PgSelect201[["PgSelect[201∈5]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object16 & PgClassExpression164 --> PgSelect201
-    List209{{"List[209∈5]<br />ᐸ207,208ᐳ<br />ᐳRelationalChecklist"}}:::plan
-    Constant207{{"Constant[207∈5]<br />ᐸ'relational_checklists'ᐳ<br />ᐳRelationalChecklist"}}:::plan
-    PgClassExpression208{{"PgClassExpression[208∈5]<br />ᐸ__relation...t_item_id”ᐳ"}}:::plan
-    Constant207 & PgClassExpression208 --> List209
-    PgSelect213[["PgSelect[213∈5]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object16 & PgClassExpression164 --> PgSelect213
-    List221{{"List[221∈5]<br />ᐸ219,220ᐳ<br />ᐳRelationalChecklistItem"}}:::plan
-    Constant219{{"Constant[219∈5]<br />ᐸ'relational_checklist_items'ᐳ<br />ᐳRelationalChecklistItem"}}:::plan
-    PgClassExpression220{{"PgClassExpression[220∈5]<br />ᐸ__relation...m_item_id”ᐳ"}}:::plan
-    Constant219 & PgClassExpression220 --> List221
-    First169{{"First[169∈5]"}}:::plan
-    PgSelect165 --> First169
-    PgSelectSingle170{{"PgSelectSingle[170∈5]<br />ᐸrelational_topicsᐳ"}}:::plan
-    First169 --> PgSelectSingle170
-    PgSelectSingle170 --> PgClassExpression172
-    Lambda174{{"Lambda[174∈5]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List173 --> Lambda174
-    First181{{"First[181∈5]"}}:::plan
-    PgSelect177 --> First181
-    PgSelectSingle182{{"PgSelectSingle[182∈5]<br />ᐸrelational_postsᐳ"}}:::plan
-    First181 --> PgSelectSingle182
-    PgSelectSingle182 --> PgClassExpression184
-    Lambda186{{"Lambda[186∈5]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List185 --> Lambda186
-    First193{{"First[193∈5]"}}:::plan
-    PgSelect189 --> First193
-    PgSelectSingle194{{"PgSelectSingle[194∈5]<br />ᐸrelational_dividersᐳ"}}:::plan
-    First193 --> PgSelectSingle194
-    PgSelectSingle194 --> PgClassExpression196
-    Lambda198{{"Lambda[198∈5]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List197 --> Lambda198
-    First205{{"First[205∈5]"}}:::plan
-    PgSelect201 --> First205
-    PgSelectSingle206{{"PgSelectSingle[206∈5]<br />ᐸrelational_checklistsᐳ"}}:::plan
-    First205 --> PgSelectSingle206
-    PgSelectSingle206 --> PgClassExpression208
-    Lambda210{{"Lambda[210∈5]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List209 --> Lambda210
-    First217{{"First[217∈5]"}}:::plan
-    PgSelect213 --> First217
-    PgSelectSingle218{{"PgSelectSingle[218∈5]<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
-    First217 --> PgSelectSingle218
-    PgSelectSingle218 --> PgClassExpression220
-    Lambda222{{"Lambda[222∈5]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List221 --> Lambda222
-    List265{{"List[265∈6]<br />ᐸ240,246,252,258,264ᐳ"}}:::plan
-    Object240{{"Object[240∈6]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object246{{"Object[246∈6]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object252{{"Object[252∈6]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object258{{"Object[258∈6]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object264{{"Object[264∈6]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object240 & Object246 & Object252 & Object258 & Object264 --> List265
-    List299{{"List[299∈6]<br />ᐸ274,280,286,292,298ᐳ"}}:::plan
-    Object274{{"Object[274∈6]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object280{{"Object[280∈6]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object286{{"Object[286∈6]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object292{{"Object[292∈6]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object298{{"Object[298∈6]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object274 & Object280 & Object286 & Object292 & Object298 --> List299
-    PgInsertSingle229[["PgInsertSingle[229∈6]<br />ᐸrelational_item_relation_composite_pks(child_id,parent_id)ᐳ"]]:::sideeffectplan
-    Object232{{"Object[232∈6]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Access267{{"Access[267∈6]<br />ᐸ266.0ᐳ"}}:::plan
-    Access301{{"Access[301∈6]<br />ᐸ300.0ᐳ"}}:::plan
-    Object232 & Access267 & Access301 --> PgInsertSingle229
-    Access230{{"Access[230∈6]<br />ᐸ3.pgSettingsᐳ"}}:::plan
-    Access231{{"Access[231∈6]<br />ᐸ3.withPgClientᐳ"}}:::plan
-    Access230 & Access231 --> Object232
-    Lambda238[["Lambda[238∈6]"]]:::unbatchedplan
-    List239{{"List[239∈6]<br />ᐸ739ᐳ"}}:::plan
-    Lambda238 & List239 --> Object240
-    Lambda244[["Lambda[244∈6]"]]:::unbatchedplan
-    Lambda244 & List239 --> Object246
-    Lambda250[["Lambda[250∈6]"]]:::unbatchedplan
-    Lambda250 & List239 --> Object252
-    Lambda256[["Lambda[256∈6]"]]:::unbatchedplan
-    Lambda256 & List239 --> Object258
-    Lambda262[["Lambda[262∈6]"]]:::unbatchedplan
-    Lambda262 & List239 --> Object264
-    Lambda272[["Lambda[272∈6]"]]:::unbatchedplan
-    List273{{"List[273∈6]<br />ᐸ741ᐳ"}}:::plan
-    Lambda272 & List273 --> Object274
-    Lambda278[["Lambda[278∈6]"]]:::unbatchedplan
-    Lambda278 & List273 --> Object280
-    Lambda284[["Lambda[284∈6]"]]:::unbatchedplan
-    Lambda284 & List273 --> Object286
-    Lambda290[["Lambda[290∈6]"]]:::unbatchedplan
-    Lambda290 & List273 --> Object292
-    Lambda296[["Lambda[296∈6]"]]:::unbatchedplan
-    Lambda296 & List273 --> Object298
-    __Value3 --> Access230
-    __Value3 --> Access231
-    Object233{{"Object[233∈6]<br />ᐸ{result}ᐳ"}}:::plan
-    PgInsertSingle229 --> Object233
-    Lambda234{{"Lambda[234∈6]<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
-    Constant736 --> Lambda234
-    Lambda234 --> Lambda238
-    Access739{{"Access[739∈6]<br />ᐸ234.base64JSON.1ᐳ"}}:::plan
-    Access739 --> List239
-    Lambda234 --> Lambda244
-    Lambda234 --> Lambda250
-    Lambda234 --> Lambda256
-    Lambda234 --> Lambda262
-    Lambda266{{"Lambda[266∈6]"}}:::plan
-    List265 --> Lambda266
-    Lambda266 --> Access267
-    Lambda268{{"Lambda[268∈6]<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
-    Constant738 --> Lambda268
-    Lambda268 --> Lambda272
-    Access741{{"Access[741∈6]<br />ᐸ268.base64JSON.1ᐳ"}}:::plan
-    Access741 --> List273
-    Lambda268 --> Lambda278
-    Lambda268 --> Lambda284
-    Lambda268 --> Lambda290
-    Lambda268 --> Lambda296
-    Lambda300{{"Lambda[300∈6]"}}:::plan
-    List299 --> Lambda300
-    Lambda300 --> Access301
-    Lambda234 --> Access739
-    Lambda268 --> Access741
-    List305{{"List[305∈8]<br />ᐸ302,303,304ᐳ"}}:::plan
-    Constant302{{"Constant[302∈8]<br />ᐸ'relational_item_relation_composite_pks'ᐳ"}}:::plan
-    PgClassExpression303{{"PgClassExpression[303∈8]<br />ᐸ__relation...parent_id”ᐳ"}}:::plan
-    PgClassExpression304{{"PgClassExpression[304∈8]<br />ᐸ__relation...”child_id”ᐳ"}}:::plan
-    Constant302 & PgClassExpression303 & PgClassExpression304 --> List305
-    PgSelect308[["PgSelect[308∈8]<br />ᐸrelational_itemsᐳ"]]:::plan
-    Object232 & PgClassExpression304 --> PgSelect308
-    PgSelect375[["PgSelect[375∈8]<br />ᐸrelational_itemsᐳ"]]:::plan
-    Object232 & PgClassExpression303 --> PgSelect375
-    PgInsertSingle229 --> PgClassExpression303
-    PgInsertSingle229 --> PgClassExpression304
-    Lambda306{{"Lambda[306∈8]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List305 --> Lambda306
-    First312{{"First[312∈8]"}}:::plan
-    PgSelect308 --> First312
-    PgSelectSingle313{{"PgSelectSingle[313∈8]<br />ᐸrelational_itemsᐳ"}}:::plan
-    First312 --> PgSelectSingle313
-    PgClassExpression314{{"PgClassExpression[314∈8]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
-    PgSelectSingle313 --> PgClassExpression314
-    PgClassExpression325{{"PgClassExpression[325∈8]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle313 --> PgClassExpression325
-    First379{{"First[379∈8]"}}:::plan
-    PgSelect375 --> First379
-    PgSelectSingle380{{"PgSelectSingle[380∈8]<br />ᐸrelational_itemsᐳ"}}:::plan
-    First379 --> PgSelectSingle380
-    PgClassExpression381{{"PgClassExpression[381∈8]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
-    PgSelectSingle380 --> PgClassExpression381
-    PgClassExpression392{{"PgClassExpression[392∈8]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle380 --> PgClassExpression392
-    PgSelect315[["PgSelect[315∈9]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    Object232 & PgClassExpression314 --> PgSelect315
-    List323{{"List[323∈9]<br />ᐸ321,322ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Constant321{{"Constant[321∈9]<br />ᐸ'relational_topics'ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgClassExpression322{{"PgClassExpression[322∈9]<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
-    Constant321 & PgClassExpression322 --> List323
-    PgSelect327[["PgSelect[327∈9]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object232 & PgClassExpression314 --> PgSelect327
-    List335{{"List[335∈9]<br />ᐸ333,334ᐳ<br />ᐳRelationalPost"}}:::plan
-    Constant333{{"Constant[333∈9]<br />ᐸ'relational_posts'ᐳ<br />ᐳRelationalPost"}}:::plan
-    PgClassExpression334{{"PgClassExpression[334∈9]<br />ᐸ__relation...t_item_id”ᐳ"}}:::plan
+    Lambda19 --> Lambda23
+    Lambda19 --> Lambda29
+    Lambda19 --> Lambda35
+    Lambda19 --> Lambda41
+    Lambda19 --> Lambda47
+    Lambda51{{"Lambda[51∈1]"}}:::plan
+    List50 --> Lambda51
+    Access52{{"Access[52∈1]<br />ᐸ51.0ᐳ"}}:::plan
+    Lambda51 --> Access52
+    Access52 --> __Flag53
+    Lambda56 --> Lambda60
+    Lambda56 --> Lambda66
+    Lambda56 --> Lambda72
+    Lambda56 --> Lambda78
+    Lambda56 --> Lambda84
+    Lambda88{{"Lambda[88∈1]"}}:::plan
+    List87 --> Lambda88
+    Access89{{"Access[89∈1]<br />ᐸ88.0ᐳ"}}:::plan
+    Lambda88 --> Access89
+    Access89 --> __Flag90
+    List94{{"List[94∈3]<br />ᐸ92,93ᐳ"}}:::plan
+    Constant92{{"Constant[92∈3]<br />ᐸ'relational_item_relations'ᐳ"}}:::plan
+    PgClassExpression93{{"PgClassExpression[93∈3]<br />ᐸ__relation...ons__.”id”ᐳ"}}:::plan
+    Constant92 & PgClassExpression93 --> List94
+    PgSelect97[["PgSelect[97∈3]<br />ᐸrelational_itemsᐳ"]]:::plan
+    PgClassExpression96{{"PgClassExpression[96∈3]<br />ᐸ__relation...”child_id”ᐳ"}}:::plan
+    Object16 & PgClassExpression96 --> PgSelect97
+    PgSelect164[["PgSelect[164∈3]<br />ᐸrelational_itemsᐳ"]]:::plan
+    PgClassExpression163{{"PgClassExpression[163∈3]<br />ᐸ__relation...parent_id”ᐳ"}}:::plan
+    Object16 & PgClassExpression163 --> PgSelect164
+    PgInsertSingle13 --> PgClassExpression93
+    Lambda95{{"Lambda[95∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List94 --> Lambda95
+    PgInsertSingle13 --> PgClassExpression96
+    First101{{"First[101∈3]"}}:::plan
+    PgSelect97 --> First101
+    PgSelectSingle102{{"PgSelectSingle[102∈3]<br />ᐸrelational_itemsᐳ"}}:::plan
+    First101 --> PgSelectSingle102
+    PgClassExpression103{{"PgClassExpression[103∈3]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle102 --> PgClassExpression103
+    PgClassExpression114{{"PgClassExpression[114∈3]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle102 --> PgClassExpression114
+    PgInsertSingle13 --> PgClassExpression163
+    First168{{"First[168∈3]"}}:::plan
+    PgSelect164 --> First168
+    PgSelectSingle169{{"PgSelectSingle[169∈3]<br />ᐸrelational_itemsᐳ"}}:::plan
+    First168 --> PgSelectSingle169
+    PgClassExpression170{{"PgClassExpression[170∈3]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle169 --> PgClassExpression170
+    PgClassExpression181{{"PgClassExpression[181∈3]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle169 --> PgClassExpression181
+    PgSelect104[["PgSelect[104∈4]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
+    Object16 & PgClassExpression103 --> PgSelect104
+    List112{{"List[112∈4]<br />ᐸ110,111ᐳ<br />ᐳRelationalTopic"}}:::plan
+    Constant110{{"Constant[110∈4]<br />ᐸ'relational_topics'ᐳ<br />ᐳRelationalTopic"}}:::plan
+    PgClassExpression111{{"PgClassExpression[111∈4]<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
+    Constant110 & PgClassExpression111 --> List112
+    PgSelect116[["PgSelect[116∈4]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
+    Object16 & PgClassExpression103 --> PgSelect116
+    List124{{"List[124∈4]<br />ᐸ122,123ᐳ<br />ᐳRelationalPost"}}:::plan
+    Constant122{{"Constant[122∈4]<br />ᐸ'relational_posts'ᐳ<br />ᐳRelationalPost"}}:::plan
+    PgClassExpression123{{"PgClassExpression[123∈4]<br />ᐸ__relation...t_item_id”ᐳ"}}:::plan
+    Constant122 & PgClassExpression123 --> List124
+    PgSelect128[["PgSelect[128∈4]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
+    Object16 & PgClassExpression103 --> PgSelect128
+    List136{{"List[136∈4]<br />ᐸ134,135ᐳ<br />ᐳRelationalDivider"}}:::plan
+    Constant134{{"Constant[134∈4]<br />ᐸ'relational_dividers'ᐳ<br />ᐳRelationalDivider"}}:::plan
+    PgClassExpression135{{"PgClassExpression[135∈4]<br />ᐸ__relation...r_item_id”ᐳ"}}:::plan
+    Constant134 & PgClassExpression135 --> List136
+    PgSelect140[["PgSelect[140∈4]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
+    Object16 & PgClassExpression103 --> PgSelect140
+    List148{{"List[148∈4]<br />ᐸ146,147ᐳ<br />ᐳRelationalChecklist"}}:::plan
+    Constant146{{"Constant[146∈4]<br />ᐸ'relational_checklists'ᐳ<br />ᐳRelationalChecklist"}}:::plan
+    PgClassExpression147{{"PgClassExpression[147∈4]<br />ᐸ__relation...t_item_id”ᐳ"}}:::plan
+    Constant146 & PgClassExpression147 --> List148
+    PgSelect152[["PgSelect[152∈4]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
+    Object16 & PgClassExpression103 --> PgSelect152
+    List160{{"List[160∈4]<br />ᐸ158,159ᐳ<br />ᐳRelationalChecklistItem"}}:::plan
+    Constant158{{"Constant[158∈4]<br />ᐸ'relational_checklist_items'ᐳ<br />ᐳRelationalChecklistItem"}}:::plan
+    PgClassExpression159{{"PgClassExpression[159∈4]<br />ᐸ__relation...m_item_id”ᐳ"}}:::plan
+    Constant158 & PgClassExpression159 --> List160
+    First108{{"First[108∈4]"}}:::plan
+    PgSelect104 --> First108
+    PgSelectSingle109{{"PgSelectSingle[109∈4]<br />ᐸrelational_topicsᐳ"}}:::plan
+    First108 --> PgSelectSingle109
+    PgSelectSingle109 --> PgClassExpression111
+    Lambda113{{"Lambda[113∈4]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List112 --> Lambda113
+    First120{{"First[120∈4]"}}:::plan
+    PgSelect116 --> First120
+    PgSelectSingle121{{"PgSelectSingle[121∈4]<br />ᐸrelational_postsᐳ"}}:::plan
+    First120 --> PgSelectSingle121
+    PgSelectSingle121 --> PgClassExpression123
+    Lambda125{{"Lambda[125∈4]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List124 --> Lambda125
+    First132{{"First[132∈4]"}}:::plan
+    PgSelect128 --> First132
+    PgSelectSingle133{{"PgSelectSingle[133∈4]<br />ᐸrelational_dividersᐳ"}}:::plan
+    First132 --> PgSelectSingle133
+    PgSelectSingle133 --> PgClassExpression135
+    Lambda137{{"Lambda[137∈4]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List136 --> Lambda137
+    First144{{"First[144∈4]"}}:::plan
+    PgSelect140 --> First144
+    PgSelectSingle145{{"PgSelectSingle[145∈4]<br />ᐸrelational_checklistsᐳ"}}:::plan
+    First144 --> PgSelectSingle145
+    PgSelectSingle145 --> PgClassExpression147
+    Lambda149{{"Lambda[149∈4]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List148 --> Lambda149
+    First156{{"First[156∈4]"}}:::plan
+    PgSelect152 --> First156
+    PgSelectSingle157{{"PgSelectSingle[157∈4]<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
+    First156 --> PgSelectSingle157
+    PgSelectSingle157 --> PgClassExpression159
+    Lambda161{{"Lambda[161∈4]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List160 --> Lambda161
+    PgSelect171[["PgSelect[171∈5]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
+    Object16 & PgClassExpression170 --> PgSelect171
+    List179{{"List[179∈5]<br />ᐸ177,178ᐳ<br />ᐳRelationalTopic"}}:::plan
+    Constant177{{"Constant[177∈5]<br />ᐸ'relational_topics'ᐳ<br />ᐳRelationalTopic"}}:::plan
+    PgClassExpression178{{"PgClassExpression[178∈5]<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
+    Constant177 & PgClassExpression178 --> List179
+    PgSelect183[["PgSelect[183∈5]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
+    Object16 & PgClassExpression170 --> PgSelect183
+    List191{{"List[191∈5]<br />ᐸ189,190ᐳ<br />ᐳRelationalPost"}}:::plan
+    Constant189{{"Constant[189∈5]<br />ᐸ'relational_posts'ᐳ<br />ᐳRelationalPost"}}:::plan
+    PgClassExpression190{{"PgClassExpression[190∈5]<br />ᐸ__relation...t_item_id”ᐳ"}}:::plan
+    Constant189 & PgClassExpression190 --> List191
+    PgSelect195[["PgSelect[195∈5]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
+    Object16 & PgClassExpression170 --> PgSelect195
+    List203{{"List[203∈5]<br />ᐸ201,202ᐳ<br />ᐳRelationalDivider"}}:::plan
+    Constant201{{"Constant[201∈5]<br />ᐸ'relational_dividers'ᐳ<br />ᐳRelationalDivider"}}:::plan
+    PgClassExpression202{{"PgClassExpression[202∈5]<br />ᐸ__relation...r_item_id”ᐳ"}}:::plan
+    Constant201 & PgClassExpression202 --> List203
+    PgSelect207[["PgSelect[207∈5]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
+    Object16 & PgClassExpression170 --> PgSelect207
+    List215{{"List[215∈5]<br />ᐸ213,214ᐳ<br />ᐳRelationalChecklist"}}:::plan
+    Constant213{{"Constant[213∈5]<br />ᐸ'relational_checklists'ᐳ<br />ᐳRelationalChecklist"}}:::plan
+    PgClassExpression214{{"PgClassExpression[214∈5]<br />ᐸ__relation...t_item_id”ᐳ"}}:::plan
+    Constant213 & PgClassExpression214 --> List215
+    PgSelect219[["PgSelect[219∈5]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
+    Object16 & PgClassExpression170 --> PgSelect219
+    List227{{"List[227∈5]<br />ᐸ225,226ᐳ<br />ᐳRelationalChecklistItem"}}:::plan
+    Constant225{{"Constant[225∈5]<br />ᐸ'relational_checklist_items'ᐳ<br />ᐳRelationalChecklistItem"}}:::plan
+    PgClassExpression226{{"PgClassExpression[226∈5]<br />ᐸ__relation...m_item_id”ᐳ"}}:::plan
+    Constant225 & PgClassExpression226 --> List227
+    First175{{"First[175∈5]"}}:::plan
+    PgSelect171 --> First175
+    PgSelectSingle176{{"PgSelectSingle[176∈5]<br />ᐸrelational_topicsᐳ"}}:::plan
+    First175 --> PgSelectSingle176
+    PgSelectSingle176 --> PgClassExpression178
+    Lambda180{{"Lambda[180∈5]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List179 --> Lambda180
+    First187{{"First[187∈5]"}}:::plan
+    PgSelect183 --> First187
+    PgSelectSingle188{{"PgSelectSingle[188∈5]<br />ᐸrelational_postsᐳ"}}:::plan
+    First187 --> PgSelectSingle188
+    PgSelectSingle188 --> PgClassExpression190
+    Lambda192{{"Lambda[192∈5]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List191 --> Lambda192
+    First199{{"First[199∈5]"}}:::plan
+    PgSelect195 --> First199
+    PgSelectSingle200{{"PgSelectSingle[200∈5]<br />ᐸrelational_dividersᐳ"}}:::plan
+    First199 --> PgSelectSingle200
+    PgSelectSingle200 --> PgClassExpression202
+    Lambda204{{"Lambda[204∈5]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List203 --> Lambda204
+    First211{{"First[211∈5]"}}:::plan
+    PgSelect207 --> First211
+    PgSelectSingle212{{"PgSelectSingle[212∈5]<br />ᐸrelational_checklistsᐳ"}}:::plan
+    First211 --> PgSelectSingle212
+    PgSelectSingle212 --> PgClassExpression214
+    Lambda216{{"Lambda[216∈5]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List215 --> Lambda216
+    First223{{"First[223∈5]"}}:::plan
+    PgSelect219 --> First223
+    PgSelectSingle224{{"PgSelectSingle[224∈5]<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
+    First223 --> PgSelectSingle224
+    PgSelectSingle224 --> PgClassExpression226
+    Lambda228{{"Lambda[228∈5]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List227 --> Lambda228
+    List272{{"List[272∈6]<br />ᐸ247,253,259,265,271ᐳ"}}:::plan
+    Object247{{"Object[247∈6]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object253{{"Object[253∈6]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object259{{"Object[259∈6]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object265{{"Object[265∈6]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object271{{"Object[271∈6]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object247 & Object253 & Object259 & Object265 & Object271 --> List272
+    List309{{"List[309∈6]<br />ᐸ284,290,296,302,308ᐳ"}}:::plan
+    Object284{{"Object[284∈6]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object290{{"Object[290∈6]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object296{{"Object[296∈6]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object302{{"Object[302∈6]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object308{{"Object[308∈6]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object284 & Object290 & Object296 & Object302 & Object308 --> List309
+    PgInsertSingle235[["PgInsertSingle[235∈6]<br />ᐸrelational_item_relation_composite_pks(child_id,parent_id)ᐳ"]]:::sideeffectplan
+    Object238{{"Object[238∈6]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    __Flag276[["__Flag[276∈6]<br />ᐸ275, if(240), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
+    __Flag313[["__Flag[313∈6]<br />ᐸ312, if(277), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
+    Object238 & __Flag276 & __Flag313 --> PgInsertSingle235
+    Access236{{"Access[236∈6]<br />ᐸ3.pgSettingsᐳ"}}:::plan
+    Access237{{"Access[237∈6]<br />ᐸ3.withPgClientᐳ"}}:::plan
+    Access236 & Access237 --> Object238
+    Lambda245[["Lambda[245∈6]"]]:::unbatchedplan
+    List246{{"List[246∈6]<br />ᐸ763ᐳ"}}:::plan
+    Lambda245 & List246 --> Object247
+    Lambda251[["Lambda[251∈6]"]]:::unbatchedplan
+    Lambda251 & List246 --> Object253
+    Lambda257[["Lambda[257∈6]"]]:::unbatchedplan
+    Lambda257 & List246 --> Object259
+    Lambda263[["Lambda[263∈6]"]]:::unbatchedplan
+    Lambda263 & List246 --> Object265
+    Lambda269[["Lambda[269∈6]"]]:::unbatchedplan
+    Lambda269 & List246 --> Object271
+    __Flag275[["__Flag[275∈6]<br />ᐸ274, trapInhibited, onReject: INHIBITᐳ"]]:::plan
+    Condition240{{"Condition[240∈6]<br />ᐸexistsᐳ"}}:::plan
+    __Flag275 & Condition240 --> __Flag276
+    Lambda282[["Lambda[282∈6]"]]:::unbatchedplan
+    List283{{"List[283∈6]<br />ᐸ765ᐳ"}}:::plan
+    Lambda282 & List283 --> Object284
+    Lambda288[["Lambda[288∈6]"]]:::unbatchedplan
+    Lambda288 & List283 --> Object290
+    Lambda294[["Lambda[294∈6]"]]:::unbatchedplan
+    Lambda294 & List283 --> Object296
+    Lambda300[["Lambda[300∈6]"]]:::unbatchedplan
+    Lambda300 & List283 --> Object302
+    Lambda306[["Lambda[306∈6]"]]:::unbatchedplan
+    Lambda306 & List283 --> Object308
+    __Flag312[["__Flag[312∈6]<br />ᐸ311, trapInhibited, onReject: INHIBITᐳ"]]:::plan
+    Condition277{{"Condition[277∈6]<br />ᐸexistsᐳ"}}:::plan
+    __Flag312 & Condition277 --> __Flag313
+    __Value3 --> Access236
+    __Value3 --> Access237
+    Object239{{"Object[239∈6]<br />ᐸ{result}ᐳ"}}:::plan
+    PgInsertSingle235 --> Object239
+    Constant760 --> Condition240
+    Lambda241{{"Lambda[241∈6]<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
+    Constant760 --> Lambda241
+    Lambda241 --> Lambda245
+    Access763{{"Access[763∈6]<br />ᐸ241.base64JSON.1ᐳ"}}:::plan
+    Access763 --> List246
+    Lambda241 --> Lambda251
+    Lambda241 --> Lambda257
+    Lambda241 --> Lambda263
+    Lambda241 --> Lambda269
+    Lambda273{{"Lambda[273∈6]"}}:::plan
+    List272 --> Lambda273
+    Access274{{"Access[274∈6]<br />ᐸ273.0ᐳ"}}:::plan
+    Lambda273 --> Access274
+    Access274 --> __Flag275
+    Constant762 --> Condition277
+    Lambda278{{"Lambda[278∈6]<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
+    Constant762 --> Lambda278
+    Lambda278 --> Lambda282
+    Access765{{"Access[765∈6]<br />ᐸ278.base64JSON.1ᐳ"}}:::plan
+    Access765 --> List283
+    Lambda278 --> Lambda288
+    Lambda278 --> Lambda294
+    Lambda278 --> Lambda300
+    Lambda278 --> Lambda306
+    Lambda310{{"Lambda[310∈6]"}}:::plan
+    List309 --> Lambda310
+    Access311{{"Access[311∈6]<br />ᐸ310.0ᐳ"}}:::plan
+    Lambda310 --> Access311
+    Access311 --> __Flag312
+    Lambda241 --> Access763
+    Lambda278 --> Access765
+    List317{{"List[317∈8]<br />ᐸ314,315,316ᐳ"}}:::plan
+    Constant314{{"Constant[314∈8]<br />ᐸ'relational_item_relation_composite_pks'ᐳ"}}:::plan
+    PgClassExpression315{{"PgClassExpression[315∈8]<br />ᐸ__relation...parent_id”ᐳ"}}:::plan
+    PgClassExpression316{{"PgClassExpression[316∈8]<br />ᐸ__relation...”child_id”ᐳ"}}:::plan
+    Constant314 & PgClassExpression315 & PgClassExpression316 --> List317
+    PgSelect320[["PgSelect[320∈8]<br />ᐸrelational_itemsᐳ"]]:::plan
+    Object238 & PgClassExpression316 --> PgSelect320
+    PgSelect387[["PgSelect[387∈8]<br />ᐸrelational_itemsᐳ"]]:::plan
+    Object238 & PgClassExpression315 --> PgSelect387
+    PgInsertSingle235 --> PgClassExpression315
+    PgInsertSingle235 --> PgClassExpression316
+    Lambda318{{"Lambda[318∈8]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List317 --> Lambda318
+    First324{{"First[324∈8]"}}:::plan
+    PgSelect320 --> First324
+    PgSelectSingle325{{"PgSelectSingle[325∈8]<br />ᐸrelational_itemsᐳ"}}:::plan
+    First324 --> PgSelectSingle325
+    PgClassExpression326{{"PgClassExpression[326∈8]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle325 --> PgClassExpression326
+    PgClassExpression337{{"PgClassExpression[337∈8]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle325 --> PgClassExpression337
+    First391{{"First[391∈8]"}}:::plan
+    PgSelect387 --> First391
+    PgSelectSingle392{{"PgSelectSingle[392∈8]<br />ᐸrelational_itemsᐳ"}}:::plan
+    First391 --> PgSelectSingle392
+    PgClassExpression393{{"PgClassExpression[393∈8]<br />ᐸ__relation...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle392 --> PgClassExpression393
+    PgClassExpression404{{"PgClassExpression[404∈8]<br />ᐸ__relation...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle392 --> PgClassExpression404
+    PgSelect327[["PgSelect[327∈9]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
+    Object238 & PgClassExpression326 --> PgSelect327
+    List335{{"List[335∈9]<br />ᐸ333,334ᐳ<br />ᐳRelationalTopic"}}:::plan
+    Constant333{{"Constant[333∈9]<br />ᐸ'relational_topics'ᐳ<br />ᐳRelationalTopic"}}:::plan
+    PgClassExpression334{{"PgClassExpression[334∈9]<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
     Constant333 & PgClassExpression334 --> List335
-    PgSelect339[["PgSelect[339∈9]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object232 & PgClassExpression314 --> PgSelect339
-    List347{{"List[347∈9]<br />ᐸ345,346ᐳ<br />ᐳRelationalDivider"}}:::plan
-    Constant345{{"Constant[345∈9]<br />ᐸ'relational_dividers'ᐳ<br />ᐳRelationalDivider"}}:::plan
-    PgClassExpression346{{"PgClassExpression[346∈9]<br />ᐸ__relation...r_item_id”ᐳ"}}:::plan
+    PgSelect339[["PgSelect[339∈9]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
+    Object238 & PgClassExpression326 --> PgSelect339
+    List347{{"List[347∈9]<br />ᐸ345,346ᐳ<br />ᐳRelationalPost"}}:::plan
+    Constant345{{"Constant[345∈9]<br />ᐸ'relational_posts'ᐳ<br />ᐳRelationalPost"}}:::plan
+    PgClassExpression346{{"PgClassExpression[346∈9]<br />ᐸ__relation...t_item_id”ᐳ"}}:::plan
     Constant345 & PgClassExpression346 --> List347
-    PgSelect351[["PgSelect[351∈9]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object232 & PgClassExpression314 --> PgSelect351
-    List359{{"List[359∈9]<br />ᐸ357,358ᐳ<br />ᐳRelationalChecklist"}}:::plan
-    Constant357{{"Constant[357∈9]<br />ᐸ'relational_checklists'ᐳ<br />ᐳRelationalChecklist"}}:::plan
-    PgClassExpression358{{"PgClassExpression[358∈9]<br />ᐸ__relation...t_item_id”ᐳ"}}:::plan
+    PgSelect351[["PgSelect[351∈9]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
+    Object238 & PgClassExpression326 --> PgSelect351
+    List359{{"List[359∈9]<br />ᐸ357,358ᐳ<br />ᐳRelationalDivider"}}:::plan
+    Constant357{{"Constant[357∈9]<br />ᐸ'relational_dividers'ᐳ<br />ᐳRelationalDivider"}}:::plan
+    PgClassExpression358{{"PgClassExpression[358∈9]<br />ᐸ__relation...r_item_id”ᐳ"}}:::plan
     Constant357 & PgClassExpression358 --> List359
-    PgSelect363[["PgSelect[363∈9]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object232 & PgClassExpression314 --> PgSelect363
-    List371{{"List[371∈9]<br />ᐸ369,370ᐳ<br />ᐳRelationalChecklistItem"}}:::plan
-    Constant369{{"Constant[369∈9]<br />ᐸ'relational_checklist_items'ᐳ<br />ᐳRelationalChecklistItem"}}:::plan
-    PgClassExpression370{{"PgClassExpression[370∈9]<br />ᐸ__relation...m_item_id”ᐳ"}}:::plan
+    PgSelect363[["PgSelect[363∈9]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
+    Object238 & PgClassExpression326 --> PgSelect363
+    List371{{"List[371∈9]<br />ᐸ369,370ᐳ<br />ᐳRelationalChecklist"}}:::plan
+    Constant369{{"Constant[369∈9]<br />ᐸ'relational_checklists'ᐳ<br />ᐳRelationalChecklist"}}:::plan
+    PgClassExpression370{{"PgClassExpression[370∈9]<br />ᐸ__relation...t_item_id”ᐳ"}}:::plan
     Constant369 & PgClassExpression370 --> List371
-    First319{{"First[319∈9]"}}:::plan
-    PgSelect315 --> First319
-    PgSelectSingle320{{"PgSelectSingle[320∈9]<br />ᐸrelational_topicsᐳ"}}:::plan
-    First319 --> PgSelectSingle320
-    PgSelectSingle320 --> PgClassExpression322
-    Lambda324{{"Lambda[324∈9]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List323 --> Lambda324
+    PgSelect375[["PgSelect[375∈9]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
+    Object238 & PgClassExpression326 --> PgSelect375
+    List383{{"List[383∈9]<br />ᐸ381,382ᐳ<br />ᐳRelationalChecklistItem"}}:::plan
+    Constant381{{"Constant[381∈9]<br />ᐸ'relational_checklist_items'ᐳ<br />ᐳRelationalChecklistItem"}}:::plan
+    PgClassExpression382{{"PgClassExpression[382∈9]<br />ᐸ__relation...m_item_id”ᐳ"}}:::plan
+    Constant381 & PgClassExpression382 --> List383
     First331{{"First[331∈9]"}}:::plan
     PgSelect327 --> First331
-    PgSelectSingle332{{"PgSelectSingle[332∈9]<br />ᐸrelational_postsᐳ"}}:::plan
+    PgSelectSingle332{{"PgSelectSingle[332∈9]<br />ᐸrelational_topicsᐳ"}}:::plan
     First331 --> PgSelectSingle332
     PgSelectSingle332 --> PgClassExpression334
     Lambda336{{"Lambda[336∈9]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List335 --> Lambda336
     First343{{"First[343∈9]"}}:::plan
     PgSelect339 --> First343
-    PgSelectSingle344{{"PgSelectSingle[344∈9]<br />ᐸrelational_dividersᐳ"}}:::plan
+    PgSelectSingle344{{"PgSelectSingle[344∈9]<br />ᐸrelational_postsᐳ"}}:::plan
     First343 --> PgSelectSingle344
     PgSelectSingle344 --> PgClassExpression346
     Lambda348{{"Lambda[348∈9]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List347 --> Lambda348
     First355{{"First[355∈9]"}}:::plan
     PgSelect351 --> First355
-    PgSelectSingle356{{"PgSelectSingle[356∈9]<br />ᐸrelational_checklistsᐳ"}}:::plan
+    PgSelectSingle356{{"PgSelectSingle[356∈9]<br />ᐸrelational_dividersᐳ"}}:::plan
     First355 --> PgSelectSingle356
     PgSelectSingle356 --> PgClassExpression358
     Lambda360{{"Lambda[360∈9]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List359 --> Lambda360
     First367{{"First[367∈9]"}}:::plan
     PgSelect363 --> First367
-    PgSelectSingle368{{"PgSelectSingle[368∈9]<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
+    PgSelectSingle368{{"PgSelectSingle[368∈9]<br />ᐸrelational_checklistsᐳ"}}:::plan
     First367 --> PgSelectSingle368
     PgSelectSingle368 --> PgClassExpression370
     Lambda372{{"Lambda[372∈9]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List371 --> Lambda372
-    PgSelect382[["PgSelect[382∈10]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
-    Object232 & PgClassExpression381 --> PgSelect382
-    List390{{"List[390∈10]<br />ᐸ388,389ᐳ<br />ᐳRelationalTopic"}}:::plan
-    Constant388{{"Constant[388∈10]<br />ᐸ'relational_topics'ᐳ<br />ᐳRelationalTopic"}}:::plan
-    PgClassExpression389{{"PgClassExpression[389∈10]<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
-    Constant388 & PgClassExpression389 --> List390
-    PgSelect394[["PgSelect[394∈10]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
-    Object232 & PgClassExpression381 --> PgSelect394
-    List402{{"List[402∈10]<br />ᐸ400,401ᐳ<br />ᐳRelationalPost"}}:::plan
-    Constant400{{"Constant[400∈10]<br />ᐸ'relational_posts'ᐳ<br />ᐳRelationalPost"}}:::plan
-    PgClassExpression401{{"PgClassExpression[401∈10]<br />ᐸ__relation...t_item_id”ᐳ"}}:::plan
+    First379{{"First[379∈9]"}}:::plan
+    PgSelect375 --> First379
+    PgSelectSingle380{{"PgSelectSingle[380∈9]<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
+    First379 --> PgSelectSingle380
+    PgSelectSingle380 --> PgClassExpression382
+    Lambda384{{"Lambda[384∈9]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List383 --> Lambda384
+    PgSelect394[["PgSelect[394∈10]<br />ᐸrelational_topicsᐳ<br />ᐳRelationalTopic"]]:::plan
+    Object238 & PgClassExpression393 --> PgSelect394
+    List402{{"List[402∈10]<br />ᐸ400,401ᐳ<br />ᐳRelationalTopic"}}:::plan
+    Constant400{{"Constant[400∈10]<br />ᐸ'relational_topics'ᐳ<br />ᐳRelationalTopic"}}:::plan
+    PgClassExpression401{{"PgClassExpression[401∈10]<br />ᐸ__relation...c_item_id”ᐳ"}}:::plan
     Constant400 & PgClassExpression401 --> List402
-    PgSelect406[["PgSelect[406∈10]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
-    Object232 & PgClassExpression381 --> PgSelect406
-    List414{{"List[414∈10]<br />ᐸ412,413ᐳ<br />ᐳRelationalDivider"}}:::plan
-    Constant412{{"Constant[412∈10]<br />ᐸ'relational_dividers'ᐳ<br />ᐳRelationalDivider"}}:::plan
-    PgClassExpression413{{"PgClassExpression[413∈10]<br />ᐸ__relation...r_item_id”ᐳ"}}:::plan
+    PgSelect406[["PgSelect[406∈10]<br />ᐸrelational_postsᐳ<br />ᐳRelationalPost"]]:::plan
+    Object238 & PgClassExpression393 --> PgSelect406
+    List414{{"List[414∈10]<br />ᐸ412,413ᐳ<br />ᐳRelationalPost"}}:::plan
+    Constant412{{"Constant[412∈10]<br />ᐸ'relational_posts'ᐳ<br />ᐳRelationalPost"}}:::plan
+    PgClassExpression413{{"PgClassExpression[413∈10]<br />ᐸ__relation...t_item_id”ᐳ"}}:::plan
     Constant412 & PgClassExpression413 --> List414
-    PgSelect418[["PgSelect[418∈10]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
-    Object232 & PgClassExpression381 --> PgSelect418
-    List426{{"List[426∈10]<br />ᐸ424,425ᐳ<br />ᐳRelationalChecklist"}}:::plan
-    Constant424{{"Constant[424∈10]<br />ᐸ'relational_checklists'ᐳ<br />ᐳRelationalChecklist"}}:::plan
-    PgClassExpression425{{"PgClassExpression[425∈10]<br />ᐸ__relation...t_item_id”ᐳ"}}:::plan
+    PgSelect418[["PgSelect[418∈10]<br />ᐸrelational_dividersᐳ<br />ᐳRelationalDivider"]]:::plan
+    Object238 & PgClassExpression393 --> PgSelect418
+    List426{{"List[426∈10]<br />ᐸ424,425ᐳ<br />ᐳRelationalDivider"}}:::plan
+    Constant424{{"Constant[424∈10]<br />ᐸ'relational_dividers'ᐳ<br />ᐳRelationalDivider"}}:::plan
+    PgClassExpression425{{"PgClassExpression[425∈10]<br />ᐸ__relation...r_item_id”ᐳ"}}:::plan
     Constant424 & PgClassExpression425 --> List426
-    PgSelect430[["PgSelect[430∈10]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
-    Object232 & PgClassExpression381 --> PgSelect430
-    List438{{"List[438∈10]<br />ᐸ436,437ᐳ<br />ᐳRelationalChecklistItem"}}:::plan
-    Constant436{{"Constant[436∈10]<br />ᐸ'relational_checklist_items'ᐳ<br />ᐳRelationalChecklistItem"}}:::plan
-    PgClassExpression437{{"PgClassExpression[437∈10]<br />ᐸ__relation...m_item_id”ᐳ"}}:::plan
+    PgSelect430[["PgSelect[430∈10]<br />ᐸrelational_checklistsᐳ<br />ᐳRelationalChecklist"]]:::plan
+    Object238 & PgClassExpression393 --> PgSelect430
+    List438{{"List[438∈10]<br />ᐸ436,437ᐳ<br />ᐳRelationalChecklist"}}:::plan
+    Constant436{{"Constant[436∈10]<br />ᐸ'relational_checklists'ᐳ<br />ᐳRelationalChecklist"}}:::plan
+    PgClassExpression437{{"PgClassExpression[437∈10]<br />ᐸ__relation...t_item_id”ᐳ"}}:::plan
     Constant436 & PgClassExpression437 --> List438
-    First386{{"First[386∈10]"}}:::plan
-    PgSelect382 --> First386
-    PgSelectSingle387{{"PgSelectSingle[387∈10]<br />ᐸrelational_topicsᐳ"}}:::plan
-    First386 --> PgSelectSingle387
-    PgSelectSingle387 --> PgClassExpression389
-    Lambda391{{"Lambda[391∈10]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List390 --> Lambda391
+    PgSelect442[["PgSelect[442∈10]<br />ᐸrelational_checklist_itemsᐳ<br />ᐳRelationalChecklistItem"]]:::plan
+    Object238 & PgClassExpression393 --> PgSelect442
+    List450{{"List[450∈10]<br />ᐸ448,449ᐳ<br />ᐳRelationalChecklistItem"}}:::plan
+    Constant448{{"Constant[448∈10]<br />ᐸ'relational_checklist_items'ᐳ<br />ᐳRelationalChecklistItem"}}:::plan
+    PgClassExpression449{{"PgClassExpression[449∈10]<br />ᐸ__relation...m_item_id”ᐳ"}}:::plan
+    Constant448 & PgClassExpression449 --> List450
     First398{{"First[398∈10]"}}:::plan
     PgSelect394 --> First398
-    PgSelectSingle399{{"PgSelectSingle[399∈10]<br />ᐸrelational_postsᐳ"}}:::plan
+    PgSelectSingle399{{"PgSelectSingle[399∈10]<br />ᐸrelational_topicsᐳ"}}:::plan
     First398 --> PgSelectSingle399
     PgSelectSingle399 --> PgClassExpression401
     Lambda403{{"Lambda[403∈10]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List402 --> Lambda403
     First410{{"First[410∈10]"}}:::plan
     PgSelect406 --> First410
-    PgSelectSingle411{{"PgSelectSingle[411∈10]<br />ᐸrelational_dividersᐳ"}}:::plan
+    PgSelectSingle411{{"PgSelectSingle[411∈10]<br />ᐸrelational_postsᐳ"}}:::plan
     First410 --> PgSelectSingle411
     PgSelectSingle411 --> PgClassExpression413
     Lambda415{{"Lambda[415∈10]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List414 --> Lambda415
     First422{{"First[422∈10]"}}:::plan
     PgSelect418 --> First422
-    PgSelectSingle423{{"PgSelectSingle[423∈10]<br />ᐸrelational_checklistsᐳ"}}:::plan
+    PgSelectSingle423{{"PgSelectSingle[423∈10]<br />ᐸrelational_dividersᐳ"}}:::plan
     First422 --> PgSelectSingle423
     PgSelectSingle423 --> PgClassExpression425
     Lambda427{{"Lambda[427∈10]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List426 --> Lambda427
     First434{{"First[434∈10]"}}:::plan
     PgSelect430 --> First434
-    PgSelectSingle435{{"PgSelectSingle[435∈10]<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
+    PgSelectSingle435{{"PgSelectSingle[435∈10]<br />ᐸrelational_checklistsᐳ"}}:::plan
     First434 --> PgSelectSingle435
     PgSelectSingle435 --> PgClassExpression437
     Lambda439{{"Lambda[439∈10]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List438 --> Lambda439
-    List483{{"List[483∈11]<br />ᐸ458,464,470,476,482ᐳ"}}:::plan
-    Object458{{"Object[458∈11]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object464{{"Object[464∈11]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object470{{"Object[470∈11]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object476{{"Object[476∈11]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object482{{"Object[482∈11]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object458 & Object464 & Object470 & Object476 & Object482 --> List483
-    List517{{"List[517∈11]<br />ᐸ492,498,504,510,516ᐳ"}}:::plan
-    Object492{{"Object[492∈11]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object498{{"Object[498∈11]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object504{{"Object[504∈11]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object510{{"Object[510∈11]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object516{{"Object[516∈11]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object492 & Object498 & Object504 & Object510 & Object516 --> List517
-    PgInsertSingle447[["PgInsertSingle[447∈11]<br />ᐸsingle_table_item_relations(child_id,parent_id)ᐳ"]]:::sideeffectplan
-    Object450{{"Object[450∈11]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Access485{{"Access[485∈11]<br />ᐸ484.0ᐳ"}}:::plan
-    Access519{{"Access[519∈11]<br />ᐸ518.0ᐳ"}}:::plan
-    Object450 & Access485 & Access519 --> PgInsertSingle447
-    Access448{{"Access[448∈11]<br />ᐸ3.pgSettingsᐳ"}}:::plan
-    Access449{{"Access[449∈11]<br />ᐸ3.withPgClientᐳ"}}:::plan
-    Access448 & Access449 --> Object450
-    Lambda456[["Lambda[456∈11]"]]:::unbatchedplan
-    List457{{"List[457∈11]<br />ᐸ743ᐳ"}}:::plan
-    Lambda456 & List457 --> Object458
-    Lambda462[["Lambda[462∈11]"]]:::unbatchedplan
-    Lambda462 & List457 --> Object464
-    Lambda468[["Lambda[468∈11]"]]:::unbatchedplan
-    Lambda468 & List457 --> Object470
-    Lambda474[["Lambda[474∈11]"]]:::unbatchedplan
-    Lambda474 & List457 --> Object476
-    Lambda480[["Lambda[480∈11]"]]:::unbatchedplan
-    Lambda480 & List457 --> Object482
-    Lambda490[["Lambda[490∈11]"]]:::unbatchedplan
-    List491{{"List[491∈11]<br />ᐸ745ᐳ"}}:::plan
-    Lambda490 & List491 --> Object492
-    Lambda496[["Lambda[496∈11]"]]:::unbatchedplan
-    Lambda496 & List491 --> Object498
-    Lambda502[["Lambda[502∈11]"]]:::unbatchedplan
-    Lambda502 & List491 --> Object504
-    Lambda508[["Lambda[508∈11]"]]:::unbatchedplan
-    Lambda508 & List491 --> Object510
-    Lambda514[["Lambda[514∈11]"]]:::unbatchedplan
-    Lambda514 & List491 --> Object516
-    __Value3 --> Access448
-    __Value3 --> Access449
-    Object451{{"Object[451∈11]<br />ᐸ{result}ᐳ"}}:::plan
-    PgInsertSingle447 --> Object451
-    Lambda452{{"Lambda[452∈11]<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
-    Constant744 --> Lambda452
-    Lambda452 --> Lambda456
-    Access743{{"Access[743∈11]<br />ᐸ452.base64JSON.1ᐳ"}}:::plan
-    Access743 --> List457
-    Lambda452 --> Lambda462
-    Lambda452 --> Lambda468
-    Lambda452 --> Lambda474
-    Lambda452 --> Lambda480
-    Lambda484{{"Lambda[484∈11]"}}:::plan
-    List483 --> Lambda484
-    Lambda484 --> Access485
-    Lambda486{{"Lambda[486∈11]<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
-    Constant746 --> Lambda486
-    Lambda486 --> Lambda490
-    Access745{{"Access[745∈11]<br />ᐸ486.base64JSON.1ᐳ"}}:::plan
-    Access745 --> List491
-    Lambda486 --> Lambda496
-    Lambda486 --> Lambda502
-    Lambda486 --> Lambda508
-    Lambda486 --> Lambda514
-    Lambda518{{"Lambda[518∈11]"}}:::plan
-    List517 --> Lambda518
-    Lambda518 --> Access519
-    Lambda452 --> Access743
-    Lambda486 --> Access745
-    List522{{"List[522∈13]<br />ᐸ520,521ᐳ"}}:::plan
-    Constant520{{"Constant[520∈13]<br />ᐸ'single_table_item_relations'ᐳ"}}:::plan
-    PgClassExpression521{{"PgClassExpression[521∈13]<br />ᐸ__single_t...ons__.”id”ᐳ"}}:::plan
-    Constant520 & PgClassExpression521 --> List522
-    PgSelect525[["PgSelect[525∈13]<br />ᐸsingle_table_itemsᐳ"]]:::plan
-    PgClassExpression524{{"PgClassExpression[524∈13]<br />ᐸ__single_t...”child_id”ᐳ"}}:::plan
-    Object450 & PgClassExpression524 --> PgSelect525
-    PgSelect557[["PgSelect[557∈13]<br />ᐸsingle_table_itemsᐳ"]]:::plan
-    PgClassExpression556{{"PgClassExpression[556∈13]<br />ᐸ__single_t...parent_id”ᐳ"}}:::plan
-    Object450 & PgClassExpression556 --> PgSelect557
-    PgInsertSingle447 --> PgClassExpression521
-    Lambda523{{"Lambda[523∈13]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List522 --> Lambda523
-    PgInsertSingle447 --> PgClassExpression524
-    First529{{"First[529∈13]"}}:::plan
-    PgSelect525 --> First529
-    PgSelectSingle530{{"PgSelectSingle[530∈13]<br />ᐸsingle_table_itemsᐳ"}}:::plan
-    First529 --> PgSelectSingle530
-    PgClassExpression532{{"PgClassExpression[532∈13]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
-    PgSelectSingle530 --> PgClassExpression532
-    PgClassExpression535{{"PgClassExpression[535∈13]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle530 --> PgClassExpression535
-    PgInsertSingle447 --> PgClassExpression556
-    First561{{"First[561∈13]"}}:::plan
-    PgSelect557 --> First561
-    PgSelectSingle562{{"PgSelectSingle[562∈13]<br />ᐸsingle_table_itemsᐳ"}}:::plan
-    First561 --> PgSelectSingle562
-    PgClassExpression564{{"PgClassExpression[564∈13]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
-    PgSelectSingle562 --> PgClassExpression564
-    PgClassExpression567{{"PgClassExpression[567∈13]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle562 --> PgClassExpression567
-    List533{{"List[533∈14]<br />ᐸ531,532ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    Constant531{{"Constant[531∈14]<br />ᐸ'SingleTableTopic'ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    Constant531 & PgClassExpression532 --> List533
-    List538{{"List[538∈14]<br />ᐸ536,532ᐳ<br />ᐳSingleTablePost"}}:::plan
-    Constant536{{"Constant[536∈14]<br />ᐸ'SingleTablePost'ᐳ<br />ᐳSingleTablePost"}}:::plan
-    Constant536 & PgClassExpression532 --> List538
-    List543{{"List[543∈14]<br />ᐸ541,532ᐳ<br />ᐳSingleTableDivider"}}:::plan
-    Constant541{{"Constant[541∈14]<br />ᐸ'SingleTableDivider'ᐳ<br />ᐳSingleTableDivider"}}:::plan
-    Constant541 & PgClassExpression532 --> List543
-    List548{{"List[548∈14]<br />ᐸ546,532ᐳ<br />ᐳSingleTableChecklist"}}:::plan
-    Constant546{{"Constant[546∈14]<br />ᐸ'SingleTableChecklist'ᐳ<br />ᐳSingleTableChecklist"}}:::plan
-    Constant546 & PgClassExpression532 --> List548
-    List553{{"List[553∈14]<br />ᐸ551,532ᐳ<br />ᐳSingleTableChecklistItem"}}:::plan
-    Constant551{{"Constant[551∈14]<br />ᐸ'SingleTableChecklistItem'ᐳ<br />ᐳSingleTableChecklistItem"}}:::plan
-    Constant551 & PgClassExpression532 --> List553
-    Lambda534{{"Lambda[534∈14]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    First446{{"First[446∈10]"}}:::plan
+    PgSelect442 --> First446
+    PgSelectSingle447{{"PgSelectSingle[447∈10]<br />ᐸrelational_checklist_itemsᐳ"}}:::plan
+    First446 --> PgSelectSingle447
+    PgSelectSingle447 --> PgClassExpression449
+    Lambda451{{"Lambda[451∈10]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List450 --> Lambda451
+    List496{{"List[496∈11]<br />ᐸ471,477,483,489,495ᐳ"}}:::plan
+    Object471{{"Object[471∈11]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object477{{"Object[477∈11]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object483{{"Object[483∈11]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object489{{"Object[489∈11]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object495{{"Object[495∈11]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object471 & Object477 & Object483 & Object489 & Object495 --> List496
+    List533{{"List[533∈11]<br />ᐸ508,514,520,526,532ᐳ"}}:::plan
+    Object508{{"Object[508∈11]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object514{{"Object[514∈11]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object520{{"Object[520∈11]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object526{{"Object[526∈11]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object532{{"Object[532∈11]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object508 & Object514 & Object520 & Object526 & Object532 --> List533
+    PgInsertSingle459[["PgInsertSingle[459∈11]<br />ᐸsingle_table_item_relations(child_id,parent_id)ᐳ"]]:::sideeffectplan
+    Object462{{"Object[462∈11]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    __Flag500[["__Flag[500∈11]<br />ᐸ499, if(464), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
+    __Flag537[["__Flag[537∈11]<br />ᐸ536, if(501), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
+    Object462 & __Flag500 & __Flag537 --> PgInsertSingle459
+    Access460{{"Access[460∈11]<br />ᐸ3.pgSettingsᐳ"}}:::plan
+    Access461{{"Access[461∈11]<br />ᐸ3.withPgClientᐳ"}}:::plan
+    Access460 & Access461 --> Object462
+    Lambda469[["Lambda[469∈11]"]]:::unbatchedplan
+    List470{{"List[470∈11]<br />ᐸ767ᐳ"}}:::plan
+    Lambda469 & List470 --> Object471
+    Lambda475[["Lambda[475∈11]"]]:::unbatchedplan
+    Lambda475 & List470 --> Object477
+    Lambda481[["Lambda[481∈11]"]]:::unbatchedplan
+    Lambda481 & List470 --> Object483
+    Lambda487[["Lambda[487∈11]"]]:::unbatchedplan
+    Lambda487 & List470 --> Object489
+    Lambda493[["Lambda[493∈11]"]]:::unbatchedplan
+    Lambda493 & List470 --> Object495
+    __Flag499[["__Flag[499∈11]<br />ᐸ498, trapInhibited, onReject: INHIBITᐳ"]]:::plan
+    Condition464{{"Condition[464∈11]<br />ᐸexistsᐳ"}}:::plan
+    __Flag499 & Condition464 --> __Flag500
+    Lambda506[["Lambda[506∈11]"]]:::unbatchedplan
+    List507{{"List[507∈11]<br />ᐸ769ᐳ"}}:::plan
+    Lambda506 & List507 --> Object508
+    Lambda512[["Lambda[512∈11]"]]:::unbatchedplan
+    Lambda512 & List507 --> Object514
+    Lambda518[["Lambda[518∈11]"]]:::unbatchedplan
+    Lambda518 & List507 --> Object520
+    Lambda524[["Lambda[524∈11]"]]:::unbatchedplan
+    Lambda524 & List507 --> Object526
+    Lambda530[["Lambda[530∈11]"]]:::unbatchedplan
+    Lambda530 & List507 --> Object532
+    __Flag536[["__Flag[536∈11]<br />ᐸ535, trapInhibited, onReject: INHIBITᐳ"]]:::plan
+    Condition501{{"Condition[501∈11]<br />ᐸexistsᐳ"}}:::plan
+    __Flag536 & Condition501 --> __Flag537
+    __Value3 --> Access460
+    __Value3 --> Access461
+    Object463{{"Object[463∈11]<br />ᐸ{result}ᐳ"}}:::plan
+    PgInsertSingle459 --> Object463
+    Constant768 --> Condition464
+    Lambda465{{"Lambda[465∈11]<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
+    Constant768 --> Lambda465
+    Lambda465 --> Lambda469
+    Access767{{"Access[767∈11]<br />ᐸ465.base64JSON.1ᐳ"}}:::plan
+    Access767 --> List470
+    Lambda465 --> Lambda475
+    Lambda465 --> Lambda481
+    Lambda465 --> Lambda487
+    Lambda465 --> Lambda493
+    Lambda497{{"Lambda[497∈11]"}}:::plan
+    List496 --> Lambda497
+    Access498{{"Access[498∈11]<br />ᐸ497.0ᐳ"}}:::plan
+    Lambda497 --> Access498
+    Access498 --> __Flag499
+    Constant770 --> Condition501
+    Lambda502{{"Lambda[502∈11]<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
+    Constant770 --> Lambda502
+    Lambda502 --> Lambda506
+    Access769{{"Access[769∈11]<br />ᐸ502.base64JSON.1ᐳ"}}:::plan
+    Access769 --> List507
+    Lambda502 --> Lambda512
+    Lambda502 --> Lambda518
+    Lambda502 --> Lambda524
+    Lambda502 --> Lambda530
+    Lambda534{{"Lambda[534∈11]"}}:::plan
     List533 --> Lambda534
-    Lambda539{{"Lambda[539∈14]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List538 --> Lambda539
-    Lambda544{{"Lambda[544∈14]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List543 --> Lambda544
-    Lambda549{{"Lambda[549∈14]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List548 --> Lambda549
-    Lambda554{{"Lambda[554∈14]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List553 --> Lambda554
-    List565{{"List[565∈15]<br />ᐸ563,564ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    Constant563{{"Constant[563∈15]<br />ᐸ'SingleTableTopic'ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    Constant563 & PgClassExpression564 --> List565
-    List570{{"List[570∈15]<br />ᐸ568,564ᐳ<br />ᐳSingleTablePost"}}:::plan
-    Constant568{{"Constant[568∈15]<br />ᐸ'SingleTablePost'ᐳ<br />ᐳSingleTablePost"}}:::plan
-    Constant568 & PgClassExpression564 --> List570
-    List575{{"List[575∈15]<br />ᐸ573,564ᐳ<br />ᐳSingleTableDivider"}}:::plan
-    Constant573{{"Constant[573∈15]<br />ᐸ'SingleTableDivider'ᐳ<br />ᐳSingleTableDivider"}}:::plan
-    Constant573 & PgClassExpression564 --> List575
-    List580{{"List[580∈15]<br />ᐸ578,564ᐳ<br />ᐳSingleTableChecklist"}}:::plan
-    Constant578{{"Constant[578∈15]<br />ᐸ'SingleTableChecklist'ᐳ<br />ᐳSingleTableChecklist"}}:::plan
-    Constant578 & PgClassExpression564 --> List580
-    List585{{"List[585∈15]<br />ᐸ583,564ᐳ<br />ᐳSingleTableChecklistItem"}}:::plan
-    Constant583{{"Constant[583∈15]<br />ᐸ'SingleTableChecklistItem'ᐳ<br />ᐳSingleTableChecklistItem"}}:::plan
-    Constant583 & PgClassExpression564 --> List585
-    Lambda566{{"Lambda[566∈15]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List565 --> Lambda566
-    Lambda571{{"Lambda[571∈15]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List570 --> Lambda571
-    Lambda576{{"Lambda[576∈15]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List575 --> Lambda576
-    Lambda581{{"Lambda[581∈15]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List580 --> Lambda581
-    Lambda586{{"Lambda[586∈15]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List585 --> Lambda586
-    List629{{"List[629∈16]<br />ᐸ604,610,616,622,628ᐳ"}}:::plan
-    Object604{{"Object[604∈16]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object610{{"Object[610∈16]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object616{{"Object[616∈16]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object622{{"Object[622∈16]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object628{{"Object[628∈16]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object604 & Object610 & Object616 & Object622 & Object628 --> List629
-    List663{{"List[663∈16]<br />ᐸ638,644,650,656,662ᐳ"}}:::plan
-    Object638{{"Object[638∈16]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object644{{"Object[644∈16]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object650{{"Object[650∈16]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object656{{"Object[656∈16]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object662{{"Object[662∈16]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object638 & Object644 & Object650 & Object656 & Object662 --> List663
-    PgInsertSingle593[["PgInsertSingle[593∈16]<br />ᐸsingle_table_item_relation_composite_pks(child_id,parent_id)ᐳ"]]:::sideeffectplan
-    Object596{{"Object[596∈16]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Access631{{"Access[631∈16]<br />ᐸ630.0ᐳ"}}:::plan
-    Access665{{"Access[665∈16]<br />ᐸ664.0ᐳ"}}:::plan
-    Object596 & Access631 & Access665 --> PgInsertSingle593
-    Access594{{"Access[594∈16]<br />ᐸ3.pgSettingsᐳ"}}:::plan
-    Access595{{"Access[595∈16]<br />ᐸ3.withPgClientᐳ"}}:::plan
-    Access594 & Access595 --> Object596
-    Lambda602[["Lambda[602∈16]"]]:::unbatchedplan
-    List603{{"List[603∈16]<br />ᐸ747ᐳ"}}:::plan
-    Lambda602 & List603 --> Object604
-    Lambda608[["Lambda[608∈16]"]]:::unbatchedplan
-    Lambda608 & List603 --> Object610
-    Lambda614[["Lambda[614∈16]"]]:::unbatchedplan
-    Lambda614 & List603 --> Object616
-    Lambda620[["Lambda[620∈16]"]]:::unbatchedplan
-    Lambda620 & List603 --> Object622
-    Lambda626[["Lambda[626∈16]"]]:::unbatchedplan
-    Lambda626 & List603 --> Object628
-    Lambda636[["Lambda[636∈16]"]]:::unbatchedplan
-    List637{{"List[637∈16]<br />ᐸ749ᐳ"}}:::plan
-    Lambda636 & List637 --> Object638
-    Lambda642[["Lambda[642∈16]"]]:::unbatchedplan
-    Lambda642 & List637 --> Object644
-    Lambda648[["Lambda[648∈16]"]]:::unbatchedplan
-    Lambda648 & List637 --> Object650
-    Lambda654[["Lambda[654∈16]"]]:::unbatchedplan
-    Lambda654 & List637 --> Object656
-    Lambda660[["Lambda[660∈16]"]]:::unbatchedplan
-    Lambda660 & List637 --> Object662
-    __Value3 --> Access594
-    __Value3 --> Access595
-    Object597{{"Object[597∈16]<br />ᐸ{result}ᐳ"}}:::plan
-    PgInsertSingle593 --> Object597
-    Lambda598{{"Lambda[598∈16]<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
-    Constant744 --> Lambda598
-    Lambda598 --> Lambda602
-    Access747{{"Access[747∈16]<br />ᐸ598.base64JSON.1ᐳ"}}:::plan
-    Access747 --> List603
-    Lambda598 --> Lambda608
-    Lambda598 --> Lambda614
-    Lambda598 --> Lambda620
-    Lambda598 --> Lambda626
-    Lambda630{{"Lambda[630∈16]"}}:::plan
-    List629 --> Lambda630
-    Lambda630 --> Access631
-    Lambda632{{"Lambda[632∈16]<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
-    Constant746 --> Lambda632
-    Lambda632 --> Lambda636
-    Access749{{"Access[749∈16]<br />ᐸ632.base64JSON.1ᐳ"}}:::plan
-    Access749 --> List637
-    Lambda632 --> Lambda642
-    Lambda632 --> Lambda648
-    Lambda632 --> Lambda654
-    Lambda632 --> Lambda660
-    Lambda664{{"Lambda[664∈16]"}}:::plan
-    List663 --> Lambda664
-    Lambda664 --> Access665
-    Lambda598 --> Access747
-    Lambda632 --> Access749
-    List669{{"List[669∈18]<br />ᐸ666,667,668ᐳ"}}:::plan
-    Constant666{{"Constant[666∈18]<br />ᐸ'single_table_item_relation_composite_pks'ᐳ"}}:::plan
-    PgClassExpression667{{"PgClassExpression[667∈18]<br />ᐸ__single_t...parent_id”ᐳ"}}:::plan
-    PgClassExpression668{{"PgClassExpression[668∈18]<br />ᐸ__single_t...”child_id”ᐳ"}}:::plan
-    Constant666 & PgClassExpression667 & PgClassExpression668 --> List669
-    PgSelect672[["PgSelect[672∈18]<br />ᐸsingle_table_itemsᐳ"]]:::plan
-    Object596 & PgClassExpression668 --> PgSelect672
-    PgSelect704[["PgSelect[704∈18]<br />ᐸsingle_table_itemsᐳ"]]:::plan
-    Object596 & PgClassExpression667 --> PgSelect704
-    PgInsertSingle593 --> PgClassExpression667
-    PgInsertSingle593 --> PgClassExpression668
-    Lambda670{{"Lambda[670∈18]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List669 --> Lambda670
-    First676{{"First[676∈18]"}}:::plan
-    PgSelect672 --> First676
-    PgSelectSingle677{{"PgSelectSingle[677∈18]<br />ᐸsingle_table_itemsᐳ"}}:::plan
-    First676 --> PgSelectSingle677
-    PgClassExpression679{{"PgClassExpression[679∈18]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
-    PgSelectSingle677 --> PgClassExpression679
-    PgClassExpression682{{"PgClassExpression[682∈18]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle677 --> PgClassExpression682
-    First708{{"First[708∈18]"}}:::plan
-    PgSelect704 --> First708
-    PgSelectSingle709{{"PgSelectSingle[709∈18]<br />ᐸsingle_table_itemsᐳ"}}:::plan
-    First708 --> PgSelectSingle709
-    PgClassExpression711{{"PgClassExpression[711∈18]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
-    PgSelectSingle709 --> PgClassExpression711
-    PgClassExpression714{{"PgClassExpression[714∈18]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
-    PgSelectSingle709 --> PgClassExpression714
-    List680{{"List[680∈19]<br />ᐸ678,679ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    Constant678{{"Constant[678∈19]<br />ᐸ'SingleTableTopic'ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    Constant678 & PgClassExpression679 --> List680
-    List685{{"List[685∈19]<br />ᐸ683,679ᐳ<br />ᐳSingleTablePost"}}:::plan
-    Constant683{{"Constant[683∈19]<br />ᐸ'SingleTablePost'ᐳ<br />ᐳSingleTablePost"}}:::plan
-    Constant683 & PgClassExpression679 --> List685
-    List690{{"List[690∈19]<br />ᐸ688,679ᐳ<br />ᐳSingleTableDivider"}}:::plan
-    Constant688{{"Constant[688∈19]<br />ᐸ'SingleTableDivider'ᐳ<br />ᐳSingleTableDivider"}}:::plan
-    Constant688 & PgClassExpression679 --> List690
-    List695{{"List[695∈19]<br />ᐸ693,679ᐳ<br />ᐳSingleTableChecklist"}}:::plan
-    Constant693{{"Constant[693∈19]<br />ᐸ'SingleTableChecklist'ᐳ<br />ᐳSingleTableChecklist"}}:::plan
-    Constant693 & PgClassExpression679 --> List695
-    List700{{"List[700∈19]<br />ᐸ698,679ᐳ<br />ᐳSingleTableChecklistItem"}}:::plan
-    Constant698{{"Constant[698∈19]<br />ᐸ'SingleTableChecklistItem'ᐳ<br />ᐳSingleTableChecklistItem"}}:::plan
-    Constant698 & PgClassExpression679 --> List700
-    Lambda681{{"Lambda[681∈19]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List680 --> Lambda681
-    Lambda686{{"Lambda[686∈19]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    Access535{{"Access[535∈11]<br />ᐸ534.0ᐳ"}}:::plan
+    Lambda534 --> Access535
+    Access535 --> __Flag536
+    Lambda465 --> Access767
+    Lambda502 --> Access769
+    List540{{"List[540∈13]<br />ᐸ538,539ᐳ"}}:::plan
+    Constant538{{"Constant[538∈13]<br />ᐸ'single_table_item_relations'ᐳ"}}:::plan
+    PgClassExpression539{{"PgClassExpression[539∈13]<br />ᐸ__single_t...ons__.”id”ᐳ"}}:::plan
+    Constant538 & PgClassExpression539 --> List540
+    PgSelect543[["PgSelect[543∈13]<br />ᐸsingle_table_itemsᐳ"]]:::plan
+    PgClassExpression542{{"PgClassExpression[542∈13]<br />ᐸ__single_t...”child_id”ᐳ"}}:::plan
+    Object462 & PgClassExpression542 --> PgSelect543
+    PgSelect575[["PgSelect[575∈13]<br />ᐸsingle_table_itemsᐳ"]]:::plan
+    PgClassExpression574{{"PgClassExpression[574∈13]<br />ᐸ__single_t...parent_id”ᐳ"}}:::plan
+    Object462 & PgClassExpression574 --> PgSelect575
+    PgInsertSingle459 --> PgClassExpression539
+    Lambda541{{"Lambda[541∈13]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List540 --> Lambda541
+    PgInsertSingle459 --> PgClassExpression542
+    First547{{"First[547∈13]"}}:::plan
+    PgSelect543 --> First547
+    PgSelectSingle548{{"PgSelectSingle[548∈13]<br />ᐸsingle_table_itemsᐳ"}}:::plan
+    First547 --> PgSelectSingle548
+    PgClassExpression550{{"PgClassExpression[550∈13]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle548 --> PgClassExpression550
+    PgClassExpression553{{"PgClassExpression[553∈13]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle548 --> PgClassExpression553
+    PgInsertSingle459 --> PgClassExpression574
+    First579{{"First[579∈13]"}}:::plan
+    PgSelect575 --> First579
+    PgSelectSingle580{{"PgSelectSingle[580∈13]<br />ᐸsingle_table_itemsᐳ"}}:::plan
+    First579 --> PgSelectSingle580
+    PgClassExpression582{{"PgClassExpression[582∈13]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle580 --> PgClassExpression582
+    PgClassExpression585{{"PgClassExpression[585∈13]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle580 --> PgClassExpression585
+    List551{{"List[551∈14]<br />ᐸ549,550ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    Constant549{{"Constant[549∈14]<br />ᐸ'SingleTableTopic'ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    Constant549 & PgClassExpression550 --> List551
+    List556{{"List[556∈14]<br />ᐸ554,550ᐳ<br />ᐳSingleTablePost"}}:::plan
+    Constant554{{"Constant[554∈14]<br />ᐸ'SingleTablePost'ᐳ<br />ᐳSingleTablePost"}}:::plan
+    Constant554 & PgClassExpression550 --> List556
+    List561{{"List[561∈14]<br />ᐸ559,550ᐳ<br />ᐳSingleTableDivider"}}:::plan
+    Constant559{{"Constant[559∈14]<br />ᐸ'SingleTableDivider'ᐳ<br />ᐳSingleTableDivider"}}:::plan
+    Constant559 & PgClassExpression550 --> List561
+    List566{{"List[566∈14]<br />ᐸ564,550ᐳ<br />ᐳSingleTableChecklist"}}:::plan
+    Constant564{{"Constant[564∈14]<br />ᐸ'SingleTableChecklist'ᐳ<br />ᐳSingleTableChecklist"}}:::plan
+    Constant564 & PgClassExpression550 --> List566
+    List571{{"List[571∈14]<br />ᐸ569,550ᐳ<br />ᐳSingleTableChecklistItem"}}:::plan
+    Constant569{{"Constant[569∈14]<br />ᐸ'SingleTableChecklistItem'ᐳ<br />ᐳSingleTableChecklistItem"}}:::plan
+    Constant569 & PgClassExpression550 --> List571
+    Lambda552{{"Lambda[552∈14]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List551 --> Lambda552
+    Lambda557{{"Lambda[557∈14]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List556 --> Lambda557
+    Lambda562{{"Lambda[562∈14]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List561 --> Lambda562
+    Lambda567{{"Lambda[567∈14]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List566 --> Lambda567
+    Lambda572{{"Lambda[572∈14]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List571 --> Lambda572
+    List583{{"List[583∈15]<br />ᐸ581,582ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    Constant581{{"Constant[581∈15]<br />ᐸ'SingleTableTopic'ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    Constant581 & PgClassExpression582 --> List583
+    List588{{"List[588∈15]<br />ᐸ586,582ᐳ<br />ᐳSingleTablePost"}}:::plan
+    Constant586{{"Constant[586∈15]<br />ᐸ'SingleTablePost'ᐳ<br />ᐳSingleTablePost"}}:::plan
+    Constant586 & PgClassExpression582 --> List588
+    List593{{"List[593∈15]<br />ᐸ591,582ᐳ<br />ᐳSingleTableDivider"}}:::plan
+    Constant591{{"Constant[591∈15]<br />ᐸ'SingleTableDivider'ᐳ<br />ᐳSingleTableDivider"}}:::plan
+    Constant591 & PgClassExpression582 --> List593
+    List598{{"List[598∈15]<br />ᐸ596,582ᐳ<br />ᐳSingleTableChecklist"}}:::plan
+    Constant596{{"Constant[596∈15]<br />ᐸ'SingleTableChecklist'ᐳ<br />ᐳSingleTableChecklist"}}:::plan
+    Constant596 & PgClassExpression582 --> List598
+    List603{{"List[603∈15]<br />ᐸ601,582ᐳ<br />ᐳSingleTableChecklistItem"}}:::plan
+    Constant601{{"Constant[601∈15]<br />ᐸ'SingleTableChecklistItem'ᐳ<br />ᐳSingleTableChecklistItem"}}:::plan
+    Constant601 & PgClassExpression582 --> List603
+    Lambda584{{"Lambda[584∈15]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List583 --> Lambda584
+    Lambda589{{"Lambda[589∈15]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List588 --> Lambda589
+    Lambda594{{"Lambda[594∈15]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List593 --> Lambda594
+    Lambda599{{"Lambda[599∈15]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List598 --> Lambda599
+    Lambda604{{"Lambda[604∈15]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List603 --> Lambda604
+    List648{{"List[648∈16]<br />ᐸ623,629,635,641,647ᐳ"}}:::plan
+    Object623{{"Object[623∈16]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object629{{"Object[629∈16]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object635{{"Object[635∈16]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object641{{"Object[641∈16]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object647{{"Object[647∈16]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object623 & Object629 & Object635 & Object641 & Object647 --> List648
+    List685{{"List[685∈16]<br />ᐸ660,666,672,678,684ᐳ"}}:::plan
+    Object660{{"Object[660∈16]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object666{{"Object[666∈16]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object672{{"Object[672∈16]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object678{{"Object[678∈16]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object684{{"Object[684∈16]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object660 & Object666 & Object672 & Object678 & Object684 --> List685
+    PgInsertSingle611[["PgInsertSingle[611∈16]<br />ᐸsingle_table_item_relation_composite_pks(child_id,parent_id)ᐳ"]]:::sideeffectplan
+    Object614{{"Object[614∈16]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    __Flag652[["__Flag[652∈16]<br />ᐸ651, if(616), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
+    __Flag689[["__Flag[689∈16]<br />ᐸ688, if(653), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
+    Object614 & __Flag652 & __Flag689 --> PgInsertSingle611
+    Access612{{"Access[612∈16]<br />ᐸ3.pgSettingsᐳ"}}:::plan
+    Access613{{"Access[613∈16]<br />ᐸ3.withPgClientᐳ"}}:::plan
+    Access612 & Access613 --> Object614
+    Lambda621[["Lambda[621∈16]"]]:::unbatchedplan
+    List622{{"List[622∈16]<br />ᐸ771ᐳ"}}:::plan
+    Lambda621 & List622 --> Object623
+    Lambda627[["Lambda[627∈16]"]]:::unbatchedplan
+    Lambda627 & List622 --> Object629
+    Lambda633[["Lambda[633∈16]"]]:::unbatchedplan
+    Lambda633 & List622 --> Object635
+    Lambda639[["Lambda[639∈16]"]]:::unbatchedplan
+    Lambda639 & List622 --> Object641
+    Lambda645[["Lambda[645∈16]"]]:::unbatchedplan
+    Lambda645 & List622 --> Object647
+    __Flag651[["__Flag[651∈16]<br />ᐸ650, trapInhibited, onReject: INHIBITᐳ"]]:::plan
+    Condition616{{"Condition[616∈16]<br />ᐸexistsᐳ"}}:::plan
+    __Flag651 & Condition616 --> __Flag652
+    Lambda658[["Lambda[658∈16]"]]:::unbatchedplan
+    List659{{"List[659∈16]<br />ᐸ773ᐳ"}}:::plan
+    Lambda658 & List659 --> Object660
+    Lambda664[["Lambda[664∈16]"]]:::unbatchedplan
+    Lambda664 & List659 --> Object666
+    Lambda670[["Lambda[670∈16]"]]:::unbatchedplan
+    Lambda670 & List659 --> Object672
+    Lambda676[["Lambda[676∈16]"]]:::unbatchedplan
+    Lambda676 & List659 --> Object678
+    Lambda682[["Lambda[682∈16]"]]:::unbatchedplan
+    Lambda682 & List659 --> Object684
+    __Flag688[["__Flag[688∈16]<br />ᐸ687, trapInhibited, onReject: INHIBITᐳ"]]:::plan
+    Condition653{{"Condition[653∈16]<br />ᐸexistsᐳ"}}:::plan
+    __Flag688 & Condition653 --> __Flag689
+    __Value3 --> Access612
+    __Value3 --> Access613
+    Object615{{"Object[615∈16]<br />ᐸ{result}ᐳ"}}:::plan
+    PgInsertSingle611 --> Object615
+    Constant768 --> Condition616
+    Lambda617{{"Lambda[617∈16]<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
+    Constant768 --> Lambda617
+    Lambda617 --> Lambda621
+    Access771{{"Access[771∈16]<br />ᐸ617.base64JSON.1ᐳ"}}:::plan
+    Access771 --> List622
+    Lambda617 --> Lambda627
+    Lambda617 --> Lambda633
+    Lambda617 --> Lambda639
+    Lambda617 --> Lambda645
+    Lambda649{{"Lambda[649∈16]"}}:::plan
+    List648 --> Lambda649
+    Access650{{"Access[650∈16]<br />ᐸ649.0ᐳ"}}:::plan
+    Lambda649 --> Access650
+    Access650 --> __Flag651
+    Constant770 --> Condition653
+    Lambda654{{"Lambda[654∈16]<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
+    Constant770 --> Lambda654
+    Lambda654 --> Lambda658
+    Access773{{"Access[773∈16]<br />ᐸ654.base64JSON.1ᐳ"}}:::plan
+    Access773 --> List659
+    Lambda654 --> Lambda664
+    Lambda654 --> Lambda670
+    Lambda654 --> Lambda676
+    Lambda654 --> Lambda682
+    Lambda686{{"Lambda[686∈16]"}}:::plan
     List685 --> Lambda686
-    Lambda691{{"Lambda[691∈19]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List690 --> Lambda691
-    Lambda696{{"Lambda[696∈19]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List695 --> Lambda696
-    Lambda701{{"Lambda[701∈19]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List700 --> Lambda701
-    List712{{"List[712∈20]<br />ᐸ710,711ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    Constant710{{"Constant[710∈20]<br />ᐸ'SingleTableTopic'ᐳ<br />ᐳSingleTableTopic"}}:::plan
-    Constant710 & PgClassExpression711 --> List712
-    List717{{"List[717∈20]<br />ᐸ715,711ᐳ<br />ᐳSingleTablePost"}}:::plan
-    Constant715{{"Constant[715∈20]<br />ᐸ'SingleTablePost'ᐳ<br />ᐳSingleTablePost"}}:::plan
-    Constant715 & PgClassExpression711 --> List717
-    List722{{"List[722∈20]<br />ᐸ720,711ᐳ<br />ᐳSingleTableDivider"}}:::plan
-    Constant720{{"Constant[720∈20]<br />ᐸ'SingleTableDivider'ᐳ<br />ᐳSingleTableDivider"}}:::plan
-    Constant720 & PgClassExpression711 --> List722
-    List727{{"List[727∈20]<br />ᐸ725,711ᐳ<br />ᐳSingleTableChecklist"}}:::plan
-    Constant725{{"Constant[725∈20]<br />ᐸ'SingleTableChecklist'ᐳ<br />ᐳSingleTableChecklist"}}:::plan
-    Constant725 & PgClassExpression711 --> List727
-    List732{{"List[732∈20]<br />ᐸ730,711ᐳ<br />ᐳSingleTableChecklistItem"}}:::plan
-    Constant730{{"Constant[730∈20]<br />ᐸ'SingleTableChecklistItem'ᐳ<br />ᐳSingleTableChecklistItem"}}:::plan
-    Constant730 & PgClassExpression711 --> List732
-    Lambda713{{"Lambda[713∈20]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List712 --> Lambda713
-    Lambda718{{"Lambda[718∈20]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List717 --> Lambda718
-    Lambda723{{"Lambda[723∈20]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List722 --> Lambda723
-    Lambda728{{"Lambda[728∈20]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List727 --> Lambda728
-    Lambda733{{"Lambda[733∈20]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List732 --> Lambda733
+    Access687{{"Access[687∈16]<br />ᐸ686.0ᐳ"}}:::plan
+    Lambda686 --> Access687
+    Access687 --> __Flag688
+    Lambda617 --> Access771
+    Lambda654 --> Access773
+    List693{{"List[693∈18]<br />ᐸ690,691,692ᐳ"}}:::plan
+    Constant690{{"Constant[690∈18]<br />ᐸ'single_table_item_relation_composite_pks'ᐳ"}}:::plan
+    PgClassExpression691{{"PgClassExpression[691∈18]<br />ᐸ__single_t...parent_id”ᐳ"}}:::plan
+    PgClassExpression692{{"PgClassExpression[692∈18]<br />ᐸ__single_t...”child_id”ᐳ"}}:::plan
+    Constant690 & PgClassExpression691 & PgClassExpression692 --> List693
+    PgSelect696[["PgSelect[696∈18]<br />ᐸsingle_table_itemsᐳ"]]:::plan
+    Object614 & PgClassExpression692 --> PgSelect696
+    PgSelect728[["PgSelect[728∈18]<br />ᐸsingle_table_itemsᐳ"]]:::plan
+    Object614 & PgClassExpression691 --> PgSelect728
+    PgInsertSingle611 --> PgClassExpression691
+    PgInsertSingle611 --> PgClassExpression692
+    Lambda694{{"Lambda[694∈18]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List693 --> Lambda694
+    First700{{"First[700∈18]"}}:::plan
+    PgSelect696 --> First700
+    PgSelectSingle701{{"PgSelectSingle[701∈18]<br />ᐸsingle_table_itemsᐳ"}}:::plan
+    First700 --> PgSelectSingle701
+    PgClassExpression703{{"PgClassExpression[703∈18]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle701 --> PgClassExpression703
+    PgClassExpression706{{"PgClassExpression[706∈18]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle701 --> PgClassExpression706
+    First732{{"First[732∈18]"}}:::plan
+    PgSelect728 --> First732
+    PgSelectSingle733{{"PgSelectSingle[733∈18]<br />ᐸsingle_table_itemsᐳ"}}:::plan
+    First732 --> PgSelectSingle733
+    PgClassExpression735{{"PgClassExpression[735∈18]<br />ᐸ__single_t...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle733 --> PgClassExpression735
+    PgClassExpression738{{"PgClassExpression[738∈18]<br />ᐸ__single_t...s__.”type”ᐳ"}}:::plan
+    PgSelectSingle733 --> PgClassExpression738
+    List704{{"List[704∈19]<br />ᐸ702,703ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    Constant702{{"Constant[702∈19]<br />ᐸ'SingleTableTopic'ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    Constant702 & PgClassExpression703 --> List704
+    List709{{"List[709∈19]<br />ᐸ707,703ᐳ<br />ᐳSingleTablePost"}}:::plan
+    Constant707{{"Constant[707∈19]<br />ᐸ'SingleTablePost'ᐳ<br />ᐳSingleTablePost"}}:::plan
+    Constant707 & PgClassExpression703 --> List709
+    List714{{"List[714∈19]<br />ᐸ712,703ᐳ<br />ᐳSingleTableDivider"}}:::plan
+    Constant712{{"Constant[712∈19]<br />ᐸ'SingleTableDivider'ᐳ<br />ᐳSingleTableDivider"}}:::plan
+    Constant712 & PgClassExpression703 --> List714
+    List719{{"List[719∈19]<br />ᐸ717,703ᐳ<br />ᐳSingleTableChecklist"}}:::plan
+    Constant717{{"Constant[717∈19]<br />ᐸ'SingleTableChecklist'ᐳ<br />ᐳSingleTableChecklist"}}:::plan
+    Constant717 & PgClassExpression703 --> List719
+    List724{{"List[724∈19]<br />ᐸ722,703ᐳ<br />ᐳSingleTableChecklistItem"}}:::plan
+    Constant722{{"Constant[722∈19]<br />ᐸ'SingleTableChecklistItem'ᐳ<br />ᐳSingleTableChecklistItem"}}:::plan
+    Constant722 & PgClassExpression703 --> List724
+    Lambda705{{"Lambda[705∈19]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List704 --> Lambda705
+    Lambda710{{"Lambda[710∈19]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List709 --> Lambda710
+    Lambda715{{"Lambda[715∈19]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List714 --> Lambda715
+    Lambda720{{"Lambda[720∈19]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List719 --> Lambda720
+    Lambda725{{"Lambda[725∈19]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List724 --> Lambda725
+    List736{{"List[736∈20]<br />ᐸ734,735ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    Constant734{{"Constant[734∈20]<br />ᐸ'SingleTableTopic'ᐳ<br />ᐳSingleTableTopic"}}:::plan
+    Constant734 & PgClassExpression735 --> List736
+    List741{{"List[741∈20]<br />ᐸ739,735ᐳ<br />ᐳSingleTablePost"}}:::plan
+    Constant739{{"Constant[739∈20]<br />ᐸ'SingleTablePost'ᐳ<br />ᐳSingleTablePost"}}:::plan
+    Constant739 & PgClassExpression735 --> List741
+    List746{{"List[746∈20]<br />ᐸ744,735ᐳ<br />ᐳSingleTableDivider"}}:::plan
+    Constant744{{"Constant[744∈20]<br />ᐸ'SingleTableDivider'ᐳ<br />ᐳSingleTableDivider"}}:::plan
+    Constant744 & PgClassExpression735 --> List746
+    List751{{"List[751∈20]<br />ᐸ749,735ᐳ<br />ᐳSingleTableChecklist"}}:::plan
+    Constant749{{"Constant[749∈20]<br />ᐸ'SingleTableChecklist'ᐳ<br />ᐳSingleTableChecklist"}}:::plan
+    Constant749 & PgClassExpression735 --> List751
+    List756{{"List[756∈20]<br />ᐸ754,735ᐳ<br />ᐳSingleTableChecklistItem"}}:::plan
+    Constant754{{"Constant[754∈20]<br />ᐸ'SingleTableChecklistItem'ᐳ<br />ᐳSingleTableChecklistItem"}}:::plan
+    Constant754 & PgClassExpression735 --> List756
+    Lambda737{{"Lambda[737∈20]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List736 --> Lambda737
+    Lambda742{{"Lambda[742∈20]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List741 --> Lambda742
+    Lambda747{{"Lambda[747∈20]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List746 --> Lambda747
+    Lambda752{{"Lambda[752∈20]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List751 --> Lambda752
+    Lambda757{{"Lambda[757∈20]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List756 --> Lambda757
 
     %% define steps
 
     subgraph "Buckets for mutations/v4/polymorphic.relay"
     Bucket0("Bucket 0 (root)"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value3,__Value5,Access14,Access15,Object16,Lambda18,List23,Lambda52,List57,Access735,Constant736,Access737,Constant738,Constant744,Constant746 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 16, 18, 23, 52, 57<br /><br />1: Lambda[22]<br />2: Object[24]<br />3: Lambda[28]<br />4: Object[30]<br />5: Lambda[34]<br />6: Object[36]<br />7: Lambda[40]<br />8: Object[42]<br />9: Lambda[46]<br />10: Object[48]<br />11: List[49]<br />12: Lambda[50]<br />13: Access[51]<br />14: Lambda[56]<br />15: Object[58]<br />16: Lambda[62]<br />17: Object[64]<br />18: Lambda[68]<br />19: Object[70]<br />20: Lambda[74]<br />21: Object[76]<br />22: Lambda[80]<br />23: Object[82]<br />24: List[83]<br />25: Lambda[84]<br />26: Access[85]<br />27: PgInsertSingle[13]<br />28: <br />ᐳ: Object[17]"):::bucket
+    class Bucket0,__Value0,__Value3,__Value5,Access14,Access15,Object16,Condition18,Lambda19,List24,Condition55,Lambda56,List61,Access759,Constant760,Access761,Constant762,Constant768,Constant770 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 16, 19, 24, 18, 56, 61, 55<br /><br />1: Lambda[23]<br />2: Object[25]<br />3: Lambda[29]<br />4: Object[31]<br />5: Lambda[35]<br />6: Object[37]<br />7: Lambda[41]<br />8: Object[43]<br />9: Lambda[47]<br />10: Object[49]<br />11: List[50]<br />12: Lambda[51]<br />13: Access[52]<br />14: __Flag[53]<br />15: __Flag[54]<br />16: Lambda[60]<br />17: Object[62]<br />18: Lambda[66]<br />19: Object[68]<br />20: Lambda[72]<br />21: Object[74]<br />22: Lambda[78]<br />23: Object[80]<br />24: Lambda[84]<br />25: Object[86]<br />26: List[87]<br />27: Lambda[88]<br />28: Access[89]<br />29: __Flag[90]<br />30: __Flag[91]<br />31: PgInsertSingle[13]<br />32: <br />ᐳ: Object[17]"):::bucket
     classDef bucket1 stroke:#00bfff
-    class Bucket1,PgInsertSingle13,Object17,Lambda22,Object24,Lambda28,Object30,Lambda34,Object36,Lambda40,Object42,Lambda46,Object48,List49,Lambda50,Access51,Lambda56,Object58,Lambda62,Object64,Lambda68,Object70,Lambda74,Object76,Lambda80,Object82,List83,Lambda84,Access85 bucket1
+    class Bucket1,PgInsertSingle13,Object17,Lambda23,Object25,Lambda29,Object31,Lambda35,Object37,Lambda41,Object43,Lambda47,Object49,List50,Lambda51,Access52,__Flag53,__Flag54,Lambda60,Object62,Lambda66,Object68,Lambda72,Object74,Lambda78,Object80,Lambda84,Object86,List87,Lambda88,Access89,__Flag90,__Flag91 bucket1
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 17, 13, 16<br /><br />ROOT Object{1}ᐸ{result}ᐳ[17]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 16<br /><br />ROOT PgInsertSingle{1}ᐸrelational_item_relations(child_id,parent_id)ᐳ[13]<br />1: <br />ᐳ: 86, 87, 90, 157, 88, 89<br />2: PgSelect[91], PgSelect[158]<br />ᐳ: 95, 96, 97, 108, 162, 163, 164, 175"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 13, 16<br /><br />ROOT PgInsertSingle{1}ᐸrelational_item_relations(child_id,parent_id)ᐳ[13]<br />1: <br />ᐳ: 92, 93, 96, 163, 94, 95<br />2: PgSelect[97], PgSelect[164]<br />ᐳ: 101, 102, 103, 114, 168, 169, 170, 181"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,Constant86,PgClassExpression87,List88,Lambda89,PgClassExpression90,PgSelect91,First95,PgSelectSingle96,PgClassExpression97,PgClassExpression108,PgClassExpression157,PgSelect158,First162,PgSelectSingle163,PgClassExpression164,PgClassExpression175 bucket3
-    Bucket4("Bucket 4 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 16, 97, 96, 108<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"):::bucket
+    class Bucket3,Constant92,PgClassExpression93,List94,Lambda95,PgClassExpression96,PgSelect97,First101,PgSelectSingle102,PgClassExpression103,PgClassExpression114,PgClassExpression163,PgSelect164,First168,PgSelectSingle169,PgClassExpression170,PgClassExpression181 bucket3
+    Bucket4("Bucket 4 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 16, 103, 102, 114<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgSelect98,First102,PgSelectSingle103,Constant104,PgClassExpression105,List106,Lambda107,PgSelect110,First114,PgSelectSingle115,Constant116,PgClassExpression117,List118,Lambda119,PgSelect122,First126,PgSelectSingle127,Constant128,PgClassExpression129,List130,Lambda131,PgSelect134,First138,PgSelectSingle139,Constant140,PgClassExpression141,List142,Lambda143,PgSelect146,First150,PgSelectSingle151,Constant152,PgClassExpression153,List154,Lambda155 bucket4
-    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 16, 164, 163, 175<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"):::bucket
+    class Bucket4,PgSelect104,First108,PgSelectSingle109,Constant110,PgClassExpression111,List112,Lambda113,PgSelect116,First120,PgSelectSingle121,Constant122,PgClassExpression123,List124,Lambda125,PgSelect128,First132,PgSelectSingle133,Constant134,PgClassExpression135,List136,Lambda137,PgSelect140,First144,PgSelectSingle145,Constant146,PgClassExpression147,List148,Lambda149,PgSelect152,First156,PgSelectSingle157,Constant158,PgClassExpression159,List160,Lambda161 bucket4
+    Bucket5("Bucket 5 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 16, 170, 169, 181<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,PgSelect165,First169,PgSelectSingle170,Constant171,PgClassExpression172,List173,Lambda174,PgSelect177,First181,PgSelectSingle182,Constant183,PgClassExpression184,List185,Lambda186,PgSelect189,First193,PgSelectSingle194,Constant195,PgClassExpression196,List197,Lambda198,PgSelect201,First205,PgSelectSingle206,Constant207,PgClassExpression208,List209,Lambda210,PgSelect213,First217,PgSelectSingle218,Constant219,PgClassExpression220,List221,Lambda222 bucket5
-    Bucket6("Bucket 6 (mutationField)<br />Deps: 3, 736, 738<br /><br />1: Access[230]<br />2: Access[231]<br />3: Object[232]<br />4: Lambda[234]<br />5: Lambda[238]<br />6: Access[739]<br />7: List[239]<br />8: Object[240]<br />9: Lambda[244]<br />10: Object[246]<br />11: Lambda[250]<br />12: Object[252]<br />13: Lambda[256]<br />14: Object[258]<br />15: Lambda[262]<br />16: Object[264]<br />17: List[265]<br />18: Lambda[266]<br />19: Access[267]<br />20: Lambda[268]<br />21: Lambda[272]<br />22: Access[741]<br />23: List[273]<br />24: Object[274]<br />25: Lambda[278]<br />26: Object[280]<br />27: Lambda[284]<br />28: Object[286]<br />29: Lambda[290]<br />30: Object[292]<br />31: Lambda[296]<br />32: Object[298]<br />33: List[299]<br />34: Lambda[300]<br />35: Access[301]<br />36: PgInsertSingle[229]<br />37: <br />ᐳ: Object[233]"):::bucket
+    class Bucket5,PgSelect171,First175,PgSelectSingle176,Constant177,PgClassExpression178,List179,Lambda180,PgSelect183,First187,PgSelectSingle188,Constant189,PgClassExpression190,List191,Lambda192,PgSelect195,First199,PgSelectSingle200,Constant201,PgClassExpression202,List203,Lambda204,PgSelect207,First211,PgSelectSingle212,Constant213,PgClassExpression214,List215,Lambda216,PgSelect219,First223,PgSelectSingle224,Constant225,PgClassExpression226,List227,Lambda228 bucket5
+    Bucket6("Bucket 6 (mutationField)<br />Deps: 3, 760, 762<br /><br />1: Access[236]<br />2: Access[237]<br />3: Object[238]<br />4: Lambda[241]<br />5: Lambda[245]<br />6: Access[763]<br />7: List[246]<br />8: Object[247]<br />9: Lambda[251]<br />10: Object[253]<br />11: Lambda[257]<br />12: Object[259]<br />13: Lambda[263]<br />14: Object[265]<br />15: Lambda[269]<br />16: Object[271]<br />17: List[272]<br />18: Lambda[273]<br />19: Access[274]<br />20: __Flag[275]<br />21: Condition[240]<br />22: __Flag[276]<br />23: Lambda[278]<br />24: Lambda[282]<br />25: Access[765]<br />26: List[283]<br />27: Object[284]<br />28: Lambda[288]<br />29: Object[290]<br />30: Lambda[294]<br />31: Object[296]<br />32: Lambda[300]<br />33: Object[302]<br />34: Lambda[306]<br />35: Object[308]<br />36: List[309]<br />37: Lambda[310]<br />38: Access[311]<br />39: __Flag[312]<br />40: Condition[277]<br />41: __Flag[313]<br />42: PgInsertSingle[235]<br />43: <br />ᐳ: Object[239]"):::bucket
     classDef bucket6 stroke:#ff1493
-    class Bucket6,PgInsertSingle229,Access230,Access231,Object232,Object233,Lambda234,Lambda238,List239,Object240,Lambda244,Object246,Lambda250,Object252,Lambda256,Object258,Lambda262,Object264,List265,Lambda266,Access267,Lambda268,Lambda272,List273,Object274,Lambda278,Object280,Lambda284,Object286,Lambda290,Object292,Lambda296,Object298,List299,Lambda300,Access301,Access739,Access741 bucket6
-    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 233, 229, 232<br /><br />ROOT Object{6}ᐸ{result}ᐳ[233]"):::bucket
+    class Bucket6,PgInsertSingle235,Access236,Access237,Object238,Object239,Condition240,Lambda241,Lambda245,List246,Object247,Lambda251,Object253,Lambda257,Object259,Lambda263,Object265,Lambda269,Object271,List272,Lambda273,Access274,__Flag275,__Flag276,Condition277,Lambda278,Lambda282,List283,Object284,Lambda288,Object290,Lambda294,Object296,Lambda300,Object302,Lambda306,Object308,List309,Lambda310,Access311,__Flag312,__Flag313,Access763,Access765 bucket6
+    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 239, 235, 238<br /><br />ROOT Object{6}ᐸ{result}ᐳ[239]"):::bucket
     classDef bucket7 stroke:#808000
     class Bucket7 bucket7
-    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 229, 232<br /><br />ROOT PgInsertSingle{6}ᐸrelational_item_relation_composite_pks(child_id,parent_id)ᐳ[229]<br />1: <br />ᐳ: 302, 303, 304, 305, 306<br />2: PgSelect[308], PgSelect[375]<br />ᐳ: 312, 313, 314, 325, 379, 380, 381, 392"):::bucket
+    Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 235, 238<br /><br />ROOT PgInsertSingle{6}ᐸrelational_item_relation_composite_pks(child_id,parent_id)ᐳ[235]<br />1: <br />ᐳ: 314, 315, 316, 317, 318<br />2: PgSelect[320], PgSelect[387]<br />ᐳ: 324, 325, 326, 337, 391, 392, 393, 404"):::bucket
     classDef bucket8 stroke:#dda0dd
-    class Bucket8,Constant302,PgClassExpression303,PgClassExpression304,List305,Lambda306,PgSelect308,First312,PgSelectSingle313,PgClassExpression314,PgClassExpression325,PgSelect375,First379,PgSelectSingle380,PgClassExpression381,PgClassExpression392 bucket8
-    Bucket9("Bucket 9 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 232, 314, 313, 325<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"):::bucket
+    class Bucket8,Constant314,PgClassExpression315,PgClassExpression316,List317,Lambda318,PgSelect320,First324,PgSelectSingle325,PgClassExpression326,PgClassExpression337,PgSelect387,First391,PgSelectSingle392,PgClassExpression393,PgClassExpression404 bucket8
+    Bucket9("Bucket 9 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 238, 326, 325, 337<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"):::bucket
     classDef bucket9 stroke:#ff0000
-    class Bucket9,PgSelect315,First319,PgSelectSingle320,Constant321,PgClassExpression322,List323,Lambda324,PgSelect327,First331,PgSelectSingle332,Constant333,PgClassExpression334,List335,Lambda336,PgSelect339,First343,PgSelectSingle344,Constant345,PgClassExpression346,List347,Lambda348,PgSelect351,First355,PgSelectSingle356,Constant357,PgClassExpression358,List359,Lambda360,PgSelect363,First367,PgSelectSingle368,Constant369,PgClassExpression370,List371,Lambda372 bucket9
-    Bucket10("Bucket 10 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 232, 381, 380, 392<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"):::bucket
+    class Bucket9,PgSelect327,First331,PgSelectSingle332,Constant333,PgClassExpression334,List335,Lambda336,PgSelect339,First343,PgSelectSingle344,Constant345,PgClassExpression346,List347,Lambda348,PgSelect351,First355,PgSelectSingle356,Constant357,PgClassExpression358,List359,Lambda360,PgSelect363,First367,PgSelectSingle368,Constant369,PgClassExpression370,List371,Lambda372,PgSelect375,First379,PgSelectSingle380,Constant381,PgClassExpression382,List383,Lambda384 bucket9
+    Bucket10("Bucket 10 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 238, 393, 392, 404<br />ᐳRelationalTopic<br />ᐳRelationalPost<br />ᐳRelationalDivider<br />ᐳRelationalChecklist<br />ᐳRelationalChecklistItem"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,PgSelect382,First386,PgSelectSingle387,Constant388,PgClassExpression389,List390,Lambda391,PgSelect394,First398,PgSelectSingle399,Constant400,PgClassExpression401,List402,Lambda403,PgSelect406,First410,PgSelectSingle411,Constant412,PgClassExpression413,List414,Lambda415,PgSelect418,First422,PgSelectSingle423,Constant424,PgClassExpression425,List426,Lambda427,PgSelect430,First434,PgSelectSingle435,Constant436,PgClassExpression437,List438,Lambda439 bucket10
-    Bucket11("Bucket 11 (mutationField)<br />Deps: 3, 744, 746<br /><br />1: Access[448]<br />2: Access[449]<br />3: Object[450]<br />4: Lambda[452]<br />5: Lambda[456]<br />6: Access[743]<br />7: List[457]<br />8: Object[458]<br />9: Lambda[462]<br />10: Object[464]<br />11: Lambda[468]<br />12: Object[470]<br />13: Lambda[474]<br />14: Object[476]<br />15: Lambda[480]<br />16: Object[482]<br />17: List[483]<br />18: Lambda[484]<br />19: Access[485]<br />20: Lambda[486]<br />21: Lambda[490]<br />22: Access[745]<br />23: List[491]<br />24: Object[492]<br />25: Lambda[496]<br />26: Object[498]<br />27: Lambda[502]<br />28: Object[504]<br />29: Lambda[508]<br />30: Object[510]<br />31: Lambda[514]<br />32: Object[516]<br />33: List[517]<br />34: Lambda[518]<br />35: Access[519]<br />36: PgInsertSingle[447]<br />37: <br />ᐳ: Object[451]"):::bucket
+    class Bucket10,PgSelect394,First398,PgSelectSingle399,Constant400,PgClassExpression401,List402,Lambda403,PgSelect406,First410,PgSelectSingle411,Constant412,PgClassExpression413,List414,Lambda415,PgSelect418,First422,PgSelectSingle423,Constant424,PgClassExpression425,List426,Lambda427,PgSelect430,First434,PgSelectSingle435,Constant436,PgClassExpression437,List438,Lambda439,PgSelect442,First446,PgSelectSingle447,Constant448,PgClassExpression449,List450,Lambda451 bucket10
+    Bucket11("Bucket 11 (mutationField)<br />Deps: 3, 768, 770<br /><br />1: Access[460]<br />2: Access[461]<br />3: Object[462]<br />4: Lambda[465]<br />5: Lambda[469]<br />6: Access[767]<br />7: List[470]<br />8: Object[471]<br />9: Lambda[475]<br />10: Object[477]<br />11: Lambda[481]<br />12: Object[483]<br />13: Lambda[487]<br />14: Object[489]<br />15: Lambda[493]<br />16: Object[495]<br />17: List[496]<br />18: Lambda[497]<br />19: Access[498]<br />20: __Flag[499]<br />21: Condition[464]<br />22: __Flag[500]<br />23: Lambda[502]<br />24: Lambda[506]<br />25: Access[769]<br />26: List[507]<br />27: Object[508]<br />28: Lambda[512]<br />29: Object[514]<br />30: Lambda[518]<br />31: Object[520]<br />32: Lambda[524]<br />33: Object[526]<br />34: Lambda[530]<br />35: Object[532]<br />36: List[533]<br />37: Lambda[534]<br />38: Access[535]<br />39: __Flag[536]<br />40: Condition[501]<br />41: __Flag[537]<br />42: PgInsertSingle[459]<br />43: <br />ᐳ: Object[463]"):::bucket
     classDef bucket11 stroke:#00ffff
-    class Bucket11,PgInsertSingle447,Access448,Access449,Object450,Object451,Lambda452,Lambda456,List457,Object458,Lambda462,Object464,Lambda468,Object470,Lambda474,Object476,Lambda480,Object482,List483,Lambda484,Access485,Lambda486,Lambda490,List491,Object492,Lambda496,Object498,Lambda502,Object504,Lambda508,Object510,Lambda514,Object516,List517,Lambda518,Access519,Access743,Access745 bucket11
-    Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 451, 447, 450<br /><br />ROOT Object{11}ᐸ{result}ᐳ[451]"):::bucket
+    class Bucket11,PgInsertSingle459,Access460,Access461,Object462,Object463,Condition464,Lambda465,Lambda469,List470,Object471,Lambda475,Object477,Lambda481,Object483,Lambda487,Object489,Lambda493,Object495,List496,Lambda497,Access498,__Flag499,__Flag500,Condition501,Lambda502,Lambda506,List507,Object508,Lambda512,Object514,Lambda518,Object520,Lambda524,Object526,Lambda530,Object532,List533,Lambda534,Access535,__Flag536,__Flag537,Access767,Access769 bucket11
+    Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 463, 459, 462<br /><br />ROOT Object{11}ᐸ{result}ᐳ[463]"):::bucket
     classDef bucket12 stroke:#4169e1
     class Bucket12 bucket12
-    Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 447, 450<br /><br />ROOT PgInsertSingle{11}ᐸsingle_table_item_relations(child_id,parent_id)ᐳ[447]<br />1: <br />ᐳ: 520, 521, 524, 556, 522, 523<br />2: PgSelect[525], PgSelect[557]<br />ᐳ: 529, 530, 532, 535, 561, 562, 564, 567"):::bucket
+    Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 459, 462<br /><br />ROOT PgInsertSingle{11}ᐸsingle_table_item_relations(child_id,parent_id)ᐳ[459]<br />1: <br />ᐳ: 538, 539, 542, 574, 540, 541<br />2: PgSelect[543], PgSelect[575]<br />ᐳ: 547, 548, 550, 553, 579, 580, 582, 585"):::bucket
     classDef bucket13 stroke:#3cb371
-    class Bucket13,Constant520,PgClassExpression521,List522,Lambda523,PgClassExpression524,PgSelect525,First529,PgSelectSingle530,PgClassExpression532,PgClassExpression535,PgClassExpression556,PgSelect557,First561,PgSelectSingle562,PgClassExpression564,PgClassExpression567 bucket13
-    Bucket14("Bucket 14 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 532, 530, 535<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
+    class Bucket13,Constant538,PgClassExpression539,List540,Lambda541,PgClassExpression542,PgSelect543,First547,PgSelectSingle548,PgClassExpression550,PgClassExpression553,PgClassExpression574,PgSelect575,First579,PgSelectSingle580,PgClassExpression582,PgClassExpression585 bucket13
+    Bucket14("Bucket 14 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 550, 548, 553<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
     classDef bucket14 stroke:#a52a2a
-    class Bucket14,Constant531,List533,Lambda534,Constant536,List538,Lambda539,Constant541,List543,Lambda544,Constant546,List548,Lambda549,Constant551,List553,Lambda554 bucket14
-    Bucket15("Bucket 15 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 564, 562, 567<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
+    class Bucket14,Constant549,List551,Lambda552,Constant554,List556,Lambda557,Constant559,List561,Lambda562,Constant564,List566,Lambda567,Constant569,List571,Lambda572 bucket14
+    Bucket15("Bucket 15 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 582, 580, 585<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
     classDef bucket15 stroke:#ff00ff
-    class Bucket15,Constant563,List565,Lambda566,Constant568,List570,Lambda571,Constant573,List575,Lambda576,Constant578,List580,Lambda581,Constant583,List585,Lambda586 bucket15
-    Bucket16("Bucket 16 (mutationField)<br />Deps: 3, 744, 746<br /><br />1: Access[594]<br />2: Access[595]<br />3: Object[596]<br />4: Lambda[598]<br />5: Lambda[602]<br />6: Access[747]<br />7: List[603]<br />8: Object[604]<br />9: Lambda[608]<br />10: Object[610]<br />11: Lambda[614]<br />12: Object[616]<br />13: Lambda[620]<br />14: Object[622]<br />15: Lambda[626]<br />16: Object[628]<br />17: List[629]<br />18: Lambda[630]<br />19: Access[631]<br />20: Lambda[632]<br />21: Lambda[636]<br />22: Access[749]<br />23: List[637]<br />24: Object[638]<br />25: Lambda[642]<br />26: Object[644]<br />27: Lambda[648]<br />28: Object[650]<br />29: Lambda[654]<br />30: Object[656]<br />31: Lambda[660]<br />32: Object[662]<br />33: List[663]<br />34: Lambda[664]<br />35: Access[665]<br />36: PgInsertSingle[593]<br />37: <br />ᐳ: Object[597]"):::bucket
+    class Bucket15,Constant581,List583,Lambda584,Constant586,List588,Lambda589,Constant591,List593,Lambda594,Constant596,List598,Lambda599,Constant601,List603,Lambda604 bucket15
+    Bucket16("Bucket 16 (mutationField)<br />Deps: 3, 768, 770<br /><br />1: Access[612]<br />2: Access[613]<br />3: Object[614]<br />4: Lambda[617]<br />5: Lambda[621]<br />6: Access[771]<br />7: List[622]<br />8: Object[623]<br />9: Lambda[627]<br />10: Object[629]<br />11: Lambda[633]<br />12: Object[635]<br />13: Lambda[639]<br />14: Object[641]<br />15: Lambda[645]<br />16: Object[647]<br />17: List[648]<br />18: Lambda[649]<br />19: Access[650]<br />20: __Flag[651]<br />21: Condition[616]<br />22: __Flag[652]<br />23: Lambda[654]<br />24: Lambda[658]<br />25: Access[773]<br />26: List[659]<br />27: Object[660]<br />28: Lambda[664]<br />29: Object[666]<br />30: Lambda[670]<br />31: Object[672]<br />32: Lambda[676]<br />33: Object[678]<br />34: Lambda[682]<br />35: Object[684]<br />36: List[685]<br />37: Lambda[686]<br />38: Access[687]<br />39: __Flag[688]<br />40: Condition[653]<br />41: __Flag[689]<br />42: PgInsertSingle[611]<br />43: <br />ᐳ: Object[615]"):::bucket
     classDef bucket16 stroke:#f5deb3
-    class Bucket16,PgInsertSingle593,Access594,Access595,Object596,Object597,Lambda598,Lambda602,List603,Object604,Lambda608,Object610,Lambda614,Object616,Lambda620,Object622,Lambda626,Object628,List629,Lambda630,Access631,Lambda632,Lambda636,List637,Object638,Lambda642,Object644,Lambda648,Object650,Lambda654,Object656,Lambda660,Object662,List663,Lambda664,Access665,Access747,Access749 bucket16
-    Bucket17("Bucket 17 (nullableBoundary)<br />Deps: 597, 593, 596<br /><br />ROOT Object{16}ᐸ{result}ᐳ[597]"):::bucket
+    class Bucket16,PgInsertSingle611,Access612,Access613,Object614,Object615,Condition616,Lambda617,Lambda621,List622,Object623,Lambda627,Object629,Lambda633,Object635,Lambda639,Object641,Lambda645,Object647,List648,Lambda649,Access650,__Flag651,__Flag652,Condition653,Lambda654,Lambda658,List659,Object660,Lambda664,Object666,Lambda670,Object672,Lambda676,Object678,Lambda682,Object684,List685,Lambda686,Access687,__Flag688,__Flag689,Access771,Access773 bucket16
+    Bucket17("Bucket 17 (nullableBoundary)<br />Deps: 615, 611, 614<br /><br />ROOT Object{16}ᐸ{result}ᐳ[615]"):::bucket
     classDef bucket17 stroke:#696969
     class Bucket17 bucket17
-    Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 593, 596<br /><br />ROOT PgInsertSingle{16}ᐸsingle_table_item_relation_composite_pks(child_id,parent_id)ᐳ[593]<br />1: <br />ᐳ: 666, 667, 668, 669, 670<br />2: PgSelect[672], PgSelect[704]<br />ᐳ: 676, 677, 679, 682, 708, 709, 711, 714"):::bucket
+    Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 611, 614<br /><br />ROOT PgInsertSingle{16}ᐸsingle_table_item_relation_composite_pks(child_id,parent_id)ᐳ[611]<br />1: <br />ᐳ: 690, 691, 692, 693, 694<br />2: PgSelect[696], PgSelect[728]<br />ᐳ: 700, 701, 703, 706, 732, 733, 735, 738"):::bucket
     classDef bucket18 stroke:#00bfff
-    class Bucket18,Constant666,PgClassExpression667,PgClassExpression668,List669,Lambda670,PgSelect672,First676,PgSelectSingle677,PgClassExpression679,PgClassExpression682,PgSelect704,First708,PgSelectSingle709,PgClassExpression711,PgClassExpression714 bucket18
-    Bucket19("Bucket 19 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 679, 677, 682<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
+    class Bucket18,Constant690,PgClassExpression691,PgClassExpression692,List693,Lambda694,PgSelect696,First700,PgSelectSingle701,PgClassExpression703,PgClassExpression706,PgSelect728,First732,PgSelectSingle733,PgClassExpression735,PgClassExpression738 bucket18
+    Bucket19("Bucket 19 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 703, 701, 706<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
     classDef bucket19 stroke:#7f007f
-    class Bucket19,Constant678,List680,Lambda681,Constant683,List685,Lambda686,Constant688,List690,Lambda691,Constant693,List695,Lambda696,Constant698,List700,Lambda701 bucket19
-    Bucket20("Bucket 20 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 711, 709, 714<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
+    class Bucket19,Constant702,List704,Lambda705,Constant707,List709,Lambda710,Constant712,List714,Lambda715,Constant717,List719,Lambda720,Constant722,List724,Lambda725 bucket19
+    Bucket20("Bucket 20 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 735, 733, 738<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
     classDef bucket20 stroke:#ffa500
-    class Bucket20,Constant710,List712,Lambda713,Constant715,List717,Lambda718,Constant720,List722,Lambda723,Constant725,List727,Lambda728,Constant730,List732,Lambda733 bucket20
+    class Bucket20,Constant734,List736,Lambda737,Constant739,List741,Lambda742,Constant744,List746,Lambda747,Constant749,List751,Lambda752,Constant754,List756,Lambda757 bucket20
     Bucket0 --> Bucket1 & Bucket6 & Bucket11 & Bucket16
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3
@@ -873,5 +921,5 @@ graph TD
     Bucket17 --> Bucket18
     Bucket18 --> Bucket19 & Bucket20
     classDef unary fill:#fafffa,borderWidth:8px
-    class Object16,Access14,Access15,Lambda18,List23,Lambda52,List57,Access735,Access737,__Value0,__Value3,__Value5,Constant736,Constant738,Constant744,Constant746,List49,List83,PgInsertSingle13,Object24,Object30,Object36,Object42,Object48,Object58,Object64,Object70,Object76,Object82,Object17,Lambda22,Lambda28,Lambda34,Lambda40,Lambda46,Lambda50,Access51,Lambda56,Lambda62,Lambda68,Lambda74,Lambda80,Lambda84,Access85,List88,PgSelect91,PgSelect158,PgClassExpression87,Lambda89,PgClassExpression90,First95,PgSelectSingle96,PgClassExpression97,PgClassExpression108,PgClassExpression157,First162,PgSelectSingle163,PgClassExpression164,PgClassExpression175,Constant86,PgSelect98,List106,PgSelect110,List118,PgSelect122,List130,PgSelect134,List142,PgSelect146,List154,First102,PgSelectSingle103,PgClassExpression105,Lambda107,First114,PgSelectSingle115,PgClassExpression117,Lambda119,First126,PgSelectSingle127,PgClassExpression129,Lambda131,First138,PgSelectSingle139,PgClassExpression141,Lambda143,First150,PgSelectSingle151,PgClassExpression153,Lambda155,Constant104,Constant116,Constant128,Constant140,Constant152,PgSelect165,List173,PgSelect177,List185,PgSelect189,List197,PgSelect201,List209,PgSelect213,List221,First169,PgSelectSingle170,PgClassExpression172,Lambda174,First181,PgSelectSingle182,PgClassExpression184,Lambda186,First193,PgSelectSingle194,PgClassExpression196,Lambda198,First205,PgSelectSingle206,PgClassExpression208,Lambda210,First217,PgSelectSingle218,PgClassExpression220,Lambda222,Constant171,Constant183,Constant195,Constant207,Constant219,List265,List299,PgInsertSingle229,Object232,Object240,Object246,Object252,Object258,Object264,Object274,Object280,Object286,Object292,Object298,Access230,Access231,Object233,Lambda234,Lambda238,List239,Lambda244,Lambda250,Lambda256,Lambda262,Lambda266,Access267,Lambda268,Lambda272,List273,Lambda278,Lambda284,Lambda290,Lambda296,Lambda300,Access301,Access739,Access741,List305,PgSelect308,PgSelect375,PgClassExpression303,PgClassExpression304,Lambda306,First312,PgSelectSingle313,PgClassExpression314,PgClassExpression325,First379,PgSelectSingle380,PgClassExpression381,PgClassExpression392,Constant302,PgSelect315,List323,PgSelect327,List335,PgSelect339,List347,PgSelect351,List359,PgSelect363,List371,First319,PgSelectSingle320,PgClassExpression322,Lambda324,First331,PgSelectSingle332,PgClassExpression334,Lambda336,First343,PgSelectSingle344,PgClassExpression346,Lambda348,First355,PgSelectSingle356,PgClassExpression358,Lambda360,First367,PgSelectSingle368,PgClassExpression370,Lambda372,Constant321,Constant333,Constant345,Constant357,Constant369,PgSelect382,List390,PgSelect394,List402,PgSelect406,List414,PgSelect418,List426,PgSelect430,List438,First386,PgSelectSingle387,PgClassExpression389,Lambda391,First398,PgSelectSingle399,PgClassExpression401,Lambda403,First410,PgSelectSingle411,PgClassExpression413,Lambda415,First422,PgSelectSingle423,PgClassExpression425,Lambda427,First434,PgSelectSingle435,PgClassExpression437,Lambda439,Constant388,Constant400,Constant412,Constant424,Constant436,List483,List517,PgInsertSingle447,Object450,Object458,Object464,Object470,Object476,Object482,Object492,Object498,Object504,Object510,Object516,Access448,Access449,Object451,Lambda452,Lambda456,List457,Lambda462,Lambda468,Lambda474,Lambda480,Lambda484,Access485,Lambda486,Lambda490,List491,Lambda496,Lambda502,Lambda508,Lambda514,Lambda518,Access519,Access743,Access745,List522,PgSelect525,PgSelect557,PgClassExpression521,Lambda523,PgClassExpression524,First529,PgSelectSingle530,PgClassExpression532,PgClassExpression535,PgClassExpression556,First561,PgSelectSingle562,PgClassExpression564,PgClassExpression567,Constant520,List533,List538,List543,List548,List553,Lambda534,Lambda539,Lambda544,Lambda549,Lambda554,Constant531,Constant536,Constant541,Constant546,Constant551,List565,List570,List575,List580,List585,Lambda566,Lambda571,Lambda576,Lambda581,Lambda586,Constant563,Constant568,Constant573,Constant578,Constant583,List629,List663,PgInsertSingle593,Object596,Object604,Object610,Object616,Object622,Object628,Object638,Object644,Object650,Object656,Object662,Access594,Access595,Object597,Lambda598,Lambda602,List603,Lambda608,Lambda614,Lambda620,Lambda626,Lambda630,Access631,Lambda632,Lambda636,List637,Lambda642,Lambda648,Lambda654,Lambda660,Lambda664,Access665,Access747,Access749,List669,PgSelect672,PgSelect704,PgClassExpression667,PgClassExpression668,Lambda670,First676,PgSelectSingle677,PgClassExpression679,PgClassExpression682,First708,PgSelectSingle709,PgClassExpression711,PgClassExpression714,Constant666,List680,List685,List690,List695,List700,Lambda681,Lambda686,Lambda691,Lambda696,Lambda701,Constant678,Constant683,Constant688,Constant693,Constant698,List712,List717,List722,List727,List732,Lambda713,Lambda718,Lambda723,Lambda728,Lambda733,Constant710,Constant715,Constant720,Constant725,Constant730 unary
+    class Object16,Access14,Access15,Condition18,Lambda19,List24,Condition55,Lambda56,List61,Access759,Access761,__Value0,__Value3,__Value5,Constant760,Constant762,Constant768,Constant770,List50,List87,PgInsertSingle13,Object25,Object31,Object37,Object43,Object49,__Flag54,Object62,Object68,Object74,Object80,Object86,__Flag91,Object17,Lambda23,Lambda29,Lambda35,Lambda41,Lambda47,Lambda51,Access52,__Flag53,Lambda60,Lambda66,Lambda72,Lambda78,Lambda84,Lambda88,Access89,__Flag90,List94,PgSelect97,PgSelect164,PgClassExpression93,Lambda95,PgClassExpression96,First101,PgSelectSingle102,PgClassExpression103,PgClassExpression114,PgClassExpression163,First168,PgSelectSingle169,PgClassExpression170,PgClassExpression181,Constant92,PgSelect104,List112,PgSelect116,List124,PgSelect128,List136,PgSelect140,List148,PgSelect152,List160,First108,PgSelectSingle109,PgClassExpression111,Lambda113,First120,PgSelectSingle121,PgClassExpression123,Lambda125,First132,PgSelectSingle133,PgClassExpression135,Lambda137,First144,PgSelectSingle145,PgClassExpression147,Lambda149,First156,PgSelectSingle157,PgClassExpression159,Lambda161,Constant110,Constant122,Constant134,Constant146,Constant158,PgSelect171,List179,PgSelect183,List191,PgSelect195,List203,PgSelect207,List215,PgSelect219,List227,First175,PgSelectSingle176,PgClassExpression178,Lambda180,First187,PgSelectSingle188,PgClassExpression190,Lambda192,First199,PgSelectSingle200,PgClassExpression202,Lambda204,First211,PgSelectSingle212,PgClassExpression214,Lambda216,First223,PgSelectSingle224,PgClassExpression226,Lambda228,Constant177,Constant189,Constant201,Constant213,Constant225,List272,List309,PgInsertSingle235,Object238,Object247,Object253,Object259,Object265,Object271,__Flag276,Object284,Object290,Object296,Object302,Object308,__Flag313,Access236,Access237,Object239,Condition240,Lambda241,Lambda245,List246,Lambda251,Lambda257,Lambda263,Lambda269,Lambda273,Access274,__Flag275,Condition277,Lambda278,Lambda282,List283,Lambda288,Lambda294,Lambda300,Lambda306,Lambda310,Access311,__Flag312,Access763,Access765,List317,PgSelect320,PgSelect387,PgClassExpression315,PgClassExpression316,Lambda318,First324,PgSelectSingle325,PgClassExpression326,PgClassExpression337,First391,PgSelectSingle392,PgClassExpression393,PgClassExpression404,Constant314,PgSelect327,List335,PgSelect339,List347,PgSelect351,List359,PgSelect363,List371,PgSelect375,List383,First331,PgSelectSingle332,PgClassExpression334,Lambda336,First343,PgSelectSingle344,PgClassExpression346,Lambda348,First355,PgSelectSingle356,PgClassExpression358,Lambda360,First367,PgSelectSingle368,PgClassExpression370,Lambda372,First379,PgSelectSingle380,PgClassExpression382,Lambda384,Constant333,Constant345,Constant357,Constant369,Constant381,PgSelect394,List402,PgSelect406,List414,PgSelect418,List426,PgSelect430,List438,PgSelect442,List450,First398,PgSelectSingle399,PgClassExpression401,Lambda403,First410,PgSelectSingle411,PgClassExpression413,Lambda415,First422,PgSelectSingle423,PgClassExpression425,Lambda427,First434,PgSelectSingle435,PgClassExpression437,Lambda439,First446,PgSelectSingle447,PgClassExpression449,Lambda451,Constant400,Constant412,Constant424,Constant436,Constant448,List496,List533,PgInsertSingle459,Object462,Object471,Object477,Object483,Object489,Object495,__Flag500,Object508,Object514,Object520,Object526,Object532,__Flag537,Access460,Access461,Object463,Condition464,Lambda465,Lambda469,List470,Lambda475,Lambda481,Lambda487,Lambda493,Lambda497,Access498,__Flag499,Condition501,Lambda502,Lambda506,List507,Lambda512,Lambda518,Lambda524,Lambda530,Lambda534,Access535,__Flag536,Access767,Access769,List540,PgSelect543,PgSelect575,PgClassExpression539,Lambda541,PgClassExpression542,First547,PgSelectSingle548,PgClassExpression550,PgClassExpression553,PgClassExpression574,First579,PgSelectSingle580,PgClassExpression582,PgClassExpression585,Constant538,List551,List556,List561,List566,List571,Lambda552,Lambda557,Lambda562,Lambda567,Lambda572,Constant549,Constant554,Constant559,Constant564,Constant569,List583,List588,List593,List598,List603,Lambda584,Lambda589,Lambda594,Lambda599,Lambda604,Constant581,Constant586,Constant591,Constant596,Constant601,List648,List685,PgInsertSingle611,Object614,Object623,Object629,Object635,Object641,Object647,__Flag652,Object660,Object666,Object672,Object678,Object684,__Flag689,Access612,Access613,Object615,Condition616,Lambda617,Lambda621,List622,Lambda627,Lambda633,Lambda639,Lambda645,Lambda649,Access650,__Flag651,Condition653,Lambda654,Lambda658,List659,Lambda664,Lambda670,Lambda676,Lambda682,Lambda686,Access687,__Flag688,Access771,Access773,List693,PgSelect696,PgSelect728,PgClassExpression691,PgClassExpression692,Lambda694,First700,PgSelectSingle701,PgClassExpression703,PgClassExpression706,First732,PgSelectSingle733,PgClassExpression735,PgClassExpression738,Constant690,List704,List709,List714,List719,List724,Lambda705,Lambda710,Lambda715,Lambda720,Lambda725,Constant702,Constant707,Constant712,Constant717,Constant722,List736,List741,List746,List751,List756,Lambda737,Lambda742,Lambda747,Lambda752,Lambda757,Constant734,Constant739,Constant744,Constant749,Constant754 unary
     end

--- a/postgraphile/postgraphile/__tests__/mutations/v4/relay.createLeftArm.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/relay.createLeftArm.mermaid
@@ -13,71 +13,78 @@ graph TD
     Access15{{"Access[15∈0]<br />ᐸ3.pgSettingsᐳ"}}:::plan
     Access16{{"Access[16∈0]<br />ᐸ3.withPgClientᐳ"}}:::plan
     Access15 & Access16 --> Object17
+    __Flag24[["__Flag[24∈0]<br />ᐸ23, if(19), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
+    __Flag23[["__Flag[23∈0]<br />ᐸ22, trapInhibited, onReject: INHIBITᐳ"]]:::plan
+    Condition19{{"Condition[19∈0]<br />ᐸexistsᐳ"}}:::plan
+    __Flag23 & Condition19 --> __Flag24
     __Value3["__Value[3∈0]<br />ᐸcontextᐳ"]:::plan
     __Value3 --> Access15
     __Value3 --> Access16
-    Lambda19{{"Lambda[19∈0]<br />ᐸspecifier_Person_base64JSONᐳ"}}:::plan
-    Constant40{{"Constant[40∈0]<br />ᐸ'WyJwZW9wbGUiLDZd'ᐳ"}}:::plan
-    Constant40 --> Lambda19
-    Access20{{"Access[20∈0]<br />ᐸ19.1ᐳ"}}:::plan
-    Lambda19 --> Access20
+    Constant43{{"Constant[43∈0]<br />ᐸ'WyJwZW9wbGUiLDZd'ᐳ"}}:::plan
+    Constant43 --> Condition19
+    Lambda20{{"Lambda[20∈0]<br />ᐸspecifier_Person_base64JSONᐳ"}}:::plan
+    Constant43 --> Lambda20
+    Access21{{"Access[21∈0]<br />ᐸ20.1ᐳ"}}:::plan
+    Lambda20 --> Access21
+    __Flag22[["__Flag[22∈0]<br />ᐸ21, rejectNull, onReject: INHIBITᐳ"]]:::plan
+    Access21 --> __Flag22
+    __Flag22 --> __Flag23
     __Value0["__Value[0∈0]"]:::plan
     __Value5["__Value[5∈0]<br />ᐸrootValueᐳ"]:::plan
-    Constant39{{"Constant[39∈0]<br />ᐸ0.69ᐳ"}}:::plan
+    Constant42{{"Constant[42∈0]<br />ᐸ0.69ᐳ"}}:::plan
     PgInsertSingle14[["PgInsertSingle[14∈1]<br />ᐸleft_arm(length_in_metres,person_id)ᐳ"]]:::sideeffectplan
-    Constant39 -->|rejectNull| PgInsertSingle14
-    Object17 & Access20 --> PgInsertSingle14
+    Object17 & Constant42 & __Flag24 --> PgInsertSingle14
     Object18{{"Object[18∈1]<br />ᐸ{result}ᐳ"}}:::plan
     PgInsertSingle14 --> Object18
-    List24{{"List[24∈3]<br />ᐸ22,23ᐳ"}}:::plan
-    Constant22{{"Constant[22∈3]<br />ᐸ'left_arms'ᐳ"}}:::plan
-    PgClassExpression23{{"PgClassExpression[23∈3]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
-    Constant22 & PgClassExpression23 --> List24
-    PgSelect27[["PgSelect[27∈3]<br />ᐸpersonᐳ"]]:::plan
-    PgClassExpression26{{"PgClassExpression[26∈3]<br />ᐸ__left_arm...person_id”ᐳ"}}:::plan
-    Object17 & PgClassExpression26 --> PgSelect27
-    PgInsertSingle14 --> PgClassExpression23
-    Lambda25{{"Lambda[25∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List24 --> Lambda25
+    List27{{"List[27∈3]<br />ᐸ25,26ᐳ"}}:::plan
+    Constant25{{"Constant[25∈3]<br />ᐸ'left_arms'ᐳ"}}:::plan
+    PgClassExpression26{{"PgClassExpression[26∈3]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
+    Constant25 & PgClassExpression26 --> List27
+    PgSelect30[["PgSelect[30∈3]<br />ᐸpersonᐳ"]]:::plan
+    PgClassExpression29{{"PgClassExpression[29∈3]<br />ᐸ__left_arm...person_id”ᐳ"}}:::plan
+    Object17 & PgClassExpression29 --> PgSelect30
     PgInsertSingle14 --> PgClassExpression26
-    First31{{"First[31∈3]"}}:::plan
-    PgSelect27 --> First31
-    PgSelectSingle32{{"PgSelectSingle[32∈3]<br />ᐸpersonᐳ"}}:::plan
-    First31 --> PgSelectSingle32
-    PgClassExpression37{{"PgClassExpression[37∈3]<br />ᐸ__left_arm...in_metres”ᐳ"}}:::plan
-    PgInsertSingle14 --> PgClassExpression37
-    PgClassExpression38{{"PgClassExpression[38∈3]<br />ᐸ__left_arm__.”mood”ᐳ"}}:::plan
-    PgInsertSingle14 --> PgClassExpression38
-    Constant33{{"Constant[33∈3]<br />ᐸ'people'ᐳ"}}:::plan
-    List35{{"List[35∈4]<br />ᐸ33,34ᐳ"}}:::plan
-    PgClassExpression34{{"PgClassExpression[34∈4]<br />ᐸ__person__.”id”ᐳ"}}:::plan
-    Constant33 & PgClassExpression34 --> List35
-    PgSelectSingle32 --> PgClassExpression34
-    Lambda36{{"Lambda[36∈4]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List35 --> Lambda36
+    Lambda28{{"Lambda[28∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List27 --> Lambda28
+    PgInsertSingle14 --> PgClassExpression29
+    First34{{"First[34∈3]"}}:::plan
+    PgSelect30 --> First34
+    PgSelectSingle35{{"PgSelectSingle[35∈3]<br />ᐸpersonᐳ"}}:::plan
+    First34 --> PgSelectSingle35
+    PgClassExpression40{{"PgClassExpression[40∈3]<br />ᐸ__left_arm...in_metres”ᐳ"}}:::plan
+    PgInsertSingle14 --> PgClassExpression40
+    PgClassExpression41{{"PgClassExpression[41∈3]<br />ᐸ__left_arm__.”mood”ᐳ"}}:::plan
+    PgInsertSingle14 --> PgClassExpression41
+    Constant36{{"Constant[36∈3]<br />ᐸ'people'ᐳ"}}:::plan
+    List38{{"List[38∈4]<br />ᐸ36,37ᐳ"}}:::plan
+    PgClassExpression37{{"PgClassExpression[37∈4]<br />ᐸ__person__.”id”ᐳ"}}:::plan
+    Constant36 & PgClassExpression37 --> List38
+    PgSelectSingle35 --> PgClassExpression37
+    Lambda39{{"Lambda[39∈4]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List38 --> Lambda39
 
     %% define steps
 
     subgraph "Buckets for mutations/v4/relay.createLeftArm"
-    Bucket0("Bucket 0 (root)"):::bucket
+    Bucket0("Bucket 0 (root)<br />1: <br />ᐳ: 15, 16, 42, 43, 17, 19, 20, 21<br />2: __Flag[22]<br />3: __Flag[23]<br />4: __Flag[24]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value3,__Value5,Access15,Access16,Object17,Lambda19,Access20,Constant39,Constant40 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 17, 39, 20<br /><br />1: PgInsertSingle[14]<br />2: <br />ᐳ: Object[18]"):::bucket
+    class Bucket0,__Value0,__Value3,__Value5,Access15,Access16,Object17,Condition19,Lambda20,Access21,__Flag22,__Flag23,__Flag24,Constant42,Constant43 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 17, 42, 24<br /><br />1: PgInsertSingle[14]<br />2: <br />ᐳ: Object[18]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgInsertSingle14,Object18 bucket1
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 18, 14, 17<br /><br />ROOT Object{1}ᐸ{result}ᐳ[18]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 14, 17<br /><br />ROOT PgInsertSingle{1}ᐸleft_arm(length_in_metres,person_id)ᐳ[14]<br />1: <br />ᐳ: 22, 23, 26, 33, 37, 38, 24, 25<br />2: PgSelect[27]<br />ᐳ: First[31], PgSelectSingle[32]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 14, 17<br /><br />ROOT PgInsertSingle{1}ᐸleft_arm(length_in_metres,person_id)ᐳ[14]<br />1: <br />ᐳ: 25, 26, 29, 36, 40, 41, 27, 28<br />2: PgSelect[30]<br />ᐳ: First[34], PgSelectSingle[35]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,Constant22,PgClassExpression23,List24,Lambda25,PgClassExpression26,PgSelect27,First31,PgSelectSingle32,Constant33,PgClassExpression37,PgClassExpression38 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 32, 33<br /><br />ROOT PgSelectSingle{3}ᐸpersonᐳ[32]"):::bucket
+    class Bucket3,Constant25,PgClassExpression26,List27,Lambda28,PgClassExpression29,PgSelect30,First34,PgSelectSingle35,Constant36,PgClassExpression40,PgClassExpression41 bucket3
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 35, 36<br /><br />ROOT PgSelectSingle{3}ᐸpersonᐳ[35]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgClassExpression34,List35,Lambda36 bucket4
+    class Bucket4,PgClassExpression37,List38,Lambda39 bucket4
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3
     Bucket3 --> Bucket4
     classDef unary fill:#fafffa,borderWidth:8px
-    class Object17,Access15,Access16,Lambda19,Access20,__Value0,__Value3,__Value5,Constant39,Constant40,PgInsertSingle14,Object18,List24,PgSelect27,PgClassExpression23,Lambda25,PgClassExpression26,First31,PgSelectSingle32,PgClassExpression37,PgClassExpression38,Constant22,Constant33,List35,PgClassExpression34,Lambda36 unary
+    class Object17,__Flag24,Access15,Access16,Condition19,Lambda20,Access21,__Flag22,__Flag23,__Value0,__Value3,__Value5,Constant42,Constant43,PgInsertSingle14,Object18,List27,PgSelect30,PgClassExpression26,Lambda28,PgClassExpression29,First34,PgSelectSingle35,PgClassExpression40,PgClassExpression41,Constant25,Constant36,List38,PgClassExpression37,Lambda39 unary
     end

--- a/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.differentPerson.json5
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.differentPerson.json5
@@ -1,0 +1,12 @@
+{
+  updateLeftArm: {
+    leftArm: {
+      id: "WyJsZWZ0X2FybXMiLDQyXQ==",
+      personByPersonId: {
+        id: "WyJwZW9wbGUiLDNd",
+      },
+      lengthInMetres: 0.74,
+      mood: "neutral",
+    },
+  },
+}

--- a/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.differentPerson.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.differentPerson.mermaid
@@ -1,0 +1,96 @@
+%%{init: {'themeVariables': { 'fontSize': '12px'}}}%%
+graph TD
+    classDef path fill:#eee,stroke:#000,color:#000
+    classDef plan fill:#fff,stroke-width:1px,color:#000
+    classDef itemplan fill:#fff,stroke-width:2px,color:#000
+    classDef unbatchedplan fill:#dff,stroke-width:1px,color:#000
+    classDef sideeffectplan fill:#fcc,stroke-width:2px,color:#000
+    classDef bucket fill:#f6f6f6,color:#000,stroke-width:2px,text-align:left
+
+
+    %% plan dependencies
+    Object20{{"Object[20∈0]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access18{{"Access[18∈0]<br />ᐸ3.pgSettingsᐳ"}}:::plan
+    Access19{{"Access[19∈0]<br />ᐸ3.withPgClientᐳ"}}:::plan
+    Access18 & Access19 --> Object20
+    __Flag27[["__Flag[27∈0]<br />ᐸ26, if(22), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
+    __Flag26[["__Flag[26∈0]<br />ᐸ25, trapInhibited, onReject: INHIBITᐳ"]]:::plan
+    Condition22{{"Condition[22∈0]<br />ᐸexistsᐳ"}}:::plan
+    __Flag26 & Condition22 --> __Flag27
+    Lambda14{{"Lambda[14∈0]<br />ᐸdecode_LeftArm_base64JSONᐳ"}}:::plan
+    Constant45{{"Constant[45∈0]<br />ᐸ'WyJsZWZ0X2FybXMiLDQyXQ=='ᐳ"}}:::plan
+    Constant45 --> Lambda14
+    Access15{{"Access[15∈0]<br />ᐸ14.1ᐳ"}}:::plan
+    Lambda14 --> Access15
+    __Value3["__Value[3∈0]<br />ᐸcontextᐳ"]:::plan
+    __Value3 --> Access18
+    __Value3 --> Access19
+    Constant47{{"Constant[47∈0]<br />ᐸ'WyJwZW9wbGUiLDNd'ᐳ"}}:::plan
+    Constant47 --> Condition22
+    Lambda23{{"Lambda[23∈0]<br />ᐸspecifier_Person_base64JSONᐳ"}}:::plan
+    Constant47 --> Lambda23
+    Access24{{"Access[24∈0]<br />ᐸ23.1ᐳ"}}:::plan
+    Lambda23 --> Access24
+    __Flag25[["__Flag[25∈0]<br />ᐸ24, rejectNull, onReject: INHIBITᐳ"]]:::plan
+    Access24 --> __Flag25
+    __Flag25 --> __Flag26
+    __Value0["__Value[0∈0]"]:::plan
+    __Value5["__Value[5∈0]<br />ᐸrootValueᐳ"]:::plan
+    Constant46{{"Constant[46∈0]<br />ᐸ0.74ᐳ"}}:::plan
+    PgUpdateSingle17[["PgUpdateSingle[17∈1]<br />ᐸleft_arm(id;length_in_metres,person_id)ᐳ"]]:::sideeffectplan
+    Object20 -->|rejectNull| PgUpdateSingle17
+    Access15 & Constant46 & __Flag27 --> PgUpdateSingle17
+    Object21{{"Object[21∈1]<br />ᐸ{result}ᐳ"}}:::plan
+    PgUpdateSingle17 --> Object21
+    List30{{"List[30∈3]<br />ᐸ28,29ᐳ"}}:::plan
+    Constant28{{"Constant[28∈3]<br />ᐸ'left_arms'ᐳ"}}:::plan
+    PgClassExpression29{{"PgClassExpression[29∈3]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
+    Constant28 & PgClassExpression29 --> List30
+    PgSelect33[["PgSelect[33∈3]<br />ᐸpersonᐳ"]]:::plan
+    PgClassExpression32{{"PgClassExpression[32∈3]<br />ᐸ__left_arm...person_id”ᐳ"}}:::plan
+    Object20 & PgClassExpression32 --> PgSelect33
+    PgUpdateSingle17 --> PgClassExpression29
+    Lambda31{{"Lambda[31∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List30 --> Lambda31
+    PgUpdateSingle17 --> PgClassExpression32
+    First37{{"First[37∈3]"}}:::plan
+    PgSelect33 --> First37
+    PgSelectSingle38{{"PgSelectSingle[38∈3]<br />ᐸpersonᐳ"}}:::plan
+    First37 --> PgSelectSingle38
+    PgClassExpression43{{"PgClassExpression[43∈3]<br />ᐸ__left_arm...in_metres”ᐳ"}}:::plan
+    PgUpdateSingle17 --> PgClassExpression43
+    PgClassExpression44{{"PgClassExpression[44∈3]<br />ᐸ__left_arm__.”mood”ᐳ"}}:::plan
+    PgUpdateSingle17 --> PgClassExpression44
+    Constant39{{"Constant[39∈3]<br />ᐸ'people'ᐳ"}}:::plan
+    List41{{"List[41∈4]<br />ᐸ39,40ᐳ"}}:::plan
+    PgClassExpression40{{"PgClassExpression[40∈4]<br />ᐸ__person__.”id”ᐳ"}}:::plan
+    Constant39 & PgClassExpression40 --> List41
+    PgSelectSingle38 --> PgClassExpression40
+    Lambda42{{"Lambda[42∈4]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List41 --> Lambda42
+
+    %% define steps
+
+    subgraph "Buckets for mutations/v4/relay.updateLeftArm.differentPerson"
+    Bucket0("Bucket 0 (root)<br />1: <br />ᐳ: 18, 19, 45, 46, 47, 14, 15, 20, 22, 23, 24<br />2: __Flag[25]<br />3: __Flag[26]<br />4: __Flag[27]"):::bucket
+    classDef bucket0 stroke:#696969
+    class Bucket0,__Value0,__Value3,__Value5,Lambda14,Access15,Access18,Access19,Object20,Condition22,Lambda23,Access24,__Flag25,__Flag26,__Flag27,Constant45,Constant46,Constant47 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 20, 15, 46, 27<br /><br />1: PgUpdateSingle[17]<br />2: <br />ᐳ: Object[21]"):::bucket
+    classDef bucket1 stroke:#00bfff
+    class Bucket1,PgUpdateSingle17,Object21 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 21, 17, 20<br /><br />ROOT Object{1}ᐸ{result}ᐳ[21]"):::bucket
+    classDef bucket2 stroke:#7f007f
+    class Bucket2 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 20<br /><br />ROOT PgUpdateSingle{1}ᐸleft_arm(id;length_in_metres,person_id)ᐳ[17]<br />1: <br />ᐳ: 28, 29, 32, 39, 43, 44, 30, 31<br />2: PgSelect[33]<br />ᐳ: First[37], PgSelectSingle[38]"):::bucket
+    classDef bucket3 stroke:#ffa500
+    class Bucket3,Constant28,PgClassExpression29,List30,Lambda31,PgClassExpression32,PgSelect33,First37,PgSelectSingle38,Constant39,PgClassExpression43,PgClassExpression44 bucket3
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 38, 39<br /><br />ROOT PgSelectSingle{3}ᐸpersonᐳ[38]"):::bucket
+    classDef bucket4 stroke:#0000ff
+    class Bucket4,PgClassExpression40,List41,Lambda42 bucket4
+    Bucket0 --> Bucket1
+    Bucket1 --> Bucket2
+    Bucket2 --> Bucket3
+    Bucket3 --> Bucket4
+    classDef unary fill:#fafffa,borderWidth:8px
+    class Object20,__Flag27,Lambda14,Access15,Access18,Access19,Condition22,Lambda23,Access24,__Flag25,__Flag26,__Value0,__Value3,__Value5,Constant45,Constant46,Constant47,PgUpdateSingle17,Object21,List30,PgSelect33,PgClassExpression29,Lambda31,PgClassExpression32,First37,PgSelectSingle38,PgClassExpression43,PgClassExpression44,Constant28,Constant39,List41,PgClassExpression40,Lambda42 unary
+    end

--- a/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.differentPerson.sql
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.differentPerson.sql
@@ -1,0 +1,17 @@
+update "c"."left_arm" as __left_arm__ set "length_in_metres" = $1::"float8", "person_id" = $2::"int4" where (__left_arm__."id" = $3::"int4") returning
+  __left_arm__."id"::text as "0",
+  __left_arm__."person_id"::text as "1",
+  __left_arm__."length_in_metres"::text as "2",
+  __left_arm__."mood" as "3";
+
+select __person_result__.*
+from (select 0 as idx, $1::"int4" as "id0") as __person_identifiers__,
+lateral (
+  select
+    __person__."id"::text as "0",
+    __person_identifiers__.idx as "1"
+  from "c"."person" as __person__
+  where (
+    __person__."id" = __person_identifiers__."id0"
+  )
+) as __person_result__;

--- a/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.differentPerson.test.graphql
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.differentPerson.test.graphql
@@ -1,0 +1,24 @@
+## expect(errors).toBeFalsy();
+#> schema: ["a", "b", "c"]
+#> extends: ["postgraphile/presets/relay:PgRelayPreset"]
+mutation {
+  updateLeftArm(
+    input: {
+      id: "WyJsZWZ0X2FybXMiLDQyXQ=="
+      leftArmPatch: {
+        # person 3
+        personByPersonId: "WyJwZW9wbGUiLDNd"
+        lengthInMetres: 0.74
+      }
+    }
+  ) {
+    leftArm {
+      id
+      personByPersonId {
+        id
+      }
+      lengthInMetres
+      mood
+    }
+  }
+}

--- a/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.invalidId.errors.json5
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.invalidId.errors.json5
@@ -1,0 +1,14 @@
+[
+  {
+    message: "Invalid node identifier for 'Person'",
+    locations: [
+      {
+        line: 2,
+        column: 3,
+      },
+    ],
+    path: [
+      'updateLeftArm',
+    ],
+  },
+]

--- a/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.invalidId.json5
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.invalidId.json5
@@ -1,0 +1,3 @@
+{
+  updateLeftArm: null,
+}

--- a/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.invalidId.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.invalidId.mermaid
@@ -1,0 +1,96 @@
+%%{init: {'themeVariables': { 'fontSize': '12px'}}}%%
+graph TD
+    classDef path fill:#eee,stroke:#000,color:#000
+    classDef plan fill:#fff,stroke-width:1px,color:#000
+    classDef itemplan fill:#fff,stroke-width:2px,color:#000
+    classDef unbatchedplan fill:#dff,stroke-width:1px,color:#000
+    classDef sideeffectplan fill:#fcc,stroke-width:2px,color:#000
+    classDef bucket fill:#f6f6f6,color:#000,stroke-width:2px,text-align:left
+
+
+    %% plan dependencies
+    Object20{{"Object[20∈0]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access18{{"Access[18∈0]<br />ᐸ3.pgSettingsᐳ"}}:::plan
+    Access19{{"Access[19∈0]<br />ᐸ3.withPgClientᐳ"}}:::plan
+    Access18 & Access19 --> Object20
+    __Flag27[["__Flag[27∈0]<br />ᐸ26, if(22), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
+    __Flag26[["__Flag[26∈0]<br />ᐸ25, trapInhibited, onReject: INHIBITᐳ"]]:::plan
+    Condition22{{"Condition[22∈0]<br />ᐸexistsᐳ"}}:::plan
+    __Flag26 & Condition22 --> __Flag27
+    Lambda14{{"Lambda[14∈0]<br />ᐸdecode_LeftArm_base64JSONᐳ"}}:::plan
+    Constant45{{"Constant[45∈0]<br />ᐸ'WyJsZWZ0X2FybXMiLDQyXQ=='ᐳ"}}:::plan
+    Constant45 --> Lambda14
+    Access15{{"Access[15∈0]<br />ᐸ14.1ᐳ"}}:::plan
+    Lambda14 --> Access15
+    __Value3["__Value[3∈0]<br />ᐸcontextᐳ"]:::plan
+    __Value3 --> Access18
+    __Value3 --> Access19
+    Constant47{{"Constant[47∈0]<br />ᐸ'WyJteV90YWJsZXMiLDFd'ᐳ"}}:::plan
+    Constant47 --> Condition22
+    Lambda23{{"Lambda[23∈0]<br />ᐸspecifier_Person_base64JSONᐳ"}}:::plan
+    Constant47 --> Lambda23
+    Access24{{"Access[24∈0]<br />ᐸ23.1ᐳ"}}:::plan
+    Lambda23 --> Access24
+    __Flag25[["__Flag[25∈0]<br />ᐸ24, rejectNull, onReject: INHIBITᐳ"]]:::plan
+    Access24 --> __Flag25
+    __Flag25 --> __Flag26
+    __Value0["__Value[0∈0]"]:::plan
+    __Value5["__Value[5∈0]<br />ᐸrootValueᐳ"]:::plan
+    Constant46{{"Constant[46∈0]<br />ᐸ0.75ᐳ"}}:::plan
+    PgUpdateSingle17[["PgUpdateSingle[17∈1]<br />ᐸleft_arm(id;length_in_metres,person_id)ᐳ"]]:::sideeffectplan
+    Object20 -->|rejectNull| PgUpdateSingle17
+    Access15 & Constant46 & __Flag27 --> PgUpdateSingle17
+    Object21{{"Object[21∈1]<br />ᐸ{result}ᐳ"}}:::plan
+    PgUpdateSingle17 --> Object21
+    List30{{"List[30∈3]<br />ᐸ28,29ᐳ"}}:::plan
+    Constant28{{"Constant[28∈3]<br />ᐸ'left_arms'ᐳ"}}:::plan
+    PgClassExpression29{{"PgClassExpression[29∈3]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
+    Constant28 & PgClassExpression29 --> List30
+    PgSelect33[["PgSelect[33∈3]<br />ᐸpersonᐳ"]]:::plan
+    PgClassExpression32{{"PgClassExpression[32∈3]<br />ᐸ__left_arm...person_id”ᐳ"}}:::plan
+    Object20 & PgClassExpression32 --> PgSelect33
+    PgUpdateSingle17 --> PgClassExpression29
+    Lambda31{{"Lambda[31∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List30 --> Lambda31
+    PgUpdateSingle17 --> PgClassExpression32
+    First37{{"First[37∈3]"}}:::plan
+    PgSelect33 --> First37
+    PgSelectSingle38{{"PgSelectSingle[38∈3]<br />ᐸpersonᐳ"}}:::plan
+    First37 --> PgSelectSingle38
+    PgClassExpression43{{"PgClassExpression[43∈3]<br />ᐸ__left_arm...in_metres”ᐳ"}}:::plan
+    PgUpdateSingle17 --> PgClassExpression43
+    PgClassExpression44{{"PgClassExpression[44∈3]<br />ᐸ__left_arm__.”mood”ᐳ"}}:::plan
+    PgUpdateSingle17 --> PgClassExpression44
+    Constant39{{"Constant[39∈3]<br />ᐸ'people'ᐳ"}}:::plan
+    List41{{"List[41∈4]<br />ᐸ39,40ᐳ"}}:::plan
+    PgClassExpression40{{"PgClassExpression[40∈4]<br />ᐸ__person__.”id”ᐳ"}}:::plan
+    Constant39 & PgClassExpression40 --> List41
+    PgSelectSingle38 --> PgClassExpression40
+    Lambda42{{"Lambda[42∈4]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List41 --> Lambda42
+
+    %% define steps
+
+    subgraph "Buckets for mutations/v4/relay.updateLeftArm.invalidId"
+    Bucket0("Bucket 0 (root)<br />1: <br />ᐳ: 18, 19, 45, 46, 47, 14, 15, 20, 22, 23, 24<br />2: __Flag[25]<br />3: __Flag[26]<br />4: __Flag[27]"):::bucket
+    classDef bucket0 stroke:#696969
+    class Bucket0,__Value0,__Value3,__Value5,Lambda14,Access15,Access18,Access19,Object20,Condition22,Lambda23,Access24,__Flag25,__Flag26,__Flag27,Constant45,Constant46,Constant47 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 20, 15, 46, 27<br /><br />1: PgUpdateSingle[17]<br />2: <br />ᐳ: Object[21]"):::bucket
+    classDef bucket1 stroke:#00bfff
+    class Bucket1,PgUpdateSingle17,Object21 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 21, 17, 20<br /><br />ROOT Object{1}ᐸ{result}ᐳ[21]"):::bucket
+    classDef bucket2 stroke:#7f007f
+    class Bucket2 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 20<br /><br />ROOT PgUpdateSingle{1}ᐸleft_arm(id;length_in_metres,person_id)ᐳ[17]<br />1: <br />ᐳ: 28, 29, 32, 39, 43, 44, 30, 31<br />2: PgSelect[33]<br />ᐳ: First[37], PgSelectSingle[38]"):::bucket
+    classDef bucket3 stroke:#ffa500
+    class Bucket3,Constant28,PgClassExpression29,List30,Lambda31,PgClassExpression32,PgSelect33,First37,PgSelectSingle38,Constant39,PgClassExpression43,PgClassExpression44 bucket3
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 38, 39<br /><br />ROOT PgSelectSingle{3}ᐸpersonᐳ[38]"):::bucket
+    classDef bucket4 stroke:#0000ff
+    class Bucket4,PgClassExpression40,List41,Lambda42 bucket4
+    Bucket0 --> Bucket1
+    Bucket1 --> Bucket2
+    Bucket2 --> Bucket3
+    Bucket3 --> Bucket4
+    classDef unary fill:#fafffa,borderWidth:8px
+    class Object20,__Flag27,Lambda14,Access15,Access18,Access19,Condition22,Lambda23,Access24,__Flag25,__Flag26,__Value0,__Value3,__Value5,Constant45,Constant46,Constant47,PgUpdateSingle17,Object21,List30,PgSelect33,PgClassExpression29,Lambda31,PgClassExpression32,First37,PgSelectSingle38,PgClassExpression43,PgClassExpression44,Constant28,Constant39,List41,PgClassExpression40,Lambda42 unary
+    end

--- a/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.invalidId.test.graphql
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.invalidId.test.graphql
@@ -1,0 +1,25 @@
+## expect(errors).toHaveLength(1);
+## expect(errors[0].message).toMatch(/invalid node identifier/i);
+#> schema: ["a", "b", "c"]
+#> extends: ["postgraphile/presets/relay:PgRelayPreset"]
+mutation {
+  updateLeftArm(
+    input: {
+      id: "WyJsZWZ0X2FybXMiLDQyXQ=="
+      leftArmPatch: {
+        # my_table 1 - doesn't make sense!
+        personByPersonId: "WyJteV90YWJsZXMiLDFd"
+        lengthInMetres: 0.75
+      }
+    }
+  ) {
+    leftArm {
+      id
+      personByPersonId {
+        id
+      }
+      lengthInMetres
+      mood
+    }
+  }
+}

--- a/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.json5
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.json5
@@ -1,0 +1,10 @@
+{
+  updateLeftArm: {
+    leftArm: {
+      "id": "WyJsZWZ0X2FybXMiLDQyXQ==",
+      "personByPersonId": null,
+      "lengthInMetres": 0.71,
+      "mood": "neutral"
+    },
+  },
+}

--- a/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.json5
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.json5
@@ -1,10 +1,10 @@
 {
   updateLeftArm: {
     leftArm: {
-      "id": "WyJsZWZ0X2FybXMiLDQyXQ==",
-      "personByPersonId": null,
-      "lengthInMetres": 0.71,
-      "mood": "neutral"
+      id: "WyJsZWZ0X2FybXMiLDQyXQ==",
+      personByPersonId: null,
+      lengthInMetres: 0.71,
+      mood: "neutral",
     },
   },
 }

--- a/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.mermaid
@@ -13,77 +13,84 @@ graph TD
     Access18{{"Access[18∈0]<br />ᐸ3.pgSettingsᐳ"}}:::plan
     Access19{{"Access[19∈0]<br />ᐸ3.withPgClientᐳ"}}:::plan
     Access18 & Access19 --> Object20
+    __Flag27[["__Flag[27∈0]<br />ᐸ26, if(22), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
+    __Flag26[["__Flag[26∈0]<br />ᐸ25, trapInhibited, onReject: INHIBITᐳ"]]:::plan
+    Condition22{{"Condition[22∈0]<br />ᐸexistsᐳ"}}:::plan
+    __Flag26 & Condition22 --> __Flag27
     Lambda14{{"Lambda[14∈0]<br />ᐸdecode_LeftArm_base64JSONᐳ"}}:::plan
-    Constant42{{"Constant[42∈0]<br />ᐸ'WyJsZWZ0X2FybXMiLDQyXQ=='ᐳ"}}:::plan
-    Constant42 --> Lambda14
+    Constant45{{"Constant[45∈0]<br />ᐸ'WyJsZWZ0X2FybXMiLDQyXQ=='ᐳ"}}:::plan
+    Constant45 --> Lambda14
     Access15{{"Access[15∈0]<br />ᐸ14.1ᐳ"}}:::plan
     Lambda14 --> Access15
     __Value3["__Value[3∈0]<br />ᐸcontextᐳ"]:::plan
     __Value3 --> Access18
     __Value3 --> Access19
-    Lambda22{{"Lambda[22∈0]<br />ᐸspecifier_Person_base64JSONᐳ"}}:::plan
-    Constant44{{"Constant[44∈0]<br />ᐸnullᐳ"}}:::plan
-    Constant44 --> Lambda22
-    Access23{{"Access[23∈0]<br />ᐸ22.1ᐳ"}}:::plan
-    Lambda22 --> Access23
+    Constant47{{"Constant[47∈0]<br />ᐸnullᐳ"}}:::plan
+    Constant47 --> Condition22
+    Lambda23{{"Lambda[23∈0]<br />ᐸspecifier_Person_base64JSONᐳ"}}:::plan
+    Constant47 --> Lambda23
+    Access24{{"Access[24∈0]<br />ᐸ23.1ᐳ"}}:::plan
+    Lambda23 --> Access24
+    __Flag25[["__Flag[25∈0]<br />ᐸ24, rejectNull, onReject: INHIBITᐳ"]]:::plan
+    Access24 --> __Flag25
+    __Flag25 --> __Flag26
     __Value0["__Value[0∈0]"]:::plan
     __Value5["__Value[5∈0]<br />ᐸrootValueᐳ"]:::plan
-    Constant43{{"Constant[43∈0]<br />ᐸ0.71ᐳ"}}:::plan
+    Constant46{{"Constant[46∈0]<br />ᐸ0.71ᐳ"}}:::plan
     PgUpdateSingle17[["PgUpdateSingle[17∈1]<br />ᐸleft_arm(id;length_in_metres,person_id)ᐳ"]]:::sideeffectplan
     Object20 -->|rejectNull| PgUpdateSingle17
-    Constant43 -->|rejectNull| PgUpdateSingle17
-    Access15 & Access23 --> PgUpdateSingle17
+    Access15 & Constant46 & __Flag27 --> PgUpdateSingle17
     Object21{{"Object[21∈1]<br />ᐸ{result}ᐳ"}}:::plan
     PgUpdateSingle17 --> Object21
-    List27{{"List[27∈3]<br />ᐸ25,26ᐳ"}}:::plan
-    Constant25{{"Constant[25∈3]<br />ᐸ'left_arms'ᐳ"}}:::plan
-    PgClassExpression26{{"PgClassExpression[26∈3]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
-    Constant25 & PgClassExpression26 --> List27
-    PgSelect30[["PgSelect[30∈3]<br />ᐸpersonᐳ"]]:::plan
-    PgClassExpression29{{"PgClassExpression[29∈3]<br />ᐸ__left_arm...person_id”ᐳ"}}:::plan
-    Object20 & PgClassExpression29 --> PgSelect30
-    PgUpdateSingle17 --> PgClassExpression26
-    Lambda28{{"Lambda[28∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List27 --> Lambda28
+    List30{{"List[30∈3]<br />ᐸ28,29ᐳ"}}:::plan
+    Constant28{{"Constant[28∈3]<br />ᐸ'left_arms'ᐳ"}}:::plan
+    PgClassExpression29{{"PgClassExpression[29∈3]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
+    Constant28 & PgClassExpression29 --> List30
+    PgSelect33[["PgSelect[33∈3]<br />ᐸpersonᐳ"]]:::plan
+    PgClassExpression32{{"PgClassExpression[32∈3]<br />ᐸ__left_arm...person_id”ᐳ"}}:::plan
+    Object20 & PgClassExpression32 --> PgSelect33
     PgUpdateSingle17 --> PgClassExpression29
-    First34{{"First[34∈3]"}}:::plan
-    PgSelect30 --> First34
-    PgSelectSingle35{{"PgSelectSingle[35∈3]<br />ᐸpersonᐳ"}}:::plan
-    First34 --> PgSelectSingle35
-    PgClassExpression40{{"PgClassExpression[40∈3]<br />ᐸ__left_arm...in_metres”ᐳ"}}:::plan
-    PgUpdateSingle17 --> PgClassExpression40
-    PgClassExpression41{{"PgClassExpression[41∈3]<br />ᐸ__left_arm__.”mood”ᐳ"}}:::plan
-    PgUpdateSingle17 --> PgClassExpression41
-    Constant36{{"Constant[36∈3]<br />ᐸ'people'ᐳ"}}:::plan
-    List38{{"List[38∈4]<br />ᐸ36,37ᐳ"}}:::plan
-    PgClassExpression37{{"PgClassExpression[37∈4]<br />ᐸ__person__.”id”ᐳ"}}:::plan
-    Constant36 & PgClassExpression37 --> List38
-    PgSelectSingle35 --> PgClassExpression37
-    Lambda39{{"Lambda[39∈4]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
-    List38 --> Lambda39
+    Lambda31{{"Lambda[31∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List30 --> Lambda31
+    PgUpdateSingle17 --> PgClassExpression32
+    First37{{"First[37∈3]"}}:::plan
+    PgSelect33 --> First37
+    PgSelectSingle38{{"PgSelectSingle[38∈3]<br />ᐸpersonᐳ"}}:::plan
+    First37 --> PgSelectSingle38
+    PgClassExpression43{{"PgClassExpression[43∈3]<br />ᐸ__left_arm...in_metres”ᐳ"}}:::plan
+    PgUpdateSingle17 --> PgClassExpression43
+    PgClassExpression44{{"PgClassExpression[44∈3]<br />ᐸ__left_arm__.”mood”ᐳ"}}:::plan
+    PgUpdateSingle17 --> PgClassExpression44
+    Constant39{{"Constant[39∈3]<br />ᐸ'people'ᐳ"}}:::plan
+    List41{{"List[41∈4]<br />ᐸ39,40ᐳ"}}:::plan
+    PgClassExpression40{{"PgClassExpression[40∈4]<br />ᐸ__person__.”id”ᐳ"}}:::plan
+    Constant39 & PgClassExpression40 --> List41
+    PgSelectSingle38 --> PgClassExpression40
+    Lambda42{{"Lambda[42∈4]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List41 --> Lambda42
 
     %% define steps
 
     subgraph "Buckets for mutations/v4/relay.updateLeftArm"
-    Bucket0("Bucket 0 (root)"):::bucket
+    Bucket0("Bucket 0 (root)<br />1: <br />ᐳ: 18, 19, 45, 46, 47, 14, 15, 20, 22, 23, 24<br />2: __Flag[25]<br />3: __Flag[26]<br />4: __Flag[27]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value0,__Value3,__Value5,Lambda14,Access15,Access18,Access19,Object20,Lambda22,Access23,Constant42,Constant43,Constant44 bucket0
-    Bucket1("Bucket 1 (mutationField)<br />Deps: 20, 15, 43, 23<br /><br />1: PgUpdateSingle[17]<br />2: <br />ᐳ: Object[21]"):::bucket
+    class Bucket0,__Value0,__Value3,__Value5,Lambda14,Access15,Access18,Access19,Object20,Condition22,Lambda23,Access24,__Flag25,__Flag26,__Flag27,Constant45,Constant46,Constant47 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 20, 15, 46, 27<br /><br />1: PgUpdateSingle[17]<br />2: <br />ᐳ: Object[21]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgUpdateSingle17,Object21 bucket1
     Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 21, 17, 20<br /><br />ROOT Object{1}ᐸ{result}ᐳ[21]"):::bucket
     classDef bucket2 stroke:#7f007f
     class Bucket2 bucket2
-    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 20<br /><br />ROOT PgUpdateSingle{1}ᐸleft_arm(id;length_in_metres,person_id)ᐳ[17]<br />1: <br />ᐳ: 25, 26, 29, 36, 40, 41, 27, 28<br />2: PgSelect[30]<br />ᐳ: First[34], PgSelectSingle[35]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 20<br /><br />ROOT PgUpdateSingle{1}ᐸleft_arm(id;length_in_metres,person_id)ᐳ[17]<br />1: <br />ᐳ: 28, 29, 32, 39, 43, 44, 30, 31<br />2: PgSelect[33]<br />ᐳ: First[37], PgSelectSingle[38]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,Constant25,PgClassExpression26,List27,Lambda28,PgClassExpression29,PgSelect30,First34,PgSelectSingle35,Constant36,PgClassExpression40,PgClassExpression41 bucket3
-    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 35, 36<br /><br />ROOT PgSelectSingle{3}ᐸpersonᐳ[35]"):::bucket
+    class Bucket3,Constant28,PgClassExpression29,List30,Lambda31,PgClassExpression32,PgSelect33,First37,PgSelectSingle38,Constant39,PgClassExpression43,PgClassExpression44 bucket3
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 38, 39<br /><br />ROOT PgSelectSingle{3}ᐸpersonᐳ[38]"):::bucket
     classDef bucket4 stroke:#0000ff
-    class Bucket4,PgClassExpression37,List38,Lambda39 bucket4
+    class Bucket4,PgClassExpression40,List41,Lambda42 bucket4
     Bucket0 --> Bucket1
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3
     Bucket3 --> Bucket4
     classDef unary fill:#fafffa,borderWidth:8px
-    class Object20,Lambda14,Access15,Access18,Access19,Lambda22,Access23,__Value0,__Value3,__Value5,Constant42,Constant43,Constant44,PgUpdateSingle17,Object21,List27,PgSelect30,PgClassExpression26,Lambda28,PgClassExpression29,First34,PgSelectSingle35,PgClassExpression40,PgClassExpression41,Constant25,Constant36,List38,PgClassExpression37,Lambda39 unary
+    class Object20,__Flag27,Lambda14,Access15,Access18,Access19,Condition22,Lambda23,Access24,__Flag25,__Flag26,__Value0,__Value3,__Value5,Constant45,Constant46,Constant47,PgUpdateSingle17,Object21,List30,PgSelect33,PgClassExpression29,Lambda31,PgClassExpression32,First37,PgSelectSingle38,PgClassExpression43,PgClassExpression44,Constant28,Constant39,List41,PgClassExpression40,Lambda42 unary
     end

--- a/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.mermaid
@@ -1,0 +1,89 @@
+%%{init: {'themeVariables': { 'fontSize': '12px'}}}%%
+graph TD
+    classDef path fill:#eee,stroke:#000,color:#000
+    classDef plan fill:#fff,stroke-width:1px,color:#000
+    classDef itemplan fill:#fff,stroke-width:2px,color:#000
+    classDef unbatchedplan fill:#dff,stroke-width:1px,color:#000
+    classDef sideeffectplan fill:#fcc,stroke-width:2px,color:#000
+    classDef bucket fill:#f6f6f6,color:#000,stroke-width:2px,text-align:left
+
+
+    %% plan dependencies
+    Object20{{"Object[20∈0]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access18{{"Access[18∈0]<br />ᐸ3.pgSettingsᐳ"}}:::plan
+    Access19{{"Access[19∈0]<br />ᐸ3.withPgClientᐳ"}}:::plan
+    Access18 & Access19 --> Object20
+    Lambda14{{"Lambda[14∈0]<br />ᐸdecode_LeftArm_base64JSONᐳ"}}:::plan
+    Constant42{{"Constant[42∈0]<br />ᐸ'WyJsZWZ0X2FybXMiLDQyXQ=='ᐳ"}}:::plan
+    Constant42 --> Lambda14
+    Access15{{"Access[15∈0]<br />ᐸ14.1ᐳ"}}:::plan
+    Lambda14 --> Access15
+    __Value3["__Value[3∈0]<br />ᐸcontextᐳ"]:::plan
+    __Value3 --> Access18
+    __Value3 --> Access19
+    Lambda22{{"Lambda[22∈0]<br />ᐸspecifier_Person_base64JSONᐳ"}}:::plan
+    Constant44{{"Constant[44∈0]<br />ᐸnullᐳ"}}:::plan
+    Constant44 --> Lambda22
+    Access23{{"Access[23∈0]<br />ᐸ22.1ᐳ"}}:::plan
+    Lambda22 --> Access23
+    __Value0["__Value[0∈0]"]:::plan
+    __Value5["__Value[5∈0]<br />ᐸrootValueᐳ"]:::plan
+    Constant43{{"Constant[43∈0]<br />ᐸ0.71ᐳ"}}:::plan
+    PgUpdateSingle17[["PgUpdateSingle[17∈1]<br />ᐸleft_arm(id;length_in_metres,person_id)ᐳ"]]:::sideeffectplan
+    Object20 -->|rejectNull| PgUpdateSingle17
+    Constant43 -->|rejectNull| PgUpdateSingle17
+    Access15 & Access23 --> PgUpdateSingle17
+    Object21{{"Object[21∈1]<br />ᐸ{result}ᐳ"}}:::plan
+    PgUpdateSingle17 --> Object21
+    List27{{"List[27∈3]<br />ᐸ25,26ᐳ"}}:::plan
+    Constant25{{"Constant[25∈3]<br />ᐸ'left_arms'ᐳ"}}:::plan
+    PgClassExpression26{{"PgClassExpression[26∈3]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
+    Constant25 & PgClassExpression26 --> List27
+    PgSelect30[["PgSelect[30∈3]<br />ᐸpersonᐳ"]]:::plan
+    PgClassExpression29{{"PgClassExpression[29∈3]<br />ᐸ__left_arm...person_id”ᐳ"}}:::plan
+    Object20 & PgClassExpression29 --> PgSelect30
+    PgUpdateSingle17 --> PgClassExpression26
+    Lambda28{{"Lambda[28∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List27 --> Lambda28
+    PgUpdateSingle17 --> PgClassExpression29
+    First34{{"First[34∈3]"}}:::plan
+    PgSelect30 --> First34
+    PgSelectSingle35{{"PgSelectSingle[35∈3]<br />ᐸpersonᐳ"}}:::plan
+    First34 --> PgSelectSingle35
+    PgClassExpression40{{"PgClassExpression[40∈3]<br />ᐸ__left_arm...in_metres”ᐳ"}}:::plan
+    PgUpdateSingle17 --> PgClassExpression40
+    PgClassExpression41{{"PgClassExpression[41∈3]<br />ᐸ__left_arm__.”mood”ᐳ"}}:::plan
+    PgUpdateSingle17 --> PgClassExpression41
+    Constant36{{"Constant[36∈3]<br />ᐸ'people'ᐳ"}}:::plan
+    List38{{"List[38∈4]<br />ᐸ36,37ᐳ"}}:::plan
+    PgClassExpression37{{"PgClassExpression[37∈4]<br />ᐸ__person__.”id”ᐳ"}}:::plan
+    Constant36 & PgClassExpression37 --> List38
+    PgSelectSingle35 --> PgClassExpression37
+    Lambda39{{"Lambda[39∈4]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List38 --> Lambda39
+
+    %% define steps
+
+    subgraph "Buckets for mutations/v4/relay.updateLeftArm"
+    Bucket0("Bucket 0 (root)"):::bucket
+    classDef bucket0 stroke:#696969
+    class Bucket0,__Value0,__Value3,__Value5,Lambda14,Access15,Access18,Access19,Object20,Lambda22,Access23,Constant42,Constant43,Constant44 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 20, 15, 43, 23<br /><br />1: PgUpdateSingle[17]<br />2: <br />ᐳ: Object[21]"):::bucket
+    classDef bucket1 stroke:#00bfff
+    class Bucket1,PgUpdateSingle17,Object21 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 21, 17, 20<br /><br />ROOT Object{1}ᐸ{result}ᐳ[21]"):::bucket
+    classDef bucket2 stroke:#7f007f
+    class Bucket2 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 20<br /><br />ROOT PgUpdateSingle{1}ᐸleft_arm(id;length_in_metres,person_id)ᐳ[17]<br />1: <br />ᐳ: 25, 26, 29, 36, 40, 41, 27, 28<br />2: PgSelect[30]<br />ᐳ: First[34], PgSelectSingle[35]"):::bucket
+    classDef bucket3 stroke:#ffa500
+    class Bucket3,Constant25,PgClassExpression26,List27,Lambda28,PgClassExpression29,PgSelect30,First34,PgSelectSingle35,Constant36,PgClassExpression40,PgClassExpression41 bucket3
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 35, 36<br /><br />ROOT PgSelectSingle{3}ᐸpersonᐳ[35]"):::bucket
+    classDef bucket4 stroke:#0000ff
+    class Bucket4,PgClassExpression37,List38,Lambda39 bucket4
+    Bucket0 --> Bucket1
+    Bucket1 --> Bucket2
+    Bucket2 --> Bucket3
+    Bucket3 --> Bucket4
+    classDef unary fill:#fafffa,borderWidth:8px
+    class Object20,Lambda14,Access15,Access18,Access19,Lambda22,Access23,__Value0,__Value3,__Value5,Constant42,Constant43,Constant44,PgUpdateSingle17,Object21,List27,PgSelect30,PgClassExpression26,Lambda28,PgClassExpression29,First34,PgSelectSingle35,PgClassExpression40,PgClassExpression41,Constant25,Constant36,List38,PgClassExpression37,Lambda39 unary
+    end

--- a/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.sql
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.sql
@@ -1,4 +1,4 @@
-update "c"."left_arm" as __left_arm__ set "person_id" = $1::"int4", "length_in_metres" = $2::"float8" where (__left_arm__."id" = $3::"int4") returning
+update "c"."left_arm" as __left_arm__ set "length_in_metres" = $1::"float8", "person_id" = $2::"int4" where (__left_arm__."id" = $3::"int4") returning
   __left_arm__."id"::text as "0",
   __left_arm__."person_id"::text as "1",
   __left_arm__."length_in_metres"::text as "2",

--- a/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.sql
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.sql
@@ -1,0 +1,17 @@
+update "c"."left_arm" as __left_arm__ set "person_id" = $1::"int4", "length_in_metres" = $2::"float8" where (__left_arm__."id" = $3::"int4") returning
+  __left_arm__."id"::text as "0",
+  __left_arm__."person_id"::text as "1",
+  __left_arm__."length_in_metres"::text as "2",
+  __left_arm__."mood" as "3";
+
+select __person_result__.*
+from (select 0 as idx, $1::"int4" as "id0") as __person_identifiers__,
+lateral (
+  select
+    __person__."id"::text as "0",
+    __person_identifiers__.idx as "1"
+  from "c"."person" as __person__
+  where (
+    __person__."id" = __person_identifiers__."id0"
+  )
+) as __person_result__;

--- a/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.test.graphql
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.test.graphql
@@ -1,0 +1,20 @@
+## expect(errors).toBeFalsy();
+#> schema: ["a", "b", "c"]
+#> extends: ["postgraphile/presets/relay:PgRelayPreset"]
+mutation {
+  updateLeftArm(
+    input: {
+      id: "WyJsZWZ0X2FybXMiLDQyXQ=="
+      leftArmPatch: { personByPersonId: null, lengthInMetres: 0.71 }
+    }
+  ) {
+    leftArm {
+      id
+      personByPersonId {
+        id
+      }
+      lengthInMetres
+      mood
+    }
+  }
+}

--- a/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.withoutPersonId.json5
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.withoutPersonId.json5
@@ -1,0 +1,12 @@
+{
+  updateLeftArm: {
+    leftArm: {
+      id: "WyJsZWZ0X2FybXMiLDQyXQ==",
+      personByPersonId: {
+        id: "WyJwZW9wbGUiLDRd",
+      },
+      lengthInMetres: 0.71,
+      mood: "neutral",
+    },
+  },
+}

--- a/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.withoutPersonId.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.withoutPersonId.mermaid
@@ -1,0 +1,83 @@
+%%{init: {'themeVariables': { 'fontSize': '12px'}}}%%
+graph TD
+    classDef path fill:#eee,stroke:#000,color:#000
+    classDef plan fill:#fff,stroke-width:1px,color:#000
+    classDef itemplan fill:#fff,stroke-width:2px,color:#000
+    classDef unbatchedplan fill:#dff,stroke-width:1px,color:#000
+    classDef sideeffectplan fill:#fcc,stroke-width:2px,color:#000
+    classDef bucket fill:#f6f6f6,color:#000,stroke-width:2px,text-align:left
+
+
+    %% plan dependencies
+    Object20{{"Object[20∈0]<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Access18{{"Access[18∈0]<br />ᐸ3.pgSettingsᐳ"}}:::plan
+    Access19{{"Access[19∈0]<br />ᐸ3.withPgClientᐳ"}}:::plan
+    Access18 & Access19 --> Object20
+    Lambda14{{"Lambda[14∈0]<br />ᐸdecode_LeftArm_base64JSONᐳ"}}:::plan
+    Constant39{{"Constant[39∈0]<br />ᐸ'WyJsZWZ0X2FybXMiLDQyXQ=='ᐳ"}}:::plan
+    Constant39 --> Lambda14
+    Access15{{"Access[15∈0]<br />ᐸ14.1ᐳ"}}:::plan
+    Lambda14 --> Access15
+    __Value3["__Value[3∈0]<br />ᐸcontextᐳ"]:::plan
+    __Value3 --> Access18
+    __Value3 --> Access19
+    __Value0["__Value[0∈0]"]:::plan
+    __Value5["__Value[5∈0]<br />ᐸrootValueᐳ"]:::plan
+    Constant40{{"Constant[40∈0]<br />ᐸ0.71ᐳ"}}:::plan
+    PgUpdateSingle17[["PgUpdateSingle[17∈1]<br />ᐸleft_arm(id;length_in_metres)ᐳ"]]:::sideeffectplan
+    Object20 -->|rejectNull| PgUpdateSingle17
+    Access15 & Constant40 --> PgUpdateSingle17
+    Object21{{"Object[21∈1]<br />ᐸ{result}ᐳ"}}:::plan
+    PgUpdateSingle17 --> Object21
+    List24{{"List[24∈3]<br />ᐸ22,23ᐳ"}}:::plan
+    Constant22{{"Constant[22∈3]<br />ᐸ'left_arms'ᐳ"}}:::plan
+    PgClassExpression23{{"PgClassExpression[23∈3]<br />ᐸ__left_arm__.”id”ᐳ"}}:::plan
+    Constant22 & PgClassExpression23 --> List24
+    PgSelect27[["PgSelect[27∈3]<br />ᐸpersonᐳ"]]:::plan
+    PgClassExpression26{{"PgClassExpression[26∈3]<br />ᐸ__left_arm...person_id”ᐳ"}}:::plan
+    Object20 & PgClassExpression26 --> PgSelect27
+    PgUpdateSingle17 --> PgClassExpression23
+    Lambda25{{"Lambda[25∈3]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List24 --> Lambda25
+    PgUpdateSingle17 --> PgClassExpression26
+    First31{{"First[31∈3]"}}:::plan
+    PgSelect27 --> First31
+    PgSelectSingle32{{"PgSelectSingle[32∈3]<br />ᐸpersonᐳ"}}:::plan
+    First31 --> PgSelectSingle32
+    PgClassExpression37{{"PgClassExpression[37∈3]<br />ᐸ__left_arm...in_metres”ᐳ"}}:::plan
+    PgUpdateSingle17 --> PgClassExpression37
+    PgClassExpression38{{"PgClassExpression[38∈3]<br />ᐸ__left_arm__.”mood”ᐳ"}}:::plan
+    PgUpdateSingle17 --> PgClassExpression38
+    Constant33{{"Constant[33∈3]<br />ᐸ'people'ᐳ"}}:::plan
+    List35{{"List[35∈4]<br />ᐸ33,34ᐳ"}}:::plan
+    PgClassExpression34{{"PgClassExpression[34∈4]<br />ᐸ__person__.”id”ᐳ"}}:::plan
+    Constant33 & PgClassExpression34 --> List35
+    PgSelectSingle32 --> PgClassExpression34
+    Lambda36{{"Lambda[36∈4]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
+    List35 --> Lambda36
+
+    %% define steps
+
+    subgraph "Buckets for mutations/v4/relay.updateLeftArm.withoutPersonId"
+    Bucket0("Bucket 0 (root)"):::bucket
+    classDef bucket0 stroke:#696969
+    class Bucket0,__Value0,__Value3,__Value5,Lambda14,Access15,Access18,Access19,Object20,Constant39,Constant40 bucket0
+    Bucket1("Bucket 1 (mutationField)<br />Deps: 20, 15, 40<br /><br />1: PgUpdateSingle[17]<br />2: <br />ᐳ: Object[21]"):::bucket
+    classDef bucket1 stroke:#00bfff
+    class Bucket1,PgUpdateSingle17,Object21 bucket1
+    Bucket2("Bucket 2 (nullableBoundary)<br />Deps: 21, 17, 20<br /><br />ROOT Object{1}ᐸ{result}ᐳ[21]"):::bucket
+    classDef bucket2 stroke:#7f007f
+    class Bucket2 bucket2
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 17, 20<br /><br />ROOT PgUpdateSingle{1}ᐸleft_arm(id;length_in_metres)ᐳ[17]<br />1: <br />ᐳ: 22, 23, 26, 33, 37, 38, 24, 25<br />2: PgSelect[27]<br />ᐳ: First[31], PgSelectSingle[32]"):::bucket
+    classDef bucket3 stroke:#ffa500
+    class Bucket3,Constant22,PgClassExpression23,List24,Lambda25,PgClassExpression26,PgSelect27,First31,PgSelectSingle32,Constant33,PgClassExpression37,PgClassExpression38 bucket3
+    Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 32, 33<br /><br />ROOT PgSelectSingle{3}ᐸpersonᐳ[32]"):::bucket
+    classDef bucket4 stroke:#0000ff
+    class Bucket4,PgClassExpression34,List35,Lambda36 bucket4
+    Bucket0 --> Bucket1
+    Bucket1 --> Bucket2
+    Bucket2 --> Bucket3
+    Bucket3 --> Bucket4
+    classDef unary fill:#fafffa,borderWidth:8px
+    class Object20,Lambda14,Access15,Access18,Access19,__Value0,__Value3,__Value5,Constant39,Constant40,PgUpdateSingle17,Object21,List24,PgSelect27,PgClassExpression23,Lambda25,PgClassExpression26,First31,PgSelectSingle32,PgClassExpression37,PgClassExpression38,Constant22,Constant33,List35,PgClassExpression34,Lambda36 unary
+    end

--- a/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.withoutPersonId.sql
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.withoutPersonId.sql
@@ -1,0 +1,17 @@
+update "c"."left_arm" as __left_arm__ set "length_in_metres" = $1::"float8" where (__left_arm__."id" = $2::"int4") returning
+  __left_arm__."id"::text as "0",
+  __left_arm__."person_id"::text as "1",
+  __left_arm__."length_in_metres"::text as "2",
+  __left_arm__."mood" as "3";
+
+select __person_result__.*
+from (select 0 as idx, $1::"int4" as "id0") as __person_identifiers__,
+lateral (
+  select
+    __person__."id"::text as "0",
+    __person_identifiers__.idx as "1"
+  from "c"."person" as __person__
+  where (
+    __person__."id" = __person_identifiers__."id0"
+  )
+) as __person_result__;

--- a/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.withoutPersonId.test.graphql
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/relay.updateLeftArm.withoutPersonId.test.graphql
@@ -1,0 +1,20 @@
+## expect(errors).toBeFalsy();
+#> schema: ["a", "b", "c"]
+#> extends: ["postgraphile/presets/relay:PgRelayPreset"]
+mutation {
+  updateLeftArm(
+    input: {
+      id: "WyJsZWZ0X2FybXMiLDQyXQ=="
+      leftArmPatch: { lengthInMetres: 0.71 }
+    }
+  ) {
+    leftArm {
+      id
+      personByPersonId {
+        id
+      }
+      lengthInMetres
+      mood
+    }
+  }
+}

--- a/postgraphile/postgraphile/__tests__/queries/polymorphic/relay.polyroot_with_related_poly.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/polymorphic/relay.polyroot_with_related_poly.mermaid
@@ -544,47 +544,47 @@ graph TD
     PgSelectSingle613 --> PgClassExpression615
     Lambda617{{"Lambda[617∈12]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List616 --> Lambda617
-    List665{{"List[665∈13]<br />ᐸ640,646,652,658,664ᐳ"}}:::plan
-    Object640{{"Object[640∈13]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object646{{"Object[646∈13]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object652{{"Object[652∈13]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object658{{"Object[658∈13]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object664{{"Object[664∈13]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object640 & Object646 & Object652 & Object658 & Object664 --> List665
+    List666{{"List[666∈13]<br />ᐸ641,647,653,659,665ᐳ"}}:::plan
+    Object641{{"Object[641∈13]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object647{{"Object[647∈13]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object653{{"Object[653∈13]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object659{{"Object[659∈13]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object665{{"Object[665∈13]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object641 & Object647 & Object653 & Object659 & Object665 --> List666
     PgSelect671[["PgSelect[671∈13]<br />ᐸsingle_table_item_relationsᐳ"]]:::plan
-    __Flag670[["__Flag[670∈13]<br />ᐸ668, if(669), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
+    __Flag670[["__Flag[670∈13]<br />ᐸ669, if(634), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
     Object18 & __Flag670 & Connection633 --> PgSelect671
-    Lambda638[["Lambda[638∈13]"]]:::unbatchedplan
-    List639{{"List[639∈13]<br />ᐸ943ᐳ"}}:::plan
-    Lambda638 & List639 --> Object640
-    Lambda644[["Lambda[644∈13]"]]:::unbatchedplan
-    Lambda644 & List639 --> Object646
-    Lambda650[["Lambda[650∈13]"]]:::unbatchedplan
-    Lambda650 & List639 --> Object652
-    Lambda656[["Lambda[656∈13]"]]:::unbatchedplan
-    Lambda656 & List639 --> Object658
-    Lambda662[["Lambda[662∈13]"]]:::unbatchedplan
-    Lambda662 & List639 --> Object664
-    __Flag668[["__Flag[668∈13]<br />ᐸ667, trapInhibited, onReject: INHIBITᐳ"]]:::plan
-    Condition669{{"Condition[669∈13]<br />ᐸexistsᐳ"}}:::plan
-    __Flag668 & Condition669 --> __Flag670
-    Lambda634{{"Lambda[634∈13]<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
+    Lambda639[["Lambda[639∈13]"]]:::unbatchedplan
+    List640{{"List[640∈13]<br />ᐸ943ᐳ"}}:::plan
+    Lambda639 & List640 --> Object641
+    Lambda645[["Lambda[645∈13]"]]:::unbatchedplan
+    Lambda645 & List640 --> Object647
+    Lambda651[["Lambda[651∈13]"]]:::unbatchedplan
+    Lambda651 & List640 --> Object653
+    Lambda657[["Lambda[657∈13]"]]:::unbatchedplan
+    Lambda657 & List640 --> Object659
+    Lambda663[["Lambda[663∈13]"]]:::unbatchedplan
+    Lambda663 & List640 --> Object665
+    __Flag669[["__Flag[669∈13]<br />ᐸ668, trapInhibited, onReject: INHIBITᐳ"]]:::plan
+    Condition634{{"Condition[634∈13]<br />ᐸexistsᐳ"}}:::plan
+    __Flag669 & Condition634 --> __Flag670
     Constant944{{"Constant[944∈13]<br />ᐸ'WyJTaW5nbGVUYWJsZURpdmlkZXIiLDNd'ᐳ"}}:::plan
-    Constant944 --> Lambda634
-    Lambda634 --> Lambda638
-    Access943{{"Access[943∈13]<br />ᐸ634.base64JSON.1ᐳ"}}:::plan
-    Access943 --> List639
-    Lambda634 --> Lambda644
-    Lambda634 --> Lambda650
-    Lambda634 --> Lambda656
-    Lambda634 --> Lambda662
-    Lambda666{{"Lambda[666∈13]"}}:::plan
-    List665 --> Lambda666
-    Access667{{"Access[667∈13]<br />ᐸ666.0ᐳ"}}:::plan
-    Lambda666 --> Access667
-    Access667 --> __Flag668
-    Constant944 --> Condition669
-    Lambda634 --> Access943
+    Constant944 --> Condition634
+    Lambda635{{"Lambda[635∈13]<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
+    Constant944 --> Lambda635
+    Lambda635 --> Lambda639
+    Access943{{"Access[943∈13]<br />ᐸ635.base64JSON.1ᐳ"}}:::plan
+    Access943 --> List640
+    Lambda635 --> Lambda645
+    Lambda635 --> Lambda651
+    Lambda635 --> Lambda657
+    Lambda635 --> Lambda663
+    Lambda667{{"Lambda[667∈13]"}}:::plan
+    List666 --> Lambda667
+    Access668{{"Access[668∈13]<br />ᐸ667.0ᐳ"}}:::plan
+    Lambda667 --> Access668
+    Access668 --> __Flag669
+    Lambda635 --> Access943
     Constant674{{"Constant[674∈13]<br />ᐸ'single_table_item_relations'ᐳ"}}:::plan
     __Item672[/"__Item[672∈14]<br />ᐸ671ᐳ"\]:::itemplan
     PgSelect671 ==> __Item672
@@ -662,47 +662,47 @@ graph TD
     List734 --> Lambda735
     Lambda740{{"Lambda[740∈17]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List739 --> Lambda740
-    List788{{"List[788∈18]<br />ᐸ763,769,775,781,787ᐳ"}}:::plan
-    Object763{{"Object[763∈18]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object769{{"Object[769∈18]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object775{{"Object[775∈18]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object781{{"Object[781∈18]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object787{{"Object[787∈18]<br />ᐸ{match,pks}ᐳ"}}:::plan
-    Object763 & Object769 & Object775 & Object781 & Object787 --> List788
+    List789{{"List[789∈18]<br />ᐸ764,770,776,782,788ᐳ"}}:::plan
+    Object764{{"Object[764∈18]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object770{{"Object[770∈18]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object776{{"Object[776∈18]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object782{{"Object[782∈18]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object788{{"Object[788∈18]<br />ᐸ{match,pks}ᐳ"}}:::plan
+    Object764 & Object770 & Object776 & Object782 & Object788 --> List789
     PgSelect794[["PgSelect[794∈18]<br />ᐸrelational_item_relationsᐳ"]]:::plan
-    __Flag793[["__Flag[793∈18]<br />ᐸ791, if(792), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
+    __Flag793[["__Flag[793∈18]<br />ᐸ792, if(757), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
     Object18 & __Flag793 & Connection756 --> PgSelect794
-    Lambda761[["Lambda[761∈18]"]]:::unbatchedplan
-    List762{{"List[762∈18]<br />ᐸ945ᐳ"}}:::plan
-    Lambda761 & List762 --> Object763
-    Lambda767[["Lambda[767∈18]"]]:::unbatchedplan
-    Lambda767 & List762 --> Object769
-    Lambda773[["Lambda[773∈18]"]]:::unbatchedplan
-    Lambda773 & List762 --> Object775
-    Lambda779[["Lambda[779∈18]"]]:::unbatchedplan
-    Lambda779 & List762 --> Object781
-    Lambda785[["Lambda[785∈18]"]]:::unbatchedplan
-    Lambda785 & List762 --> Object787
-    __Flag791[["__Flag[791∈18]<br />ᐸ790, trapInhibited, onReject: INHIBITᐳ"]]:::plan
-    Condition792{{"Condition[792∈18]<br />ᐸexistsᐳ"}}:::plan
-    __Flag791 & Condition792 --> __Flag793
-    Lambda757{{"Lambda[757∈18]<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
+    Lambda762[["Lambda[762∈18]"]]:::unbatchedplan
+    List763{{"List[763∈18]<br />ᐸ945ᐳ"}}:::plan
+    Lambda762 & List763 --> Object764
+    Lambda768[["Lambda[768∈18]"]]:::unbatchedplan
+    Lambda768 & List763 --> Object770
+    Lambda774[["Lambda[774∈18]"]]:::unbatchedplan
+    Lambda774 & List763 --> Object776
+    Lambda780[["Lambda[780∈18]"]]:::unbatchedplan
+    Lambda780 & List763 --> Object782
+    Lambda786[["Lambda[786∈18]"]]:::unbatchedplan
+    Lambda786 & List763 --> Object788
+    __Flag792[["__Flag[792∈18]<br />ᐸ791, trapInhibited, onReject: INHIBITᐳ"]]:::plan
+    Condition757{{"Condition[757∈18]<br />ᐸexistsᐳ"}}:::plan
+    __Flag792 & Condition757 --> __Flag793
     Constant946{{"Constant[946∈18]<br />ᐸ'WyJyZWxhdGlvbmFsX2NoZWNrbGlzdF9pdGVtcyIsMjFd'ᐳ"}}:::plan
-    Constant946 --> Lambda757
-    Lambda757 --> Lambda761
-    Access945{{"Access[945∈18]<br />ᐸ757.base64JSON.1ᐳ"}}:::plan
-    Access945 --> List762
-    Lambda757 --> Lambda767
-    Lambda757 --> Lambda773
-    Lambda757 --> Lambda779
-    Lambda757 --> Lambda785
-    Lambda789{{"Lambda[789∈18]"}}:::plan
-    List788 --> Lambda789
-    Access790{{"Access[790∈18]<br />ᐸ789.0ᐳ"}}:::plan
-    Lambda789 --> Access790
-    Access790 --> __Flag791
-    Constant946 --> Condition792
-    Lambda757 --> Access945
+    Constant946 --> Condition757
+    Lambda758{{"Lambda[758∈18]<br />ᐸdecodeNodeIdWithCodecsᐳ"}}:::plan
+    Constant946 --> Lambda758
+    Lambda758 --> Lambda762
+    Access945{{"Access[945∈18]<br />ᐸ758.base64JSON.1ᐳ"}}:::plan
+    Access945 --> List763
+    Lambda758 --> Lambda768
+    Lambda758 --> Lambda774
+    Lambda758 --> Lambda780
+    Lambda758 --> Lambda786
+    Lambda790{{"Lambda[790∈18]"}}:::plan
+    List789 --> Lambda790
+    Access791{{"Access[791∈18]<br />ᐸ790.0ᐳ"}}:::plan
+    Lambda790 --> Access791
+    Access791 --> __Flag792
+    Lambda758 --> Access945
     Constant797{{"Constant[797∈18]<br />ᐸ'relational_item_relations'ᐳ"}}:::plan
     __Item795[/"__Item[795∈19]<br />ᐸ794ᐳ"\]:::itemplan
     PgSelect794 ==> __Item795
@@ -903,9 +903,9 @@ graph TD
     Bucket12("Bucket 12 (polymorphic)<br />RelationalTopic,RelationalPost,RelationalDivider,RelationalChecklist,RelationalChecklistItem<br />Deps: 18, 559, 558, 570<br />ᐳRelationalChecklistItemᐳRelationalTopic<br />ᐳRelationalChecklistItemᐳRelationalPost<br />ᐳRelationalChecklistItemᐳRelationalDivider<br />ᐳRelationalChecklistItemᐳRelationalChecklist<br />ᐳRelationalChecklistItemᐳRelationalChecklistItem"):::bucket
     classDef bucket12 stroke:#4169e1
     class Bucket12,PgSelect560,First564,PgSelectSingle565,Constant566,PgClassExpression567,List568,Lambda569,PgSelect572,First576,PgSelectSingle577,Constant578,PgClassExpression579,List580,Lambda581,PgSelect584,First588,PgSelectSingle589,Constant590,PgClassExpression591,List592,Lambda593,PgSelect596,First600,PgSelectSingle601,Constant602,PgClassExpression603,List604,Lambda605,PgSelect608,First612,PgSelectSingle613,Constant614,PgClassExpression615,List616,Lambda617 bucket12
-    Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 18, 633<br /><br />ROOT Connectionᐸ629ᐳ[633]<br />1: <br />ᐳ: 674, 944, 634, 669, 943, 639<br />2: 638, 644, 650, 656, 662<br />ᐳ: 640, 646, 652, 658, 664, 665, 666, 667<br />3: __Flag[668]<br />4: __Flag[670]<br />5: PgSelect[671]"):::bucket
+    Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 18, 633<br /><br />ROOT Connectionᐸ629ᐳ[633]<br />1: <br />ᐳ: 674, 944, 634, 635, 943, 640<br />2: 639, 645, 651, 657, 663<br />ᐳ: 641, 647, 653, 659, 665, 666, 667, 668<br />3: __Flag[669]<br />4: __Flag[670]<br />5: PgSelect[671]"):::bucket
     classDef bucket13 stroke:#3cb371
-    class Bucket13,Lambda634,Lambda638,List639,Object640,Lambda644,Object646,Lambda650,Object652,Lambda656,Object658,Lambda662,Object664,List665,Lambda666,Access667,__Flag668,Condition669,__Flag670,PgSelect671,Constant674,Access943,Constant944 bucket13
+    class Bucket13,Condition634,Lambda635,Lambda639,List640,Object641,Lambda645,Object647,Lambda651,Object653,Lambda657,Object659,Lambda663,Object665,List666,Lambda667,Access668,__Flag669,__Flag670,PgSelect671,Constant674,Access943,Constant944 bucket13
     Bucket14("Bucket 14 (listItem)<br />Deps: 674<br /><br />ROOT __Item{14}ᐸ671ᐳ[672]"):::bucket
     classDef bucket14 stroke:#a52a2a
     class Bucket14,__Item672,PgSelectSingle673 bucket14
@@ -918,9 +918,9 @@ graph TD
     Bucket17("Bucket 17 (polymorphic)<br />SingleTableTopic,SingleTablePost,SingleTableDivider,SingleTableChecklist,SingleTableChecklistItem<br />Deps: 718, 716, 721<br />ᐳSingleTableTopic<br />ᐳSingleTablePost<br />ᐳSingleTableDivider<br />ᐳSingleTableChecklist<br />ᐳSingleTableChecklistItem"):::bucket
     classDef bucket17 stroke:#696969
     class Bucket17,Constant717,List719,Lambda720,Constant722,List724,Lambda725,Constant727,List729,Lambda730,Constant732,List734,Lambda735,Constant737,List739,Lambda740 bucket17
-    Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 18, 756<br /><br />ROOT Connectionᐸ752ᐳ[756]<br />1: <br />ᐳ: 797, 946, 757, 792, 945, 762<br />2: 761, 767, 773, 779, 785<br />ᐳ: 763, 769, 775, 781, 787, 788, 789, 790<br />3: __Flag[791]<br />4: __Flag[793]<br />5: PgSelect[794]"):::bucket
+    Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 18, 756<br /><br />ROOT Connectionᐸ752ᐳ[756]<br />1: <br />ᐳ: 797, 946, 757, 758, 945, 763<br />2: 762, 768, 774, 780, 786<br />ᐳ: 764, 770, 776, 782, 788, 789, 790, 791<br />3: __Flag[792]<br />4: __Flag[793]<br />5: PgSelect[794]"):::bucket
     classDef bucket18 stroke:#00bfff
-    class Bucket18,Lambda757,Lambda761,List762,Object763,Lambda767,Object769,Lambda773,Object775,Lambda779,Object781,Lambda785,Object787,List788,Lambda789,Access790,__Flag791,Condition792,__Flag793,PgSelect794,Constant797,Access945,Constant946 bucket18
+    class Bucket18,Condition757,Lambda758,Lambda762,List763,Object764,Lambda768,Object770,Lambda774,Object776,Lambda780,Object782,Lambda786,Object788,List789,Lambda790,Access791,__Flag792,__Flag793,PgSelect794,Constant797,Access945,Constant946 bucket18
     Bucket19("Bucket 19 (listItem)<br />Deps: 797, 18<br /><br />ROOT __Item{19}ᐸ794ᐳ[795]"):::bucket
     classDef bucket19 stroke:#7f007f
     class Bucket19,__Item795,PgSelectSingle796 bucket19
@@ -947,5 +947,5 @@ graph TD
     Bucket19 --> Bucket20
     Bucket20 --> Bucket21 & Bucket22
     classDef unary fill:#fafffa,borderWidth:8px
-    class Object18,Access16,Access17,__Value0,__Value3,__Value5,Connection19,Connection220,Connection633,Connection756,PgSelect20,Constant23,Constant60,Constant97,Constant134,Constant171,Constant35,Constant40,Constant45,Constant50,Constant55,PgSelect221,Constant231,Constant310,Constant389,Constant468,Constant547,Constant250,Constant262,Constant274,Constant286,Constant298,Constant329,Constant341,Constant353,Constant365,Constant377,Constant408,Constant420,Constant432,Constant444,Constant456,Constant487,Constant499,Constant511,Constant523,Constant535,Constant566,Constant578,Constant590,Constant602,Constant614,List665,PgSelect671,Object640,Object646,Object652,Object658,Object664,__Flag670,Lambda634,Lambda638,List639,Lambda644,Lambda650,Lambda656,Lambda662,Lambda666,Access667,__Flag668,Condition669,Access943,Constant674,Constant944,Constant685,Constant690,Constant695,Constant700,Constant705,Constant717,Constant722,Constant727,Constant732,Constant737,List788,PgSelect794,Object763,Object769,Object775,Object781,Object787,__Flag793,Lambda757,Lambda761,List762,Lambda767,Lambda773,Lambda779,Lambda785,Lambda789,Access790,__Flag791,Condition792,Access945,Constant797,Constant946,Constant815,Constant827,Constant839,Constant851,Constant863,Constant882,Constant894,Constant906,Constant918,Constant930 unary
+    class Object18,Access16,Access17,__Value0,__Value3,__Value5,Connection19,Connection220,Connection633,Connection756,PgSelect20,Constant23,Constant60,Constant97,Constant134,Constant171,Constant35,Constant40,Constant45,Constant50,Constant55,PgSelect221,Constant231,Constant310,Constant389,Constant468,Constant547,Constant250,Constant262,Constant274,Constant286,Constant298,Constant329,Constant341,Constant353,Constant365,Constant377,Constant408,Constant420,Constant432,Constant444,Constant456,Constant487,Constant499,Constant511,Constant523,Constant535,Constant566,Constant578,Constant590,Constant602,Constant614,List666,PgSelect671,Object641,Object647,Object653,Object659,Object665,__Flag670,Condition634,Lambda635,Lambda639,List640,Lambda645,Lambda651,Lambda657,Lambda663,Lambda667,Access668,__Flag669,Access943,Constant674,Constant944,Constant685,Constant690,Constant695,Constant700,Constant705,Constant717,Constant722,Constant727,Constant732,Constant737,List789,PgSelect794,Object764,Object770,Object776,Object782,Object788,__Flag793,Condition757,Lambda758,Lambda762,List763,Lambda768,Lambda774,Lambda780,Lambda786,Lambda790,Access791,__Flag792,Access945,Constant797,Constant946,Constant815,Constant827,Constant839,Constant851,Constant863,Constant882,Constant894,Constant906,Constant918,Constant930 unary
     end

--- a/postgraphile/postgraphile/__tests__/queries/relay/conditionNodeId.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/relay/conditionNodeId.mermaid
@@ -41,21 +41,21 @@ graph TD
     Lambda36{{"Lambda[36∈4]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List35 --> Lambda36
     PgSelect60[["PgSelect[60∈5]<br />ᐸpostᐳ"]]:::plan
-    __Flag59[["__Flag[59∈5]<br />ᐸ57, if(58), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
+    __Flag59[["__Flag[59∈5]<br />ᐸ58, if(54), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
     Object21 & __Flag59 & Connection53 --> PgSelect60
-    __Flag57[["__Flag[57∈5]<br />ᐸ56, trapInhibited, onReject: INHIBITᐳ"]]:::plan
-    Condition58{{"Condition[58∈5]<br />ᐸexistsᐳ"}}:::plan
-    __Flag57 & Condition58 --> __Flag59
+    __Flag58[["__Flag[58∈5]<br />ᐸ57, trapInhibited, onReject: INHIBITᐳ"]]:::plan
+    Condition54{{"Condition[54∈5]<br />ᐸexistsᐳ"}}:::plan
+    __Flag58 & Condition54 --> __Flag59
     Access47{{"Access[47∈5]<br />ᐸ1.aliceᐳ"}}:::plan
     __Value1 --> Access47
-    Lambda54{{"Lambda[54∈5]<br />ᐸspecifier_Person_base64JSONᐳ"}}:::plan
-    Access47 --> Lambda54
-    Access55{{"Access[55∈5]<br />ᐸ54.1ᐳ"}}:::plan
-    Lambda54 --> Access55
-    __Flag56[["__Flag[56∈5]<br />ᐸ55, rejectNull, onReject: INHIBITᐳ"]]:::plan
-    Access55 --> __Flag56
-    __Flag56 --> __Flag57
-    Access47 --> Condition58
+    Access47 --> Condition54
+    Lambda55{{"Lambda[55∈5]<br />ᐸspecifier_Person_base64JSONᐳ"}}:::plan
+    Access47 --> Lambda55
+    Access56{{"Access[56∈5]<br />ᐸ55.1ᐳ"}}:::plan
+    Lambda55 --> Access56
+    __Flag57[["__Flag[57∈5]<br />ᐸ56, rejectNull, onReject: INHIBITᐳ"]]:::plan
+    Access56 --> __Flag57
+    __Flag57 --> __Flag58
     __Item61[/"__Item[61∈6]<br />ᐸ60ᐳ"\]:::itemplan
     PgSelect60 ==> __Item61
     PgSelectSingle62{{"PgSelectSingle[62∈6]<br />ᐸpostᐳ"}}:::plan
@@ -71,20 +71,20 @@ graph TD
     Lambda73{{"Lambda[73∈8]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List72 --> Lambda73
     PgSelect96[["PgSelect[96∈9]<br />ᐸpostᐳ"]]:::plan
-    __Flag95[["__Flag[95∈9]<br />ᐸ93, if(94), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
+    __Flag95[["__Flag[95∈9]<br />ᐸ94, if(90), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
     Object21 & __Flag95 & Connection89 --> PgSelect96
-    __Flag93[["__Flag[93∈9]<br />ᐸ92, trapInhibited, onReject: INHIBITᐳ"]]:::plan
-    Condition94{{"Condition[94∈9]<br />ᐸexistsᐳ"}}:::plan
-    __Flag93 & Condition94 --> __Flag95
-    Lambda90{{"Lambda[90∈9]<br />ᐸspecifier_Person_base64JSONᐳ"}}:::plan
+    __Flag94[["__Flag[94∈9]<br />ᐸ93, trapInhibited, onReject: INHIBITᐳ"]]:::plan
+    Condition90{{"Condition[90∈9]<br />ᐸexistsᐳ"}}:::plan
+    __Flag94 & Condition90 --> __Flag95
     Constant156{{"Constant[156∈9]<br />ᐸnullᐳ"}}:::plan
-    Constant156 --> Lambda90
-    Access91{{"Access[91∈9]<br />ᐸ90.1ᐳ"}}:::plan
-    Lambda90 --> Access91
-    __Flag92[["__Flag[92∈9]<br />ᐸ91, rejectNull, onReject: INHIBITᐳ"]]:::plan
-    Access91 --> __Flag92
-    __Flag92 --> __Flag93
-    Constant156 --> Condition94
+    Constant156 --> Condition90
+    Lambda91{{"Lambda[91∈9]<br />ᐸspecifier_Person_base64JSONᐳ"}}:::plan
+    Constant156 --> Lambda91
+    Access92{{"Access[92∈9]<br />ᐸ91.1ᐳ"}}:::plan
+    Lambda91 --> Access92
+    __Flag93[["__Flag[93∈9]<br />ᐸ92, rejectNull, onReject: INHIBITᐳ"]]:::plan
+    Access92 --> __Flag93
+    __Flag93 --> __Flag94
     __Item97[/"__Item[97∈10]<br />ᐸ96ᐳ"\]:::itemplan
     PgSelect96 ==> __Item97
     PgSelectSingle98{{"PgSelectSingle[98∈10]<br />ᐸpostᐳ"}}:::plan
@@ -100,21 +100,21 @@ graph TD
     Lambda109{{"Lambda[109∈12]<br />ᐸbase64JSONEncodeᐳ"}}:::plan
     List108 --> Lambda109
     PgSelect133[["PgSelect[133∈13]<br />ᐸpostᐳ"]]:::plan
-    __Flag132[["__Flag[132∈13]<br />ᐸ130, if(131), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
+    __Flag132[["__Flag[132∈13]<br />ᐸ131, if(127), rejectNull, onReject: Error: Invali…ᐳ"]]:::plan
     Object21 & __Flag132 & Connection126 --> PgSelect133
-    __Flag130[["__Flag[130∈13]<br />ᐸ129, trapInhibited, onReject: INHIBITᐳ"]]:::plan
-    Condition131{{"Condition[131∈13]<br />ᐸexistsᐳ"}}:::plan
-    __Flag130 & Condition131 --> __Flag132
+    __Flag131[["__Flag[131∈13]<br />ᐸ130, trapInhibited, onReject: INHIBITᐳ"]]:::plan
+    Condition127{{"Condition[127∈13]<br />ᐸexistsᐳ"}}:::plan
+    __Flag131 & Condition127 --> __Flag132
     Access120{{"Access[120∈13]<br />ᐸ1.post3ᐳ"}}:::plan
     __Value1 --> Access120
-    Lambda127{{"Lambda[127∈13]<br />ᐸspecifier_Person_base64JSONᐳ"}}:::plan
-    Access120 --> Lambda127
-    Access128{{"Access[128∈13]<br />ᐸ127.1ᐳ"}}:::plan
-    Lambda127 --> Access128
-    __Flag129[["__Flag[129∈13]<br />ᐸ128, rejectNull, onReject: INHIBITᐳ"]]:::plan
-    Access128 --> __Flag129
-    __Flag129 --> __Flag130
-    Access120 --> Condition131
+    Access120 --> Condition127
+    Lambda128{{"Lambda[128∈13]<br />ᐸspecifier_Person_base64JSONᐳ"}}:::plan
+    Access120 --> Lambda128
+    Access129{{"Access[129∈13]<br />ᐸ128.1ᐳ"}}:::plan
+    Lambda128 --> Access129
+    __Flag130[["__Flag[130∈13]<br />ᐸ129, rejectNull, onReject: INHIBITᐳ"]]:::plan
+    Access129 --> __Flag130
+    __Flag130 --> __Flag131
     __Item134[/"__Item[134∈14]<br />ᐸ133ᐳ"\]:::itemplan
     PgSelect133 ==> __Item134
     PgSelectSingle135{{"PgSelectSingle[135∈14]<br />ᐸpostᐳ"}}:::plan
@@ -148,9 +148,9 @@ graph TD
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 32, 33<br /><br />ROOT PgSelectSingle{3}ᐸpersonᐳ[32]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression34,List35,Lambda36 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 1, 21, 53, 33<br /><br />ROOT Connectionᐸ49ᐳ[53]<br />1: <br />ᐳ: 47, 54, 55, 58<br />2: __Flag[56]<br />3: __Flag[57]<br />4: __Flag[59]<br />5: PgSelect[60]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 1, 21, 53, 33<br /><br />ROOT Connectionᐸ49ᐳ[53]<br />1: <br />ᐳ: 47, 54, 55, 56<br />2: __Flag[57]<br />3: __Flag[58]<br />4: __Flag[59]<br />5: PgSelect[60]"):::bucket
     classDef bucket5 stroke:#7fff00
-    class Bucket5,Access47,Lambda54,Access55,__Flag56,__Flag57,Condition58,__Flag59,PgSelect60 bucket5
+    class Bucket5,Access47,Condition54,Lambda55,Access56,__Flag57,__Flag58,__Flag59,PgSelect60 bucket5
     Bucket6("Bucket 6 (listItem)<br />Deps: 33<br /><br />ROOT __Item{6}ᐸ60ᐳ[61]"):::bucket
     classDef bucket6 stroke:#ff1493
     class Bucket6,__Item61,PgSelectSingle62 bucket6
@@ -160,9 +160,9 @@ graph TD
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 69, 33<br /><br />ROOT PgSelectSingle{7}ᐸpersonᐳ[69]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgClassExpression71,List72,Lambda73 bucket8
-    Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 21, 89, 33<br /><br />ROOT Connectionᐸ85ᐳ[89]<br />1: <br />ᐳ: 156, 90, 91, 94<br />2: __Flag[92]<br />3: __Flag[93]<br />4: __Flag[95]<br />5: PgSelect[96]"):::bucket
+    Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 21, 89, 33<br /><br />ROOT Connectionᐸ85ᐳ[89]<br />1: <br />ᐳ: 156, 90, 91, 92<br />2: __Flag[93]<br />3: __Flag[94]<br />4: __Flag[95]<br />5: PgSelect[96]"):::bucket
     classDef bucket9 stroke:#ff0000
-    class Bucket9,Lambda90,Access91,__Flag92,__Flag93,Condition94,__Flag95,PgSelect96,Constant156 bucket9
+    class Bucket9,Condition90,Lambda91,Access92,__Flag93,__Flag94,__Flag95,PgSelect96,Constant156 bucket9
     Bucket10("Bucket 10 (listItem)<br />Deps: 33<br /><br />ROOT __Item{10}ᐸ96ᐳ[97]"):::bucket
     classDef bucket10 stroke:#ffff00
     class Bucket10,__Item97,PgSelectSingle98 bucket10
@@ -172,9 +172,9 @@ graph TD
     Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 105, 33<br /><br />ROOT PgSelectSingle{11}ᐸpersonᐳ[105]"):::bucket
     classDef bucket12 stroke:#4169e1
     class Bucket12,PgClassExpression107,List108,Lambda109 bucket12
-    Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 1, 21, 126, 33<br /><br />ROOT Connectionᐸ122ᐳ[126]<br />1: <br />ᐳ: 120, 127, 128, 131<br />2: __Flag[129]<br />3: __Flag[130]<br />4: __Flag[132]<br />5: PgSelect[133]"):::bucket
+    Bucket13("Bucket 13 (nullableBoundary)<br />Deps: 1, 21, 126, 33<br /><br />ROOT Connectionᐸ122ᐳ[126]<br />1: <br />ᐳ: 120, 127, 128, 129<br />2: __Flag[130]<br />3: __Flag[131]<br />4: __Flag[132]<br />5: PgSelect[133]"):::bucket
     classDef bucket13 stroke:#3cb371
-    class Bucket13,Access120,Lambda127,Access128,__Flag129,__Flag130,Condition131,__Flag132,PgSelect133 bucket13
+    class Bucket13,Access120,Condition127,Lambda128,Access129,__Flag130,__Flag131,__Flag132,PgSelect133 bucket13
     Bucket14("Bucket 14 (listItem)<br />Deps: 33<br /><br />ROOT __Item{14}ᐸ133ᐳ[134]"):::bucket
     classDef bucket14 stroke:#a52a2a
     class Bucket14,__Item134,PgSelectSingle135 bucket14
@@ -198,5 +198,5 @@ graph TD
     Bucket14 --> Bucket15
     Bucket15 --> Bucket16
     classDef unary fill:#fafffa,borderWidth:8px
-    class Object21,Access19,Access20,__Value0,__Value1,__Value3,__Value5,Connection22,Constant33,Connection53,Connection89,Connection126,PgSelect23,PgSelect60,__Flag59,Access47,Lambda54,Access55,__Flag56,__Flag57,Condition58,PgSelect96,__Flag95,Lambda90,Access91,__Flag92,__Flag93,Condition94,Constant156,PgSelect133,__Flag132,Access120,Lambda127,Access128,__Flag129,__Flag130,Condition131 unary
+    class Object21,Access19,Access20,__Value0,__Value1,__Value3,__Value5,Connection22,Constant33,Connection53,Connection89,Connection126,PgSelect23,PgSelect60,__Flag59,Access47,Condition54,Lambda55,Access56,__Flag57,__Flag58,PgSelect96,__Flag95,Condition90,Lambda91,Access92,__Flag93,__Flag94,Constant156,PgSelect133,__Flag132,Access120,Condition127,Lambda128,Access129,__Flag130,__Flag131 unary
     end

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.export.mjs
@@ -1302,7 +1302,7 @@ const spec_leftArm = {
     person_id: {
       description: undefined,
       codec: TYPES.int,
-      notNull: true,
+      notNull: false,
       hasDefault: true,
       extensions: {
         tags: {}
@@ -18780,7 +18780,7 @@ type LeftArm implements Node {
   """
   nodeId: ID!
   id: Int!
-  personId: Int!
+  personId: Int
   lengthInMetres: Float
   mood: String!
 

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.graphql
@@ -3321,7 +3321,7 @@ type LeftArm implements Node {
 
   """Reads a single `Person` that is related to this `LeftArm`."""
   personByPersonId: Person
-  personId: Int!
+  personId: Int
 }
 
 """An input representation of `LeftArm` with nullable fields."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.export.mjs
@@ -1302,7 +1302,7 @@ const spec_leftArm = {
     person_id: {
       description: undefined,
       codec: TYPES.int,
-      notNull: true,
+      notNull: false,
       hasDefault: true,
       extensions: {
         tags: {}
@@ -18780,7 +18780,7 @@ type LeftArm implements Node {
   """
   nodeId: ID!
   id: Int!
-  personId: Int!
+  personId: Int
   lengthInMetres: Float
   mood: String!
 

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.graphql
@@ -3321,7 +3321,7 @@ type LeftArm implements Node {
 
   """Reads a single `Person` that is related to this `LeftArm`."""
   personByPersonId: Person
-  personId: Int!
+  personId: Int
 }
 
 """An input representation of `LeftArm` with nullable fields."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.export.mjs
@@ -664,7 +664,7 @@ const spec_leftArm = {
     person_id: {
       description: undefined,
       codec: TYPES.int,
-      notNull: true,
+      notNull: false,
       hasDefault: true,
       extensions: {
         tags: {}
@@ -10488,7 +10488,7 @@ type LeftArm implements Node {
   """
   nodeId: ID!
   id: Int!
-  personId: Int!
+  personId: Int
   lengthInMetres: Float
   mood: String!
 

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.graphql
@@ -1533,7 +1533,7 @@ type LeftArm implements Node {
 
   """Reads a single `Person` that is related to this `LeftArm`."""
   personByPersonId: Person
-  personId: Int!
+  personId: Int
 }
 
 """An input representation of `LeftArm` with nullable fields."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-good.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-good.1.export.mjs
@@ -664,7 +664,7 @@ const spec_leftArm = {
     person_id: {
       description: undefined,
       codec: TYPES.int,
-      notNull: true,
+      notNull: false,
       hasDefault: true,
       extensions: {
         tags: {}
@@ -10489,7 +10489,7 @@ type LeftArm implements Node {
   """
   nodeId: ID!
   id: Int!
-  personId: Int!
+  personId: Int
   lengthInMetres: Float
   mood: String!
 

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-good.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-good.1.graphql
@@ -1544,7 +1544,7 @@ type LeftArm implements Node {
 
   """Reads a single `Person` that is related to this `LeftArm`."""
   personByPersonId: Person
-  personId: Int!
+  personId: Int
 }
 
 """An input representation of `LeftArm` with nullable fields."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.export.mjs
@@ -1302,7 +1302,7 @@ const spec_leftArm = {
     person_id: {
       description: undefined,
       codec: TYPES.int,
-      notNull: true,
+      notNull: false,
       hasDefault: true,
       extensions: {
         tags: {}
@@ -18756,7 +18756,7 @@ type LeftArm implements Node {
   """
   nodeId: ID!
   id: Int!
-  personId: Int!
+  personId: Int
   lengthInMetres: Float
   mood: String!
 

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.graphql
@@ -3317,7 +3317,7 @@ type LeftArm implements Node {
 
   """Reads a single `Person` that is related to this `LeftArm`."""
   personByPersonId: Person
-  personId: Int!
+  personId: Int
 }
 
 """An input representation of `LeftArm` with nullable fields."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.export.mjs
@@ -1302,7 +1302,7 @@ const spec_leftArm = {
     person_id: {
       description: undefined,
       codec: TYPES.int,
-      notNull: true,
+      notNull: false,
       hasDefault: true,
       extensions: {
         tags: {}
@@ -18808,7 +18808,7 @@ type LeftArm implements Node {
   """
   nodeId: ID!
   id: Int!
-  personId: Int!
+  personId: Int
   lengthInMetres: Float
   mood: String!
 

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.graphql
@@ -3321,7 +3321,7 @@ type LeftArm implements Node {
 
   """Reads a single `Person` that is related to this `LeftArm`."""
   personByPersonId: Person
-  personId: Int!
+  personId: Int
 }
 
 """An input representation of `LeftArm` with nullable fields."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.export.mjs
@@ -1360,7 +1360,7 @@ const spec_leftArm = {
     person_id: {
       description: undefined,
       codec: TYPES.int,
-      notNull: true,
+      notNull: false,
       hasDefault: true,
       extensions: {
         tags: {}
@@ -18533,7 +18533,7 @@ type LeftArm implements Node {
   """
   nodeId: ID!
   id: Int!
-  personId: Int!
+  personId: Int
   lengthInMetres: Float
   mood: String!
 

--- a/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.graphql
@@ -3230,7 +3230,7 @@ type LeftArm implements Node {
 
   """Reads a single `Person` that is related to this `LeftArm`."""
   personByPersonId: Person
-  personId: Int!
+  personId: Int
 }
 
 """An input representation of `LeftArm` with nullable fields."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.export.mjs
@@ -1302,7 +1302,7 @@ const spec_leftArm = {
     person_id: {
       description: undefined,
       codec: TYPES.int,
-      notNull: true,
+      notNull: false,
       hasDefault: true,
       extensions: {
         tags: {}
@@ -18785,7 +18785,7 @@ type LeftArm implements N {
   """
   nodeId: ID!
   id: Int!
-  personId: Int!
+  personId: Int
   lengthInMetres: Float
   mood: String!
 

--- a/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.graphql
@@ -3326,7 +3326,7 @@ type LeftArm implements N {
 
   """Reads a single `Person` that is related to this `LeftArm`."""
   personByPersonId: Person
-  personId: Int!
+  personId: Int
 }
 
 """An input representation of `LeftArm` with nullable fields."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.export.mjs
@@ -663,7 +663,7 @@ const spec_leftArm = {
     person_id: {
       description: undefined,
       codec: TYPES.int,
-      notNull: true,
+      notNull: false,
       hasDefault: true,
       extensions: {
         tags: {}
@@ -10359,7 +10359,7 @@ type LeftArm implements Node {
   """
   nodeId: ID!
   id: Int!
-  personId: Int!
+  personId: Int
   lengthInMetres: Float
   mood: String!
 

--- a/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.graphql
@@ -833,7 +833,7 @@ type LeftArm implements Node {
 
   """Reads a single `Person` that is related to this `LeftArm`."""
   personByPersonId: Person
-  personId: Int!
+  personId: Int
 }
 
 """An input representation of `LeftArm` with nullable fields."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/rbac.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/rbac.1.export.mjs
@@ -1493,7 +1493,7 @@ const spec_leftArm = {
     person_id: {
       description: undefined,
       codec: TYPES.int,
-      notNull: true,
+      notNull: false,
       hasDefault: true,
       extensions: {
         tags: {
@@ -9432,7 +9432,7 @@ type LeftArm implements Node {
   """
   nodeId: ID!
   id: Int!
-  personId: Int!
+  personId: Int
   lengthInMetres: Float
   mood: String!
 

--- a/postgraphile/postgraphile/__tests__/schema/v4/rbac.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/rbac.1.graphql
@@ -328,7 +328,7 @@ type LeftArm implements Node {
 
   """Reads a single `Person` that is related to this `LeftArm`."""
   personByPersonId: Person
-  personId: Int!
+  personId: Int
 }
 
 """An input representation of `LeftArm` with nullable fields."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.export.mjs
@@ -1302,7 +1302,7 @@ const spec_leftArm = {
     person_id: {
       description: undefined,
       codec: TYPES.int,
-      notNull: true,
+      notNull: false,
       hasDefault: true,
       extensions: {
         tags: {}
@@ -18780,7 +18780,7 @@ type LeftArm implements Node {
   """
   nodeId: ID!
   id: Int!
-  personId: Int!
+  personId: Int
   lengthInMetres: Float
   mood: String!
 

--- a/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.graphql
@@ -3321,7 +3321,7 @@ type LeftArm implements Node {
 
   """Reads a single `Person` that is related to this `LeftArm`."""
   personByPersonId: Person
-  personId: Int!
+  personId: Int
 }
 
 """An input representation of `LeftArm` with nullable fields."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/relay.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/relay.1.export.mjs
@@ -4245,17 +4245,19 @@ export const plans = {
     author: {
       applyPlan($condition, val) {
         const $nodeId = val.get();
+        const $nodeIdExists = condition("exists", $nodeId);
         const spec = getSpec2($nodeId);
         for (let i = 0, l = registryConfig.pgRelations.post.author.localAttributes.length; i < l; i++) {
           const localName = registryConfig.pgRelations.post.author.localAttributes[i];
           const codec = localAttributeCodecs[i];
           const remoteName = registryConfig.pgRelations.post.author.remoteAttributes[i];
-          const $rawCol = spec[remoteName];
-          // const $col = nodeIdentifierColumnOrNull($nodeId, spec, 'id')
-          const $col = assertNotNull(trap($rawCol, 4), `Invalid node identifier for '${"Person"}'`, {
-            if: condition("exists", $nodeId)
+          // Set `null` if invalid
+          const $rawValue = trap(spec[remoteName], 4);
+          // If `null` but `$nodeId` wasn't null, throw an error: invalid Node ID!
+          const $value = assertNotNull($rawValue, `Invalid node identifier for '${"Person"}'`, {
+            if: $nodeIdExists
           });
-          const sqlRemoteValue = $condition.placeholder($col, codec);
+          const sqlRemoteValue = $condition.placeholder($value, codec);
           $condition.where({
             type: "attribute",
             attribute: localName,
@@ -4594,17 +4596,19 @@ export const plans = {
     tvShowByShowId: {
       applyPlan($condition, val) {
         const $nodeId = val.get();
+        const $nodeIdExists = condition("exists", $nodeId);
         const spec = getSpec3($nodeId);
         for (let i = 0, l = registryConfig.pgRelations.tvEpisodes.tvShowsByMyShowId.localAttributes.length; i < l; i++) {
           const localName = registryConfig.pgRelations.tvEpisodes.tvShowsByMyShowId.localAttributes[i];
           const codec = localAttributeCodecs2[i];
           const remoteName = registryConfig.pgRelations.tvEpisodes.tvShowsByMyShowId.remoteAttributes[i];
-          const $rawCol = spec[remoteName];
-          // const $col = nodeIdentifierColumnOrNull($nodeId, spec, 'id')
-          const $col = assertNotNull(trap($rawCol, 4), `Invalid node identifier for '${"TvShow"}'`, {
-            if: condition("exists", $nodeId)
+          // Set `null` if invalid
+          const $rawValue = trap(spec[remoteName], 4);
+          // If `null` but `$nodeId` wasn't null, throw an error: invalid Node ID!
+          const $value = assertNotNull($rawValue, `Invalid node identifier for '${"TvShow"}'`, {
+            if: $nodeIdExists
           });
-          const sqlRemoteValue = $condition.placeholder($col, codec);
+          const sqlRemoteValue = $condition.placeholder($value, codec);
           $condition.where({
             type: "attribute",
             attribute: localName,
@@ -4725,17 +4729,19 @@ export const plans = {
     studioByStudioId: {
       applyPlan($condition, val) {
         const $nodeId = val.get();
+        const $nodeIdExists = condition("exists", $nodeId);
         const spec = getSpec4($nodeId);
         for (let i = 0, l = registryConfig.pgRelations.tvShows.studiosByMyStudioId.localAttributes.length; i < l; i++) {
           const localName = registryConfig.pgRelations.tvShows.studiosByMyStudioId.localAttributes[i];
           const codec = localAttributeCodecs3[i];
           const remoteName = registryConfig.pgRelations.tvShows.studiosByMyStudioId.remoteAttributes[i];
-          const $rawCol = spec[remoteName];
-          // const $col = nodeIdentifierColumnOrNull($nodeId, spec, 'id')
-          const $col = assertNotNull(trap($rawCol, 4), `Invalid node identifier for '${"Studio"}'`, {
-            if: condition("exists", $nodeId)
+          // Set `null` if invalid
+          const $rawValue = trap(spec[remoteName], 4);
+          // If `null` but `$nodeId` wasn't null, throw an error: invalid Node ID!
+          const $value = assertNotNull($rawValue, `Invalid node identifier for '${"Studio"}'`, {
+            if: $nodeIdExists
           });
-          const sqlRemoteValue = $condition.placeholder($col, codec);
+          const sqlRemoteValue = $condition.placeholder($value, codec);
           $condition.where({
             type: "attribute",
             attribute: localName,
@@ -6170,12 +6176,19 @@ export const plans = {
     },
     author: {
       applyPlan($insert, val) {
-        const spec = getSpec5(val.get());
+        const $nodeId = val.get();
+        const $nodeIdExists = condition("exists", $nodeId);
+        const spec = getSpec5($nodeId);
         for (let i = 0, l = registryConfig.pgRelations.post.author.localAttributes.length; i < l; i++) {
           const localName = registryConfig.pgRelations.post.author.localAttributes[i];
           const remoteName = registryConfig.pgRelations.post.author.remoteAttributes[i];
-          const $val = spec[remoteName];
-          $insert.set(localName, $val);
+          // Set `null` if invalid
+          const $rawValue = trap(spec[remoteName], 4);
+          // If `null` but `$nodeId` wasn't null, throw an error: invalid Node ID!
+          const $value = assertNotNull($rawValue, `Invalid node identifier for '${"Person"}'`, {
+            if: $nodeIdExists
+          });
+          $insert.set(localName, $value);
         }
       },
       autoApplyAfterParentInputPlan: true,
@@ -6260,12 +6273,19 @@ export const plans = {
     },
     tvShowByShowId: {
       applyPlan($insert, val) {
-        const spec = getSpec6(val.get());
+        const $nodeId = val.get();
+        const $nodeIdExists = condition("exists", $nodeId);
+        const spec = getSpec6($nodeId);
         for (let i = 0, l = registryConfig.pgRelations.tvEpisodes.tvShowsByMyShowId.localAttributes.length; i < l; i++) {
           const localName = registryConfig.pgRelations.tvEpisodes.tvShowsByMyShowId.localAttributes[i];
           const remoteName = registryConfig.pgRelations.tvEpisodes.tvShowsByMyShowId.remoteAttributes[i];
-          const $val = spec[remoteName];
-          $insert.set(localName, $val);
+          // Set `null` if invalid
+          const $rawValue = trap(spec[remoteName], 4);
+          // If `null` but `$nodeId` wasn't null, throw an error: invalid Node ID!
+          const $value = assertNotNull($rawValue, `Invalid node identifier for '${"TvShow"}'`, {
+            if: $nodeIdExists
+          });
+          $insert.set(localName, $value);
         }
       },
       autoApplyAfterParentInputPlan: true,
@@ -6350,12 +6370,19 @@ export const plans = {
     },
     studioByStudioId: {
       applyPlan($insert, val) {
-        const spec = getSpec7(val.get());
+        const $nodeId = val.get();
+        const $nodeIdExists = condition("exists", $nodeId);
+        const spec = getSpec7($nodeId);
         for (let i = 0, l = registryConfig.pgRelations.tvShows.studiosByMyStudioId.localAttributes.length; i < l; i++) {
           const localName = registryConfig.pgRelations.tvShows.studiosByMyStudioId.localAttributes[i];
           const remoteName = registryConfig.pgRelations.tvShows.studiosByMyStudioId.remoteAttributes[i];
-          const $val = spec[remoteName];
-          $insert.set(localName, $val);
+          // Set `null` if invalid
+          const $rawValue = trap(spec[remoteName], 4);
+          // If `null` but `$nodeId` wasn't null, throw an error: invalid Node ID!
+          const $value = assertNotNull($rawValue, `Invalid node identifier for '${"Studio"}'`, {
+            if: $nodeIdExists
+          });
+          $insert.set(localName, $value);
         }
       },
       autoApplyAfterParentInputPlan: true,
@@ -6675,12 +6702,19 @@ export const plans = {
     },
     author: {
       applyPlan($insert, val) {
-        const spec = getSpec8(val.get());
+        const $nodeId = val.get();
+        const $nodeIdExists = condition("exists", $nodeId);
+        const spec = getSpec8($nodeId);
         for (let i = 0, l = registryConfig.pgRelations.post.author.localAttributes.length; i < l; i++) {
           const localName = registryConfig.pgRelations.post.author.localAttributes[i];
           const remoteName = registryConfig.pgRelations.post.author.remoteAttributes[i];
-          const $val = spec[remoteName];
-          $insert.set(localName, $val);
+          // Set `null` if invalid
+          const $rawValue = trap(spec[remoteName], 4);
+          // If `null` but `$nodeId` wasn't null, throw an error: invalid Node ID!
+          const $value = assertNotNull($rawValue, `Invalid node identifier for '${"Person"}'`, {
+            if: $nodeIdExists
+          });
+          $insert.set(localName, $value);
         }
       },
       autoApplyAfterParentInputPlan: true,
@@ -6757,12 +6791,19 @@ export const plans = {
     },
     tvShowByShowId: {
       applyPlan($insert, val) {
-        const spec = getSpec9(val.get());
+        const $nodeId = val.get();
+        const $nodeIdExists = condition("exists", $nodeId);
+        const spec = getSpec9($nodeId);
         for (let i = 0, l = registryConfig.pgRelations.tvEpisodes.tvShowsByMyShowId.localAttributes.length; i < l; i++) {
           const localName = registryConfig.pgRelations.tvEpisodes.tvShowsByMyShowId.localAttributes[i];
           const remoteName = registryConfig.pgRelations.tvEpisodes.tvShowsByMyShowId.remoteAttributes[i];
-          const $val = spec[remoteName];
-          $insert.set(localName, $val);
+          // Set `null` if invalid
+          const $rawValue = trap(spec[remoteName], 4);
+          // If `null` but `$nodeId` wasn't null, throw an error: invalid Node ID!
+          const $value = assertNotNull($rawValue, `Invalid node identifier for '${"TvShow"}'`, {
+            if: $nodeIdExists
+          });
+          $insert.set(localName, $value);
         }
       },
       autoApplyAfterParentInputPlan: true,
@@ -6839,12 +6880,19 @@ export const plans = {
     },
     studioByStudioId: {
       applyPlan($insert, val) {
-        const spec = getSpec10(val.get());
+        const $nodeId = val.get();
+        const $nodeIdExists = condition("exists", $nodeId);
+        const spec = getSpec10($nodeId);
         for (let i = 0, l = registryConfig.pgRelations.tvShows.studiosByMyStudioId.localAttributes.length; i < l; i++) {
           const localName = registryConfig.pgRelations.tvShows.studiosByMyStudioId.localAttributes[i];
           const remoteName = registryConfig.pgRelations.tvShows.studiosByMyStudioId.remoteAttributes[i];
-          const $val = spec[remoteName];
-          $insert.set(localName, $val);
+          // Set `null` if invalid
+          const $rawValue = trap(spec[remoteName], 4);
+          // If `null` but `$nodeId` wasn't null, throw an error: invalid Node ID!
+          const $value = assertNotNull($rawValue, `Invalid node identifier for '${"Studio"}'`, {
+            if: $nodeIdExists
+          });
+          $insert.set(localName, $value);
         }
       },
       autoApplyAfterParentInputPlan: true,

--- a/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.export.mjs
@@ -663,7 +663,7 @@ const spec_leftArm = {
     person_id: {
       description: undefined,
       codec: TYPES.int,
-      notNull: true,
+      notNull: false,
       hasDefault: true,
       extensions: {
         tags: {}
@@ -10415,7 +10415,7 @@ type LeftArm implements Node {
   """
   id: ID!
   rowId: Int!
-  personId: Int!
+  personId: Int
   lengthInMetres: Float
   mood: String!
 

--- a/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.graphql
@@ -1524,7 +1524,7 @@ type LeftArm implements Node {
 
   """Reads a single `Person` that is related to this `LeftArm`."""
   personByPersonId: Person
-  personId: Int!
+  personId: Int
   rowId: Int!
 }
 

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.export.mjs
@@ -663,7 +663,7 @@ const spec_leftArm = {
     person_id: {
       description: undefined,
       codec: TYPES.int,
-      notNull: true,
+      notNull: false,
       hasDefault: true,
       extensions: {
         tags: {}
@@ -10698,7 +10698,7 @@ type LeftArm implements Node {
   """
   nodeId: ID!
   id: Int!
-  personId: Int!
+  personId: Int
   lengthInMetres: Float
   mood: String!
 

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.graphql
@@ -1527,7 +1527,7 @@ type LeftArm implements Node {
 
   """Reads a single `Person` that is related to this `LeftArm`."""
   personByPersonId: Person
-  personId: Int!
+  personId: Int
 }
 
 """An input representation of `LeftArm` with nullable fields."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only.1.export.mjs
@@ -663,7 +663,7 @@ const spec_leftArm = {
     person_id: {
       description: undefined,
       codec: TYPES.int,
-      notNull: true,
+      notNull: false,
       hasDefault: true,
       extensions: {
         tags: {}
@@ -9927,7 +9927,7 @@ type LeftArm implements Node {
   """
   nodeId: ID!
   id: Int!
-  personId: Int!
+  personId: Int
   lengthInMetres: Float
   mood: String!
 

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only.1.graphql
@@ -1168,7 +1168,7 @@ type LeftArm implements Node {
 
   """Reads a single `Person` that is related to this `LeftArm`."""
   personByPersonId: Person
-  personId: Int!
+  personId: Int
 }
 
 """An input representation of `LeftArm` with nullable fields."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.export.mjs
@@ -1302,7 +1302,7 @@ const spec_leftArm = {
     person_id: {
       description: undefined,
       codec: TYPES.int,
-      notNull: true,
+      notNull: false,
       hasDefault: true,
       extensions: {
         tags: {}
@@ -18780,7 +18780,7 @@ type LeftArm implements Node {
   """
   nodeId: ID!
   id: Int!
-  personId: Int!
+  personId: Int
   lengthInMetres: Float
   mood: String!
 

--- a/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.graphql
@@ -2643,7 +2643,7 @@ type LeftArm implements Node {
   """
   nodeId: ID!
   id: Int!
-  personId: Int!
+  personId: Int
   lengthInMetres: Float
   mood: String!
 

--- a/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.1.export.mjs
@@ -1240,7 +1240,7 @@ const spec_leftArm = {
     person_id: {
       description: undefined,
       codec: TYPES.int,
-      notNull: true,
+      notNull: false,
       hasDefault: true,
       extensions: {
         tags: {}
@@ -17874,7 +17874,7 @@ type PersonSecret {
 """Tracks metadata about the left arms of various people"""
 type LeftArm {
   id: Int!
-  personId: Int!
+  personId: Int
   lengthInMetres: Float
   mood: String!
 

--- a/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.1.graphql
@@ -3026,7 +3026,7 @@ type LeftArm {
 
   """Reads a single `Person` that is related to this `LeftArm`."""
   personByPersonId: Person
-  personId: Int!
+  personId: Int
 }
 
 """An input representation of `LeftArm` with nullable fields."""

--- a/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.1.export.mjs
@@ -1238,7 +1238,7 @@ const spec_cLeftArm = {
     person_id: {
       description: undefined,
       codec: TYPES.int,
-      notNull: true,
+      notNull: false,
       hasDefault: true,
       extensions: {
         tags: {}
@@ -17930,7 +17930,7 @@ type CPersonSecret {
 """Tracks metadata about the left arms of various people"""
 type CLeftArm {
   rowId: Int!
-  personId: Int!
+  personId: Int
   lengthInMetres: Float
   mood: String!
 

--- a/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.1.graphql
@@ -1881,7 +1881,7 @@ type CLeftArm {
   cPersonByPersonId: CPerson
   lengthInMetres: Float
   mood: String!
-  personId: Int!
+  personId: Int
   rowId: Int!
 }
 


### PR DESCRIPTION
Our test coverage wasn't sufficient to catch a bug in Beta22 related to updating records by their NodeID. This PR fixes the bug and increases test coverage in this area, checking what happens with a valid ID, a null, an invalid ID, and omitting the ID entirely. It also synchronizes the approach between condition steps and patch steps.