### PR TITLE
Upgrade GraphQL to 16.9.0

### DIFF
--- a/grafast/bench/package.json
+++ b/grafast/bench/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "grafast": "workspace:^",
     "graphile-config": "workspace:^",
-    "graphql": "^16.1.0-experimental-stream-defer.6",
+    "graphql": "^16.9.0",
     "tslib": "^2.6.2"
   },
   "engines": {

--- a/grafast/dataplan-pg/package.json
+++ b/grafast/dataplan-pg/package.json
@@ -91,7 +91,7 @@
     "glob": "^10.3.4",
     "grafserv": "workspace:*",
     "graphile-export": "workspace:*",
-    "graphql": "16.1.0-experimental-stream-defer.6",
+    "graphql": "^16.9.0",
     "iterall": "^1.3.0",
     "jest": "^29.6.4",
     "jest-serializer-simple": "workspace:^",

--- a/grafast/dataplan-pg/src/examples/exampleSchema.ts
+++ b/grafast/dataplan-pg/src/examples/exampleSchema.ts
@@ -5262,6 +5262,7 @@ export function makeExampleSchema(
         ],
       },
     },
+    // @ts-ignore
     enableDeferStream: true,
   });
 }

--- a/grafast/grafast/package.json
+++ b/grafast/grafast/package.json
@@ -66,7 +66,7 @@
     "chalk": "^4.1.2",
     "debug": "^4.3.4",
     "eventemitter3": "^5.0.1",
-    "graphql": "^16.1.0-experimental-stream-defer.6",
+    "graphql": "^16.9.0",
     "iterall": "^1.3.0",
     "tamedevil": "workspace:^",
     "tslib": "^2.6.2"
