### PR TITLE
Allow pgClassExpressions to be embedded directly into SQL expressions

### DIFF
--- a/.changeset/empty-needles-press.md
+++ b/.changeset/empty-needles-press.md
@@ -1,0 +1,6 @@
+---
+"@dataplan/pg": patch
+---
+
+Allow `PgClassExpressionStep` instances to be embedded directly into SQL
+expressions.

--- a/grafast/dataplan-pg/src/steps/pgClassExpression.ts
+++ b/grafast/dataplan-pg/src/steps/pgClassExpression.ts
@@ -1,7 +1,7 @@
 import type { UnbatchedExecutionExtra } from "grafast";
 import { access, exportAs, UnbatchedExecutableStep } from "grafast";
 import type { SQL } from "pg-sql2";
-import sql from "pg-sql2";
+import sql, { $$toSQL } from "pg-sql2";
 
 import type { PgResource } from "../datasource.js";
 import type {
@@ -252,6 +252,10 @@ export class PgClassExpressionStep<
       (p) => sql.isEquivalent(this.expression, p.expression, options),
       // TODO: when we defer placeholders until finalize we'll need to do additional comparison here
     );
+  }
+
+  public [$$toSQL](): SQL {
+    return this.expression;
   }
 
   public toSQL(): SQL {


### PR DESCRIPTION
## Description

We already had `.toSQL()`; this adds the symbol that pg-sql2 requires to know that this is safe to do.

## Performance impact

None known.

## Security impact

None known.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
