### PR TITLE
Fix evaluation of orderBy

### DIFF
--- a/.changeset/bright-rocks-compare.md
+++ b/.changeset/bright-rocks-compare.md
@@ -1,0 +1,6 @@
+---
+"graphile-build-pg": patch
+---
+
+Fix bug in orderBy planning that caused a new plan to be required for every
+request.

--- a/.changeset/bright-rocks-compare.md
+++ b/.changeset/bright-rocks-compare.md
@@ -1,5 +1,6 @@
 ---
 "graphile-build-pg": patch
+"postgraphile": patch
 ---
 
 Fix bug in orderBy planning that caused a new plan to be required for every

--- a/.changeset/clean-timers-draw.md
+++ b/.changeset/clean-timers-draw.md
@@ -1,0 +1,5 @@
+---
+"grafast": patch
+---
+
+`constant()` steps now have an `evalLength()` method.

--- a/grafast/grafast/src/steps/constant.ts
+++ b/grafast/grafast/src/steps/constant.ts
@@ -52,6 +52,10 @@ export class ConstantStep<TData> extends UnbatchedExecutableStep<TData> {
     );
   }
 
+  evalLength() {
+    return Array.isArray(this.data) ? this.data.length : null;
+  }
+
   unbatchedExecute() {
     return this.data;
   }

