### PR TITLE
#2096: allow `postgraphile/adaptors/pg` settings to be set in `makePgService`

### DIFF
--- a/grafast/dataplan-pg/src/adaptors/pg.ts
+++ b/grafast/dataplan-pg/src/adaptors/pg.ts
@@ -38,15 +38,6 @@ declare global {
       pgSubscriber: PgSubscriber | null;
     }
   }
-  namespace GraphileConfig {
-    interface PgAdaptors {
-      "@dataplan/pg/adaptors/pg": {
-        adaptorSettings: PgAdaptorSettings | undefined;
-        makePgServiceOptions: PgAdaptorMakePgServiceOptions;
-        client: NodePostgresPgClient;
-      };
-    }
-  }
 }
 
 // Set `DATAPLAN_PG_PREPARED_STATEMENT_CACHE_SIZE=0` to disable prepared statements
@@ -438,7 +429,7 @@ export function createWithPgClient(
 }
 
 // This is here as a TypeScript assertion, to ensure we conform to PgAdaptor
-const adaptor: PgAdaptor<"@dataplan/pg/adaptors/pg"> = {
+const adaptor: PgAdaptor<PgAdaptorSettings, PgAdaptorMakePgServiceOptions> = {
   createWithPgClient,
   makePgService,
 };
@@ -734,7 +725,7 @@ export interface PgAdaptorMakePgServiceOptions extends MakePgServiceOptions {
 
 export function makePgService(
   options: PgAdaptorMakePgServiceOptions,
-): GraphileConfig.PgServiceConfiguration<"@dataplan/pg/adaptors/pg"> {
+): GraphileConfig.PgServiceConfiguration<typeof adaptor> {
   const {
     name = "main",
     connectionString,
@@ -775,7 +766,7 @@ export function makePgService(
     pgSubscriber = new PgSubscriber(pool);
     releasers.push(() => pgSubscriber!.release?.());
   }
-  const service: GraphileConfig.PgServiceConfiguration<"@dataplan/pg/adaptors/pg"> =
+  const service: GraphileConfig.PgServiceConfiguration<typeof adaptor> =
     {
       name,
       schemas: Array.isArray(schemas) ? schemas : [schemas ?? "public"],

--- a/grafast/dataplan-pg/src/adaptors/pg.ts
+++ b/grafast/dataplan-pg/src/adaptors/pg.ts
@@ -766,27 +766,26 @@ export function makePgService(
     pgSubscriber = new PgSubscriber(pool);
     releasers.push(() => pgSubscriber!.release?.());
   }
-  const service: GraphileConfig.PgServiceConfiguration<typeof adaptor> =
-    {
-      name,
-      schemas: Array.isArray(schemas) ? schemas : [schemas ?? "public"],
-      withPgClientKey: withPgClientKey as any,
-      pgSettingsKey: pgSettingsKey as any,
-      pgSubscriberKey: pgSubscriberKey as any,
-      pgSettings,
-      pgSettingsForIntrospection,
-      pgSubscriber,
-      adaptor,
-      adaptorSettings: {
-        pool,
-        superuserConnectionString,
-      },
-      async release() {
-        // Release in reverse order
-        for (const releaser of [...releasers].reverse()) {
-          await releaser();
-        }
-      },
-    };
+  const service: GraphileConfig.PgServiceConfiguration<typeof adaptor> = {
+    name,
+    schemas: Array.isArray(schemas) ? schemas : [schemas ?? "public"],
+    withPgClientKey: withPgClientKey as any,
+    pgSettingsKey: pgSettingsKey as any,
+    pgSubscriberKey: pgSubscriberKey as any,
+    pgSettings,
+    pgSettingsForIntrospection,
+    pgSubscriber,
+    adaptor,
+    adaptorSettings: {
+      pool,
+      superuserConnectionString,
+    },
+    async release() {
+      // Release in reverse order
+      for (const releaser of [...releasers].reverse()) {
+        await releaser();
+      }
+    },
+  };
   return service;
 }

--- a/grafast/dataplan-pg/src/index.ts
+++ b/grafast/dataplan-pg/src/index.ts
@@ -427,19 +427,21 @@ export { version } from "./version.js";
 declare global {
   namespace GraphileConfig {
     interface PgServiceConfiguration<
-      TAdaptor extends
-        keyof GraphileConfig.PgAdaptors = keyof GraphileConfig.PgAdaptors,
+      TAdaptor extends PgAdaptor<any, any, any>,
     > {
       name: string;
       schemas?: string[];
 
-      adaptor: PgAdaptor<TAdaptor>;
-      adaptorSettings?: GraphileConfig.PgAdaptors[TAdaptor]["adaptorSettings"];
+      adaptor: TAdaptor;
+      adaptorSettings?: Exclude<
+        TAdaptor["typeOptionalAdaptorSettings"],
+        undefined
+      >;
 
       /** The key on 'context' where the withPgClient function will be sourced */
       withPgClientKey: KeysOfType<
         Grafast.Context & object,
-        WithPgClient<GraphileConfig.PgAdaptors[TAdaptor]["client"]>
+        WithPgClient<Exclude<TAdaptor["typeOptionalPgClient"], undefined>>
       >;
 
       /** Return settings to set in the session */
@@ -473,26 +475,7 @@ declare global {
     }
 
     interface Preset {
-      pgServices?: ReadonlyArray<
-        {
-          [Key in keyof GraphileConfig.PgAdaptors]: PgServiceConfiguration<Key>;
-        }[keyof GraphileConfig.PgAdaptors]
-      >;
-    }
-
-    interface PgAdaptors {
-      /*
-       * Add your adaptor configurations via declaration merging; they should
-       * conform to this:
-       *
-       * ```
-       * [moduleName: string]: {
-       *   adaptorSettings: { ... } | undefined;
-       *   makePgServiceOptions: MakePgServiceOptions & { ... };
-       *   client: PgClient & MyPgClientStuff;
-       * };
-       * ```
-       */
+      pgServices?: ReadonlyArray<PgAdaptor<any, any, any>>;
     }
   }
   namespace DataplanPg {

--- a/grafast/dataplan-pg/src/index.ts
+++ b/grafast/dataplan-pg/src/index.ts
@@ -109,9 +109,9 @@ import {
   TuplePlanMap,
 } from "./interfaces.js";
 import { PgLockableParameter, PgLockCallback } from "./pgLocker.js";
-import type { PgAdaptor } from "./pgServices.js";
 import {
   getWithPgClientFromPgService,
+  type PgAdaptor,
   withPgClientFromPgService,
   withSuperuserPgClientFromPgService,
 } from "./pgServices.js";

--- a/grafast/dataplan-pg/src/index.ts
+++ b/grafast/dataplan-pg/src/index.ts
@@ -475,7 +475,7 @@ declare global {
     }
 
     interface Preset {
-      pgServices?: ReadonlyArray<PgAdaptor<any, any, any>>;
+      pgServices?: ReadonlyArray<PgServiceConfiguration<any>>;
     }
   }
   namespace DataplanPg {

--- a/grafast/dataplan-pg/src/interfaces.ts
+++ b/grafast/dataplan-pg/src/interfaces.ts
@@ -418,7 +418,7 @@ export type KeysOfType<TObject, TValueType> = {
 export interface MakePgServiceOptions
   extends Partial<
     Pick<
-      GraphileConfig.PgServiceConfiguration,
+      GraphileConfig.PgServiceConfiguration<any>,
       | "name"
       | "pgSettings"
       | "pgSettingsForIntrospection"

--- a/graphile-build/graphile-build-pg/src/plugins/PgIntrospectionPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgIntrospectionPlugin.ts
@@ -66,7 +66,7 @@ declare global {
         getIntrospection(): PromiseOrDirect<IntrospectionResults>;
         getService(serviceName: string): Promise<{
           introspection: Introspection;
-          pgService: GraphileConfig.PgServiceConfiguration;
+          pgService: GraphileConfig.PgServiceConfiguration<any>;
         }>;
         getExecutorForService(serviceName: string): PgExecutor;
 
@@ -229,7 +229,7 @@ declare global {
 }
 
 type IntrospectionResults = Array<{
-  pgService: GraphileConfig.PgServiceConfiguration;
+  pgService: GraphileConfig.PgServiceConfiguration<any>;
   introspection: Introspection;
 }>;
 
@@ -705,7 +705,9 @@ export const PgIntrospectionPlugin: GraphileConfig.Plugin = {
 };
 
 function introspectPgServices(
-  pgServices: ReadonlyArray<GraphileConfig.PgServiceConfiguration> | undefined,
+  pgServices:
+    | ReadonlyArray<GraphileConfig.PgServiceConfiguration<any>>
+    | undefined,
 ): Promise<IntrospectionResults> {
   if (!pgServices) {
     return Promise.resolve([]);

--- a/postgraphile/postgraphile/src/cli.ts
+++ b/postgraphile/postgraphile/src/cli.ts
@@ -3,6 +3,10 @@ import { pathToFileURL } from "node:url";
 import { inspect } from "node:util";
 
 import type { PgAdaptor } from "@dataplan/pg";
+import type {
+  PgAdaptorMakePgServiceOptions,
+  PgAdaptorSettings,
+} from "@dataplan/pg/adaptors/pg";
 import { grafserv } from "grafserv/node";
 import { resolvePresets } from "graphile-config";
 import type { ArgsFromOptions, Argv } from "graphile-config/cli";
@@ -300,7 +304,7 @@ export async function run(args: ArgsFromOptions<typeof options>) {
 }
 
 async function loadDefaultAdaptor(): Promise<
-  PgAdaptor<"@dataplan/pg/adaptors/pg">
+  PgAdaptor<PgAdaptorSettings, PgAdaptorMakePgServiceOptions>
 > {
   const mod = await import("@dataplan/pg/adaptors/pg");
   return typeof mod.makePgService === "function" ? mod : mod.default;

--- a/postgraphile/website/postgraphile/config.mdx
+++ b/postgraphile/website/postgraphile/config.mdx
@@ -393,7 +393,7 @@ common set of optional configuration parameters:
 - `schemas`
 - `superuserConnectionString`
 - `pubsub` (create a pgSubscriber entry; should default to `true`)
-- pass-through options (same as in `pgServices` above):
+- a subset of pass-through options from `pgServices` above:
   - `name` (default: "main")
   - `pgSettingsKey` (default with default `name`: `pgSettings`, otherwise: `${name}_pgSettings`)
   - `withPgClientKey` (default with default `name`: `withPgClient`, otherwise: `${name}_withPgClient`)

--- a/postgraphile/website/postgraphile/config.mdx
+++ b/postgraphile/website/postgraphile/config.mdx
@@ -399,6 +399,8 @@ common set of optional configuration parameters:
   - `withPgClientKey` (default with default `name`: `withPgClient`, otherwise: `${name}_withPgClient`)
   - `pgSubscriberKey` (default with default `name`: `pgSubscriber`, otherwise: `${name}_pgSubscriber`)
   - `pgSettings`
+  - `pgSettingsForIntrospection`
+  - `pgSubscriber`
 
 :::info
 


### PR DESCRIPTION
## Description

This PR primarily attempts to fix an issue where it was not possible to define `adaptorSettings` in `makePgService` (see [discussion on discord](https://discord.com/channels/489127045289476126/498852330754801666/1251556573508010054)).

The PR also aims to improve the related documentation at https://postgraphile.org/postgraphile/next/config#adaptorsettings **however, this is not yet completed**.

Related issue is #2096 

Please note that I'm having problems getting the tests to run locally so I cannot check that they pass - I'll have to look at the CI builds.

## Performance impact

unknown, likely none.

## Security impact

unknown, likely none.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
