### PR TITLE
Allow accepting poolConfig via makePgService

### DIFF
--- a/.changeset/cold-seahorses-sell.md
+++ b/.changeset/cold-seahorses-sell.md
@@ -1,0 +1,6 @@
+---
+"postgraphile": patch
+"@dataplan/pg": patch
+---
+
+Add support for accepting poolConfig via makePgService

--- a/.changeset/eight-poems-sniff.md
+++ b/.changeset/eight-poems-sniff.md
@@ -1,0 +1,6 @@
+---
+"@dataplan/pg": patch
+---
+
+Superuser connection now uses `superuserPoolConfig` rather than `poolConfig`
+when creating a pool.

--- a/grafast/dataplan-pg/src/adaptors/pg.ts
+++ b/grafast/dataplan-pg/src/adaptors/pg.ts
@@ -417,7 +417,7 @@ export function createWithPgClient(
       );
     } else if (options.superuserConnectionString) {
       const pool = new PgPool({
-        ...options.poolConfig,
+        ...options.superuserPoolConfig,
         connectionString: options.superuserConnectionString,
       });
       const release = () => pool.end();

--- a/grafast/dataplan-pg/src/interfaces.ts
+++ b/grafast/dataplan-pg/src/interfaces.ts
@@ -421,9 +421,9 @@ export interface MakePgServiceOptions
       GraphileConfig.PgServiceConfiguration,
       | "name"
       | "pgSettings"
+      | "pgSettingsKey"
       | "pgSettingsForIntrospection"
       | "withPgClientKey"
-      | "pgSettingsKey"
       | "pgSubscriber"
       | "pgSubscriberKey"
     >

--- a/grafast/website/grafast/step-library/dataplan-pg/adaptors.md
+++ b/grafast/website/grafast/step-library/dataplan-pg/adaptors.md
@@ -117,7 +117,7 @@ properties:
   `connectionString`
 
 Exactly one of `pool` or `connectionString` must be set, all other options are
-optional.
+optional, and `poolConfig` is ignored if `pool` is specified.
 
 ### new PgSubscriber(pool)
 

--- a/postgraphile/postgraphile/src/cli.ts
+++ b/postgraphile/postgraphile/src/cli.ts
@@ -185,8 +185,8 @@ export async function run(args: ArgsFromOptions<typeof options>) {
       );
     }
     const schemas = rawSchema?.split(",") ?? ["public"];
-    const adaptor =
-      preset.pgServices?.[0]?.adaptor ?? (await loadDefaultAdaptor());
+    const svc = preset.pgServices?.[0];
+    const adaptor = svc?.adaptor ?? (await loadDefaultAdaptor());
 
     const makePgService = adaptor.makePgService;
     if (typeof makePgService !== "function") {
@@ -194,10 +194,13 @@ export async function run(args: ArgsFromOptions<typeof options>) {
         `Loaded adaptor '${adaptor}' but it does not export a 'makePgService' helper`,
       );
     }