--- a/graphile-build/graphile-build-pg/src/plugins/PgConnectionArgOrderByPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgConnectionArgOrderByPlugin.ts
@@ -233,14 +233,16 @@ export const applyOrderToPlan = EXPORTABLE(
       $value: InputStep,
       TableOrderByType: GraphQLEnumType,
     ) => {
-      const val = $value.eval();
-      if (val == null) {
+      if (!("evalLength" in $value)) {
         return;
       }
-      if (!Array.isArray(val)) {
-        throw new Error("Invalid!");
+      const length = $value.evalLength();
+      if (length == null) {
+        return;
       }
-      val.forEach((order) => {
+      for (let i = 0; i < length; i++) {
+        const order = $value.at(i).eval();
+        if (order == null) continue;
         const config = getEnumValueConfig(TableOrderByType, order);
         const plan = config?.extensions?.grafast?.applyPlan;
         if (typeof plan !== "function") {
@@ -254,7 +256,7 @@ export const applyOrderToPlan = EXPORTABLE(
           );
         }
         plan($select);
-      });
+      }
     },
   [SafeError, getEnumValueConfig, inspect],
 );

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.export.mjs
@@ -11236,14 +11236,16 @@ const getSelectPlanFromParentAndArgs12 = ($root, args, _info) => {
   return resource_table_set_queryPgResource.execute(selectArgs);
 };
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -11251,7 +11253,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 const argDetailsSimple46 = [];
 const makeArgs46 = (args, path = []) => {

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.inheritence.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.inheritence.1.export.mjs
@@ -433,14 +433,16 @@ const fetcher3 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.UserFile);
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -448,7 +450,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function CursorSerialize(value) {
   return "" + value;

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.nested_arrays.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.nested_arrays.1.export.mjs
@@ -406,14 +406,16 @@ const fetcher = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.T);
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -421,7 +423,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 const resource_frmcdc_workHourPgResource = registry.pgResources["frmcdc_workHour"];
 function CursorSerialize(value) {

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.export.mjs
@@ -11236,14 +11236,16 @@ const getSelectPlanFromParentAndArgs12 = ($root, args, _info) => {
   return resource_table_set_queryPgResource.execute(selectArgs);
 };
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -11251,7 +11253,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 const argDetailsSimple46 = [];
 const makeArgs46 = (args, path = []) => {

--- a/postgraphile/postgraphile/__tests__/schema/v4/enum_tables.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/enum_tables.1.export.mjs
@@ -1092,14 +1092,16 @@ const fetcher2 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.ReferencingTable);
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -1107,7 +1109,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function CursorSerialize(value) {
   return "" + value;

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.export.mjs
@@ -6685,14 +6685,16 @@ const getSelectPlanFromParentAndArgs10 = ($root, args, _info) => {
   return resource_table_set_queryPgResource.execute(selectArgs);
 };
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -6700,7 +6702,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 const argDetailsSimple30 = [];
 const makeArgs30 = (args, path = []) => {

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-good.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-good.1.export.mjs
@@ -6683,14 +6683,16 @@ const getSelectPlanFromParentAndArgs10 = ($root, args, _info) => {
   return resource_table_set_queryPgResource.execute(selectArgs);
 };
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -6698,7 +6700,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 const argDetailsSimple30 = [];
 const makeArgs30 = (args, path = []) => {

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.export.mjs
@@ -11270,14 +11270,16 @@ const getSelectPlanFromParentAndArgs12 = ($root, args, _info) => {
   return resource_table_set_queryPgResource.execute(selectArgs);
 };
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -11285,7 +11287,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 const argDetailsSimple46 = [];
 const makeArgs46 = (args, path = []) => {

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.export.mjs
@@ -11264,14 +11264,16 @@ const getSelectPlanFromParentAndArgs12 = ($root, args, _info) => {
   return resource_table_set_queryPgResource.execute(selectArgs);
 };
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -11279,7 +11281,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 const argDetailsSimple46 = [];
 const makeArgs46 = (args, path = []) => {

--- a/postgraphile/postgraphile/__tests__/schema/v4/geometry.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/geometry.1.export.mjs
@@ -270,14 +270,16 @@ const fetcher = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Geom);
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -285,7 +287,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function CursorSerialize(value) {
   return "" + value;

--- a/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.export.mjs
@@ -11488,14 +11488,16 @@ const getSelectPlanFromParentAndArgs12 = ($root, args, _info) => {
   return resource_table_set_queryPgResource.execute(selectArgs);
 };
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -11503,7 +11505,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 const argDetailsSimple46 = [];
 const makeArgs46 = (args, path = []) => {

--- a/postgraphile/postgraphile/__tests__/schema/v4/indexes.index_expressions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/indexes.index_expressions.1.export.mjs
@@ -209,14 +209,16 @@ const fetcher = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Employee);
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -224,7 +226,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function CursorSerialize(value) {
   return "" + value;

--- a/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.export.mjs
@@ -11236,14 +11236,16 @@ const getSelectPlanFromParentAndArgs12 = ($root, args, _info) => {
   return resource_table_set_queryPgResource.execute(selectArgs);
 };
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -11251,7 +11253,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 const argDetailsSimple46 = [];
 const makeArgs46 = (args, path = []) => {

--- a/postgraphile/postgraphile/__tests__/schema/v4/js-reserved.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/js-reserved.1.export.mjs
@@ -1546,14 +1546,16 @@ const specFromRecord = $record => {
   }, Object.create(null));
 };
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -1561,7 +1563,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 const specFromRecord2 = $record => {
   return registryConfig.pgRelations.building.relationalItemsByTheirConstructor.remoteAttributes.reduce((memo, remoteAttributeName, i) => {

--- a/postgraphile/postgraphile/__tests__/schema/v4/jwt.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/jwt.1.export.mjs
@@ -2264,14 +2264,16 @@ const fetcher = (handler => {
 })(nodeIdHandlerByTypeName.Type);
 const resource_updatable_viewPgResource = registry.pgResources["updatable_view"];
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -2279,7 +2281,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
 const resource_frmcdc_nestedCompoundTypePgResource = registry.pgResources["frmcdc_nestedCompoundType"];

--- a/postgraphile/postgraphile/__tests__/schema/v4/network_types.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/network_types.1.export.mjs
@@ -221,14 +221,16 @@ const fetcher = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Network);
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -236,7 +238,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function InternetAddressSerialize(value) {
   return "" + value;

--- a/postgraphile/postgraphile/__tests__/schema/v4/network_types.custom.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/network_types.custom.1.export.mjs
@@ -221,14 +221,16 @@ const fetcher = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Network);
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -236,7 +238,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function InternetAddressSerialize(value) {
   return "" + value;

--- a/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.export.mjs
@@ -6644,14 +6644,16 @@ const getSelectPlanFromParentAndArgs10 = ($root, args, _info) => {
   return resource_table_set_queryPgResource.execute(selectArgs);
 };
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -6659,7 +6661,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 const argDetailsSimple30 = [];
 const makeArgs30 = (args, path = []) => {

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.1.export.mjs
@@ -1375,14 +1375,16 @@ const fetcher6 = (handler => {
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -1390,7 +1392,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function CursorSerialize(value) {
   return "" + value;

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.1.export.mjs
@@ -1378,14 +1378,16 @@ const fetcher6 = (handler => {
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -1393,7 +1395,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function CursorSerialize(value) {
   return "" + value;

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.execute.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.execute.1.export.mjs
@@ -1311,14 +1311,16 @@ const fetcher6 = (handler => {
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -1326,7 +1328,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function CursorSerialize(value) {
   return "" + value;

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.loads-title.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.loads-title.1.export.mjs
@@ -1378,14 +1378,16 @@ const fetcher6 = (handler => {
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -1393,7 +1395,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function CursorSerialize(value) {
   return "" + value;

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.shows-title-asterisk.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.shows-title-asterisk.1.export.mjs
@@ -1381,14 +1381,16 @@ const fetcher6 = (handler => {
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -1396,7 +1398,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function CursorSerialize(value) {
   return "" + value;

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.title-order.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.title-order.1.export.mjs
@@ -1378,14 +1378,16 @@ const fetcher6 = (handler => {
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -1393,7 +1395,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function CursorSerialize(value) {
   return "" + value;

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.update-title.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.update-title.1.export.mjs
@@ -1378,14 +1378,16 @@ const fetcher6 = (handler => {
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -1393,7 +1395,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function CursorSerialize(value) {
   return "" + value;

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.1.export.mjs
@@ -1381,14 +1381,16 @@ const fetcher6 = (handler => {
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -1396,7 +1398,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function CursorSerialize(value) {
   return "" + value;

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.constraints.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.constraints.1.export.mjs
@@ -1383,14 +1383,16 @@ const fetcher6 = (handler => {
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -1398,7 +1400,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-asterisk.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-asterisk.1.export.mjs
@@ -1329,14 +1329,16 @@ const fetcher4 = (handler => {
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -1344,7 +1346,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-create.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-create.1.export.mjs
@@ -1381,14 +1381,16 @@ const fetcher6 = (handler => {
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -1396,7 +1398,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function CursorSerialize(value) {
   return "" + value;

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-delete.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-delete.1.export.mjs
@@ -1381,14 +1381,16 @@ const fetcher6 = (handler => {
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -1396,7 +1398,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function CursorSerialize(value) {
   return "" + value;

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-loads.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-loads.1.export.mjs
@@ -1352,14 +1352,16 @@ const fetcher5 = (handler => {
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -1367,7 +1369,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function CursorSerialize(value) {
   return "" + value;

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-update.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-update.1.export.mjs
@@ -1381,14 +1381,16 @@ const fetcher6 = (handler => {
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -1396,7 +1398,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function CursorSerialize(value) {
   return "" + value;

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.shows-order.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.shows-order.1.export.mjs
@@ -1380,14 +1380,16 @@ const fetcher6 = (handler => {
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -1395,7 +1397,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function CursorSerialize(value) {
   return "" + value;

--- a/postgraphile/postgraphile/__tests__/schema/v4/partitions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/partitions.1.export.mjs
@@ -352,14 +352,16 @@ const fetcher2 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Measurement);
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -367,7 +369,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function DatetimeSerialize(value) {
   return "" + value;

--- a/postgraphile/postgraphile/__tests__/schema/v4/pg11.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/pg11.1.export.mjs
@@ -733,14 +733,16 @@ const fetcher4 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Type);
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -748,7 +750,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function InternetAddressSerialize(value) {
   return "" + value;

--- a/postgraphile/postgraphile/__tests__/schema/v4/pg11.custom.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/pg11.custom.1.export.mjs
@@ -733,14 +733,16 @@ const fetcher4 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Type);
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -748,7 +750,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function InternetAddressSerialize(value) {
   return "" + value;

--- a/postgraphile/postgraphile/__tests__/schema/v4/polymorphic.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/polymorphic.1.export.mjs
@@ -4279,14 +4279,16 @@ const nodeIdCodecs = Object.assign(Object.create(null), {
 });
 const otherSource_peoplePgResource = registry.pgResources["people"];
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -4294,7 +4296,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 const otherSource_single_table_item_relationsPgResource = registry.pgResources["single_table_item_relations"];
 const otherSource_single_table_item_relation_composite_pksPgResource = registry.pgResources["single_table_item_relation_composite_pks"];

--- a/postgraphile/postgraphile/__tests__/schema/v4/rbac.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/rbac.1.export.mjs
@@ -8903,14 +8903,16 @@ const fetcher4 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Person);
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -8918,7 +8920,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
 const isValidHstoreObject = obj => {

--- a/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.export.mjs
@@ -11236,14 +11236,16 @@ const getSelectPlanFromParentAndArgs12 = ($root, args, _info) => {
   return resource_table_set_queryPgResource.execute(selectArgs);
 };
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -11251,7 +11253,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 const argDetailsSimple46 = [];
 const makeArgs46 = (args, path = []) => {

--- a/postgraphile/postgraphile/__tests__/schema/v4/refs.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/refs.1.export.mjs
@@ -353,14 +353,16 @@ const fetcher2 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Post);
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -368,7 +370,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function CursorSerialize(value) {
   return "" + value;

--- a/postgraphile/postgraphile/__tests__/schema/v4/relay.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/relay.1.export.mjs
@@ -1376,14 +1376,16 @@ const fetcher6 = (handler => {
 })(nodeIdHandlerByTypeName.Person);
 const resource_renamed_tablePgResource = registry.pgResources["renamed_table"];
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -1391,7 +1393,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";

--- a/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.export.mjs
@@ -6644,14 +6644,16 @@ const getSelectPlanFromParentAndArgs10 = ($root, args, _info) => {
   return resource_table_set_queryPgResource.execute(selectArgs);
 };
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -6659,7 +6661,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 const argDetailsSimple30 = [];
 const makeArgs30 = (args, path = []) => {

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.export.mjs
@@ -6644,14 +6644,16 @@ const getSelectPlanFromParentAndArgs10 = ($root, args, _info) => {
   return resource_table_set_queryPgResource.execute(selectArgs);
 };
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -6659,7 +6661,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 const argDetailsSimple30 = [];
 const makeArgs30 = (args, path = []) => {

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.omit-pets-simple.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.omit-pets-simple.1.export.mjs
@@ -369,14 +369,16 @@ const fetcher2 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Pet);
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -384,7 +386,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only-people-omit.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only-people-omit.1.export.mjs
@@ -374,14 +374,16 @@ const fetcher2 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Pet);
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -389,7 +391,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only.1.export.mjs
@@ -6604,14 +6604,16 @@ const makeArgs29 = (args, path = []) => {
 };
 const resource_table_set_queryPgResource = registry.pgResources["table_set_query"];
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -6619,7 +6621,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 const argDetailsSimple30 = [];
 const makeArgs30 = (args, path = []) => {

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.pets-simple.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.pets-simple.1.export.mjs
@@ -370,14 +370,16 @@ const fetcher2 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Pet);
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -385,7 +387,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function hasRecord($row) {
   return "record" in $row && typeof $row.record === "function";

--- a/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.export.mjs
@@ -11236,14 +11236,16 @@ const getSelectPlanFromParentAndArgs12 = ($root, args, _info) => {
   return resource_table_set_queryPgResource.execute(selectArgs);
 };
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -11251,7 +11253,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 const argDetailsSimple46 = [];
 const makeArgs46 = (args, path = []) => {

--- a/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.1.export.mjs
@@ -10828,14 +10828,16 @@ const getSelectPlanFromParentAndArgs12 = ($root, args, _info) => {
   return resource_table_set_queryPgResource.execute(selectArgs);
 };
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -10843,7 +10845,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 const argDetailsSimple46 = [];
 const makeArgs46 = (args, path = []) => {

--- a/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.polymorphic.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.polymorphic.1.export.mjs
@@ -4214,14 +4214,16 @@ const registry = makeRegistry(registryConfig);
 const otherSource_peoplePgResource = registry.pgResources["people"];
 const otherSource_single_table_itemsPgResource = registry.pgResources["single_table_items"];
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -4229,7 +4231,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 const otherSource_single_table_item_relationsPgResource = registry.pgResources["single_table_item_relations"];
 const otherSource_single_table_item_relation_composite_pksPgResource = registry.pgResources["single_table_item_relation_composite_pks"];

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.1.export.mjs
@@ -1382,14 +1382,16 @@ const fetcher7 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Building);
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -1397,7 +1399,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function CursorSerialize(value) {
   return "" + value;

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post.1.export.mjs
@@ -1379,14 +1379,16 @@ const fetcher7 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Building);
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -1394,7 +1396,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function CursorSerialize(value) {
   return "" + value;

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post_view.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post_view.1.export.mjs
@@ -1382,14 +1382,16 @@ const fetcher7 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Building);
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -1397,7 +1399,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function CursorSerialize(value) {
   return "" + value;

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post_view_no_pk.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.post_view_no_pk.1.export.mjs
@@ -1358,14 +1358,16 @@ const fetcher6 = (handler => {
 })(nodeIdHandlerByTypeName.Building);
 const resource_postsPgResource = registry.pgResources["posts"];
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -1373,7 +1375,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function CursorSerialize(value) {
   return "" + value;

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.view_fake_unique.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.view_fake_unique.1.export.mjs
@@ -1354,14 +1354,16 @@ const fetcher6 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Building);
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -1369,7 +1371,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function CursorSerialize(value) {
   return "" + value;

--- a/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.view_fake_unique_pk.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/smart_comment_relations.view_fake_unique_pk.1.export.mjs
@@ -1282,14 +1282,16 @@ const fetcher7 = (handler => {
   return fn;
 })(nodeIdHandlerByTypeName.Building);
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -1297,7 +1299,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 function CursorSerialize(value) {
   return "" + value;

--- a/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.1.export.mjs
@@ -11070,14 +11070,16 @@ const makeArgs50 = (args, path = []) => {
 const resource_b_type_function_listPgResource = registry.pgResources["b_type_function_list"];
 const resource_non_updatable_viewPgResource = registry.pgResources["non_updatable_view"];
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -11085,7 +11087,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 const resource_foreign_keyPgResource = registry.pgResources["foreign_key"];
 const resource_testviewPgResource = registry.pgResources["testview"];

--- a/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.polymorphic.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.polymorphic.1.export.mjs
@@ -4209,14 +4209,16 @@ const registry = makeRegistry(registryConfig);
 const otherSource_peoplePgResource = registry.pgResources["people"];
 const otherSource_single_table_itemsPgResource = registry.pgResources["single_table_items"];
 const applyOrderToPlan = ($select, $value, TableOrderByType) => {
-  const val = $value.eval();
-  if (val == null) {
+  if (!("evalLength" in $value)) {
     return;
   }
-  if (!Array.isArray(val)) {
-    throw new Error("Invalid!");
+  const length = $value.evalLength();
+  if (length == null) {
+    return;
   }
-  val.forEach(order => {
+  for (let i = 0; i < length; i++) {
+    const order = $value.at(i).eval();
+    if (order == null) continue;
     const config = getEnumValueConfig(TableOrderByType, order);
     const plan = config?.extensions?.grafast?.applyPlan;
     if (typeof plan !== "function") {
@@ -4224,7 +4226,7 @@ const applyOrderToPlan = ($select, $value, TableOrderByType) => {
       throw new SafeError("Internal server error: invalid orderBy configuration");
     }
     plan($select);
-  });
+  }
 };
 const otherSource_single_table_item_relationsPgResource = registry.pgResources["single_table_item_relations"];
 const otherSource_single_table_item_relation_composite_pksPgResource = registry.pgResources["single_table_item_relation_composite_pks"];


### PR DESCRIPTION
Reported in Discord by `@adamni21`:

> There's currently an issues, with not being able to reuse cached operation plans, if you specify an orderBy input.
> It's because of this: https://github.com/graphile/crystal/blob/main/graphile-build/graphile-build-pg/src/plugins/PgConnectionArgOrderByPlugin.ts#L236
> and the fact  `matchesConstraint()`, checks it via `value === constraint.value` instead of using `assert.deepStrictEqual()` or at least handling arrays like 
`|| (Array.isArray(constraint.value) && Array.isArray(value) && constraint.value.every((el, i) => el === value[i])`

This should never have called `.eval()` directly; no idea why it did. I've changed it to `evalLength()` and then `eval` on each underlying value.