### PR TITLE
Fix bug where `pgUnionAll().single()` would raise an error if no rows were found

### DIFF
--- a/.changeset/cuddly-rivers-destroy.md
+++ b/.changeset/cuddly-rivers-destroy.md
@@ -1,0 +1,5 @@
+---
+"@dataplan/pg": patch
+---
+
+Fix bug selecting single row via pgUnionAll where no rows were selected.

--- a/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-18.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-18.deopt.mermaid
@@ -11,8 +11,8 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸunion_itemsᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant64{{"Constant[64∈0] ➊<br />ᐸ18ᐳ"}}:::plan
-    Object10 & Constant64 --> PgSelect7
+    Constant130{{"Constant[130∈0] ➊<br />ᐸ18ᐳ"}}:::plan
+    Object10 & Constant130 --> PgSelect7
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -20,6 +20,8 @@ graph TD
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸunion_itemsᐳ"}}:::plan
     PgClassExpression13{{"PgClassExpression[13∈0] ➊<br />ᐸ__union_items__.”type”ᐳ"}}:::plan
     PgSelectSingle12 & PgClassExpression13 --> PgPolymorphic14
+    PgUnionAll65[["PgUnionAll[65∈0] ➊"]]:::plan
+    Object10 & Constant130 --> PgUnionAll65
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access8
     __Value2 --> Access9
