### PR TITLE
docs: explain how to use global object identifier with functions

### DIFF
--- a/postgraphile/website/postgraphile/node-id.md
+++ b/postgraphile/website/postgraphile/node-id.md
@@ -69,6 +69,36 @@ export const client = new ApolloClient({
 });
 ```
 
+### Using the Global Object Identifier in Function Arguments
+
+The global object identifier can be accepted as a function argument using
+[`@argNvariant nodeId`](./smart-tags/#arg0variant-arg1variant-).
+
+```sql
+create table entity_a(
+  id uuid primary key
+);
+
+create table entity_b(
+  id uuid primary key
+);
+
+create table junction(
+  a_id uuid REFERENCES entity_a(id),
+  b_id uuid REFERENCES entity_b(id),
+  primary key (a_id, b_id)
+);
+
+create function add_junction_entry(a entity_a, b entity_b) returns junction as $$
+  insert into junction values (a.id, b.id) returning *;
+$$ language sql volatile;
+
+comment on function add_junction_entry(a entity_a, b entity_b) is $$
+  @arg0variant nodeId
+  @arg1variant nodeId
+$$;
+```
+
 ### Disabling the Global Object Identifier
 
 The global object identifier is added by the amber preset. If you use the amber

--- a/postgraphile/website/postgraphile/smart-tags.md
+++ b/postgraphile/website/postgraphile/smart-tags.md
@@ -343,8 +343,10 @@ PostGraphile with the same characteristics, i.e. all `not null` columns will
 become non-nullable fields. You can let PostGraphile know that you want to
 convert the composite type into another "variant" GraphQL type with a smart
 comment. Variants include `patch` (which is equivalent to the argument to
-`update*` mutations) and `base` (which makes every column both available
-(ignores permissions) and nullable). For example:
+`update*` mutations), `nodeId` (which can be used to have a function to accept
+the type's [global object identifier](./node-id/)) and `base` (which
+makes every column both available (ignores permissions) and nullable). For
+example:
 
 ```sql
 create table example(


### PR DESCRIPTION
## Description

[@benjie additionally notes](
https://github.com/graphile/crystal/issues/2086#issuecomment-2156413952 ) that the requirement to use the table record type (rather than the pk type) in the function definition will hopefully be lifted in the future. However, as this is not yet possible, I excluded this bit of "trivia".

resolves #2086

## Performance impact

N/A

## Security impact

N/A

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
