### PR TITLE
docs: change `create` to `insert`

### DIFF
--- a/postgraphile/website/postgraphile/behavior.md
+++ b/postgraphile/website/postgraphile/behavior.md
@@ -27,7 +27,7 @@ influence whether and how that entity is exposed. You may influence their
 resulting behaviors by adding your own behavior strings to the entity, either
 directly or via smart tags/smart comments. For example, if you don't want users
 to be able to modify entries in the `forums` table, you might add a database
-comment such as `comment on table forums is '@behavior -create -update
+comment such as `comment on table forums is '@behavior -insert -update
 -delete';` (this is just one of many ways of attaching behaviors).
 
 The final behavior string of an entity is made by concatenating the behavior

--- a/postgraphile/website/postgraphile/crud-mutations.md
+++ b/postgraphile/website/postgraphile/crud-mutations.md
@@ -11,7 +11,7 @@ relevant database permissions.
 
 ### Designing mutations
 
-CRUD mutations can easily be disabled by disabling the `create`,
+CRUD mutations can easily be disabled by disabling the `insert`,
 `update` and `delete` behaviors in your preset:
 
 ```js title="graphile.config.mjs"
@@ -127,11 +127,11 @@ First of all, check for errors being output from your PostGraphile server. If
 there are no errors, here's some reasons that mutations might not show up in the
 generated schema:
 
-- Your behaviors (e.g. `defaultBehavior: "-create -update -delete"` or `@behavior -create -update -delete` smart comments on the tables) may be disabling them
+- Your behaviors (e.g. `defaultBehavior: "-insert -update -delete"` or `@behavior -insert -update -delete` smart comments on the tables) may be disabling them
 - Insufficient permissions on the tables
 - Tables not in an exposed schema
 - Views instead of tables
-- Missing primary keys (though 'create' mutations will still be added in this
+- Missing primary keys (though 'insert' mutations will still be added in this
   case)
 - If you only see mutations using primary key: You might be using the
   `PrimaryKeyMutationsOnlyPlugin`

--- a/postgraphile/website/postgraphile/crud-mutations.md
+++ b/postgraphile/website/postgraphile/crud-mutations.md
@@ -131,7 +131,7 @@ generated schema:
 - Insufficient permissions on the tables
 - Tables not in an exposed schema
 - Views instead of tables
-- Missing primary keys (though 'insert' mutations will still be added in this
+- Missing primary keys (though 'create' mutations will still be added in this
   case)
 - If you only see mutations using primary key: You might be using the
   `PrimaryKeyMutationsOnlyPlugin`


### PR DESCRIPTION
## Description

As documented in [behaviors to avoid](
https://postgraphile.org/postgraphile/next/behavior#behaviors-to-avoid ), `insert` is preferred over `create`.

resolves #2078

## Performance impact

N/A

## Security impact

N/A

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
