### PR TITLE
Allow for re-set of a Type as long as we are in the init phase

### DIFF
--- a/graphile-build/graphile-build-pg/src/plugins/PgBasicsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgBasicsPlugin.ts
@@ -325,8 +325,9 @@ export const PgBasicsPlugin: GraphileConfig.Plugin = {
 
             const situations_ = Array.isArray(variants) ? variants : [variants];
             for (const situation of situations_) {
-              if (meta.typeNameBySituation[situation] != null) {
-                // TODO: allow this?
+              if ((!build.status.isBuildPhaseComplete || build.status.isInitPhaseComplete) &&
+                  meta.typeNameBySituation[situation] != null) {
+                // TODO: allow this in more phases?
                 throw new Error("Type already set");
               }
               meta.typeNameBySituation[situation] = typeName;


### PR DESCRIPTION
## Description

Currently it's possible to alias a custom scalar type with a primitive type (Int, String, etc..) in the init phase with `build.setGraphQLTypeForPgCodec` out of the box with an init hook. However, if you want to alias one scalar type over another it's not currently possible because those scalars don't exist until after `PgCodecsPlugin` runs and once set they cannot be re-set. 

It seems reasonable that a hook set to run after `PgCodecsPlugin` but within the init phase should be able to re-set any of those automatically generated types.

## Performance impact

Unknown

## Security impact

Unknown

## Checklist

- [ ] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.
