### PR TITLE
Handle trapping errors produced by sideEffect steps

### DIFF
--- a/grafast/grafast/__tests__/trap-test.ts
+++ b/grafast/grafast/__tests__/trap-test.ts
@@ -14,10 +14,9 @@ import {
   lambda,
   list,
   makeGrafastSchema,
+  sideEffect,
   trap,
-  TRAP_ERROR,
-  sideEffect
-} from "../dist/index.js";
+  TRAP_ERROR} from "../dist/index.js";
 
 const makeSchema = () => {
   return makeGrafastSchema({
@@ -159,7 +158,7 @@ it("enables trapping an error to error", async () => {
   });
 });
 
-it("traps side effects in the chain", async () => {
+it("traps errors thrown in side effects in the chain", async () => {
   const schema = makeSchema();
 
   const source =  /* GraphQL */`

--- a/grafast/grafast/__tests__/trap-test.ts
+++ b/grafast/grafast/__tests__/trap-test.ts
@@ -56,8 +56,8 @@ const makeSchema = () => {
           const $sideEffect = sideEffect(null, () => {
             throw new Error("Test");
           })
-          const $trap = trap($sideEffect, TRAP_ERROR, { valueForError: "PASS_THROUGH"});
-          return lambda([$trap], () => {
+          const $trap = trap($sideEffect, TRAP_ERROR, { valueForError: "PASS_THROUGH" });
+          return lambda($trap, () => {
             return 1;
           });
         }
@@ -166,6 +166,6 @@ it("traps errors thrown in side effects in the chain", async () => {
       mySideEffect 
     }
   `
-  const result = await grafast({ source: `{ mySideEffect }`, schema });
+  const result = await grafast({ source, schema });
   expect(result).to.deep.equal({ data: { mySideEffect: 1 } });
 })

--- a/grafast/grafast/__tests__/trap-test.ts
+++ b/grafast/grafast/__tests__/trap-test.ts
@@ -2,23 +2,16 @@
 import { expect } from "chai";
 import type { ExecutionResult } from "graphql";
 import { it } from "mocha";
-import sqlite3 from "sqlite3";
 
 import {
-  access,
   assertNotNull,
-  context,
-  ExecutableStep,
-  ExecutionDetails,
   grafast,
-  GrafastResultsList,
   lambda,
   list,
   makeGrafastSchema,
   sideEffect,
   trap,
   TRAP_ERROR,
-  TRAP_ERROR_OR_INHIBITED,
 } from "../dist/index.js";
 
 const makeSchema = () => {
@@ -65,7 +58,7 @@ const makeSchema = () => {
           const $sideEffect = sideEffect(null, () => {
             throw new Error("Test");
           });
-          const $trap = trap($sideEffect, TRAP_ERROR_OR_INHIBITED, {
+          const $trap = trap($sideEffect, TRAP_ERROR, {
             valueForError: "PASS_THROUGH",
           });
           return lambda($trap, () => {
@@ -79,7 +72,7 @@ const makeSchema = () => {
               detail: "Goodbye, and thanks for all the fish!",
             });
           });
-          const $errorValue = trap($sideEffect, TRAP_ERROR_OR_INHIBITED, {
+          const $errorValue = trap($sideEffect, TRAP_ERROR, {
             valueForError: "PASS_THROUGH",
           });
           return $errorValue;

--- a/grafast/grafast/__tests__/trap-test.ts
+++ b/grafast/grafast/__tests__/trap-test.ts
@@ -4,19 +4,22 @@ import type { ExecutionResult } from "graphql";
 import { it } from "mocha";
 import sqlite3 from "sqlite3";
 
-import {ExecutionDetails, GrafastResultsList, TRAP_ERROR_OR_INHIBITED} from "../dist/index.js";
 import {
   access,
   assertNotNull,
   context,
   ExecutableStep,
+  ExecutionDetails,
   grafast,
+  GrafastResultsList,
   lambda,
   list,
   makeGrafastSchema,
   sideEffect,
   trap,
-  TRAP_ERROR} from "../dist/index.js";
+  TRAP_ERROR,
+  TRAP_ERROR_OR_INHIBITED,
+} from "../dist/index.js";
 
 const makeSchema = () => {
   return makeGrafastSchema({
@@ -55,12 +58,14 @@ const makeSchema = () => {
         mySideEffect() {
           const $sideEffect = sideEffect(null, () => {
             throw new Error("Test");
-          })
-          const $trap = trap($sideEffect, TRAP_ERROR_OR_INHIBITED, { valueForError: "PASS_THROUGH" });
+          });
+          const $trap = trap($sideEffect, TRAP_ERROR_OR_INHIBITED, {
+            valueForError: "PASS_THROUGH",
+          });
           return lambda($trap, () => {
             return 1;
           });
-        }
+        },
       },
     },
     enableDeferStream: false,
@@ -161,11 +166,11 @@ it("enables trapping an error to error", async () => {
 it("traps errors thrown in side effects in the chain", async () => {
   const schema = makeSchema();
 
-  const source =  /* GraphQL */`
-    query withSideEffects { 
-      mySideEffect 
+  const source = /* GraphQL */ `
+    query withSideEffects {
+      mySideEffect
     }
-  `
+  `;
   const result = await grafast({ source, schema });
   expect(result).to.deep.equal({ data: { mySideEffect: 1 } });
-})
+});

--- a/grafast/grafast/__tests__/trap-test.ts
+++ b/grafast/grafast/__tests__/trap-test.ts
@@ -4,7 +4,7 @@ import type { ExecutionResult } from "graphql";
 import { it } from "mocha";
 import sqlite3 from "sqlite3";
 
-import type { ExecutionDetails, GrafastResultsList } from "../dist/index.js";
+import {ExecutionDetails, GrafastResultsList, TRAP_ERROR_OR_INHIBITED} from "../dist/index.js";
 import {
   access,
   assertNotNull,
@@ -56,7 +56,7 @@ const makeSchema = () => {
           const $sideEffect = sideEffect(null, () => {
             throw new Error("Test");
           })
-          const $trap = trap($sideEffect, TRAP_ERROR, { valueForError: "PASS_THROUGH" });
+          const $trap = trap($sideEffect, TRAP_ERROR_OR_INHIBITED, { valueForError: "PASS_THROUGH" });
           return lambda($trap, () => {
             return 1;
           });


### PR DESCRIPTION
## Description

This is a WIP demonstrating that trying to trapi errors that where produced by sideEffects is currently not working.

## Performance impact

unknown

## Security impact

unknown

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [ ] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
