### PR TITLE
Fix `value.get()` typo in `makeAddPgTableConditionPlugin` example

### DIFF
--- a/postgraphile/website/postgraphile/make-add-pg-table-condition-plugin.md
+++ b/postgraphile/website/postgraphile/make-add-pg-table-condition-plugin.md
@@ -80,7 +80,7 @@ those where a particular user has posted in (posts are stored in
 
 ```ts
 import { makeAddPgTableConditionPlugin } from "postgraphile/utils";
-import { TYPES } from 'postgraphile/@dataplan/pg';
+import { TYPES } from "postgraphile/@dataplan/pg";
 
 export default makeAddPgTableConditionPlugin(
   { schemaName: "app_public", tableName: "forums" },

--- a/postgraphile/website/postgraphile/make-add-pg-table-condition-plugin.md
+++ b/postgraphile/website/postgraphile/make-add-pg-table-condition-plugin.md
@@ -102,7 +102,7 @@ export default makeAddPgTableConditionPlugin(
           from app_public.posts as ${sqlIdentifier}
           where ${sqlIdentifier}.forum_id = ${$condition.alias}.id
           and ${sqlIdentifier}.user_id = ${$condition.placeholder(
-            value,
+            value.get(),
             TYPES.int,
           )}
         )`);

--- a/postgraphile/website/postgraphile/make-add-pg-table-condition-plugin.md
+++ b/postgraphile/website/postgraphile/make-add-pg-table-condition-plugin.md
@@ -80,7 +80,7 @@ those where a particular user has posted in (posts are stored in
 
 ```ts
 import { makeAddPgTableConditionPlugin } from "postgraphile/utils";
-import { TYPES } from '@dataplan/pg';
+import { TYPES } from 'postgraphile/@dataplan/pg';
 
 export default makeAddPgTableConditionPlugin(
   { schemaName: "app_public", tableName: "forums" },

--- a/postgraphile/website/postgraphile/make-add-pg-table-condition-plugin.md
+++ b/postgraphile/website/postgraphile/make-add-pg-table-condition-plugin.md
@@ -80,8 +80,8 @@ those where a particular user has posted in (posts are stored in
 
 ```ts
 import { makeAddPgTableConditionPlugin } from "postgraphile/utils";
+import { TYPES } from '@dataplan/pg';
 
-/* TODO: test this plugin works! */
 export default makeAddPgTableConditionPlugin(
   { schemaName: "app_public", tableName: "forums" },
   "containsPostsByUserId",


### PR DESCRIPTION
## Description

Adds the missing `.get()` to the second `makeAddPgTableConditionPlugin` example.

## Performance impact

None

## Security impact

None

## Checklist

N/A
