### PR TITLE
Fix more type inference issues by not using never on execute

### DIFF
--- a/.changeset/quiet-rocks-draw.md
+++ b/.changeset/quiet-rocks-draw.md
@@ -1,0 +1,5 @@
+---
+"grafast": patch
+---
+
+Fix TypeScript inference in more places

--- a/grafast/grafast/__tests__/types-test.ts
+++ b/grafast/grafast/__tests__/types-test.ts
@@ -2,15 +2,19 @@ import type { Equals } from "tsafe";
 import { assert } from "tsafe";
 
 import type {
+  __ValueStep,
   ConstantStep,
   DataFromObjectSteps,
+  ExecutableStep,
   ListStep,
 } from "../dist/index.js";
 
 type Expected = {
   test: number[];
 };
-
 type Test = DataFromObjectSteps<{ test: ListStep<ConstantStep<number>[]> }>;
-
 assert<Equals<Test, Expected>>();
+
+type TStep = __ValueStep<Grafast.Context>;
+type TCtx = TStep extends ExecutableStep<infer U> ? U : never;
+assert<Equals<TCtx, Grafast.Context>>();

--- a/grafast/grafast/src/steps/__flag.ts
+++ b/grafast/grafast/src/steps/__flag.ts
@@ -17,6 +17,7 @@ import {
   FLAG_NULL,
   TRAPPABLE_FLAGS,
 } from "../interfaces.js";
+import type { ListCapableStep } from "../step.js";
 import { ExecutableStep, isListCapableStep } from "../step.js";
 import type { __ItemStep } from "./__item.js";
 
@@ -149,9 +150,13 @@ export class __FlagStep<TData> extends ExecutableStep<TData> {
   [$$deepDepSkip](): ExecutableStep {
     return this.getDepOptions(0).step;
   }
-  listItem?: ($item: __ItemStep<this>) => ExecutableStep;
+  listItem?: (
+    $item: __ItemStep<ListCapableStep<unknown, ExecutableStep<unknown>>>,
+  ) => ExecutableStep;
   // Copied over listItem if the dependent step is a list capable step
-  _listItem($item: __ItemStep<this>) {
+  _listItem(
+    $item: __ItemStep<ListCapableStep<unknown, ExecutableStep<unknown>>>,
+  ) {
     const $dep = this.dependencies[0];
     return isListCapableStep($dep) ? $dep.listItem($item) : $item;
   }

--- a/grafast/grafast/src/steps/__item.ts
+++ b/grafast/grafast/src/steps/__item.ts
@@ -1,6 +1,6 @@
 import chalk from "chalk";
 
-import type { JSONValue } from "../index.js";
+import type { GrafastResultsList, JSONValue } from "../index.js";
 import { $$deepDepSkip } from "../interfaces.js";
 import type { ExecutableStep } from "../step.js";
 import { $$noExec, UnbatchedExecutableStep } from "../step.js";
@@ -50,10 +50,10 @@ export class __ItemStep<TData> extends UnbatchedExecutableStep<TData> {
     return this.getDep(0);
   }
 
-  execute(): never {
+  execute(): GrafastResultsList<TData> {
     throw new Error("__ItemStep must never execute");
   }
-  unbatchedExecute(): never {
+  unbatchedExecute(): TData {
     throw new Error("__ItemStep must never execute");
   }
 

--- a/grafast/grafast/src/steps/__value.ts
+++ b/grafast/grafast/src/steps/__value.ts
@@ -1,3 +1,4 @@
+import type { GrafastResultsList } from "../index.js";
 import { $$noExec, ExecutableStep } from "../step.js";
 import type { AccessStep } from "./access.js";
 import { access } from "./access.js";
@@ -32,7 +33,7 @@ export class __ValueStep<TData> extends ExecutableStep<TData> {
     }
   }
 
-  execute(): never {
+  execute(): GrafastResultsList<TData> {
     // This is still an "executable plan"; we just side-step execution internally.
     throw new Error(
       `GrafastInternalError<7696a514-f452-4d47-92d3-85aeb5b23f48>: ${this} is a __ValueStep and thus must never execute`,

--- a/grafast/grafast/src/steps/listen.ts
+++ b/grafast/grafast/src/steps/listen.ts
@@ -1,6 +1,7 @@
 import { isDev } from "../dev.js";
 import { SafeError } from "../index.js";
 import type {
+  GrafastResultsList,
   GrafastResultStreamList,
   GrafastSubscriber,
   StreamDetails,
@@ -59,7 +60,7 @@ export class ListenStep<
     this.topicDep = this.addDependency($topic);
   }
 
-  execute(): never {
+  execute(): GrafastResultsList<TTopics[TTopic]> {
     throw new Error("ListenStep cannot be executed, it can only be streamed");
   }
 


### PR DESCRIPTION
Turns out using `: never` like this means that `typeof __ValueStep<Grafast.Context> extends ExecutableStep<infer U> ? U : never` resolves to `unknown` rather than `Grafast.Context`. Fixed in other places too.