### PR TITLE
Fix issues around error handling from side effect steps

### DIFF
--- a/grafast/grafast/__tests__/sideEffectsCancelFollowingSteps-test.ts
+++ b/grafast/grafast/__tests__/sideEffectsCancelFollowingSteps-test.ts
@@ -1,0 +1,94 @@
+/* eslint-disable graphile-export/exhaustive-deps, graphile-export/export-methods, graphile-export/export-instances, graphile-export/export-subclasses, graphile-export/no-nested */
+import assert from "assert";
+import { expect } from "chai";
+import type { AsyncExecutionResult } from "graphql";
+import { it } from "mocha";
+
+import type {
+  ExecutableStep,
+  ExecutionDetails,
+  PromiseOrDirect,
+} from "../dist/index.js";
+import {
+  constant,
+  context,
+  grafast,
+  lambda,
+  makeGrafastSchema,
+  sideEffect,
+} from "../dist/index.js";
+
+declare global {
+  namespace Grafast {
+    interface Context {
+      number?: number;
+    }
+  }
+}
+
+const testResolver = function () {
+  const $context = context();
+  sideEffect($context, (context) => (context.number = 3));
+  sideEffect($context, (context) => context.number!++);
+  sideEffect($context, (_context) => {
+    throw new Error("Side effect 3 failed");
+  });
+  sideEffect($context, (context) => context.number!++);
+  sideEffect($context, (context) => context.number!++);
+  return $context.get("number");
+};
+
+const schema = makeGrafastSchema({
+  typeDefs: /* GraphQL */ `
+    type Query {
+      test: Int
+    }
+    type Mutation {
+      test: Int
+    }
+  `,
+  plans: {
+    Mutation: {
+      test: testResolver,
+    },
+    Query: {
+      test: testResolver,
+    },
+  },
+  enableDeferStream: true,
+});
+
+it("cancels future steps on error", async () => {
+  const source = /* GraphQL */ `
+    mutation M {
+      test
+    }
+  `;
+  const contextValue: Grafast.Context = {} as any;
+  const result = await grafast({
+    schema,
+    source,
+    requestContext: {},
+    resolvedPreset: {},
+    contextValue,
+  });
+  if (!("data" in result) && !("error" in result)) {
+    console.dir(result);
+    throw new Error("Unexpected response shape");
+  }
+  console.dir(result);
+  console.dir(contextValue);
+  assert.equal(contextValue.number, 4);
+  assert.deepEqual(result, {
+    data: {
+      test: null,
+    },
+    errors: [
+      {
+        message: "Side effect 3 failed",
+        path: ["test"],
+        locations: [{ line: 3, column: 7 }],
+      },
+    ],
+  });
+});

--- a/grafast/grafast/__tests__/sideEffectsCancelFollowingSteps-test.ts
+++ b/grafast/grafast/__tests__/sideEffectsCancelFollowingSteps-test.ts
@@ -72,23 +72,19 @@ it("cancels future steps on error", async () => {
     resolvedPreset: {},
     contextValue,
   });