+
     const newPgServices = [
       makePgService({
+        poolConfig: svc?.adaptorSettings?.poolConfig,
         connectionString,
         schemas,
+        superuserPoolConfig: svc?.adaptorSettings?.superuserPoolConfig,
         superuserConnectionString,
         ...(rawSubscriptions ? { pubsub: true } : null),
       }),

--- a/postgraphile/website/postgraphile/config.mdx
+++ b/postgraphile/website/postgraphile/config.mdx
@@ -393,12 +393,14 @@ common set of optional configuration parameters:
 - `schemas`
 - `superuserConnectionString`
 - `pubsub` (create a pgSubscriber entry; should default to `true`)
-- pass-through options (same as in `pgServices` above):
+- pass-through options (a subset of those in `pgServices` above):
   - `name` (default: "main")
-  - `pgSettingsKey` (default with default `name`: `pgSettings`, otherwise: `${name}_pgSettings`)
-  - `withPgClientKey` (default with default `name`: `withPgClient`, otherwise: `${name}_withPgClient`)
-  - `pgSubscriberKey` (default with default `name`: `pgSubscriber`, otherwise: `${name}_pgSubscriber`)
   - `pgSettings`
+  - `pgSettingsKey` (default with default `name`: `pgSettings`, otherwise: `${name}_pgSettings`)
+  - `pgSettingsForIntrospection`
+  - `withPgClientKey` (default with default `name`: `withPgClient`, otherwise: `${name}_withPgClient`)
+  - `pgSubscriber`
+  - `pgSubscriberKey` (default with default `name`: `pgSubscriber`, otherwise: `${name}_pgSubscriber`)
 
 :::info
 

--- a/postgraphile/website/postgraphile/config.mdx
+++ b/postgraphile/website/postgraphile/config.mdx
@@ -461,8 +461,6 @@ primarily, it accepts the following options:
 - `pool` - pass your own pre-built `pg.Pool` instance to use, in which case all
   other (non-superuser) options will be ignored. You are responsible for
   releasing this pool!
-- `superuserPool` - as `pool`, but for superuser connections (only needed to
-  install the watch fixtures in watch mode)
 - `connectionString` - the database connection string to use, we'll create a
   pool for you automatically (and handle releasing it) using this connection
   string
@@ -470,10 +468,18 @@ primarily, it accepts the following options:
   `connectionString`) to pass through to `pg.Pool`; see the [pg.Pool
   options](https://node-postgres.com/apis/pool) which inherit the [pg.Client
   options](https://node-postgres.com/apis/client).
-- `superuserConnectionString` - as `connectionString`, but for superuser
-  connections (only needed to install the watch fixtures in watch mode)
 - `pubsub` (default: `true`) - enable LISTEN/NOTIFY via creation of a
   `pgSubscriber`
+- `superuserPool` - as `pool`, but for superuser connections (only used to
+  install the watch fixtures in watch mode)
+- `superuserConnectionString` - as `connectionString`, but for superuser
+  connections (only used to install the watch fixtures in watch mode)
+- `superuserPoolConfig` - as `poolConfig`, but for superuser
+  connections (only used to install the watch fixtures in watch mode)
+
+Note if `pool` is provided then `connectionString` and `poolConfig` should not
+be specified. Similarly if `superuserPool` is provided then
+`superuserConnectionString` and `superuserPoolConfig` should not be specified.
 
 ### `gather` options
 


### PR DESCRIPTION
This is an alternative fix to #2104.

`@dataplan/pg` adaptors expose two main methods, which (deliberately) accept different sets of options:

- `makePgService()` - responsible for creating an optimized `PgService` object
- `createWithPgClient()` - creates `withPgClient` functions on the fly via `adaptorSettings`

We currently only have one adaptor, `@dataplan/pg/adaptors/pg`, but this is likely to change over time. From here on we'll talk about the methods in this adaptor specifically, although the reasoning is likely applicable to future adaptors too.

`makePgService()` does not accept an `adaptorSettings` object, nor all of the keys thereof; one example why is that it would be inappropriate for `makePgService` to accept a `pgClient` to use for all requests (it could lead to parallel requests issuing competing statements in the same transaction block, leading to unpredictable results) - `pgClient` is only intended for testing in very narrow circumstances. To put it another way: `withPgClient()` only handles a single workflow at a time, so it's appropriate to use it with a single client (e.g. in tests), but `makePgService()` handles multiple workflows in parallel, so it must only accept pool-based options.

Further, `makePgService()` aims to create an optimized configuration, so it takes responsibility for creating the relevant pools and only setting these on `adaptorSettings`. This means the pools don't need to be created on the fly each time `createWithPgClient()` is called, which could potentially result in a lot more database connections than the user wished to allow.

However, @FelixZY correctly points out that it should be possible to set `poolConfig` and similar options via `makePgService()`.

This PR addresses this need by extracting the options that should be common to `makePgService()` and `createWithPgClient()` into its own interface, and merging that into both sets of options. Further, `makePgService()` has been updated to use these options when creating the relevant pools, and now creates a pool for the superuser connection too.

Furthermore, the PR updates the CLI so that it also respects these poolConfigs when accepting new connection strings to use.