### PR TITLE
GraphQL resolver emulation now cascades

### DIFF
--- a/grafast/grafast/__tests__/resolvers-test.ts
+++ b/grafast/grafast/__tests__/resolvers-test.ts
@@ -1,0 +1,105 @@
+/* eslint-disable graphile-export/exhaustive-deps, graphile-export/export-methods, graphile-export/export-instances, graphile-export/export-subclasses, graphile-export/no-nested */
+import { expect } from "chai";
+import type { ExecutionResult } from "graphql";
+import {
+  graphql,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql";
+import { it } from "mocha";
+
+import { grafast } from "../dist/index.js";
+
+const makeSchema = () => {
+  const A = new GraphQLObjectType({
+    name: "A",
+    fields: {
+      a: {
+        type: GraphQLInt,
+      },
+    },
+  });
+  const B = new GraphQLObjectType({
+    name: "B",
+    fields: {
+      b: {
+        type: GraphQLString,
+      },
+    },
+  });
+  const PolyType = new GraphQLUnionType({
+    name: "PolyType",
+    types: () => [A, B],
+    resolveType(obj) {
+      return "a" in obj ? "A" : "B";
+    },
+  });
+  const T = new GraphQLObjectType({
+    name: "T",
+    fields: () => {
+      return {
+        polyField: {
+          type: new GraphQLList(PolyType),
+        },
+      };
+    },
+  });
+  const Query = new GraphQLObjectType({
+    name: "Query",
+    fields: () => {
+      return {
+        fieldWithResolver: {
+          type: T,
+          resolve() {
+            return { polyField: [{ a: 1 }, { b: "two" }, { a: 3 }] };
+          },
+        },
+      };
+    },
+  });
+  return new GraphQLSchema({
+    query: Query,
+  });
+};
+
+it("Resolves the same in Grafast as GraphQL.js", async () => {
+  const schema = makeSchema();
+  const source = /* GraphQL */ `
+    query Q {
+      fieldWithResolver {
+        polyField {
+          ... on A {
+            a
+          }
+          ... on B {
+            b
+          }
+        }
+      }
+    }
+  `;
+  const variableValues = {};
+  const executionArgs = {
+    schema,
+    source,
+    variableValues,
+    contextValue: {},
+    resolvedPreset: {},
+    requestContext: {},
+  };
+
+  const graphqlResult = (await graphql(executionArgs)) as ExecutionResult;
+  expect(graphqlResult.errors).not.to.exist;
+  expect(graphqlResult.data).to.deep.equal({
+    fieldWithResolver: {
+      polyField: [{ a: 1 }, { b: "two" }, { a: 3 }],
+    },
+  });
+
+  const grafastResult = (await grafast(executionArgs)) as ExecutionResult;
+  expect(grafastResult).to.deep.equal(graphqlResult);
+});

--- a/grafast/grafast/src/engine/OperationPlan.ts
+++ b/grafast/grafast/src/engine/OperationPlan.ts
@@ -1067,10 +1067,18 @@ export class OperationPlan {
         const usesDefaultResolver =
           resolvedResolver == null || resolvedResolver === defaultFieldResolver;
 
+        const isPolymorphic =
+          isUnionType(namedReturnType) || isInterfaceType(namedReturnType);
+
+        // We should use a resolver if:
+        // 1. they give us a non-default resolver
+        // 2. we're emulating resolvers AND the field is polymorphic
         const resolver =
-          usesDefaultResolver && !resolverEmulation
-            ? null
-            : resolvedResolver ?? defaultFieldResolver;
+          resolvedResolver && !usesDefaultResolver
+            ? resolvedResolver
+            : resolverEmulation && isPolymorphic
+            ? defaultFieldResolver
+            : null;
 
         // Apply a default plan to fields that do not have a plan nor a resolver.
         const planResolver =
@@ -1133,7 +1141,7 @@ export class OperationPlan {
 
         if (resolver !== null) {
           this.pure = false;
-          if (!planResolver) {
+          if (!rawPlanResolver) {
             resolverEmulation = true;
           }
         }

--- a/grafast/grafast/src/engine/OperationPlan.ts
+++ b/grafast/grafast/src/engine/OperationPlan.ts
@@ -1132,8 +1132,10 @@ export class OperationPlan {
          */
 
         if (resolver !== null) {
-          resolverEmulation = true;
           this.pure = false;
+          if (!planResolver) {
+            resolverEmulation = true;
+          }
         }
 
         const resultIsPlanned = isTypePlanned(this.schema, namedReturnType);

--- a/grafast/grafast/src/engine/OperationPlan.ts
+++ b/grafast/grafast/src/engine/OperationPlan.ts
@@ -1075,7 +1075,7 @@ export class OperationPlan {
         // Apply a default plan to fields that do not have a plan nor a resolver.
         const planResolver =
           rawPlanResolver ??
-          (usesDefaultResolver ? makeDefaultPlan(fieldName) : undefined);
+          (resolver ? undefined : makeDefaultPlan(fieldName));
 
         /*
          *  When considering resolvers on fields, there's three booleans to

--- a/grafast/grafast/src/engine/OperationPlan.ts
+++ b/grafast/grafast/src/engine/OperationPlan.ts
@@ -719,6 +719,7 @@ export class OperationPlan {
       rootType,
       this.operation.selectionSet.selections,
       true,
+      true,
     );
     if (this.loc !== null) this.loc.pop();
   }

--- a/grafast/grafast/src/graphqlCollectFields.ts
+++ b/grafast/grafast/src/graphqlCollectFields.ts
@@ -130,6 +130,7 @@ export interface SelectionSetDigest {
   label: string | undefined;
   fields: Map<string, FieldNode[]>;
   deferred: SelectionSetDigest[] | undefined;
+  resolverEmulation: boolean;
 }
 
 const processFragment = (
@@ -166,6 +167,7 @@ const processFragment = (
           label,
           fields: new Map(),
           deferred: undefined,
+          resolverEmulation: selectionSetDigest.resolverEmulation,
         }
       : null;
   if (deferredDigest !== null) {
@@ -180,11 +182,20 @@ const processFragment = (
     parentStepId,
     objectType,
     fragmentSelectionSet.selections,
+    deferredDigest ?? selectionSetDigest,
     isMutation,
     visitedFragments,
-    deferredDigest ?? selectionSetDigest,
   );
 };
+
+export function newSelectionSetDigest(resolverEmulation: boolean) {
+  return {
+    label: undefined,
+    fields: new Map(),
+    deferred: undefined,
+    resolverEmulation,
+  };
+}
 
 /**
  * Implements the `GraphQLCollectFields` algorithm - like `CollectFields` the
@@ -199,14 +210,10 @@ export function graphqlCollectFields(
   parentStepId: number,
   objectType: graphql.GraphQLObjectType,
   selections: readonly SelectionNode[],
+  selectionSetDigest: SelectionSetDigest,
   isMutation = false,
   // This is significantly faster than an array or a Set
   visitedFragments: { [fragmentName: string]: true } = Object.create(null),
-  selectionSetDigest: SelectionSetDigest = {
-    label: undefined,
-    fields: new Map(),
-    deferred: undefined,
-  },
 ): SelectionSetDigest {
   // const objectTypeFields = objectType.getFields();
   const trackedVariableValuesStep = operationPlan.trackedVariableValuesStep;

--- a/grafast/grafast/src/steps/graphqlResolver.ts
+++ b/grafast/grafast/src/steps/graphqlResolver.ts
@@ -28,6 +28,7 @@ const {
   getNullableType,
   isAbstractType,
   isListType,
+  isNonNullType,
 } = graphql;
 
 type ResolveInfoBase = Omit<
@@ -241,7 +242,12 @@ export class GraphQLItemHandler
     super();
     this.addDependency($parent);
     if (isListType(nullableType)) {
-      this.nullableInnerType = nullableType.ofType;
+      const innerType = nullableType.ofType;
+      if (isNonNullType(innerType)) {
+        this.nullableInnerType = innerType.ofType;
+      } else {
+        this.nullableInnerType = innerType;
+      }
     } else {
       if (!isAbstractType(nullableType)) {
         throw new Error(


### PR DESCRIPTION
## Description

Fixes #2107.

Previously our GraphQL resolver emulation was done on a field-by-field basis, which generally worked and was efficient, but it turns out that it would fail for polymorphic fields under a GraphQL resolver because the Grafast polymorphism expectations didn't match up with what the user would have. The workaround was simple: add resolvers to these fields (`fieldName.resolve = data => data.fieldName`), but needing this workaround wasn't ideal.

To solve this, Grafast now keeps track for each selection set whether it's in "resolver emulation" mode or not. When a field kicks it into resolver emulation mode (by having a non-default resolver), Grafast will now remain in resolver emulation mode for all descendants, until a field with a plan appears. This means that polymorphism in unplanned ancestors works the way that GraphQL.js resolvers would expect.

## Performance impact

Minimal and necessary.

## Security impact

Not known.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