-  if (!("data" in result) && !("error" in result)) {
+  if (!("data" in result)) {
     console.dir(result);
     throw new Error("Unexpected response shape");
   }
-  console.dir(result);
-  console.dir(contextValue);
-  assert.equal(contextValue.number, 4);
-  assert.deepEqual(result, {
-    data: {
-      test: null,
-    },
-    errors: [
-      {
-        message: "Side effect 3 failed",
-        path: ["test"],
-        locations: [{ line: 3, column: 7 }],
-      },
-    ],
+  assert.deepEqual(result.data, {
+    test: null,
   });
+  assert.deepEqual(result.errors?.map((e) => e.toJSON()), [
+    {
+      message: "Side effect 3 failed",
+      path: ["test"],
+      locations: [{ line: 3, column: 7 }],
+    },
+  ]);
+  assert.equal(contextValue.number, 4);
 });

--- a/grafast/grafast/src/engine/LayerPlan.ts
+++ b/grafast/grafast/src/engine/LayerPlan.ts
@@ -249,6 +249,8 @@ export class LayerPlan<TReason extends LayerPlanReason = LayerPlanReason> {
   steps: ExecutableStep[] = [];
   /** @internal */
   pendingSteps: ExecutableStep[] = [];
+  /** @internal */
+  public latestSideEffectStep: ExecutableStep | null = null;
 
   /**
    * Describes the order in which the steps within this LayerPlan are executed.

--- a/grafast/grafast/src/engine/OperationPlan.ts
+++ b/grafast/grafast/src/engine/OperationPlan.ts
@@ -2031,7 +2031,7 @@ export class OperationPlan {
       if (step.id < offset) continue;
       for (const key in step) {
         const val = step[key as keyof typeof step];
-        if (val instanceof ExecutableStep) {
+        if (key !== "latestSideEffectStep" && val instanceof ExecutableStep) {
           errors.push(
             new Error(
               `ERROR: ExecutableStep ${step} has illegal reference via property '${key}' to step ${val}. You must not reference steps directly, instead add the step as a dependency (\`depId = this.addDependency($step)\`) and use \`this.getDep(depId)\` to look the step up (or, if the step is not a dependency, store the step ID and use \`this.getStep(stepId)\` each time you need to reference it). Failure to comply could result in subtle breakage during optimisation.`,

--- a/grafast/grafast/src/engine/OutputPlan.ts
+++ b/grafast/grafast/src/engine/OutputPlan.ts
@@ -13,7 +13,7 @@ import te, { stringifyJSON, stringifyString } from "tamedevil";
 import * as assert from "../assert.js";
 import type { Bucket } from "../bucket.js";
 import { isDev } from "../dev.js";
-import { AccessStep } from "../index.js";
+import { AccessStep, stepADependsOnStepB } from "../index.js";
 import { inspect } from "../inspect.js";
 import type { JSONValue, LocationDetails } from "../interfaces.js";
 import { $$concreteType, $$streamMore, FLAG_ERROR } from "../interfaces.js";
@@ -228,6 +228,11 @@ export class OutputPlan<TType extends OutputPlanType = OutputPlanType> {
    * OutputPlanMode.
    */
   public readonly rootStep: ExecutableStep;
+  /**
+   * If this output plan should resolve to an error if a side effect step
+   * raises an error, this is that side effect.
+   */
+  public readonly sideEffectStep: ExecutableStep | null;
 
   /**
    * Appended to the root step when accessed to avoid the need for AccessSteps
@@ -293,6 +298,13 @@ export class OutputPlan<TType extends OutputPlanType = OutputPlanType> {
     layerPlan.operationPlan.stepTracker.addOutputPlan(this);
     this.childByTypeName =
       this.type.mode === "polymorphic" ? Object.create(null) : undefined;
+
+    const $sideEffect = rootStep.layerPlan.latestSideEffectStep;
+    if ($sideEffect && !stepADependsOnStepB(rootStep, $sideEffect)) {
+      this.sideEffectStep = $sideEffect;
+    } else {
+      this.sideEffectStep = null;
+    }
   }
 
   public print(): string {
@@ -489,20 +501,20 @@ export class OutputPlan<TType extends OutputPlanType = OutputPlanType> {
   }
 
   optimize(): void {
-    /*
-    // PERF: re-enable this optimization, carefully.
-
     // This optimization works by ridding us of access steps at the very end of
-    // paths and just accessing properties directly. However, in rare
-    // circumstances usually involving untethered side effects this can lead to
+    // paths and just accessing properties directly. In rare circumstances
+    // involving untethered side effects in earlier versions this could lead to
     // errors being skipped and data generated previous to the error being
-    // returned. Out of an abundance of caution we're disabling this until we
-    // have time to fully evaluate it.
-  
+    // returned; but OutputPlans now check the latestSideEffectStep so this
+    // should be safe aga.
     const $root = this.layerPlan.operationPlan.dangerouslyGetStep(
       this.rootStep.id,
     );
-    if ($root instanceof AccessStep && $root.fallback === undefined) {
+    if (
+      $root instanceof AccessStep &&
+      $root.fallback === undefined &&
+      $root.latestSideEffectStep === null
+    ) {
       const expressionDetails:
         | [ReadonlyArray<string | number>, any]
         | undefined = ($root.unbatchedExecute! as any)[expressionSymbol];
@@ -519,7 +531,6 @@ export class OutputPlan<TType extends OutputPlanType = OutputPlanType> {
         });
       }
     }
-    */
   }
 
   finalize(): void {
@@ -841,6 +852,13 @@ function makeExecutorExpression<TAsString extends boolean>(
   rawBucketRootValue = bucket.store.get(this.rootStep.id).at(bucketIndex),
   bucketRootFlags = bucket.store.get(this.rootStep.id)._flagsAt(bucketIndex)
 ) {
+  if (this.sideEffectStep !== null) {
+    const seFlags = bucket.store.get(this.sideEffectStep.id)._flagsAt(bucketIndex);
+    if (seFlags & ${ref_FLAG_ERROR}) {
+      const seVal = bucket.store.get(this.sideEffectStep.id).at(bucketIndex);
+      throw seVal;
+    }
+  }
   const bucketRootValue = this.processRoot !== null ? this.processRoot(rawBucketRootValue, bucketRootFlags) : rawBucketRootValue;
 ${preamble}\
   ${

--- a/grafast/grafast/src/engine/OutputPlan.ts
+++ b/grafast/grafast/src/engine/OutputPlan.ts
@@ -489,6 +489,16 @@ export class OutputPlan<TType extends OutputPlanType = OutputPlanType> {
   }
 
   optimize(): void {
+    /*
+    // PERF: re-enable this optimization, carefully.
+
+    // This optimization works by ridding us of access steps at the very end of
+    // paths and just accessing properties directly. However, in rare
+    // circumstances usually involving untethered side effects this can lead to
+    // errors being skipped and data generated previous to the error being
+    // returned. Out of an abundance of caution we're disabling this until we
+    // have time to fully evaluate it.
+  
     const $root = this.layerPlan.operationPlan.dangerouslyGetStep(
       this.rootStep.id,
     );
@@ -509,6 +519,7 @@ export class OutputPlan<TType extends OutputPlanType = OutputPlanType> {
         });
       }
     }
+    */
   }
 
   finalize(): void {

--- a/grafast/grafast/src/engine/StepTracker.ts
+++ b/grafast/grafast/src/engine/StepTracker.ts
@@ -100,6 +100,17 @@ export class StepTracker {
   }
 
   public addStep($step: ExecutableStep): number {
+    const previousStep = this.stepById[this.stepCount];
+    // NOTE: `hasSideEffect` cannot be set on previousStep after
+    // this.stepCount++, so this is safe to do.
+    if (
+      previousStep &&
+      previousStep.layerPlan === $step.layerPlan &&
+      previousStep.hasSideEffects
+    ) {
+      $step.layerPlan.latestSideEffectStep = previousStep;
+    }
+
     const stepId = this.stepCount++;
     this.activeSteps.add($step);
     this.stepsWithNoDependencies.add($step);

--- a/grafast/grafast/src/thereCanBeOnlyOne.ts
+++ b/grafast/grafast/src/thereCanBeOnlyOne.ts
@@ -5,7 +5,9 @@ if (globalAny[$$grafast] === true) {
   // Already warned
 } else if (globalAny[$$grafast]) {
   console.trace(
-    `WARNING: more than one version of the 'grafast' module has been instantiated - you must ensure there is exactly one grafast (e.g. using yarn "resolutions" or similar techniques). Try clearing your package lockfile and reinstalling. ${globalAny[$$grafast].stack}`,
+    `WARNING: more than one version of the 'grafast' module has been instantiated - you must ensure there is exactly one grafast (e.g. using yarn "resolutions" or similar techniques). Try clearing your package lockfile and reinstalling.\n    ${String(
+      globalAny[$$grafast].stack,
+    ).replace(/\n/g, "\n    ")}`,
   );
   globalAny[$$grafast] = true;
 } else {

--- a/grafast/grafast/src/utils.ts
+++ b/grafast/grafast/src/utils.ts
@@ -928,6 +928,7 @@ export function isTypePlanned(
 export type Sudo<T> = T extends ExecutableStep<any>
   ? T & {
       dependencies: ReadonlyArray<ExecutableStep>;
+      latestSideEffectStep: ExecutableStep | null;
       dependencyForbiddenFlags: ReadonlyArray<ExecutionEntryFlags>;
       dependencyOnReject: ReadonlyArray<Error | null | undefined>;
       defaultForbiddenFlags: ExecutionEntryFlags;

--- a/grafast/grafast/src/utils.ts
+++ b/grafast/grafast/src/utils.ts
@@ -956,6 +956,10 @@ export function writeableArray<T>(a: ReadonlyArray<T>): Array<T> {
   return a as any;
 }
 
+/**
+ * Returns `true` if the first argument depends on the second argument either
+ * directly or indirectly (via a chain of dependencies).
+ */
 export function stepADependsOnStepB(
   stepA: ExecutableStep,
   stepB: ExecutableStep,
@@ -963,6 +967,13 @@ export function stepADependsOnStepB(
   if (stepA === stepB) {
     throw new Error("Invalid call to stepADependsOnStepB");
   }
+
+  // PERF: bredth-first might be better.
+
+  // PERF: we can stop looking once we pass a certain layerPlan boundary.
+
+  // PERF: maybe some form of caching here would be sensible?
+
   // Depth-first search for match
   for (const dep of sudo(stepA).dependencies) {
     if (dep === stepB) {


### PR DESCRIPTION
Plan that's hard to make sense of:

```ts
function plan($parent) {
  sideEffect($parent, parent => {
    if (parent.something) { throw new Error("Nope!"); }
  });
  return $parent;
}
```

This is something you might want to do for access control. But the issue is you're returning a pre-existing step, so this step cannot be made dependent on the side effect (that would cause a loop).

Still; when we output the field for this plan, the error from the side effect should have taken effect.

Currently you can accomplish this by making the return value explicitly dependent:

```ts
function plan($parent) {
  return sideEffect($parent, parent => {
    if (parent.something) { throw new Error("Nope!"); }
    else { return parent };
  });
}
```

but this changes the type of the return value, so it's not always desired.

Took a while to figure out what to do here, but the solution is that the OutputPlan should be dependent on the side effects.

After further thought I realised that you only need to track the latest side effect, since each side effect is implicitly dependent on previous side effects.

We also have the situation where you might _trap_ a side effect; if you do this then the explicit (but indirect) dependency on the side effect should win, so we should remove the implicit dependency (directly) on the side effect. This won't affect later steps which remain implicitly dependent on the side effect (unless dependent on the trap, of course).

So, we track the latest side effect, and every future step is implicitly (if not explicitly) dependent on it, and *also* the OutputPlan is dependent on it. This final part needs to be handled carefully, essentially if the OutputPlan's step already has a dependency change on the sideEffect (which might be trapped) then no worries; but if not then we need an implicit dependency.

TODO:

* [ ] Need to ensure we don’t execute steps after latestSideEffectStep fails
* [ ] Need to make it so when you add a dependency we remove latestSideEffectStep if it’s now in the chain
* [ ] Need to factor into deduplication
* [ ] Need to consider when a layer plan inherits - that layer plan implicitly becomes dependent on the side effect too.
* [ ] Need to make side effects implicitly dependent on previous side effects (already handled?)
* [ ] Can remove previous "side effect" error handling code with this much simpler solution; also saves us from another loop.
* [ ] Should also render these "side effect" dependencies into the plan diagram to make debugging easier.