@@ -29,6 +31,12 @@ graph TD
     PgSelectSingle12 --> PgClassExpression13
     PgClassExpression15{{"PgClassExpression[15∈0] ➊<br />ᐸ__union_items__.”id”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression15
+    First69{{"First[69∈0] ➊"}}:::plan
+    PgUnionAll65 --> First69
+    PgUnionAllSingle70["PgUnionAllSingle[70∈0] ➊"]:::plan
+    First69 --> PgUnionAllSingle70
+    Access71{{"Access[71∈0] ➊<br />ᐸ70.1ᐳ"}}:::plan
+    PgUnionAllSingle70 --> Access71
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgSelect16[["PgSelect[16∈1] ➊<br />ᐸunion_topicsᐳ<br />ᐳUnionTopic"]]:::plan
     Object10 & PgClassExpression15 --> PgSelect16
@@ -88,15 +96,96 @@ graph TD
     PgSelectSingle60 --> PgClassExpression62
     PgClassExpression63{{"PgClassExpression[63∈1] ➊<br />ᐸ__union_ch...s__.”note”ᐳ"}}:::plan
     PgSelectSingle60 --> PgClassExpression63
+    PgSelect74[["PgSelect[74∈2] ➊<br />ᐸunion_topicsᐳ<br />ᐳUnionTopic"]]:::plan
+    Access73{{"Access[73∈2] ➊<br />ᐸ72.0ᐳ"}}:::plan
+    Object10 & Access73 --> PgSelect74
+    PgSelect85[["PgSelect[85∈2] ➊<br />ᐸunion_postsᐳ<br />ᐳUnionPost"]]:::plan
+    Access84{{"Access[84∈2] ➊<br />ᐸ83.0ᐳ"}}:::plan
+    Object10 & Access84 --> PgSelect85
+    PgSelect98[["PgSelect[98∈2] ➊<br />ᐸunion_dividersᐳ<br />ᐳUnionDivider"]]:::plan
+    Access97{{"Access[97∈2] ➊<br />ᐸ96.0ᐳ"}}:::plan
+    Object10 & Access97 --> PgSelect98
+    PgSelect110[["PgSelect[110∈2] ➊<br />ᐸunion_checklistsᐳ<br />ᐳUnionChecklist"]]:::plan
+    Access109{{"Access[109∈2] ➊<br />ᐸ108.0ᐳ"}}:::plan
+    Object10 & Access109 --> PgSelect110
+    PgSelect121[["PgSelect[121∈2] ➊<br />ᐸunion_checklist_itemsᐳ<br />ᐳUnionChecklistItem"]]:::plan
+    Access120{{"Access[120∈2] ➊<br />ᐸ119.0ᐳ"}}:::plan
+    Object10 & Access120 --> PgSelect121
+    JSONParse72[["JSONParse[72∈2] ➊<br />ᐸ71ᐳ<br />ᐳUnionTopic"]]:::plan
+    Access71 --> JSONParse72
+    JSONParse72 --> Access73
+    First78{{"First[78∈2] ➊"}}:::plan
+    PgSelect74 --> First78
+    PgSelectSingle79{{"PgSelectSingle[79∈2] ➊<br />ᐸunion_topicsᐳ"}}:::plan
+    First78 --> PgSelectSingle79
+    PgClassExpression80{{"PgClassExpression[80∈2] ➊<br />ᐸ__union_topics__.”id”ᐳ"}}:::plan
+    PgSelectSingle79 --> PgClassExpression80
+    PgClassExpression81{{"PgClassExpression[81∈2] ➊<br />ᐸ__union_to...__.”title”ᐳ"}}:::plan
+    PgSelectSingle79 --> PgClassExpression81
+    JSONParse83[["JSONParse[83∈2] ➊<br />ᐸ71ᐳ<br />ᐳUnionPost"]]:::plan
+    Access71 --> JSONParse83
+    JSONParse83 --> Access84
+    First89{{"First[89∈2] ➊"}}:::plan
+    PgSelect85 --> First89
+    PgSelectSingle90{{"PgSelectSingle[90∈2] ➊<br />ᐸunion_postsᐳ"}}:::plan
+    First89 --> PgSelectSingle90
+    PgClassExpression91{{"PgClassExpression[91∈2] ➊<br />ᐸ__union_posts__.”id”ᐳ"}}:::plan
+    PgSelectSingle90 --> PgClassExpression91
+    PgClassExpression92{{"PgClassExpression[92∈2] ➊<br />ᐸ__union_posts__.”title”ᐳ"}}:::plan
+    PgSelectSingle90 --> PgClassExpression92
+    PgClassExpression93{{"PgClassExpression[93∈2] ➊<br />ᐸ__union_po...scription”ᐳ"}}:::plan
+    PgSelectSingle90 --> PgClassExpression93
+    PgClassExpression94{{"PgClassExpression[94∈2] ➊<br />ᐸ__union_posts__.”note”ᐳ"}}:::plan
+    PgSelectSingle90 --> PgClassExpression94
+    JSONParse96[["JSONParse[96∈2] ➊<br />ᐸ71ᐳ<br />ᐳUnionDivider"]]:::plan
+    Access71 --> JSONParse96
+    JSONParse96 --> Access97
+    First102{{"First[102∈2] ➊"}}:::plan
+    PgSelect98 --> First102
+    PgSelectSingle103{{"PgSelectSingle[103∈2] ➊<br />ᐸunion_dividersᐳ"}}:::plan
+    First102 --> PgSelectSingle103
+    PgClassExpression104{{"PgClassExpression[104∈2] ➊<br />ᐸ__union_dividers__.”id”ᐳ"}}:::plan
+    PgSelectSingle103 --> PgClassExpression104
+    PgClassExpression105{{"PgClassExpression[105∈2] ➊<br />ᐸ__union_di...__.”title”ᐳ"}}:::plan
+    PgSelectSingle103 --> PgClassExpression105
+    PgClassExpression106{{"PgClassExpression[106∈2] ➊<br />ᐸ__union_di...__.”color”ᐳ"}}:::plan
+    PgSelectSingle103 --> PgClassExpression106
+    JSONParse108[["JSONParse[108∈2] ➊<br />ᐸ71ᐳ<br />ᐳUnionChecklist"]]:::plan
+    Access71 --> JSONParse108
+    JSONParse108 --> Access109
+    First114{{"First[114∈2] ➊"}}:::plan
+    PgSelect110 --> First114
+    PgSelectSingle115{{"PgSelectSingle[115∈2] ➊<br />ᐸunion_checklistsᐳ"}}:::plan
+    First114 --> PgSelectSingle115
+    PgClassExpression116{{"PgClassExpression[116∈2] ➊<br />ᐸ__union_ch...sts__.”id”ᐳ"}}:::plan
+    PgSelectSingle115 --> PgClassExpression116
+    PgClassExpression117{{"PgClassExpression[117∈2] ➊<br />ᐸ__union_ch...__.”title”ᐳ"}}:::plan
+    PgSelectSingle115 --> PgClassExpression117
+    JSONParse119[["JSONParse[119∈2] ➊<br />ᐸ71ᐳ<br />ᐳUnionChecklistItem"]]:::plan
+    Access71 --> JSONParse119
+    JSONParse119 --> Access120
+    First125{{"First[125∈2] ➊"}}:::plan
+    PgSelect121 --> First125
+    PgSelectSingle126{{"PgSelectSingle[126∈2] ➊<br />ᐸunion_checklist_itemsᐳ"}}:::plan
+    First125 --> PgSelectSingle126
+    PgClassExpression127{{"PgClassExpression[127∈2] ➊<br />ᐸ__union_ch...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle126 --> PgClassExpression127
+    PgClassExpression128{{"PgClassExpression[128∈2] ➊<br />ᐸ__union_ch...scription”ᐳ"}}:::plan
+    PgSelectSingle126 --> PgClassExpression128
+    PgClassExpression129{{"PgClassExpression[129∈2] ➊<br />ᐸ__union_ch...s__.”note”ᐳ"}}:::plan
+    PgSelectSingle126 --> PgClassExpression129
 
     %% define steps
 
     subgraph "Buckets for queries/unions-table/by-id-18"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 64, 10<br />2: PgSelect[7]<br />ᐳ: 11, 12, 13, 14, 15"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 130, 10<br />2: PgSelect[7], PgUnionAll[65]<br />ᐳ: 11, 12, 13, 14, 15, 69<br />3: PgUnionAllSingle[70]<br />ᐳ: Access[71]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,PgPolymorphic14,PgClassExpression15,Constant64 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,PgPolymorphic14,PgClassExpression15,PgUnionAll65,First69,PgUnionAllSingle70,Access71,Constant130 bucket0
     Bucket1("Bucket 1 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 10, 15, 14<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgSelect16,First20,PgSelectSingle21,PgClassExpression22,PgClassExpression23,PgSelect25,First29,PgSelectSingle30,PgClassExpression31,PgClassExpression32,PgClassExpression33,PgClassExpression34,PgSelect36,First40,PgSelectSingle41,PgClassExpression42,PgClassExpression43,PgClassExpression44,PgSelect46,First50,PgSelectSingle51,PgClassExpression52,PgClassExpression53,PgSelect55,First59,PgSelectSingle60,PgClassExpression61,PgClassExpression62,PgClassExpression63 bucket1
-    Bucket0 --> Bucket1
+    Bucket2("Bucket 2 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 71, 10, 70<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: 72, 83, 96, 108, 119<br />ᐳ: 73, 84, 97, 109, 120<br />2: 74, 85, 98, 110, 121<br />ᐳ: 78, 79, 80, 81, 89, 90, 91, 92, 93, 94, 102, 103, 104, 105, 106, 114, 115, 116, 117, 125, 126, 127, 128, 129"):::bucket
+    classDef bucket2 stroke:#7f007f
+    class Bucket2,JSONParse72,Access73,PgSelect74,First78,PgSelectSingle79,PgClassExpression80,PgClassExpression81,JSONParse83,Access84,PgSelect85,First89,PgSelectSingle90,PgClassExpression91,PgClassExpression92,PgClassExpression93,PgClassExpression94,JSONParse96,Access97,PgSelect98,First102,PgSelectSingle103,PgClassExpression104,PgClassExpression105,PgClassExpression106,JSONParse108,Access109,PgSelect110,First114,PgSelectSingle115,PgClassExpression116,PgClassExpression117,JSONParse119,Access120,PgSelect121,First125,PgSelectSingle126,PgClassExpression127,PgClassExpression128,PgClassExpression129 bucket2
+    Bucket0 --> Bucket1 & Bucket2
     end

--- a/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-18.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-18.deopt.sql
@@ -14,6 +14,126 @@ lateral (
     )
 ) as __union_items_result__;
 
+select __union_result__.*
+from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+lateral (
+  select
+    __union__."0" as "0",
+    __union__."1"::text as "1",
+    __union_identifiers__.idx as "2"
+  from (
+      select
+        __union_topics__."0",
+        __union_topics__."1",
+        "n"
+      from (
+        select
+          'UnionTopic' as "0",
+          json_build_array((__union_topics__."id")::text) as "1",
+          row_number() over (
+            order by
+              __union_topics__."id" asc
+          ) as "n"
+        from interfaces_and_unions.union_topics as __union_topics__
+        where __union_topics__.id = __union_identifiers__."id0"
+        order by
+          __union_topics__."id" asc
+      ) as __union_topics__
+    union all
+      select
+        __union_posts__."0",
+        __union_posts__."1",
+        "n"
+      from (
+        select
+          'UnionPost' as "0",
+          json_build_array((__union_posts__."id")::text) as "1",
+          row_number() over (
+            order by
+              __union_posts__."id" asc
+          ) as "n"
+        from interfaces_and_unions.union_posts as __union_posts__
+        where __union_posts__.id = __union_identifiers__."id0"
+        order by
+          __union_posts__."id" asc
+      ) as __union_posts__
+    union all
+      select
+        __union_dividers__."0",
+        __union_dividers__."1",
+        "n"
+      from (
+        select
+          'UnionDivider' as "0",
+          json_build_array((__union_dividers__."id")::text) as "1",
+          row_number() over (
+            order by
+              __union_dividers__."id" asc
+          ) as "n"
+        from interfaces_and_unions.union_dividers as __union_dividers__
+        where __union_dividers__.id = __union_identifiers__."id0"
+        order by
+          __union_dividers__."id" asc
+      ) as __union_dividers__
+    union all
+      select
+        __union_checklists__."0",
+        __union_checklists__."1",
+        "n"
+      from (
+        select
+          'UnionChecklist' as "0",
+          json_build_array((__union_checklists__."id")::text) as "1",
+          row_number() over (
+            order by
+              __union_checklists__."id" asc
+          ) as "n"
+        from interfaces_and_unions.union_checklists as __union_checklists__
+        where __union_checklists__.id = __union_identifiers__."id0"
+        order by
+          __union_checklists__."id" asc
+      ) as __union_checklists__
+    union all
+      select
+        __union_checklist_items__."0",
+        __union_checklist_items__."1",
+        "n"
+      from (
+        select
+          'UnionChecklistItem' as "0",
+          json_build_array((__union_checklist_items__."id")::text) as "1",
+          row_number() over (
+            order by
+              __union_checklist_items__."id" asc
+          ) as "n"
+        from interfaces_and_unions.union_checklist_items as __union_checklist_items__
+        where __union_checklist_items__.id = __union_identifiers__."id0"
+        order by
+          __union_checklist_items__."id" asc
+      ) as __union_checklist_items__
+    order by
+      "0" asc,
+      "n" asc
+  ) __union__
+) as __union_result__;
+
+select __union_checklist_items_result__.*
+from (select 0 as idx, $1::"int4" as "id0") as __union_checklist_items_identifiers__,
+lateral (
+  select
+    __union_checklist_items__."id"::text as "0",
+    __union_checklist_items__."description" as "1",
+    __union_checklist_items__."note" as "2",
+    __union_checklist_items_identifiers__.idx as "3"
+  from interfaces_and_unions.union_checklist_items as __union_checklist_items__
+  where
+    (
+      true /* authorization checks */
+    ) and (
+      __union_checklist_items__."id" = __union_checklist_items_identifiers__."id0"
+    )
+) as __union_checklist_items_result__;
+
 select __union_checklist_items_result__.*
 from (select 0 as idx, $1::"int4" as "id0") as __union_checklist_items_identifiers__,
 lateral (

--- a/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-18.json5
+++ b/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-18.json5
@@ -4,4 +4,9 @@
     description: "Has an optimisation phase",
     note: null,
   },
+  item18ViaUnionAll: {
+    id: 18,
+    description: "Has an optimisation phase",
+    note: null,
+  },
 }

--- a/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-18.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-18.mermaid
@@ -11,8 +11,8 @@ graph TD
     %% plan dependencies
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸunion_itemsᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant64{{"Constant[64∈0] ➊<br />ᐸ18ᐳ"}}:::plan
-    Object10 & Constant64 --> PgSelect7
+    Constant130{{"Constant[130∈0] ➊<br />ᐸ18ᐳ"}}:::plan
+    Object10 & Constant130 --> PgSelect7
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access8 & Access9 --> Object10
@@ -20,6 +20,8 @@ graph TD
     PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸunion_itemsᐳ"}}:::plan
     PgClassExpression13{{"PgClassExpression[13∈0] ➊<br />ᐸ__union_items__.”type”ᐳ"}}:::plan
     PgSelectSingle12 & PgClassExpression13 --> PgPolymorphic14
+    PgUnionAll65[["PgUnionAll[65∈0] ➊"]]:::plan
+    Object10 & Constant130 --> PgUnionAll65
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access8
     __Value2 --> Access9
@@ -29,6 +31,12 @@ graph TD
     PgSelectSingle12 --> PgClassExpression13
     PgClassExpression15{{"PgClassExpression[15∈0] ➊<br />ᐸ__union_items__.”id”ᐳ"}}:::plan
     PgSelectSingle12 --> PgClassExpression15
+    First69{{"First[69∈0] ➊"}}:::plan
+    PgUnionAll65 --> First69
+    PgUnionAllSingle70["PgUnionAllSingle[70∈0] ➊"]:::plan
+    First69 --> PgUnionAllSingle70
+    Access71{{"Access[71∈0] ➊<br />ᐸ70.1ᐳ"}}:::plan
+    PgUnionAllSingle70 --> Access71
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     PgSelect16[["PgSelect[16∈1] ➊<br />ᐸunion_topicsᐳ<br />ᐳUnionTopic"]]:::plan
     Object10 & PgClassExpression15 --> PgSelect16
@@ -88,15 +96,96 @@ graph TD
     PgSelectSingle60 --> PgClassExpression62
     PgClassExpression63{{"PgClassExpression[63∈1] ➊<br />ᐸ__union_ch...s__.”note”ᐳ"}}:::plan
     PgSelectSingle60 --> PgClassExpression63
+    PgSelect74[["PgSelect[74∈2] ➊<br />ᐸunion_topicsᐳ<br />ᐳUnionTopic"]]:::plan
+    Access73{{"Access[73∈2] ➊<br />ᐸ72.0ᐳ"}}:::plan
+    Object10 & Access73 --> PgSelect74
+    PgSelect85[["PgSelect[85∈2] ➊<br />ᐸunion_postsᐳ<br />ᐳUnionPost"]]:::plan
+    Access84{{"Access[84∈2] ➊<br />ᐸ83.0ᐳ"}}:::plan
+    Object10 & Access84 --> PgSelect85
+    PgSelect98[["PgSelect[98∈2] ➊<br />ᐸunion_dividersᐳ<br />ᐳUnionDivider"]]:::plan
+    Access97{{"Access[97∈2] ➊<br />ᐸ96.0ᐳ"}}:::plan
+    Object10 & Access97 --> PgSelect98
+    PgSelect110[["PgSelect[110∈2] ➊<br />ᐸunion_checklistsᐳ<br />ᐳUnionChecklist"]]:::plan
+    Access109{{"Access[109∈2] ➊<br />ᐸ108.0ᐳ"}}:::plan
+    Object10 & Access109 --> PgSelect110
+    PgSelect121[["PgSelect[121∈2] ➊<br />ᐸunion_checklist_itemsᐳ<br />ᐳUnionChecklistItem"]]:::plan
+    Access120{{"Access[120∈2] ➊<br />ᐸ119.0ᐳ"}}:::plan
+    Object10 & Access120 --> PgSelect121
+    JSONParse72[["JSONParse[72∈2] ➊<br />ᐸ71ᐳ<br />ᐳUnionTopic"]]:::plan
+    Access71 --> JSONParse72
+    JSONParse72 --> Access73
+    First78{{"First[78∈2] ➊"}}:::plan
+    PgSelect74 --> First78
+    PgSelectSingle79{{"PgSelectSingle[79∈2] ➊<br />ᐸunion_topicsᐳ"}}:::plan
+    First78 --> PgSelectSingle79
+    PgClassExpression80{{"PgClassExpression[80∈2] ➊<br />ᐸ__union_topics__.”id”ᐳ"}}:::plan
+    PgSelectSingle79 --> PgClassExpression80
+    PgClassExpression81{{"PgClassExpression[81∈2] ➊<br />ᐸ__union_to...__.”title”ᐳ"}}:::plan
+    PgSelectSingle79 --> PgClassExpression81
+    JSONParse83[["JSONParse[83∈2] ➊<br />ᐸ71ᐳ<br />ᐳUnionPost"]]:::plan
+    Access71 --> JSONParse83
+    JSONParse83 --> Access84
+    First89{{"First[89∈2] ➊"}}:::plan
+    PgSelect85 --> First89
+    PgSelectSingle90{{"PgSelectSingle[90∈2] ➊<br />ᐸunion_postsᐳ"}}:::plan
+    First89 --> PgSelectSingle90
+    PgClassExpression91{{"PgClassExpression[91∈2] ➊<br />ᐸ__union_posts__.”id”ᐳ"}}:::plan
+    PgSelectSingle90 --> PgClassExpression91
+    PgClassExpression92{{"PgClassExpression[92∈2] ➊<br />ᐸ__union_posts__.”title”ᐳ"}}:::plan
+    PgSelectSingle90 --> PgClassExpression92
+    PgClassExpression93{{"PgClassExpression[93∈2] ➊<br />ᐸ__union_po...scription”ᐳ"}}:::plan
+    PgSelectSingle90 --> PgClassExpression93
+    PgClassExpression94{{"PgClassExpression[94∈2] ➊<br />ᐸ__union_posts__.”note”ᐳ"}}:::plan
+    PgSelectSingle90 --> PgClassExpression94
+    JSONParse96[["JSONParse[96∈2] ➊<br />ᐸ71ᐳ<br />ᐳUnionDivider"]]:::plan
+    Access71 --> JSONParse96
+    JSONParse96 --> Access97
+    First102{{"First[102∈2] ➊"}}:::plan
+    PgSelect98 --> First102
+    PgSelectSingle103{{"PgSelectSingle[103∈2] ➊<br />ᐸunion_dividersᐳ"}}:::plan
+    First102 --> PgSelectSingle103
+    PgClassExpression104{{"PgClassExpression[104∈2] ➊<br />ᐸ__union_dividers__.”id”ᐳ"}}:::plan
+    PgSelectSingle103 --> PgClassExpression104
+    PgClassExpression105{{"PgClassExpression[105∈2] ➊<br />ᐸ__union_di...__.”title”ᐳ"}}:::plan
+    PgSelectSingle103 --> PgClassExpression105
+    PgClassExpression106{{"PgClassExpression[106∈2] ➊<br />ᐸ__union_di...__.”color”ᐳ"}}:::plan
+    PgSelectSingle103 --> PgClassExpression106
+    JSONParse108[["JSONParse[108∈2] ➊<br />ᐸ71ᐳ<br />ᐳUnionChecklist"]]:::plan
+    Access71 --> JSONParse108
+    JSONParse108 --> Access109
+    First114{{"First[114∈2] ➊"}}:::plan
+    PgSelect110 --> First114
+    PgSelectSingle115{{"PgSelectSingle[115∈2] ➊<br />ᐸunion_checklistsᐳ"}}:::plan
+    First114 --> PgSelectSingle115
+    PgClassExpression116{{"PgClassExpression[116∈2] ➊<br />ᐸ__union_ch...sts__.”id”ᐳ"}}:::plan
+    PgSelectSingle115 --> PgClassExpression116
+    PgClassExpression117{{"PgClassExpression[117∈2] ➊<br />ᐸ__union_ch...__.”title”ᐳ"}}:::plan
+    PgSelectSingle115 --> PgClassExpression117
+    JSONParse119[["JSONParse[119∈2] ➊<br />ᐸ71ᐳ<br />ᐳUnionChecklistItem"]]:::plan
+    Access71 --> JSONParse119
+    JSONParse119 --> Access120
+    First125{{"First[125∈2] ➊"}}:::plan
+    PgSelect121 --> First125
+    PgSelectSingle126{{"PgSelectSingle[126∈2] ➊<br />ᐸunion_checklist_itemsᐳ"}}:::plan
+    First125 --> PgSelectSingle126
+    PgClassExpression127{{"PgClassExpression[127∈2] ➊<br />ᐸ__union_ch...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle126 --> PgClassExpression127
+    PgClassExpression128{{"PgClassExpression[128∈2] ➊<br />ᐸ__union_ch...scription”ᐳ"}}:::plan
+    PgSelectSingle126 --> PgClassExpression128
+    PgClassExpression129{{"PgClassExpression[129∈2] ➊<br />ᐸ__union_ch...s__.”note”ᐳ"}}:::plan
+    PgSelectSingle126 --> PgClassExpression129
 
     %% define steps
 
     subgraph "Buckets for queries/unions-table/by-id-18"
-    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 64, 10<br />2: PgSelect[7]<br />ᐳ: 11, 12, 13, 14, 15"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 130, 10<br />2: PgSelect[7], PgUnionAll[65]<br />ᐳ: 11, 12, 13, 14, 15, 69<br />3: PgUnionAllSingle[70]<br />ᐳ: Access[71]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,PgPolymorphic14,PgClassExpression15,Constant64 bucket0
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,PgPolymorphic14,PgClassExpression15,PgUnionAll65,First69,PgUnionAllSingle70,Access71,Constant130 bucket0
     Bucket1("Bucket 1 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 10, 15, 14<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgSelect16,First20,PgSelectSingle21,PgClassExpression22,PgClassExpression23,PgSelect25,First29,PgSelectSingle30,PgClassExpression31,PgClassExpression32,PgClassExpression33,PgClassExpression34,PgSelect36,First40,PgSelectSingle41,PgClassExpression42,PgClassExpression43,PgClassExpression44,PgSelect46,First50,PgSelectSingle51,PgClassExpression52,PgClassExpression53,PgSelect55,First59,PgSelectSingle60,PgClassExpression61,PgClassExpression62,PgClassExpression63 bucket1
-    Bucket0 --> Bucket1
+    Bucket2("Bucket 2 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 71, 10, 70<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: 72, 83, 96, 108, 119<br />ᐳ: 73, 84, 97, 109, 120<br />2: 74, 85, 98, 110, 121<br />ᐳ: 78, 79, 80, 81, 89, 90, 91, 92, 93, 94, 102, 103, 104, 105, 106, 114, 115, 116, 117, 125, 126, 127, 128, 129"):::bucket
+    classDef bucket2 stroke:#7f007f
+    class Bucket2,JSONParse72,Access73,PgSelect74,First78,PgSelectSingle79,PgClassExpression80,PgClassExpression81,JSONParse83,Access84,PgSelect85,First89,PgSelectSingle90,PgClassExpression91,PgClassExpression92,PgClassExpression93,PgClassExpression94,JSONParse96,Access97,PgSelect98,First102,PgSelectSingle103,PgClassExpression104,PgClassExpression105,PgClassExpression106,JSONParse108,Access109,PgSelect110,First114,PgSelectSingle115,PgClassExpression116,PgClassExpression117,JSONParse119,Access120,PgSelect121,First125,PgSelectSingle126,PgClassExpression127,PgClassExpression128,PgClassExpression129 bucket2
+    Bucket0 --> Bucket1 & Bucket2
     end

--- a/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-18.sql
+++ b/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-18.sql
@@ -14,6 +14,126 @@ lateral (
     )
 ) as __union_items_result__;
 
+select __union_result__.*
+from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+lateral (
+  select
+    __union__."0" as "0",
+    __union__."1"::text as "1",
+    __union_identifiers__.idx as "2"
+  from (
+      select
+        __union_topics__."0",
+        __union_topics__."1",
+        "n"
+      from (
+        select
+          'UnionTopic' as "0",
+          json_build_array((__union_topics__."id")::text) as "1",
+          row_number() over (
+            order by
+              __union_topics__."id" asc
+          ) as "n"
+        from interfaces_and_unions.union_topics as __union_topics__
+        where __union_topics__.id = __union_identifiers__."id0"
+        order by
+          __union_topics__."id" asc
+      ) as __union_topics__
+    union all
+      select
+        __union_posts__."0",
+        __union_posts__."1",
+        "n"
+      from (
+        select
+          'UnionPost' as "0",
+          json_build_array((__union_posts__."id")::text) as "1",
+          row_number() over (
+            order by
+              __union_posts__."id" asc
+          ) as "n"
+        from interfaces_and_unions.union_posts as __union_posts__
+        where __union_posts__.id = __union_identifiers__."id0"
+        order by
+          __union_posts__."id" asc
+      ) as __union_posts__
+    union all
+      select
+        __union_dividers__."0",
+        __union_dividers__."1",
+        "n"
+      from (
+        select
+          'UnionDivider' as "0",
+          json_build_array((__union_dividers__."id")::text) as "1",
+          row_number() over (
+            order by
+              __union_dividers__."id" asc
+          ) as "n"
+        from interfaces_and_unions.union_dividers as __union_dividers__
+        where __union_dividers__.id = __union_identifiers__."id0"
+        order by
+          __union_dividers__."id" asc
+      ) as __union_dividers__
+    union all
+      select
+        __union_checklists__."0",
+        __union_checklists__."1",
+        "n"
+      from (
+        select
+          'UnionChecklist' as "0",
+          json_build_array((__union_checklists__."id")::text) as "1",
+          row_number() over (
+            order by
+              __union_checklists__."id" asc
+          ) as "n"
+        from interfaces_and_unions.union_checklists as __union_checklists__
+        where __union_checklists__.id = __union_identifiers__."id0"
+        order by
+          __union_checklists__."id" asc
+      ) as __union_checklists__
+    union all
+      select
+        __union_checklist_items__."0",
+        __union_checklist_items__."1",
+        "n"
+      from (
+        select
+          'UnionChecklistItem' as "0",
+          json_build_array((__union_checklist_items__."id")::text) as "1",
+          row_number() over (
+            order by
+              __union_checklist_items__."id" asc
+          ) as "n"
+        from interfaces_and_unions.union_checklist_items as __union_checklist_items__
+        where __union_checklist_items__.id = __union_identifiers__."id0"
+        order by
+          __union_checklist_items__."id" asc
+      ) as __union_checklist_items__
+    order by
+      "0" asc,
+      "n" asc
+  ) __union__
+) as __union_result__;
+
+select __union_checklist_items_result__.*
+from (select 0 as idx, $1::"int4" as "id0") as __union_checklist_items_identifiers__,
+lateral (
+  select
+    __union_checklist_items__."id"::text as "0",
+    __union_checklist_items__."description" as "1",
+    __union_checklist_items__."note" as "2",
+    __union_checklist_items_identifiers__.idx as "3"
+  from interfaces_and_unions.union_checklist_items as __union_checklist_items__
+  where
+    (
+      true /* authorization checks */
+    ) and (
+      __union_checklist_items__."id" = __union_checklist_items_identifiers__."id0"
+    )
+) as __union_checklist_items_result__;
+
 select __union_checklist_items_result__.*
 from (select 0 as idx, $1::"int4" as "id0") as __union_checklist_items_identifiers__,
 lateral (

--- a/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-18.test.graphql
+++ b/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-18.test.graphql
@@ -1,8 +1,13 @@
 ## expect(errors).toBeFalsy()
 ## expect(data.item18.id).toEqual(18);
 ## expect(data.item18.description).toEqual('Has an optimisation phase');
+## expect(data.item18ViaUnionAll.id).toEqual(18);
+## expect(data.item18ViaUnionAll.description).toEqual('Has an optimisation phase');
 {
   item18: unionItemById(id: 18) {
+    ...Item
+  }
+  item18ViaUnionAll: unionItemByIdViaUnionAll(id: 18) {
     ...Item
   }
 }

--- a/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-987654321.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-987654321.deopt.mermaid
@@ -1,0 +1,191 @@
+%%{init: {'themeVariables': { 'fontSize': '12px'}}}%%
+graph TD
+    classDef path fill:#eee,stroke:#000,color:#000
+    classDef plan fill:#fff,stroke-width:1px,color:#000
+    classDef itemplan fill:#fff,stroke-width:2px,color:#000
+    classDef unbatchedplan fill:#dff,stroke-width:1px,color:#000
+    classDef sideeffectplan fill:#fcc,stroke-width:2px,color:#000
+    classDef bucket fill:#f6f6f6,color:#000,stroke-width:2px,text-align:left
+
+
+    %% plan dependencies
+    PgSelect7[["PgSelect[7∈0] ➊<br />ᐸunion_itemsᐳ"]]:::plan
+    Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Constant130{{"Constant[130∈0] ➊<br />ᐸ987654321ᐳ"}}:::plan
+    Object10 & Constant130 --> PgSelect7
+    Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Access8 & Access9 --> Object10
+    PgPolymorphic14{{"PgPolymorphic[14∈0] ➊"}}:::plan
+    PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸunion_itemsᐳ"}}:::plan
+    PgClassExpression13{{"PgClassExpression[13∈0] ➊<br />ᐸ__union_items__.”type”ᐳ"}}:::plan
+    PgSelectSingle12 & PgClassExpression13 --> PgPolymorphic14
+    PgUnionAll65[["PgUnionAll[65∈0] ➊"]]:::plan
+    Object10 & Constant130 --> PgUnionAll65
+    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
+    __Value2 --> Access8
+    __Value2 --> Access9
+    First11{{"First[11∈0] ➊"}}:::plan
+    PgSelect7 --> First11
+    First11 --> PgSelectSingle12
+    PgSelectSingle12 --> PgClassExpression13
+    PgClassExpression15{{"PgClassExpression[15∈0] ➊<br />ᐸ__union_items__.”id”ᐳ"}}:::plan
+    PgSelectSingle12 --> PgClassExpression15
+    First69{{"First[69∈0] ➊"}}:::plan
+    PgUnionAll65 --> First69
+    PgUnionAllSingle70["PgUnionAllSingle[70∈0] ➊"]:::plan
+    First69 --> PgUnionAllSingle70
+    Access71{{"Access[71∈0] ➊<br />ᐸ70.1ᐳ"}}:::plan
+    PgUnionAllSingle70 --> Access71
+    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
+    PgSelect16[["PgSelect[16∈1] ➊<br />ᐸunion_topicsᐳ<br />ᐳUnionTopic"]]:::plan
+    Object10 & PgClassExpression15 --> PgSelect16
+    PgSelect25[["PgSelect[25∈1] ➊<br />ᐸunion_postsᐳ<br />ᐳUnionPost"]]:::plan
+    Object10 & PgClassExpression15 --> PgSelect25
+    PgSelect36[["PgSelect[36∈1] ➊<br />ᐸunion_dividersᐳ<br />ᐳUnionDivider"]]:::plan
+    Object10 & PgClassExpression15 --> PgSelect36
+    PgSelect46[["PgSelect[46∈1] ➊<br />ᐸunion_checklistsᐳ<br />ᐳUnionChecklist"]]:::plan
+    Object10 & PgClassExpression15 --> PgSelect46
+    PgSelect55[["PgSelect[55∈1] ➊<br />ᐸunion_checklist_itemsᐳ<br />ᐳUnionChecklistItem"]]:::plan
+    Object10 & PgClassExpression15 --> PgSelect55
+    First20{{"First[20∈1] ➊"}}:::plan
+    PgSelect16 --> First20
+    PgSelectSingle21{{"PgSelectSingle[21∈1] ➊<br />ᐸunion_topicsᐳ"}}:::plan
+    First20 --> PgSelectSingle21
+    PgClassExpression22{{"PgClassExpression[22∈1] ➊<br />ᐸ__union_topics__.”id”ᐳ"}}:::plan
+    PgSelectSingle21 --> PgClassExpression22
+    PgClassExpression23{{"PgClassExpression[23∈1] ➊<br />ᐸ__union_to...__.”title”ᐳ"}}:::plan
+    PgSelectSingle21 --> PgClassExpression23
+    First29{{"First[29∈1] ➊"}}:::plan
+    PgSelect25 --> First29
+    PgSelectSingle30{{"PgSelectSingle[30∈1] ➊<br />ᐸunion_postsᐳ"}}:::plan
+    First29 --> PgSelectSingle30
+    PgClassExpression31{{"PgClassExpression[31∈1] ➊<br />ᐸ__union_posts__.”id”ᐳ"}}:::plan
+    PgSelectSingle30 --> PgClassExpression31
+    PgClassExpression32{{"PgClassExpression[32∈1] ➊<br />ᐸ__union_posts__.”title”ᐳ"}}:::plan
+    PgSelectSingle30 --> PgClassExpression32
+    PgClassExpression33{{"PgClassExpression[33∈1] ➊<br />ᐸ__union_po...scription”ᐳ"}}:::plan
+    PgSelectSingle30 --> PgClassExpression33
+    PgClassExpression34{{"PgClassExpression[34∈1] ➊<br />ᐸ__union_posts__.”note”ᐳ"}}:::plan
+    PgSelectSingle30 --> PgClassExpression34
+    First40{{"First[40∈1] ➊"}}:::plan
+    PgSelect36 --> First40
+    PgSelectSingle41{{"PgSelectSingle[41∈1] ➊<br />ᐸunion_dividersᐳ"}}:::plan
+    First40 --> PgSelectSingle41
+    PgClassExpression42{{"PgClassExpression[42∈1] ➊<br />ᐸ__union_dividers__.”id”ᐳ"}}:::plan
+    PgSelectSingle41 --> PgClassExpression42
+    PgClassExpression43{{"PgClassExpression[43∈1] ➊<br />ᐸ__union_di...__.”title”ᐳ"}}:::plan
+    PgSelectSingle41 --> PgClassExpression43
+    PgClassExpression44{{"PgClassExpression[44∈1] ➊<br />ᐸ__union_di...__.”color”ᐳ"}}:::plan
+    PgSelectSingle41 --> PgClassExpression44
+    First50{{"First[50∈1] ➊"}}:::plan
+    PgSelect46 --> First50
+    PgSelectSingle51{{"PgSelectSingle[51∈1] ➊<br />ᐸunion_checklistsᐳ"}}:::plan
+    First50 --> PgSelectSingle51
+    PgClassExpression52{{"PgClassExpression[52∈1] ➊<br />ᐸ__union_ch...sts__.”id”ᐳ"}}:::plan
+    PgSelectSingle51 --> PgClassExpression52
+    PgClassExpression53{{"PgClassExpression[53∈1] ➊<br />ᐸ__union_ch...__.”title”ᐳ"}}:::plan
+    PgSelectSingle51 --> PgClassExpression53
+    First59{{"First[59∈1] ➊"}}:::plan
+    PgSelect55 --> First59
+    PgSelectSingle60{{"PgSelectSingle[60∈1] ➊<br />ᐸunion_checklist_itemsᐳ"}}:::plan
+    First59 --> PgSelectSingle60
+    PgClassExpression61{{"PgClassExpression[61∈1] ➊<br />ᐸ__union_ch...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle60 --> PgClassExpression61
+    PgClassExpression62{{"PgClassExpression[62∈1] ➊<br />ᐸ__union_ch...scription”ᐳ"}}:::plan
+    PgSelectSingle60 --> PgClassExpression62
+    PgClassExpression63{{"PgClassExpression[63∈1] ➊<br />ᐸ__union_ch...s__.”note”ᐳ"}}:::plan
+    PgSelectSingle60 --> PgClassExpression63
+    PgSelect74[["PgSelect[74∈2] ➊<br />ᐸunion_topicsᐳ<br />ᐳUnionTopic"]]:::plan
+    Access73{{"Access[73∈2] ➊<br />ᐸ72.0ᐳ"}}:::plan
+    Object10 & Access73 --> PgSelect74
+    PgSelect85[["PgSelect[85∈2] ➊<br />ᐸunion_postsᐳ<br />ᐳUnionPost"]]:::plan
+    Access84{{"Access[84∈2] ➊<br />ᐸ83.0ᐳ"}}:::plan
+    Object10 & Access84 --> PgSelect85
+    PgSelect98[["PgSelect[98∈2] ➊<br />ᐸunion_dividersᐳ<br />ᐳUnionDivider"]]:::plan
+    Access97{{"Access[97∈2] ➊<br />ᐸ96.0ᐳ"}}:::plan
+    Object10 & Access97 --> PgSelect98
+    PgSelect110[["PgSelect[110∈2] ➊<br />ᐸunion_checklistsᐳ<br />ᐳUnionChecklist"]]:::plan
+    Access109{{"Access[109∈2] ➊<br />ᐸ108.0ᐳ"}}:::plan
+    Object10 & Access109 --> PgSelect110
+    PgSelect121[["PgSelect[121∈2] ➊<br />ᐸunion_checklist_itemsᐳ<br />ᐳUnionChecklistItem"]]:::plan
+    Access120{{"Access[120∈2] ➊<br />ᐸ119.0ᐳ"}}:::plan
+    Object10 & Access120 --> PgSelect121
+    JSONParse72[["JSONParse[72∈2] ➊<br />ᐸ71ᐳ<br />ᐳUnionTopic"]]:::plan
+    Access71 --> JSONParse72
+    JSONParse72 --> Access73
+    First78{{"First[78∈2] ➊"}}:::plan
+    PgSelect74 --> First78
+    PgSelectSingle79{{"PgSelectSingle[79∈2] ➊<br />ᐸunion_topicsᐳ"}}:::plan
+    First78 --> PgSelectSingle79
+    PgClassExpression80{{"PgClassExpression[80∈2] ➊<br />ᐸ__union_topics__.”id”ᐳ"}}:::plan
+    PgSelectSingle79 --> PgClassExpression80
+    PgClassExpression81{{"PgClassExpression[81∈2] ➊<br />ᐸ__union_to...__.”title”ᐳ"}}:::plan
+    PgSelectSingle79 --> PgClassExpression81
+    JSONParse83[["JSONParse[83∈2] ➊<br />ᐸ71ᐳ<br />ᐳUnionPost"]]:::plan
+    Access71 --> JSONParse83
+    JSONParse83 --> Access84
+    First89{{"First[89∈2] ➊"}}:::plan
+    PgSelect85 --> First89
+    PgSelectSingle90{{"PgSelectSingle[90∈2] ➊<br />ᐸunion_postsᐳ"}}:::plan
+    First89 --> PgSelectSingle90
+    PgClassExpression91{{"PgClassExpression[91∈2] ➊<br />ᐸ__union_posts__.”id”ᐳ"}}:::plan
+    PgSelectSingle90 --> PgClassExpression91
+    PgClassExpression92{{"PgClassExpression[92∈2] ➊<br />ᐸ__union_posts__.”title”ᐳ"}}:::plan
+    PgSelectSingle90 --> PgClassExpression92
+    PgClassExpression93{{"PgClassExpression[93∈2] ➊<br />ᐸ__union_po...scription”ᐳ"}}:::plan
+    PgSelectSingle90 --> PgClassExpression93
+    PgClassExpression94{{"PgClassExpression[94∈2] ➊<br />ᐸ__union_posts__.”note”ᐳ"}}:::plan
+    PgSelectSingle90 --> PgClassExpression94
+    JSONParse96[["JSONParse[96∈2] ➊<br />ᐸ71ᐳ<br />ᐳUnionDivider"]]:::plan
+    Access71 --> JSONParse96
+    JSONParse96 --> Access97
+    First102{{"First[102∈2] ➊"}}:::plan
+    PgSelect98 --> First102
+    PgSelectSingle103{{"PgSelectSingle[103∈2] ➊<br />ᐸunion_dividersᐳ"}}:::plan
+    First102 --> PgSelectSingle103
+    PgClassExpression104{{"PgClassExpression[104∈2] ➊<br />ᐸ__union_dividers__.”id”ᐳ"}}:::plan
+    PgSelectSingle103 --> PgClassExpression104
+    PgClassExpression105{{"PgClassExpression[105∈2] ➊<br />ᐸ__union_di...__.”title”ᐳ"}}:::plan
+    PgSelectSingle103 --> PgClassExpression105
+    PgClassExpression106{{"PgClassExpression[106∈2] ➊<br />ᐸ__union_di...__.”color”ᐳ"}}:::plan
+    PgSelectSingle103 --> PgClassExpression106
+    JSONParse108[["JSONParse[108∈2] ➊<br />ᐸ71ᐳ<br />ᐳUnionChecklist"]]:::plan
+    Access71 --> JSONParse108
+    JSONParse108 --> Access109
+    First114{{"First[114∈2] ➊"}}:::plan
+    PgSelect110 --> First114
+    PgSelectSingle115{{"PgSelectSingle[115∈2] ➊<br />ᐸunion_checklistsᐳ"}}:::plan
+    First114 --> PgSelectSingle115
+    PgClassExpression116{{"PgClassExpression[116∈2] ➊<br />ᐸ__union_ch...sts__.”id”ᐳ"}}:::plan
+    PgSelectSingle115 --> PgClassExpression116
+    PgClassExpression117{{"PgClassExpression[117∈2] ➊<br />ᐸ__union_ch...__.”title”ᐳ"}}:::plan
+    PgSelectSingle115 --> PgClassExpression117
+    JSONParse119[["JSONParse[119∈2] ➊<br />ᐸ71ᐳ<br />ᐳUnionChecklistItem"]]:::plan
+    Access71 --> JSONParse119
+    JSONParse119 --> Access120
+    First125{{"First[125∈2] ➊"}}:::plan
+    PgSelect121 --> First125
+    PgSelectSingle126{{"PgSelectSingle[126∈2] ➊<br />ᐸunion_checklist_itemsᐳ"}}:::plan
+    First125 --> PgSelectSingle126
+    PgClassExpression127{{"PgClassExpression[127∈2] ➊<br />ᐸ__union_ch...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle126 --> PgClassExpression127
+    PgClassExpression128{{"PgClassExpression[128∈2] ➊<br />ᐸ__union_ch...scription”ᐳ"}}:::plan
+    PgSelectSingle126 --> PgClassExpression128
+    PgClassExpression129{{"PgClassExpression[129∈2] ➊<br />ᐸ__union_ch...s__.”note”ᐳ"}}:::plan
+    PgSelectSingle126 --> PgClassExpression129
+
+    %% define steps
+
+    subgraph "Buckets for queries/unions-table/by-id-987654321"
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 130, 10<br />2: PgSelect[7], PgUnionAll[65]<br />ᐳ: 11, 12, 13, 14, 15, 69<br />3: PgUnionAllSingle[70]<br />ᐳ: Access[71]"):::bucket
+    classDef bucket0 stroke:#696969
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,PgPolymorphic14,PgClassExpression15,PgUnionAll65,First69,PgUnionAllSingle70,Access71,Constant130 bucket0
+    Bucket1("Bucket 1 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 10, 15, 14<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem"):::bucket
+    classDef bucket1 stroke:#00bfff
+    class Bucket1,PgSelect16,First20,PgSelectSingle21,PgClassExpression22,PgClassExpression23,PgSelect25,First29,PgSelectSingle30,PgClassExpression31,PgClassExpression32,PgClassExpression33,PgClassExpression34,PgSelect36,First40,PgSelectSingle41,PgClassExpression42,PgClassExpression43,PgClassExpression44,PgSelect46,First50,PgSelectSingle51,PgClassExpression52,PgClassExpression53,PgSelect55,First59,PgSelectSingle60,PgClassExpression61,PgClassExpression62,PgClassExpression63 bucket1
+    Bucket2("Bucket 2 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 71, 10, 70<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: 72, 83, 96, 108, 119<br />ᐳ: 73, 84, 97, 109, 120<br />2: 74, 85, 98, 110, 121<br />ᐳ: 78, 79, 80, 81, 89, 90, 91, 92, 93, 94, 102, 103, 104, 105, 106, 114, 115, 116, 117, 125, 126, 127, 128, 129"):::bucket
+    classDef bucket2 stroke:#7f007f
+    class Bucket2,JSONParse72,Access73,PgSelect74,First78,PgSelectSingle79,PgClassExpression80,PgClassExpression81,JSONParse83,Access84,PgSelect85,First89,PgSelectSingle90,PgClassExpression91,PgClassExpression92,PgClassExpression93,PgClassExpression94,JSONParse96,Access97,PgSelect98,First102,PgSelectSingle103,PgClassExpression104,PgClassExpression105,PgClassExpression106,JSONParse108,Access109,PgSelect110,First114,PgSelectSingle115,PgClassExpression116,PgClassExpression117,JSONParse119,Access120,PgSelect121,First125,PgSelectSingle126,PgClassExpression127,PgClassExpression128,PgClassExpression129 bucket2
+    Bucket0 --> Bucket1 & Bucket2
+    end

--- a/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-987654321.deopt.sql
+++ b/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-987654321.deopt.sql
@@ -1,0 +1,118 @@
+select __union_items_result__.*
+from (select 0 as idx, $1::"int4" as "id0") as __union_items_identifiers__,
+lateral (
+  select
+    __union_items__."type"::text as "0",
+    __union_items__."id"::text as "1",
+    __union_items_identifiers__.idx as "2"
+  from interfaces_and_unions.union_items as __union_items__
+  where
+    (
+      true /* authorization checks */
+    ) and (
+      __union_items__."id" = __union_items_identifiers__."id0"
+    )
+) as __union_items_result__;
+
+select __union_result__.*
+from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+lateral (
+  select
+    __union__."0" as "0",
+    __union__."1"::text as "1",
+    __union_identifiers__.idx as "2"
+  from (
+      select
+        __union_topics__."0",
+        __union_topics__."1",
+        "n"
+      from (
+        select
+          'UnionTopic' as "0",
+          json_build_array((__union_topics__."id")::text) as "1",
+          row_number() over (
+            order by
+              __union_topics__."id" asc
+          ) as "n"
+        from interfaces_and_unions.union_topics as __union_topics__
+        where __union_topics__.id = __union_identifiers__."id0"
+        order by
+          __union_topics__."id" asc
+      ) as __union_topics__
+    union all
+      select
+        __union_posts__."0",
+        __union_posts__."1",
+        "n"
+      from (
+        select
+          'UnionPost' as "0",
+          json_build_array((__union_posts__."id")::text) as "1",
+          row_number() over (
+            order by
+              __union_posts__."id" asc
+          ) as "n"
+        from interfaces_and_unions.union_posts as __union_posts__
+        where __union_posts__.id = __union_identifiers__."id0"
+        order by
+          __union_posts__."id" asc
+      ) as __union_posts__
+    union all
+      select
+        __union_dividers__."0",
+        __union_dividers__."1",
+        "n"
+      from (
+        select
+          'UnionDivider' as "0",
+          json_build_array((__union_dividers__."id")::text) as "1",
+          row_number() over (
+            order by
+              __union_dividers__."id" asc
+          ) as "n"
+        from interfaces_and_unions.union_dividers as __union_dividers__
+        where __union_dividers__.id = __union_identifiers__."id0"
+        order by
+          __union_dividers__."id" asc
+      ) as __union_dividers__
+    union all
+      select
+        __union_checklists__."0",
+        __union_checklists__."1",
+        "n"
+      from (
+        select
+          'UnionChecklist' as "0",
+          json_build_array((__union_checklists__."id")::text) as "1",
+          row_number() over (
+            order by
+              __union_checklists__."id" asc
+          ) as "n"
+        from interfaces_and_unions.union_checklists as __union_checklists__
+        where __union_checklists__.id = __union_identifiers__."id0"
+        order by
+          __union_checklists__."id" asc
+      ) as __union_checklists__
+    union all
+      select
+        __union_checklist_items__."0",
+        __union_checklist_items__."1",
+        "n"
+      from (
+        select
+          'UnionChecklistItem' as "0",
+          json_build_array((__union_checklist_items__."id")::text) as "1",
+          row_number() over (
+            order by
+              __union_checklist_items__."id" asc
+          ) as "n"
+        from interfaces_and_unions.union_checklist_items as __union_checklist_items__
+        where __union_checklist_items__.id = __union_identifiers__."id0"
+        order by
+          __union_checklist_items__."id" asc
+      ) as __union_checklist_items__
+    order by
+      "0" asc,
+      "n" asc
+  ) __union__
+) as __union_result__;

--- a/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-987654321.json5
+++ b/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-987654321.json5
@@ -1,0 +1,4 @@
+{
+  nx: null,
+  nx2: null,
+}

--- a/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-987654321.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-987654321.mermaid
@@ -1,0 +1,191 @@
+%%{init: {'themeVariables': { 'fontSize': '12px'}}}%%
+graph TD
+    classDef path fill:#eee,stroke:#000,color:#000
+    classDef plan fill:#fff,stroke-width:1px,color:#000
+    classDef itemplan fill:#fff,stroke-width:2px,color:#000
+    classDef unbatchedplan fill:#dff,stroke-width:1px,color:#000
+    classDef sideeffectplan fill:#fcc,stroke-width:2px,color:#000
+    classDef bucket fill:#f6f6f6,color:#000,stroke-width:2px,text-align:left
+
+
+    %% plan dependencies
+    PgSelect7[["PgSelect[7∈0] ➊<br />ᐸunion_itemsᐳ"]]:::plan
+    Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Constant130{{"Constant[130∈0] ➊<br />ᐸ987654321ᐳ"}}:::plan
+    Object10 & Constant130 --> PgSelect7
+    Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Access8 & Access9 --> Object10
+    PgPolymorphic14{{"PgPolymorphic[14∈0] ➊"}}:::plan
+    PgSelectSingle12{{"PgSelectSingle[12∈0] ➊<br />ᐸunion_itemsᐳ"}}:::plan
+    PgClassExpression13{{"PgClassExpression[13∈0] ➊<br />ᐸ__union_items__.”type”ᐳ"}}:::plan
+    PgSelectSingle12 & PgClassExpression13 --> PgPolymorphic14
+    PgUnionAll65[["PgUnionAll[65∈0] ➊"]]:::plan
+    Object10 & Constant130 --> PgUnionAll65
+    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
+    __Value2 --> Access8
+    __Value2 --> Access9
+    First11{{"First[11∈0] ➊"}}:::plan
+    PgSelect7 --> First11
+    First11 --> PgSelectSingle12
+    PgSelectSingle12 --> PgClassExpression13
+    PgClassExpression15{{"PgClassExpression[15∈0] ➊<br />ᐸ__union_items__.”id”ᐳ"}}:::plan
+    PgSelectSingle12 --> PgClassExpression15
+    First69{{"First[69∈0] ➊"}}:::plan
+    PgUnionAll65 --> First69
+    PgUnionAllSingle70["PgUnionAllSingle[70∈0] ➊"]:::plan
+    First69 --> PgUnionAllSingle70
+    Access71{{"Access[71∈0] ➊<br />ᐸ70.1ᐳ"}}:::plan
+    PgUnionAllSingle70 --> Access71
+    __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
+    PgSelect16[["PgSelect[16∈1] ➊<br />ᐸunion_topicsᐳ<br />ᐳUnionTopic"]]:::plan
+    Object10 & PgClassExpression15 --> PgSelect16
+    PgSelect25[["PgSelect[25∈1] ➊<br />ᐸunion_postsᐳ<br />ᐳUnionPost"]]:::plan
+    Object10 & PgClassExpression15 --> PgSelect25
+    PgSelect36[["PgSelect[36∈1] ➊<br />ᐸunion_dividersᐳ<br />ᐳUnionDivider"]]:::plan
+    Object10 & PgClassExpression15 --> PgSelect36
+    PgSelect46[["PgSelect[46∈1] ➊<br />ᐸunion_checklistsᐳ<br />ᐳUnionChecklist"]]:::plan
+    Object10 & PgClassExpression15 --> PgSelect46
+    PgSelect55[["PgSelect[55∈1] ➊<br />ᐸunion_checklist_itemsᐳ<br />ᐳUnionChecklistItem"]]:::plan
+    Object10 & PgClassExpression15 --> PgSelect55
+    First20{{"First[20∈1] ➊"}}:::plan
+    PgSelect16 --> First20
+    PgSelectSingle21{{"PgSelectSingle[21∈1] ➊<br />ᐸunion_topicsᐳ"}}:::plan
+    First20 --> PgSelectSingle21
+    PgClassExpression22{{"PgClassExpression[22∈1] ➊<br />ᐸ__union_topics__.”id”ᐳ"}}:::plan
+    PgSelectSingle21 --> PgClassExpression22
+    PgClassExpression23{{"PgClassExpression[23∈1] ➊<br />ᐸ__union_to...__.”title”ᐳ"}}:::plan
+    PgSelectSingle21 --> PgClassExpression23
+    First29{{"First[29∈1] ➊"}}:::plan
+    PgSelect25 --> First29
+    PgSelectSingle30{{"PgSelectSingle[30∈1] ➊<br />ᐸunion_postsᐳ"}}:::plan
+    First29 --> PgSelectSingle30
+    PgClassExpression31{{"PgClassExpression[31∈1] ➊<br />ᐸ__union_posts__.”id”ᐳ"}}:::plan
+    PgSelectSingle30 --> PgClassExpression31
+    PgClassExpression32{{"PgClassExpression[32∈1] ➊<br />ᐸ__union_posts__.”title”ᐳ"}}:::plan
+    PgSelectSingle30 --> PgClassExpression32
+    PgClassExpression33{{"PgClassExpression[33∈1] ➊<br />ᐸ__union_po...scription”ᐳ"}}:::plan
+    PgSelectSingle30 --> PgClassExpression33
+    PgClassExpression34{{"PgClassExpression[34∈1] ➊<br />ᐸ__union_posts__.”note”ᐳ"}}:::plan
+    PgSelectSingle30 --> PgClassExpression34
+    First40{{"First[40∈1] ➊"}}:::plan
+    PgSelect36 --> First40
+    PgSelectSingle41{{"PgSelectSingle[41∈1] ➊<br />ᐸunion_dividersᐳ"}}:::plan
+    First40 --> PgSelectSingle41
+    PgClassExpression42{{"PgClassExpression[42∈1] ➊<br />ᐸ__union_dividers__.”id”ᐳ"}}:::plan
+    PgSelectSingle41 --> PgClassExpression42
+    PgClassExpression43{{"PgClassExpression[43∈1] ➊<br />ᐸ__union_di...__.”title”ᐳ"}}:::plan
+    PgSelectSingle41 --> PgClassExpression43
+    PgClassExpression44{{"PgClassExpression[44∈1] ➊<br />ᐸ__union_di...__.”color”ᐳ"}}:::plan
+    PgSelectSingle41 --> PgClassExpression44
+    First50{{"First[50∈1] ➊"}}:::plan
+    PgSelect46 --> First50
+    PgSelectSingle51{{"PgSelectSingle[51∈1] ➊<br />ᐸunion_checklistsᐳ"}}:::plan
+    First50 --> PgSelectSingle51
+    PgClassExpression52{{"PgClassExpression[52∈1] ➊<br />ᐸ__union_ch...sts__.”id”ᐳ"}}:::plan
+    PgSelectSingle51 --> PgClassExpression52
+    PgClassExpression53{{"PgClassExpression[53∈1] ➊<br />ᐸ__union_ch...__.”title”ᐳ"}}:::plan
+    PgSelectSingle51 --> PgClassExpression53
+    First59{{"First[59∈1] ➊"}}:::plan
+    PgSelect55 --> First59
+    PgSelectSingle60{{"PgSelectSingle[60∈1] ➊<br />ᐸunion_checklist_itemsᐳ"}}:::plan
+    First59 --> PgSelectSingle60
+    PgClassExpression61{{"PgClassExpression[61∈1] ➊<br />ᐸ__union_ch...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle60 --> PgClassExpression61
+    PgClassExpression62{{"PgClassExpression[62∈1] ➊<br />ᐸ__union_ch...scription”ᐳ"}}:::plan
+    PgSelectSingle60 --> PgClassExpression62
+    PgClassExpression63{{"PgClassExpression[63∈1] ➊<br />ᐸ__union_ch...s__.”note”ᐳ"}}:::plan
+    PgSelectSingle60 --> PgClassExpression63
+    PgSelect74[["PgSelect[74∈2] ➊<br />ᐸunion_topicsᐳ<br />ᐳUnionTopic"]]:::plan
+    Access73{{"Access[73∈2] ➊<br />ᐸ72.0ᐳ"}}:::plan
+    Object10 & Access73 --> PgSelect74
+    PgSelect85[["PgSelect[85∈2] ➊<br />ᐸunion_postsᐳ<br />ᐳUnionPost"]]:::plan
+    Access84{{"Access[84∈2] ➊<br />ᐸ83.0ᐳ"}}:::plan
+    Object10 & Access84 --> PgSelect85
+    PgSelect98[["PgSelect[98∈2] ➊<br />ᐸunion_dividersᐳ<br />ᐳUnionDivider"]]:::plan
+    Access97{{"Access[97∈2] ➊<br />ᐸ96.0ᐳ"}}:::plan
+    Object10 & Access97 --> PgSelect98
+    PgSelect110[["PgSelect[110∈2] ➊<br />ᐸunion_checklistsᐳ<br />ᐳUnionChecklist"]]:::plan
+    Access109{{"Access[109∈2] ➊<br />ᐸ108.0ᐳ"}}:::plan
+    Object10 & Access109 --> PgSelect110
+    PgSelect121[["PgSelect[121∈2] ➊<br />ᐸunion_checklist_itemsᐳ<br />ᐳUnionChecklistItem"]]:::plan
+    Access120{{"Access[120∈2] ➊<br />ᐸ119.0ᐳ"}}:::plan
+    Object10 & Access120 --> PgSelect121
+    JSONParse72[["JSONParse[72∈2] ➊<br />ᐸ71ᐳ<br />ᐳUnionTopic"]]:::plan
+    Access71 --> JSONParse72
+    JSONParse72 --> Access73
+    First78{{"First[78∈2] ➊"}}:::plan
+    PgSelect74 --> First78
+    PgSelectSingle79{{"PgSelectSingle[79∈2] ➊<br />ᐸunion_topicsᐳ"}}:::plan
+    First78 --> PgSelectSingle79
+    PgClassExpression80{{"PgClassExpression[80∈2] ➊<br />ᐸ__union_topics__.”id”ᐳ"}}:::plan
+    PgSelectSingle79 --> PgClassExpression80
+    PgClassExpression81{{"PgClassExpression[81∈2] ➊<br />ᐸ__union_to...__.”title”ᐳ"}}:::plan
+    PgSelectSingle79 --> PgClassExpression81
+    JSONParse83[["JSONParse[83∈2] ➊<br />ᐸ71ᐳ<br />ᐳUnionPost"]]:::plan
+    Access71 --> JSONParse83
+    JSONParse83 --> Access84
+    First89{{"First[89∈2] ➊"}}:::plan
+    PgSelect85 --> First89
+    PgSelectSingle90{{"PgSelectSingle[90∈2] ➊<br />ᐸunion_postsᐳ"}}:::plan
+    First89 --> PgSelectSingle90
+    PgClassExpression91{{"PgClassExpression[91∈2] ➊<br />ᐸ__union_posts__.”id”ᐳ"}}:::plan
+    PgSelectSingle90 --> PgClassExpression91
+    PgClassExpression92{{"PgClassExpression[92∈2] ➊<br />ᐸ__union_posts__.”title”ᐳ"}}:::plan
+    PgSelectSingle90 --> PgClassExpression92
+    PgClassExpression93{{"PgClassExpression[93∈2] ➊<br />ᐸ__union_po...scription”ᐳ"}}:::plan
+    PgSelectSingle90 --> PgClassExpression93
+    PgClassExpression94{{"PgClassExpression[94∈2] ➊<br />ᐸ__union_posts__.”note”ᐳ"}}:::plan
+    PgSelectSingle90 --> PgClassExpression94
+    JSONParse96[["JSONParse[96∈2] ➊<br />ᐸ71ᐳ<br />ᐳUnionDivider"]]:::plan
+    Access71 --> JSONParse96
+    JSONParse96 --> Access97
+    First102{{"First[102∈2] ➊"}}:::plan
+    PgSelect98 --> First102
+    PgSelectSingle103{{"PgSelectSingle[103∈2] ➊<br />ᐸunion_dividersᐳ"}}:::plan
+    First102 --> PgSelectSingle103
+    PgClassExpression104{{"PgClassExpression[104∈2] ➊<br />ᐸ__union_dividers__.”id”ᐳ"}}:::plan
+    PgSelectSingle103 --> PgClassExpression104
+    PgClassExpression105{{"PgClassExpression[105∈2] ➊<br />ᐸ__union_di...__.”title”ᐳ"}}:::plan
+    PgSelectSingle103 --> PgClassExpression105
+    PgClassExpression106{{"PgClassExpression[106∈2] ➊<br />ᐸ__union_di...__.”color”ᐳ"}}:::plan
+    PgSelectSingle103 --> PgClassExpression106
+    JSONParse108[["JSONParse[108∈2] ➊<br />ᐸ71ᐳ<br />ᐳUnionChecklist"]]:::plan
+    Access71 --> JSONParse108
+    JSONParse108 --> Access109
+    First114{{"First[114∈2] ➊"}}:::plan
+    PgSelect110 --> First114
+    PgSelectSingle115{{"PgSelectSingle[115∈2] ➊<br />ᐸunion_checklistsᐳ"}}:::plan
+    First114 --> PgSelectSingle115
+    PgClassExpression116{{"PgClassExpression[116∈2] ➊<br />ᐸ__union_ch...sts__.”id”ᐳ"}}:::plan
+    PgSelectSingle115 --> PgClassExpression116
+    PgClassExpression117{{"PgClassExpression[117∈2] ➊<br />ᐸ__union_ch...__.”title”ᐳ"}}:::plan
+    PgSelectSingle115 --> PgClassExpression117
+    JSONParse119[["JSONParse[119∈2] ➊<br />ᐸ71ᐳ<br />ᐳUnionChecklistItem"]]:::plan
+    Access71 --> JSONParse119
+    JSONParse119 --> Access120
+    First125{{"First[125∈2] ➊"}}:::plan
+    PgSelect121 --> First125
+    PgSelectSingle126{{"PgSelectSingle[126∈2] ➊<br />ᐸunion_checklist_itemsᐳ"}}:::plan
+    First125 --> PgSelectSingle126
+    PgClassExpression127{{"PgClassExpression[127∈2] ➊<br />ᐸ__union_ch...ems__.”id”ᐳ"}}:::plan
+    PgSelectSingle126 --> PgClassExpression127
+    PgClassExpression128{{"PgClassExpression[128∈2] ➊<br />ᐸ__union_ch...scription”ᐳ"}}:::plan
+    PgSelectSingle126 --> PgClassExpression128
+    PgClassExpression129{{"PgClassExpression[129∈2] ➊<br />ᐸ__union_ch...s__.”note”ᐳ"}}:::plan
+    PgSelectSingle126 --> PgClassExpression129
+
+    %% define steps
+
+    subgraph "Buckets for queries/unions-table/by-id-987654321"
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 8, 9, 130, 10<br />2: PgSelect[7], PgUnionAll[65]<br />ᐳ: 11, 12, 13, 14, 15, 69<br />3: PgUnionAllSingle[70]<br />ᐳ: Access[71]"):::bucket
+    classDef bucket0 stroke:#696969
+    class Bucket0,__Value2,__Value4,PgSelect7,Access8,Access9,Object10,First11,PgSelectSingle12,PgClassExpression13,PgPolymorphic14,PgClassExpression15,PgUnionAll65,First69,PgUnionAllSingle70,Access71,Constant130 bucket0
+    Bucket1("Bucket 1 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 10, 15, 14<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem"):::bucket
+    classDef bucket1 stroke:#00bfff
+    class Bucket1,PgSelect16,First20,PgSelectSingle21,PgClassExpression22,PgClassExpression23,PgSelect25,First29,PgSelectSingle30,PgClassExpression31,PgClassExpression32,PgClassExpression33,PgClassExpression34,PgSelect36,First40,PgSelectSingle41,PgClassExpression42,PgClassExpression43,PgClassExpression44,PgSelect46,First50,PgSelectSingle51,PgClassExpression52,PgClassExpression53,PgSelect55,First59,PgSelectSingle60,PgClassExpression61,PgClassExpression62,PgClassExpression63 bucket1
+    Bucket2("Bucket 2 (polymorphic)<br />UnionTopic,UnionPost,UnionDivider,UnionChecklist,UnionChecklistItem<br />Deps: 71, 10, 70<br />ᐳUnionTopic<br />ᐳUnionPost<br />ᐳUnionDivider<br />ᐳUnionChecklist<br />ᐳUnionChecklistItem<br /><br />1: 72, 83, 96, 108, 119<br />ᐳ: 73, 84, 97, 109, 120<br />2: 74, 85, 98, 110, 121<br />ᐳ: 78, 79, 80, 81, 89, 90, 91, 92, 93, 94, 102, 103, 104, 105, 106, 114, 115, 116, 117, 125, 126, 127, 128, 129"):::bucket
+    classDef bucket2 stroke:#7f007f
+    class Bucket2,JSONParse72,Access73,PgSelect74,First78,PgSelectSingle79,PgClassExpression80,PgClassExpression81,JSONParse83,Access84,PgSelect85,First89,PgSelectSingle90,PgClassExpression91,PgClassExpression92,PgClassExpression93,PgClassExpression94,JSONParse96,Access97,PgSelect98,First102,PgSelectSingle103,PgClassExpression104,PgClassExpression105,PgClassExpression106,JSONParse108,Access109,PgSelect110,First114,PgSelectSingle115,PgClassExpression116,PgClassExpression117,JSONParse119,Access120,PgSelect121,First125,PgSelectSingle126,PgClassExpression127,PgClassExpression128,PgClassExpression129 bucket2
+    Bucket0 --> Bucket1 & Bucket2
+    end

--- a/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-987654321.sql
+++ b/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-987654321.sql
@@ -1,0 +1,118 @@
+select __union_items_result__.*
+from (select 0 as idx, $1::"int4" as "id0") as __union_items_identifiers__,
+lateral (
+  select
+    __union_items__."type"::text as "0",
+    __union_items__."id"::text as "1",
+    __union_items_identifiers__.idx as "2"
+  from interfaces_and_unions.union_items as __union_items__
+  where
+    (
+      true /* authorization checks */
+    ) and (
+      __union_items__."id" = __union_items_identifiers__."id0"
+    )
+) as __union_items_result__;
+
+select __union_result__.*
+from (select ids.ordinality - 1 as idx, (ids.value->>0)::"int4" as "id0" from json_array_elements($1::json) with ordinality as ids) as __union_identifiers__,
+lateral (
+  select
+    __union__."0" as "0",
+    __union__."1"::text as "1",
+    __union_identifiers__.idx as "2"
+  from (
+      select
+        __union_topics__."0",
+        __union_topics__."1",
+        "n"
+      from (
+        select
+          'UnionTopic' as "0",
+          json_build_array((__union_topics__."id")::text) as "1",
+          row_number() over (
+            order by
+              __union_topics__."id" asc
+          ) as "n"
+        from interfaces_and_unions.union_topics as __union_topics__
+        where __union_topics__.id = __union_identifiers__."id0"
+        order by
+          __union_topics__."id" asc
+      ) as __union_topics__
+    union all
+      select
+        __union_posts__."0",
+        __union_posts__."1",
+        "n"
+      from (
+        select
+          'UnionPost' as "0",
+          json_build_array((__union_posts__."id")::text) as "1",
+          row_number() over (
+            order by
+              __union_posts__."id" asc
+          ) as "n"
+        from interfaces_and_unions.union_posts as __union_posts__
+        where __union_posts__.id = __union_identifiers__."id0"
+        order by
+          __union_posts__."id" asc
+      ) as __union_posts__
+    union all
+      select
+        __union_dividers__."0",
+        __union_dividers__."1",
+        "n"
+      from (
+        select
+          'UnionDivider' as "0",
+          json_build_array((__union_dividers__."id")::text) as "1",
+          row_number() over (
+            order by
+              __union_dividers__."id" asc
+          ) as "n"
+        from interfaces_and_unions.union_dividers as __union_dividers__
+        where __union_dividers__.id = __union_identifiers__."id0"
+        order by
+          __union_dividers__."id" asc
+      ) as __union_dividers__
+    union all
+      select
+        __union_checklists__."0",
+        __union_checklists__."1",
+        "n"
+      from (
+        select
+          'UnionChecklist' as "0",
+          json_build_array((__union_checklists__."id")::text) as "1",
+          row_number() over (
+            order by
+              __union_checklists__."id" asc
+          ) as "n"
+        from interfaces_and_unions.union_checklists as __union_checklists__
+        where __union_checklists__.id = __union_identifiers__."id0"
+        order by
+          __union_checklists__."id" asc
+      ) as __union_checklists__
+    union all
+      select
+        __union_checklist_items__."0",
+        __union_checklist_items__."1",
+        "n"
+      from (
+        select
+          'UnionChecklistItem' as "0",
+          json_build_array((__union_checklist_items__."id")::text) as "1",
+          row_number() over (
+            order by
+              __union_checklist_items__."id" asc
+          ) as "n"
+        from interfaces_and_unions.union_checklist_items as __union_checklist_items__
+        where __union_checklist_items__.id = __union_identifiers__."id0"
+        order by
+          __union_checklist_items__."id" asc
+      ) as __union_checklist_items__
+    order by
+      "0" asc,
+      "n" asc
+  ) __union__
+) as __union_result__;

--- a/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-987654321.test.graphql
+++ b/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-987654321.test.graphql
@@ -1,5 +1,6 @@
 ## expect(errors).toBeFalsy()
 ## expect(data.nx).toEqual(null);
+## expect(data.nx2).toEqual(null);
 {
   nx: unionItemById(id: 987654321) {
     ...Item

--- a/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-987654321.test.graphql
+++ b/grafast/dataplan-pg/__tests__/queries/unions-table/by-id-987654321.test.graphql
@@ -1,0 +1,37 @@
+## expect(errors).toBeFalsy()
+## expect(data.nx).toEqual(null);
+{
+  nx: unionItemById(id: 987654321) {
+    ...Item
+  }
+  nx2: unionItemByIdViaUnionAll(id: 987654321) {
+    ...Item
+  }
+}
+
+fragment Item on UnionItem {
+  ... on UnionTopic {
+    id
+    title
+  }
+  ... on UnionPost {
+    id
+    title
+    description
+    note
+  }
+  ... on UnionDivider {
+    id
+    title
+    color
+  }
+  ... on UnionChecklist {
+    id
+    title
+  }
+  ... on UnionChecklistItem {
+    id
+    description
+    note
+  }
+}

--- a/grafast/dataplan-pg/src/examples/exampleSchema.ts
+++ b/grafast/dataplan-pg/src/examples/exampleSchema.ts
@@ -4279,6 +4279,52 @@ export function makeExampleSchema(
         ),
       },
 
+      unionItemByIdViaUnionAll: {
+        type: UnionItem,
+        args: {
+          id: {
+            type: new GraphQLNonNull(GraphQLInt),
+          },
+        },
+        plan: EXPORTABLE(
+          (
+            TYPES,
+            pgUnionAll,
+            sql,
+            unionChecklistItemsResource,
+            unionChecklistsResource,
+            unionDividersResource,
+            unionPostsResource,
+            unionTopicsResource,
+          ) =>
+            function plan(_$root, { $id }) {
+              const $items = pgUnionAll({
+                resourceByTypeName: {
+                  UnionTopic: unionTopicsResource,
+                  UnionPost: unionPostsResource,
+                  UnionDivider: unionDividersResource,
+                  UnionChecklist: unionChecklistsResource,
+                  UnionChecklistItem: unionChecklistItemsResource,
+                },
+              });
+              $items.where(
+                sql`${$items}.id = ${$items.placeholder($id, TYPES.int)}`,
+              );
+              return $items.single();
+            },
+          [
+            TYPES,
+            pgUnionAll,
+            sql,
+            unionChecklistItemsResource,
+            unionChecklistsResource,
+            unionDividersResource,
+            unionPostsResource,
+            unionTopicsResource,
+          ],
+        ),
+      },
+
       unionTopicById: {
         type: UnionTopic,
         args: {

--- a/grafast/dataplan-pg/src/steps/pgUnionAll.ts
+++ b/grafast/dataplan-pg/src/steps/pgUnionAll.ts
@@ -29,7 +29,7 @@ import {
 } from "grafast";
 import type { GraphQLObjectType } from "grafast/graphql";
 import type { SQL, SQLRawValue } from "pg-sql2";
-import { $$symbolToIdentifier, sql } from "pg-sql2";
+import { $$symbolToIdentifier, $$toSQL, sql } from "pg-sql2";
 
 import type { PgCodecAttributes } from "../codecs.js";
 import { TYPES } from "../codecs.js";
@@ -2011,6 +2011,10 @@ ${lateralText};`;
       }
       return orderedRows;
     });
+  }
+
+  [$$toSQL]() {
+    return this.alias;
   }
 }
 

--- a/grafast/dataplan-pg/src/steps/pgUnionAll.ts
+++ b/grafast/dataplan-pg/src/steps/pgUnionAll.ts
@@ -332,12 +332,15 @@ export class PgUnionAllSingleStep
       const typeKey = this.typeKey;
       return values0.isBatch
         ? values0.entries.map((v) => {
+            if (v == null) return null;
             const type = v[typeKey];
             return polymorphicWrap(type, v);
           })
         : arrayOfLength(
             count,
-            polymorphicWrap(values0.value[typeKey], values0.value),
+            values0.value == null
+              ? null
+              : polymorphicWrap(values0.value[typeKey], values0.value),
           );
     } else {
       return values0.isBatch

--- a/graphile-build/graphile-utils/__tests__/makeExtendSchemaPlugin.test.ts
+++ b/graphile-build/graphile-utils/__tests__/makeExtendSchemaPlugin.test.ts
@@ -93,9 +93,12 @@ const ExtendPlugin = makeExtendSchemaPlugin({
 });
 
 it("supports scalars", async () => {
-  const schema = buildSchema({
-    plugins: [QueryPlugin, ExtendPlugin],
-  });
+  const schema = buildSchema(
+    {
+      plugins: [QueryPlugin, ExtendPlugin],
+    },
+    {} as any,
+  );
   const result = await grafast({
     schema,
     source: /* GraphQL */ `


### PR DESCRIPTION
## Description

Fixes #2148

## Performance impact

Negligible.

## Security impact

Improvement?

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
