### PR TITLE
Add Self.name and scope.valueName to context for GraphQLEnumType_values_value hook

### DIFF
--- a/.changeset/funny-colts-whisper.md
+++ b/.changeset/funny-colts-whisper.md
@@ -1,0 +1,6 @@
+---
+"graphile-build": patch
+---
+
+Add `Self.name` and `scope.valueName` to context for
+`GraphQLEnumType_values_value` hook

--- a/graphile-build/graphile-build/src/global.ts
+++ b/graphile-build/graphile-build/src/global.ts
@@ -733,9 +733,13 @@ declare global {
     interface ScopeEnumValues extends ScopeEnum {}
     interface ContextEnumValues extends ContextEnum {
       scope: ScopeEnumValues;
+      // TODO: replace this with GraphQLEnumType once we can require GraphQL v16.9+
+      Self: { name: string };
     }
 
-    interface ScopeEnumValuesValue extends ScopeEnumValues {}
+    interface ScopeEnumValuesValue extends ScopeEnumValues {
+      valueName: string;
+    }
     interface ContextEnumValuesValue extends ContextEnumValues {
       scope: ScopeEnumValuesValue;
     }

--- a/graphile-build/graphile-build/src/newWithHooks/index.ts
+++ b/graphile-build/graphile-build/src/newWithHooks/index.ts
@@ -738,26 +738,41 @@ export function makeNewWithHooks({ builder }: MakeNewWithHooksOptions): {
             `|${rawSpec.name}`,
           );
 
+          const valuesContext: GraphileBuild.ContextEnumValues = {
+            ...enumContext,
+            Self: { name: finalSpec.name },
+          };
+
           finalSpec.values = builder.applyHooks(
             "GraphQLEnumType_values",
             finalSpec.values,
             build,
-            enumContext,
+            valuesContext,
             `|${finalSpec.name}`,
           );
 
           const values = finalSpec.values;
           finalSpec.values = Object.entries(values).reduce(
-            (memo, [valueKey, value]) => {
+            (memo, [valueName, value]) => {
+              const finalValueScope: GraphileBuild.ScopeEnumValuesValue =
+                build.extend(
+                  { valueName },
+                  scope,
+                  `Extending scope for value '${valueName}' within context for GraphQLEnumType '${rawSpec.name}'`,
+                );
+              const valueContext: GraphileBuild.ContextEnumValuesValue = {
+                ...valuesContext,
+                scope: finalValueScope,
+              };
               const newValue = builder.applyHooks(
                 "GraphQLEnumType_values_value",
                 value,
                 build,
-                enumContext,
-                `|${finalSpec.name}|${valueKey}`,
+                valueContext,
+                `|${finalSpec.name}|${valueName}`,
               );
 
-              memo[valueKey] = newValue;
+              memo[valueName] = newValue;
               return memo;
             },
             Object.create(null),


### PR DESCRIPTION
## Description

Fixes #2035 (partially).

## Performance impact

None known.

## Security impact

None known.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