@@ -74,7 +74,7 @@
   "peerDependencies": {
     "@envelop/core": "^5.0.0",
     "graphile-config": "workspace:^",
-    "graphql": "^16.1.0-experimental-stream-defer.6",
+    "graphql": "^16.9.0",
     "tamedevil": "workspace:^"
   },
   "peerDependenciesMeta": {
@@ -99,7 +99,7 @@
     "@types/node": "^20.5.7",
     "@types/nodemon": "1.19.2",
     "chai": "^4.3.8",
-    "graphql": "16.1.0-experimental-stream-defer.6",
+    "graphql": "^16.9.0",
     "jest": "^29.6.4",
     "lodash": "^4.17.21",
     "mermaid": "^9.4.3",

--- a/grafast/grafast/src/incremental.ts
+++ b/grafast/grafast/src/incremental.ts
@@ -1,0 +1,83 @@
+import {
+  DirectiveLocation,
+  GraphQLBoolean,
+  GraphQLDirective,
+  GraphQLInt,
+  GraphQLString,
+} from "graphql";
+
+// This file contains the Stream/Defer directives, to be used when GraphQL itself doesn't provide them.
+
+// Taken from https://github.com/graphql/graphql-js/blob/bc6b2e47512ee11c01eb5185d184990e743df736/src/type/directives.ts
+
+/*
+MIT License
+
+Copyright (c) GraphQL Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/**
+ * Used to conditionally defer fragments.
+ */
+export const GraphQLDeferDirective = new GraphQLDirective({
+  name: "defer",
+  description:
+    "Directs the executor to defer this fragment when the `if` argument is true or undefined.",
+  locations: [
+    DirectiveLocation.FRAGMENT_SPREAD,
+    DirectiveLocation.INLINE_FRAGMENT,
+  ],
+  args: {
+    if: {
+      type: GraphQLBoolean,
+      description: "Deferred when true or undefined.",
+    },
+    label: {
+      type: GraphQLString,
+      description: "Unique name",
+    },
+  },
+});
+
+/**
+ * Used to conditionally stream list fields.
+ */
+export const GraphQLStreamDirective = new GraphQLDirective({
+  name: "stream",
+  description:
+    "Directs the executor to stream plural fields when the `if` argument is true or undefined.",
+  locations: [DirectiveLocation.FIELD],
+  args: {
+    if: {
+      type: GraphQLBoolean,
+      description: "Stream when true or undefined.",
+    },
+    label: {
+      type: GraphQLString,
+      description: "Unique name",
+    },
+    initialCount: {
+      defaultValue: 0,
+      type: GraphQLInt,
+      description: "Number of items to return immediately",
+    },
+  },
+});

--- a/grafast/grafast/src/index.ts
+++ b/grafast/grafast/src/index.ts
@@ -5,9 +5,11 @@ import debugFactory from "debug";
 import type { CallbackOrDescriptor, MiddlewareNext } from "graphile-config";
 import type {
   DocumentNode,
+  ExecutionResult,
   GraphQLError,
   OperationDefinitionNode,
 } from "graphql";
+import type { ObjMap } from "graphql/jsutils/ObjMap";
 
 import type { __InputDynamicScalarStep } from "./steps/__inputDynamicScalar.js";
 import type { DataFromObjectSteps } from "./steps/object.js";
@@ -832,4 +834,34 @@ declare module "graphql" {
   interface GraphQLSchemaExtensions {
     grafast?: Grafast.SchemaExtensions;
   }
+}
+
+declare module "graphql/execution/execute" {
+  interface ExecutionPatchResult<
+    TData = ObjMap<unknown> | unknown,
+    TExtensions = ObjMap<unknown>,
+  > {
+    errors?: ReadonlyArray<GraphQLError>;
+    data?: TData | null;
+    path?: ReadonlyArray<string | number>;
+    label?: string;
+    hasNext: boolean;
+    extensions?: TExtensions;
+  }
+  type AsyncExecutionResult = ExecutionResult | ExecutionPatchResult;
+}
+
+declare module "graphql" {
+  interface ExecutionPatchResult<
+    TData = ObjMap<unknown> | unknown,
+    TExtensions = ObjMap<unknown>,
+  > {
+    errors?: ReadonlyArray<GraphQLError>;
+    data?: TData | null;
+    path?: ReadonlyArray<string | number>;
+    label?: string;
+    hasNext: boolean;
+    extensions?: TExtensions;
+  }
+  type AsyncExecutionResult = ExecutionResult | ExecutionPatchResult;
 }

--- a/grafast/grafast/src/makeGrafastSchema.ts
+++ b/grafast/grafast/src/makeGrafastSchema.ts
@@ -122,6 +122,7 @@ export function makeGrafastSchema(details: {
   const { typeDefs, plans, enableDeferStream = false } = details;
 
   const astSchema = buildASTSchema(parse(typeDefs), {
+    // @ts-ignore
     enableDeferStream,
   });
   const schemaConfig = astSchema.toConfig() as graphql.GraphQLSchemaConfig & {

--- a/grafast/grafserv/package.json
+++ b/grafast/grafserv/package.json
@@ -92,7 +92,7 @@
     "@envelop/core": "^5.0.0",
     "grafast": "workspace:^",
     "graphile-config": "workspace:^",
-    "graphql": "^16.1.0-experimental-stream-defer.6",
+    "graphql": "^16.9.0",
     "h3": "^1.7.1",
     "ws": "^8.12.1"
   },

--- a/grafast/ruru-components/package.json
+++ b/grafast/ruru-components/package.json
@@ -53,7 +53,7 @@
     "node": ">=16"
   },
   "peerDependencies": {
-    "graphql": "^16.1.0-experimental-stream-defer.6",
+    "graphql": "^16.9.0",
     "tamedevil": "workspace:^"
   },
   "peerDependenciesMeta": {
@@ -73,7 +73,7 @@
     "@types/nodemon": "1.19.2",
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",
-    "graphql": "16.1.0-experimental-stream-defer.6",
+    "graphql": "^16.9.0",
     "jest": "^29.6.4",
     "nodemon": "^3.0.1",
     "typescript": "^5.2.2"

--- a/grafast/ruru/package.json
+++ b/grafast/ruru/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@emotion/is-prop-valid": "^1.2.1",
     "graphile-config": "workspace:^",
-    "graphql": "^16.1.0-experimental-stream-defer.6",
+    "graphql": "^16.9.0",
     "http-proxy": "^1.18.1",
     "tslib": "^2.6.2",
     "yargs": "^17.7.2"
@@ -56,7 +56,7 @@
   },
   "peerDependencies": {
     "graphile-config": "workspace:^",
-    "graphql": "^16.1.0-experimental-stream-defer.6"
+    "graphql": "^16.9.0"
   },
   "files": [
     "dist",
@@ -69,7 +69,7 @@
     "@types/yargs": "^17.0.24",
     "css-loader": "^6.8.1",
     "file-loader": "^6.2.0",
-    "graphql": "16.1.0-experimental-stream-defer.6",
+    "graphql": "^16.9.0",
     "ruru-components": "workspace:^",
     "style-loader": "^3.3.3",
     "svg-inline-loader": "^0.8.2",

--- a/graphile-build/graphile-build-pg/package.json
+++ b/graphile-build/graphile-build-pg/package.json
@@ -57,7 +57,7 @@
     "grafast": "workspace:^",
     "graphile-build": "workspace:*",
     "graphile-config": "workspace:^",
-    "graphql": "^16.1.0-experimental-stream-defer.6",
+    "graphql": "^16.9.0",
     "pg": "^8.7.1",
     "pg-sql2": "workspace:^",
     "tamedevil": "workspace:^"
@@ -89,7 +89,7 @@
     "fastify": "^4.22.1",
     "fastify-static": "^4.7.0",
     "graphile-export": "workspace:^",
-    "graphql": "16.1.0-experimental-stream-defer.6",
+    "graphql": "^16.9.0",
     "graphql-helix": "^1.13.0",
     "graphql-ws": "^5.14.0",
     "jest": "^29.6.4",

--- a/graphile-build/graphile-build/package.json
+++ b/graphile-build/graphile-build/package.json
@@ -42,7 +42,7 @@
     "chalk": "^4.1.2",
     "debug": "^4.3.4",
     "graphile-config": "workspace:^",
-    "graphql": "^16.1.0-experimental-stream-defer.6",
+    "graphql": "^16.9.0",
     "lodash": "^4.17.21",
     "pluralize": "^7.0.0",
     "semver": "^7.5.4",
@@ -55,7 +55,7 @@
   "peerDependencies": {
     "grafast": "workspace:^",
     "graphile-config": "workspace:^",
-    "graphql": "^16.1.0-experimental-stream-defer.6"
+    "graphql": "^16.9.0"
   },
   "files": [
     "dist",
@@ -65,7 +65,7 @@
     "@types/debug": "^4.1.8",
     "@types/jest": "^29.5.4",
     "graphile-export": "workspace:^",
-    "graphql": "16.1.0-experimental-stream-defer.6",
+    "graphql": "^16.9.0",
     "jest": "^29.6.4",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2"

--- a/graphile-build/graphile-build/src/plugins/StreamDeferPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/StreamDeferPlugin.ts
@@ -14,6 +14,7 @@ export const StreamDeferPlugin: GraphileConfig.Plugin = {
     hooks: {
       GraphQLSchema: {
         callback: (schema) => {
+          // @ts-ignore
           schema.enableDeferStream = true;
           return schema;
         },

--- a/graphile-build/graphile-utils/package.json
+++ b/graphile-build/graphile-utils/package.json
@@ -50,7 +50,7 @@
     "graphile-build": "workspace:^",
     "graphile-build-pg": "workspace:^",
     "graphile-config": "workspace:^",
-    "graphql": "^16.1.0-experimental-stream-defer.6",
+    "graphql": "^16.9.0",
     "tamedevil": "workspace:^"
   },
   "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint-plugin-tsdoc": "^0.2.17",
     "eslint_d": "^12.2.1",
     "glob": "^10.3.4",
-    "graphql": "16.1.0-experimental-stream-defer.6",
+    "graphql": "^16.9.0",
     "jest": "^29.6.4",
     "mock-fs": "^5.2.0",
     "pg": "^8.11.3",
@@ -87,7 +87,7 @@
   },
   "packageManager": "yarn@4.0.0-rc.33",
   "resolutions": {
-    "graphql": "16.1.0-experimental-stream-defer.6"
+    "graphql": "^16.9.0"
   },
   "dependencies": {
     "@changesets/changelog-github": "^0.4.8",

--- a/postgraphile/pgl/package.json
+++ b/postgraphile/pgl/package.json
@@ -196,7 +196,7 @@
     "graphile-build": "workspace:*",
     "graphile-build-pg": "workspace:*",
     "graphile-config": "workspace:^",
-    "graphql": "16.1.0-experimental-stream-defer.6",
+    "graphql": "^16.9.0",
     "iterall": "^1.3.0",
     "jsonwebtoken": "^9.0.2",
     "pg": "^8.11.3",

--- a/postgraphile/postgraphile/package.json
+++ b/postgraphile/postgraphile/package.json
@@ -216,7 +216,7 @@
     "graphile-build-pg": "workspace:*",
     "graphile-config": "workspace:^",
     "graphile-utils": "workspace:^",
-    "graphql": "^16.1.0-experimental-stream-defer.6",
+    "graphql": "^16.9.0",
     "iterall": "^1.3.0",
     "jsonwebtoken": "^9.0.2",
     "pg": "^8.11.3",
@@ -234,7 +234,7 @@
     "graphile-build": "workspace:*",
     "graphile-build-pg": "workspace:*",
     "graphile-config": "workspace:^",
-    "graphql": "^16.1.0-experimental-stream-defer.6",
+    "graphql": "^16.9.0",
     "pg": "^8.7.1",
     "pg-sql2": "workspace:^",
     "tamedevil": "workspace:^"

--- a/utils/graphile-export/src/exportSchema.ts
+++ b/utils/graphile-export/src/exportSchema.ts
@@ -757,6 +757,9 @@ class CodegenFile {
             `${config.name}.extensions`,
             `${config.name}.extensions`,
           ),
+          isOneOf: config.isOneOf
+            ? t.booleanLiteral(true)
+            : t.identifier("undefined"),
           fields: t.arrowFunctionExpression(
             [],
             this.makeInputObjectFields(config.fields, config.name),
@@ -1560,9 +1563,12 @@ function exportSchemaGraphQLJS({
         "schema.extensions",
         "schema.extensions",
       ),
+      // @ts-ignore
       enableDeferStream:
+        // @ts-ignore
         config.enableDeferStream != null
-          ? t.booleanLiteral(config.enableDeferStream)
+          ? // @ts-ignore
+            t.booleanLiteral(config.enableDeferStream)
           : null,
       assumeValid: null, // TODO: t.booleanLiteral(true),
     }),
@@ -1928,6 +1934,7 @@ export async function exportSchemaAsString(
     config.directives.some((d) => d.name === "defer" || d.name === "skip")
   ) {
     // Ref: https://github.com/graphql/graphql-js/pull/3450
+    // @ts-ignore
     config.enableDeferStream = true;
   }
 

--- a/utils/jest-serializer-graphql-schema/package.json
+++ b/utils/jest-serializer-graphql-schema/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.4",
-    "graphql": "16.1.0-experimental-stream-defer.6",
+    "graphql": "^16.9.0",
     "jest": "^29.6.4",
     "pretty-format": "^29.6.3",
     "ts-node": "^10.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2264,7 +2264,7 @@ __metadata:
     glob: "npm:^10.3.4"
     grafserv: "workspace:*"
     graphile-export: "workspace:*"
-    graphql: "npm:16.1.0-experimental-stream-defer.6"
+    graphql: "npm:^16.9.0"
     iterall: "npm:^1.3.0"
     jest: "npm:^29.6.4"
     jest-serializer-simple: "workspace:^"
@@ -4004,7 +4004,7 @@ __metadata:
     glob: "npm:^10.3.4"
     grafast: "workspace:^"
     graphile-config: "workspace:^"
-    graphql: "npm:^16.1.0-experimental-stream-defer.6"
+    graphql: "npm:^16.9.0"
     nodemon: "npm:^3.0.1"
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.6.2"
@@ -12043,7 +12043,7 @@ __metadata:
     chalk: "npm:^4.1.2"
     debug: "npm:^4.3.4"
     eventemitter3: "npm:^5.0.1"
-    graphql: "npm:16.1.0-experimental-stream-defer.6"
+    graphql: "npm:^16.9.0"
     iterall: "npm:^1.3.0"
     jest: "npm:^29.6.4"
     lodash: "npm:^4.17.21"
@@ -12062,7 +12062,7 @@ __metadata:
   peerDependencies:
     "@envelop/core": ^5.0.0
     graphile-config: "workspace:^"
-    graphql: ^16.1.0-experimental-stream-defer.6
+    graphql: ^16.9.0
     tamedevil: "workspace:^"
   peerDependenciesMeta:
     "@envelop/core":
@@ -12106,7 +12106,7 @@ __metadata:
     "@envelop/core": ^5.0.0
     grafast: "workspace:^"
     graphile-config: "workspace:^"
-    graphql: ^16.1.0-experimental-stream-defer.6
+    graphql: ^16.9.0
     h3: ^1.7.1
     ws: ^8.12.1
   peerDependenciesMeta:
@@ -12153,7 +12153,7 @@ __metadata:
     fastify-static: "npm:^4.7.0"
     graphile-config: "workspace:^"
     graphile-export: "workspace:^"
-    graphql: "npm:16.1.0-experimental-stream-defer.6"
+    graphql: "npm:^16.9.0"
     graphql-helix: "npm:^1.13.0"
     graphql-ws: "npm:^5.14.0"
     jest: "npm:^29.6.4"
@@ -12170,7 +12170,7 @@ __metadata:
     grafast: "workspace:^"
     graphile-build: "workspace:*"
     graphile-config: "workspace:^"
-    graphql: ^16.1.0-experimental-stream-defer.6
+    graphql: ^16.9.0
     pg: ^8.7.1
     pg-sql2: "workspace:^"
     tamedevil: "workspace:^"
@@ -12193,7 +12193,7 @@ __metadata:
     debug: "npm:^4.3.4"
     graphile-config: "workspace:^"
     graphile-export: "workspace:^"
-    graphql: "npm:16.1.0-experimental-stream-defer.6"
+    graphql: "npm:^16.9.0"
     jest: "npm:^29.6.4"
     lodash: "npm:^4.17.21"
     pluralize: "npm:^7.0.0"
@@ -12205,7 +12205,7 @@ __metadata:
   peerDependencies:
     grafast: "workspace:^"
     graphile-config: "workspace:^"
-    graphql: ^16.1.0-experimental-stream-defer.6
+    graphql: ^16.9.0
   languageName: unknown
   linkType: soft
 
@@ -12283,7 +12283,7 @@ __metadata:
     graphile-build: "workspace:^"
     graphile-build-pg: "workspace:^"
     graphile-config: "workspace:^"
-    graphql: ^16.1.0-experimental-stream-defer.6
+    graphql: ^16.9.0
     tamedevil: "workspace:^"
   peerDependenciesMeta:
     "@dataplan/pg":
@@ -12418,10 +12418,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql@npm:16.1.0-experimental-stream-defer.6":
-  version: 16.1.0-experimental-stream-defer.6
-  resolution: "graphql@npm:16.1.0-experimental-stream-defer.6"
-  checksum: 8e280798cf5738f2013c30891fd4f720d5e0fa1b074061176597af95db7779bc435d981fd7da31b89c10c84b35ce9b3377e2f7891be62d63386bebcf45f3c2d9
+"graphql@npm:^16.9.0":
+  version: 16.9.0
+  resolution: "graphql@npm:16.9.0"
+  checksum: 09feee5ee3b791c396d73d2c49fb7bdcd09b8b0c42816f78d4bd2aa5ee356dd234c859d15be4df696b2404bc0dcaa25e5a9776034f33b6ecddc7b83f7213cc48
   languageName: node
   linkType: hard
 
@@ -14203,7 +14203,7 @@ __metadata:
   resolution: "jest-serializer-graphql-schema@workspace:utils/jest-serializer-graphql-schema"
   dependencies:
     "@types/jest": "npm:^29.5.4"
-    graphql: "npm:16.1.0-experimental-stream-defer.6"
+    graphql: "npm:^16.9.0"
     jest: "npm:^29.6.4"
     pretty-format: "npm:^29.6.3"
     ts-node: "npm:^10.9.1"
@@ -17215,7 +17215,7 @@ __metadata:
     graphile-build: "workspace:*"
     graphile-build-pg: "workspace:*"
     graphile-config: "workspace:^"
-    graphql: "npm:16.1.0-experimental-stream-defer.6"
+    graphql: "npm:^16.9.0"
     iterall: "npm:^1.3.0"
     jest: "npm:^29.6.4"
     jsonwebtoken: "npm:^9.0.2"
@@ -17835,7 +17835,7 @@ __metadata:
     graphile-config: "workspace:^"
     graphile-export: "workspace:^"
     graphile-utils: "workspace:^"
-    graphql: "npm:^16.1.0-experimental-stream-defer.6"
+    graphql: "npm:^16.9.0"
     iterall: "npm:^1.3.0"
     jest: "npm:^29.6.4"
     jsonwebtoken: "npm:^9.0.2"
@@ -17856,7 +17856,7 @@ __metadata:
     graphile-build: "workspace:*"
     graphile-build-pg: "workspace:*"
     graphile-config: "workspace:^"
-    graphql: ^16.1.0-experimental-stream-defer.6
+    graphql: ^16.9.0
     pg: ^8.7.1
     pg-sql2: "workspace:^"
     tamedevil: "workspace:^"
@@ -19231,7 +19231,7 @@ __metadata:
     eslint-plugin-tsdoc: "npm:^0.2.17"
     eslint_d: "npm:^12.2.1"
     glob: "npm:^10.3.4"
-    graphql: "npm:16.1.0-experimental-stream-defer.6"
+    graphql: "npm:^16.9.0"
     jest: "npm:^29.6.4"
     mock-fs: "npm:^5.2.0"
     pg: "npm:^8.11.3"
@@ -19291,7 +19291,7 @@ __metadata:
     "@types/react-dom": "npm:^18.2.7"
     grafast: "workspace:^"
     graphiql: "npm:^3.1.1-canary-64994e0e.0"
-    graphql: "npm:16.1.0-experimental-stream-defer.6"
+    graphql: "npm:^16.9.0"
     graphql-ws: "npm:^5.14.0"
     jest: "npm:^29.6.4"
     nodemon: "npm:^3.0.1"
@@ -19300,7 +19300,7 @@ __metadata:
     tslib: "npm:^2.6.2"
     typescript: "npm:^5.2.2"
   peerDependencies:
-    graphql: ^16.1.0-experimental-stream-defer.6
+    graphql: ^16.9.0
     tamedevil: "workspace:^"
   peerDependenciesMeta:
     tamedevil:
@@ -19319,7 +19319,7 @@ __metadata:
     css-loader: "npm:^6.8.1"
     file-loader: "npm:^6.2.0"
     graphile-config: "workspace:^"
-    graphql: "npm:16.1.0-experimental-stream-defer.6"
+    graphql: "npm:^16.9.0"
     http-proxy: "npm:^1.18.1"
     ruru-components: "workspace:^"
     style-loader: "npm:^3.3.3"
@@ -19333,7 +19333,7 @@ __metadata:
     yargs: "npm:^17.7.2"
   peerDependencies:
     graphile-config: "workspace:^"
-    graphql: ^16.1.0-experimental-stream-defer.6
+    graphql: ^16.9.0
   bin:
     ruru: ./dist/cli-run.js
   languageName: unknown


### PR DESCRIPTION
Currently on hold because we need to copy implementations from https://github.com/graphql/graphql-js/blob/v16.1.0-experimental-stream-defer.6 first; or alternatively need to update graphql@16.9.0+ to have an experimental-stream-defer branch. Better to implement the new stream/defer; but we can't leverage the new enum values callback until we have stream/defer support too.