### PR TITLE
fix: add newline between parts when logging masked error

### DIFF
--- a/.changeset/curvy-lions-shave.md
+++ b/.changeset/curvy-lions-shave.md
@@ -1,0 +1,5 @@
+---
+"grafserv": patch
+---
+
+Improve logging of masked errors (thanks @FelixZY)

--- a/grafast/grafserv/src/options.ts
+++ b/grafast/grafserv/src/options.ts
@@ -43,9 +43,12 @@ export function defaultMaskError(
     const hash = sha1(String(error));
     const errorId = randomString();
     console.error(
-      "%s\n%O",
-      `Masked GraphQL error (hash: '${hash}', id: '${errorId}')`,
+      "Masked GraphQL error (hash: '%s', id: '%s')\n%s\n%O",
+      hash,
+      errorId,
       error,
+      error.originalError ?? error,
+    )
     );
     return new GraphQLError(
       `An error occurred (logged with hash: '${hash}', id: '${errorId}')`,

--- a/grafast/grafserv/src/options.ts
+++ b/grafast/grafserv/src/options.ts
@@ -48,7 +48,6 @@ export function defaultMaskError(
       errorId,
       error,
       error.originalError ?? error,
-    )
     );
     return new GraphQLError(
       `An error occurred (logged with hash: '${hash}', id: '${errorId}')`,

--- a/grafast/grafserv/src/options.ts
+++ b/grafast/grafserv/src/options.ts
@@ -43,6 +43,7 @@ export function defaultMaskError(
     const hash = sha1(String(error));
     const errorId = randomString();
     console.error(
+      "%s\n%O",
       `Masked GraphQL error (hash: '${hash}', id: '${errorId}')`,
       error,
     );

--- a/postgraphile/postgraphile/graphile.config.ts
+++ b/postgraphile/postgraphile/graphile.config.ts
@@ -304,8 +304,14 @@ const preset: GraphileConfig.Preset = {
             throw: EXPORTABLE(
               (error) => () => {
                 return error(
-                  new Error(
-                    "You've requested the 'throw' field... which throws!",
+                  Object.assign(
+                    new Error(
+                      "You've requested the 'throw' field... which throws!",
+                    ),
+                    {
+                      metadata: true,
+                      mol: 42,
+                    },
                   ),
                 );
               },


### PR DESCRIPTION
## Description

While trying out bun, I found that the log output did not look very nice. After doing some digging, I found that the main reason was that bun displays a piece of the code from where the error originates whereas node simply prints the message line.

node:
```
Masked GraphQL error (hash: 'wiy-9FuoG4YyjQDsoOgPm0ivhaQ', id: 'CDPY2NZ8ZL') error: permission denied for table authenticated_only
    at /home/felix/private/labelt/node_modules/pg/lib/client.js:526:17
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async PgExecutor._executeWithClient (/home/felix/private/labelt/node_modules/@dataplan/pg/dist/executor.js:48:27)
    at async /home/felix/private/labelt/node_modules/@dataplan/pg/dist/adaptors/pg.js:187:36
    at async withPgClient (/home/felix/private/labelt/node_modules/@dataplan/pg/dist/adaptors/pg.js:228:20)
    at async withPgClientFromPgService (/home/felix/private/labelt/node_modules/@dataplan/pg/dist/pgServices.js:114:16)
    at async PgExecutor._execute (/home/felix/private/labelt/node_modules/@dataplan/pg/dist/executor.js:143:16)
    at async /home/felix/private/labelt/node_modules/@dataplan/pg/dist/executor.js:274:31 {
  path: [ 'authenticatedOnlies', 'edges' ],
  locations: [ { line: 3, column: 5 } ],
  extensions: [Object: null prototype] {}
}
```

bun:
```
Masked GraphQL error (hash: 'Yso1vgL5wxudmqqGcOa_Xb7uuDA', id: 'MHXAKDVRWU') 521 |         result = new this._Promise((resolve, reject) => {
522 |           query.callback = (err, res) => (err ? reject(err) : resolve(res))
523 |         }).catch((err) => {
524 |           // replace the stack trace that leads to `TCP.onStreamRead` with one that leads back to the
525 |           // application that created the query
526 |           Error.captureStackTrace(err)
                      ^
GraphQLError: permission denied for table authenticated_only
 path: "authenticatedOnlies,nodes"
      at /workspaces/labelt/node_modules/pg/lib/client.js:526:17
      at processTicksAndRejections (native:1:1)
```

While things do not look as bad in node as in bun, I would argue that a newline is better to use here as well (and looking better in bun of course does not hurt, even if it's not an officially supported platform).

With these changes, the output now looks like:

node:
```
Masked GraphQL error (hash: 'wiy-9FuoG4YyjQDsoOgPm0ivhaQ', id: 'N9VLN9QFWA')
error: permission denied for table authenticated_only
    at /home/felix/private/labelt/node_modules/pg/lib/client.js:526:17
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async PgExecutor._executeWithClient (/home/felix/private/labelt/node_modules/@dataplan/pg/dist/executor.js:48:27)
    at async /home/felix/private/labelt/node_modules/@dataplan/pg/dist/adaptors/pg.js:187:36
    at async withPgClient (/home/felix/private/labelt/node_modules/@dataplan/pg/dist/adaptors/pg.js:228:20)
    at async withPgClientFromPgService (/home/felix/private/labelt/node_modules/@dataplan/pg/dist/pgServices.js:114:16)
    at async PgExecutor._execute (/home/felix/private/labelt/node_modules/@dataplan/pg/dist/executor.js:143:16)
    at async /home/felix/private/labelt/node_modules/@dataplan/pg/dist/executor.js:274:31 {
  path: [ 'authenticatedOnlies', 'edges' ],
  locations: [ { line: 3, column: 5 } ],
  extensions: [Object: null prototype] {}
}
```

bun:
```
Masked GraphQL error (hash: 'wiy-9FuoG4YyjQDsoOgPm0ivhaQ', id: '2LJNUKMQUR')
521 |         result = new this._Promise((resolve, reject) => {
522 |           query.callback = (err, res) => (err ? reject(err) : resolve(res))
523 |         }).catch((err) => {
524 |           // replace the stack trace that leads to `TCP.onStreamRead` with one that leads back to the
525 |           // application that created the query
526 |           Error.captureStackTrace(err)
                      ^
GraphQLError: permission denied for table authenticated_only
 path: "authenticatedOnlies,edges"
      at /workspaces/labelt/node_modules/pg/lib/client.js:526:17
      at processTicksAndRejections (native:1:1)
```

## Performance impact

Unknown. The change mirrors what `console.error(a,b)` did internally, just with a different separator. I'm therefore assuming it to be minimal

## Security impact

None

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
