### PR TITLE
Resolvers should never deduplicate

### DIFF
--- a/.changeset/smart-months-deliver.md
+++ b/.changeset/smart-months-deliver.md
@@ -1,0 +1,7 @@
+---
+"grafast": patch
+---
+
+Fix bug where resolvers would incorrectly deduplicate (cannot deduplicate
+because ResolveInfo may or may not be used, and that is different for every
+field).

--- a/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object-errors.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object-errors.deopt.mermaid
@@ -39,10 +39,14 @@ graph TD
     GraphQLResolver15 & Constant46 & __Value2 & __Value0 & __Value4 --> GraphQLResolver45
     GraphQLResolver23[["GraphQLResolver[23∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     GraphQLResolver21 & Constant46 & __Value2 & __Value0 & __Value4 --> GraphQLResolver23
+    GraphQLResolver31[["GraphQLResolver[31∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
+    GraphQLResolver21 & Constant46 & __Value2 & __Value0 & __Value4 --> GraphQLResolver31
     GraphQLResolver39[["GraphQLResolver[39∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     GraphQLResolver21 & Constant46 & __Value2 & __Value0 & __Value4 --> GraphQLResolver39
     GraphQLResolver41[["GraphQLResolver[41∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     GraphQLResolver21 & Constant46 & __Value2 & __Value0 & __Value4 --> GraphQLResolver41
+    GraphQLResolver43[["GraphQLResolver[43∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
+    GraphQLResolver21 & Constant46 & __Value2 & __Value0 & __Value4 --> GraphQLResolver43
     GraphQLResolver25[["GraphQLResolver[25∈4] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     GraphQLResolver23 & Constant46 & __Value2 & __Value0 & __Value4 --> GraphQLResolver25
     GraphQLResolver27[["GraphQLResolver[27∈4] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
@@ -50,11 +54,11 @@ graph TD
     GraphQLResolver29[["GraphQLResolver[29∈4] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     GraphQLResolver23 & Constant46 & __Value2 & __Value0 & __Value4 --> GraphQLResolver29
     GraphQLResolver33[["GraphQLResolver[33∈5] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver23 & Constant46 & __Value2 & __Value0 & __Value4 --> GraphQLResolver33
+    GraphQLResolver31 & Constant46 & __Value2 & __Value0 & __Value4 --> GraphQLResolver33
     GraphQLResolver35[["GraphQLResolver[35∈5] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver23 & Constant46 & __Value2 & __Value0 & __Value4 --> GraphQLResolver35
+    GraphQLResolver31 & Constant46 & __Value2 & __Value0 & __Value4 --> GraphQLResolver35
     GraphQLResolver37[["GraphQLResolver[37∈5] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver23 & Constant46 & __Value2 & __Value0 & __Value4 --> GraphQLResolver37
+    GraphQLResolver31 & Constant46 & __Value2 & __Value0 & __Value4 --> GraphQLResolver37
 
     %% define steps
 
@@ -70,11 +74,11 @@ graph TD
     class Bucket2,GraphQLResolver17,GraphQLResolver19,GraphQLResolver21,GraphQLResolver45 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 21, 46, 2, 0, 4<br /><br />ROOT GraphQLResolver{2}ᐸresolveᐳ[21]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,GraphQLResolver23,GraphQLResolver39,GraphQLResolver41 bucket3
+    class Bucket3,GraphQLResolver23,GraphQLResolver31,GraphQLResolver39,GraphQLResolver41,GraphQLResolver43 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 23, 46, 2, 0, 4<br /><br />ROOT GraphQLResolver{3}ᐸresolveᐳ[23]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,GraphQLResolver25,GraphQLResolver27,GraphQLResolver29 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 23, 46, 2, 0, 4<br /><br />ROOT GraphQLResolver{3}ᐸresolveᐳ[23]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 31, 46, 2, 0, 4<br /><br />ROOT GraphQLResolver{3}ᐸresolveᐳ[31]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,GraphQLResolver33,GraphQLResolver35,GraphQLResolver37 bucket5
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object-errors.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object-errors.mermaid
@@ -39,10 +39,14 @@ graph TD
     GraphQLResolver15 & Constant46 & __Value2 & __Value0 & __Value4 --> GraphQLResolver45
     GraphQLResolver23[["GraphQLResolver[23∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     GraphQLResolver21 & Constant46 & __Value2 & __Value0 & __Value4 --> GraphQLResolver23
+    GraphQLResolver31[["GraphQLResolver[31∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
+    GraphQLResolver21 & Constant46 & __Value2 & __Value0 & __Value4 --> GraphQLResolver31
     GraphQLResolver39[["GraphQLResolver[39∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     GraphQLResolver21 & Constant46 & __Value2 & __Value0 & __Value4 --> GraphQLResolver39
     GraphQLResolver41[["GraphQLResolver[41∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     GraphQLResolver21 & Constant46 & __Value2 & __Value0 & __Value4 --> GraphQLResolver41
+    GraphQLResolver43[["GraphQLResolver[43∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
+    GraphQLResolver21 & Constant46 & __Value2 & __Value0 & __Value4 --> GraphQLResolver43
     GraphQLResolver25[["GraphQLResolver[25∈4] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     GraphQLResolver23 & Constant46 & __Value2 & __Value0 & __Value4 --> GraphQLResolver25
     GraphQLResolver27[["GraphQLResolver[27∈4] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
@@ -50,11 +54,11 @@ graph TD
     GraphQLResolver29[["GraphQLResolver[29∈4] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     GraphQLResolver23 & Constant46 & __Value2 & __Value0 & __Value4 --> GraphQLResolver29
     GraphQLResolver33[["GraphQLResolver[33∈5] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver23 & Constant46 & __Value2 & __Value0 & __Value4 --> GraphQLResolver33
+    GraphQLResolver31 & Constant46 & __Value2 & __Value0 & __Value4 --> GraphQLResolver33
     GraphQLResolver35[["GraphQLResolver[35∈5] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver23 & Constant46 & __Value2 & __Value0 & __Value4 --> GraphQLResolver35
+    GraphQLResolver31 & Constant46 & __Value2 & __Value0 & __Value4 --> GraphQLResolver35
     GraphQLResolver37[["GraphQLResolver[37∈5] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
-    GraphQLResolver23 & Constant46 & __Value2 & __Value0 & __Value4 --> GraphQLResolver37
+    GraphQLResolver31 & Constant46 & __Value2 & __Value0 & __Value4 --> GraphQLResolver37
 
     %% define steps
 
@@ -70,11 +74,11 @@ graph TD
     class Bucket2,GraphQLResolver17,GraphQLResolver19,GraphQLResolver21,GraphQLResolver45 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 21, 46, 2, 0, 4<br /><br />ROOT GraphQLResolver{2}ᐸresolveᐳ[21]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,GraphQLResolver23,GraphQLResolver39,GraphQLResolver41 bucket3
+    class Bucket3,GraphQLResolver23,GraphQLResolver31,GraphQLResolver39,GraphQLResolver41,GraphQLResolver43 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 23, 46, 2, 0, 4<br /><br />ROOT GraphQLResolver{3}ᐸresolveᐳ[23]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,GraphQLResolver25,GraphQLResolver27,GraphQLResolver29 bucket4
-    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 23, 46, 2, 0, 4<br /><br />ROOT GraphQLResolver{3}ᐸresolveᐳ[23]"):::bucket
+    Bucket5("Bucket 5 (nullableBoundary)<br />Deps: 31, 46, 2, 0, 4<br /><br />ROOT GraphQLResolver{3}ᐸresolveᐳ[31]"):::bucket
     classDef bucket5 stroke:#7fff00
     class Bucket5,GraphQLResolver33,GraphQLResolver35,GraphQLResolver37 bucket5
     Bucket0 --> Bucket1

--- a/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object-recursive.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object-recursive.deopt.mermaid
@@ -41,6 +41,8 @@ graph TD
     GraphQLResolver21 & Constant34 & __Value2 & __Value0 & __Value4 --> GraphQLResolver29
     GraphQLResolver31[["GraphQLResolver[31∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     GraphQLResolver21 & Constant34 & __Value2 & __Value0 & __Value4 --> GraphQLResolver31
+    GraphQLResolver33[["GraphQLResolver[33∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
+    GraphQLResolver21 & Constant34 & __Value2 & __Value0 & __Value4 --> GraphQLResolver33
     GraphQLResolver25[["GraphQLResolver[25∈4] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     GraphQLResolver23 & Constant34 & __Value2 & __Value0 & __Value4 --> GraphQLResolver25
     GraphQLResolver27[["GraphQLResolver[27∈4] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
@@ -60,7 +62,7 @@ graph TD
     class Bucket2,GraphQLResolver17,GraphQLResolver19,GraphQLResolver21 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 21, 34, 2, 0, 4<br /><br />ROOT GraphQLResolver{2}ᐸresolveᐳ[21]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,GraphQLResolver23,GraphQLResolver29,GraphQLResolver31 bucket3
+    class Bucket3,GraphQLResolver23,GraphQLResolver29,GraphQLResolver31,GraphQLResolver33 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 23, 34, 2, 0, 4<br /><br />ROOT GraphQLResolver{3}ᐸresolveᐳ[23]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,GraphQLResolver25,GraphQLResolver27 bucket4

--- a/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object-recursive.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object-recursive.mermaid
@@ -41,6 +41,8 @@ graph TD
     GraphQLResolver21 & Constant34 & __Value2 & __Value0 & __Value4 --> GraphQLResolver29
     GraphQLResolver31[["GraphQLResolver[31∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     GraphQLResolver21 & Constant34 & __Value2 & __Value0 & __Value4 --> GraphQLResolver31
+    GraphQLResolver33[["GraphQLResolver[33∈3] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
+    GraphQLResolver21 & Constant34 & __Value2 & __Value0 & __Value4 --> GraphQLResolver33
     GraphQLResolver25[["GraphQLResolver[25∈4] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     GraphQLResolver23 & Constant34 & __Value2 & __Value0 & __Value4 --> GraphQLResolver25
     GraphQLResolver27[["GraphQLResolver[27∈4] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
@@ -60,7 +62,7 @@ graph TD
     class Bucket2,GraphQLResolver17,GraphQLResolver19,GraphQLResolver21 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 21, 34, 2, 0, 4<br /><br />ROOT GraphQLResolver{2}ᐸresolveᐳ[21]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,GraphQLResolver23,GraphQLResolver29,GraphQLResolver31 bucket3
+    class Bucket3,GraphQLResolver23,GraphQLResolver29,GraphQLResolver31,GraphQLResolver33 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 23, 34, 2, 0, 4<br /><br />ROOT GraphQLResolver{3}ᐸresolveᐳ[23]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,GraphQLResolver25,GraphQLResolver27 bucket4

--- a/grafast/grafast/src/steps/graphqlResolver.ts
+++ b/grafast/grafast/src/steps/graphqlResolver.ts
@@ -135,12 +135,6 @@ export class GraphQLResolverStep extends UnbatchedExecutableStep {
     );
   }
 
-  deduplicate(peers: GraphQLResolverStep[]): GraphQLResolverStep[] {
-    // GraphQL resolvers can NEVER be deduplicated, since the ResolveInfo
-    // object passed in will be different for each position.
-    return [];
-  }
-
   unbatchedExecute(
     _extra: UnbatchedExecutionExtra,
     source: any,

--- a/grafast/grafast/src/steps/graphqlResolver.ts
+++ b/grafast/grafast/src/steps/graphqlResolver.ts
@@ -136,10 +136,9 @@ export class GraphQLResolverStep extends UnbatchedExecutableStep {
   }
 
   deduplicate(peers: GraphQLResolverStep[]): GraphQLResolverStep[] {
-    return peers.filter(
-      (peer) =>
-        peer.resolver === this.resolver && peer.subscriber === this.subscriber,
-    );
+    // GraphQL resolvers can NEVER be deduplicated, since the ResolveInfo
+    // object passed in will be different for each position.
+    return [];
   }
 
   unbatchedExecute(


### PR DESCRIPTION
Since resolvers take ResolveInfo as the third argument, they cannot be deduplicated. If we could know for certain it's not being used then we could, but alas even things like `resolver.length` aren't reliable here due to `arguments` special variable, and `...rest` parameters. For safety, we must assume resolvers can never be deduplicated.