### PR TITLE
Fix issues with planning errors and hasSideEffects=true

### DIFF
--- a/.changeset/cool-oranges-grab.md
+++ b/.changeset/cool-oranges-grab.md
@@ -1,0 +1,11 @@
+---
+"@dataplan/pg": patch
+"grafast": patch
+---
+
+Fix issue where planning errors occurring after side-effects would result in
+GrafastInternalError being thrown. Further, fix issue causing
+`$step.hasSideEffects=true` to throw a planning error if `$step` had created
+other steps (as dependencies) during its construction. (Notably, `withPgClient`
+suffered from this.) Thanks to @purge for reporting the issue and creating a
+reproduction.

--- a/grafast/dataplan-pg/src/examples/exampleSchema.ts
+++ b/grafast/dataplan-pg/src/examples/exampleSchema.ts
@@ -5138,6 +5138,10 @@ export function makeExampleSchema(
                   return rows2.map((row) => row.i);
                 },
               );
+
+              // This line is critical to test setting hasSideEffects on a withPgClient call
+              $transactionResult.hasSideEffects = true;
+
               return $transactionResult;
             },
           [

--- a/grafast/grafast/src/engine/OperationPlan.ts
+++ b/grafast/grafast/src/engine/OperationPlan.ts
@@ -1848,6 +1848,7 @@ export class OperationPlan {
     const parentStep = this.stepTracker.getStepById(rawParentStep.id);
 
     const previousStepCount = this.stepTracker.stepCount;
+    const previousSideEffectStep = layerPlan.latestSideEffectStep;
 
     if (this.loc !== null) this.loc.push(`planField(${path.join(".")})`);
     try {
@@ -1951,6 +1952,7 @@ export class OperationPlan {
 
       try {
         this.stepTracker.purgeBackTo(previousStepCount);
+        layerPlan.latestSideEffectStep = previousSideEffectStep;
       } catch (e2) {
         console.error(
           `Cleanup error occurred whilst trying to recover from field planning error: ${e2.stack}`,

--- a/grafast/grafast/src/step.ts
+++ b/grafast/grafast/src/step.ts
@@ -38,7 +38,7 @@ import {
   DEFAULT_FORBIDDEN_FLAGS,
 } from "./interfaces.js";
 import type { __ItemStep } from "./steps/index.js";
-import { stepAMayDependOnStepB } from "./utils.js";
+import { stepADependsOnStepB, stepAMayDependOnStepB } from "./utils.js";
 
 /**
  * This indicates that a step never executes (e.g. __ItemStep and __ValueStep)
@@ -305,26 +305,48 @@ export /* abstract */ class ExecutableStep<TData = any> extends BaseStep {
     this.implicitSideEffectStep = null;
     this.hasSideEffects ??= false;
     let hasSideEffects = false;
+    const stepTracker = this.layerPlan.operationPlan.stepTracker;
     Object.defineProperty(this, "hasSideEffects", {
-      get() {
+      get(this: ExecutableStep<TData>) {
         return hasSideEffects;
       },
-      set(value) {
-        if (
-          this.id ===
-          this.layerPlan.operationPlan.stepTracker.stepCount - 1
-        ) {
+      set(this: ExecutableStep<TData>, value) {
+        /**
+         * If steps were created after this step, an this step doesn't depend
+         * on them, then it's no longer safe to change hasSideEffects.
+         */
+        let nonDependentSteps: ExecutableStep[] | null = null;
+
+        const maxStepId = stepTracker.stepCount - 1;
+        if (this.id === maxStepId) {
+          // All good - no more steps were created
+        } else {
+          // If the step created them during initialization and is dependent on
+          // them, that's fine too.
+          for (let id = this.id + 1; id <= maxStepId; id++) {
+            const step = stepTracker.getStepById(id);
+            if (stepADependsOnStepB(this, step)) continue;
+            if (nonDependentSteps === null) {
+              nonDependentSteps = [step];
+            } else {
+              nonDependentSteps.push(step);
+            }
+          }
+        }
+        if (nonDependentSteps === null) {
           hasSideEffects = value;
           if (value === true) {
             this.layerPlan.latestSideEffectStep = this;
           } else if (value !== true && hasSideEffects === true) {
             throw new Error(
-              `Cannot mark a step has having no side effects after having set it to have side effects.`,
+              `Cannot mark ${this} as having no side effects after having set it to have side effects.`,
             );
           }
         } else {
           throw new Error(
-            `Attempted to mark ${this} as having side effects, but other steps have already been created.`,
+            `Attempted to mark ${this} as having side effects, but other non-dependent steps (${nonDependentSteps
+              .map(String)
+              .join(", ")}) have already been created.`,
           );
         }
       },

--- a/grafast/grafast/src/step.ts
+++ b/grafast/grafast/src/step.ts
@@ -324,7 +324,7 @@ export /* abstract */ class ExecutableStep<TData = any> extends BaseStep {
           }
         } else {
           throw new Error(
-            "You must mark a step as having side effects immediately after creating it, before any other steps are created.",
+            `Attempted to mark ${this} as having side effects, but other steps have already been created.`,
           );
         }
       },


### PR DESCRIPTION
## Description

Fixes https://github.com/benjie/ouch-my-finger/pull/13

Setting `$step.hasSideEffects = true` on a step is only allowed just after the step is created (or during its creation) because we track the fact of a side effect having happened in the layer plan so that all future steps are implicitly "dependent" on the side effect.

However, this check was too strict - it's okay for other steps to have been created, so long as `$step` ultimately depends on them. We just want to make it so that future steps (those that `$step` does not depend on) will implicitly depend on `$step` succeeding. This has been fixed.

Related; when a planning error occurs we "roll back" the plan diagram to a previous state (throwing away older steps). However; when we did this, we did not clear the fact that we were tracking a latest side effect step on the LayerPlan, which resulted in attempting to reference said step at runtime even though it had been removed. This has also been resolved.

## Performance impact

None known.

## Security impact

None known.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
