### PR TITLE
Auto-complete of plugin names in preset

### DIFF
--- a/.changeset/two-balloons-learn.md
+++ b/.changeset/two-balloons-learn.md
@@ -1,0 +1,10 @@
+---
+"graphile-build-pg": patch
+"graphile-build": patch
+"postgraphile": patch
+"graphile-config": patch
+---
+
+`disablePlugins` now supports TypeScript auto-completion of known plugin names.
+Other names are still accepted without error, so this is just a minor DX
+improvement rather than type safety.

--- a/grafast/dataplan-pg/src/plugins/PgContextPlugin.ts
+++ b/grafast/dataplan-pg/src/plugins/PgContextPlugin.ts
@@ -8,6 +8,14 @@ export const EMPTY_OBJECT: Record<string, never> = Object.freeze(
   Object.create(null),
 );
 
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      PgContextPlugin: true;
+    }
+  }
+}
+
 export const PgContextPlugin: GraphileConfig.Plugin = {
   name: "PgContextPlugin",
   description:

--- a/grafast/grafserv-persisted/src/index.ts
+++ b/grafast/grafserv-persisted/src/index.ts
@@ -14,6 +14,14 @@ import LRU from "@graphile/lru";
 import type { PersistedOperationGetter } from "./interfaces.js";
 import { version } from "./version.js";
 
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      PersistedPlugin: true;
+    }
+  }
+}
+
 const PersistedPlugin: GraphileConfig.Plugin = {
   name: "PersistedPlugin",
   description: "Enables persisted operations in Grafserv",

--- a/grafast/grafserv/src/envelop/index.ts
+++ b/grafast/grafserv/src/envelop/index.ts
@@ -18,6 +18,14 @@ declare global {
   }
 }
 
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      GrafservEnvelopPlugin: true;
+    }
+  }
+}
+
 export const GrafservEnvelopPlugin: GraphileConfig.Plugin = {
   name: "GrafservEnvelopPlugin",
   version,

--- a/graphile-build/graphile-build-pg/src/examples/NO_DATA_GATHERING.ts
+++ b/graphile-build/graphile-build-pg/src/examples/NO_DATA_GATHERING.ts
@@ -43,6 +43,14 @@ const pool = new Pool({
 });
 const withPgClient: WithPgClient = makePgAdaptorWithPgClient(pool);
 
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      UseRelationNamesPlugin: true;
+    }
+  }
+}
+
 async function main() {
   // Create our GraphQL schema by applying all the plugins
   const executor = EXPORTABLE(

--- a/graphile-build/graphile-build-pg/src/examples/config.ts
+++ b/graphile-build/graphile-build-pg/src/examples/config.ts
@@ -37,6 +37,14 @@ export function getPool() {
   return pool;
 }
 
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      EnumManglingPlugin: true;
+    }
+  }
+}
+
 const EnumManglingPlugin: GraphileConfig.Plugin = {
   name: "EnumManglingPlugin",
   description:

--- a/graphile-build/graphile-build-pg/src/plugins/PgAllRowsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgAllRowsPlugin.ts
@@ -10,6 +10,12 @@ import { tagToString } from "../utils.js";
 import { version } from "../version.js";
 
 declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      PgAllRowsPlugin: true;
+    }
+  }
+
   namespace GraphileBuild {
     interface Inflection {
       /**

--- a/graphile-build/graphile-build-pg/src/plugins/PgAttributeDeprecationPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgAttributeDeprecationPlugin.ts
@@ -2,6 +2,14 @@ import "graphile-config";
 
 import { version } from "../version.js";
 
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      PgAttributeDeprecationPlugin: true;
+    }
+  }
+}
+
 export const PgAttributeDeprecationPlugin: GraphileConfig.Plugin = {
   name: "PgAttributeDeprecationPlugin",
   description: "Marks a attribute as deprecated if it has the deprecated tag",

--- a/graphile-build/graphile-build-pg/src/plugins/PgAttributesPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgAttributesPlugin.ts
@@ -21,6 +21,12 @@ import { EXPORTABLE } from "graphile-build";
 import { version } from "../version.js";
 
 declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      PgAttributesPlugin: true;
+    }
+  }
+
   namespace GraphileBuild {
     interface Build {
       pgResolveOutputType(

--- a/graphile-build/graphile-build-pg/src/plugins/PgBasicsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgBasicsPlugin.ts
@@ -21,6 +21,12 @@ import { getCodecMetaLookupFromInput, makePgCodecMeta } from "../inputUtils.js";
 import { version } from "../version.js";
 
 declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      PgBasicsPlugin: true;
+    }
+  }
+
   namespace GraphileBuild {
     interface BuildVersions {
       "graphile-build-pg": string;

--- a/graphile-build/graphile-build-pg/src/plugins/PgCodecsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgCodecsPlugin.ts
@@ -83,6 +83,10 @@ declare global {
       PgCodecsPlugin: true;
     }
 
+    interface Provides {
+      PgCodecs: true;
+    }
+
     interface GatherHelpers {
       pgCodecs: {
         getCodecFromClass(

--- a/graphile-build/graphile-build-pg/src/plugins/PgCodecsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgCodecsPlugin.ts
@@ -79,6 +79,10 @@ declare global {
   }
 
   namespace GraphileConfig {
+    interface Plugins {
+      PgCodecsPlugin: true;
+    }
+
     interface GatherHelpers {
       pgCodecs: {
         getCodecFromClass(

--- a/graphile-build/graphile-build-pg/src/plugins/PgConditionArgumentPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgConditionArgumentPlugin.ts
@@ -13,6 +13,12 @@ import type { GraphQLInputObjectType } from "grafast/graphql";
 import { version } from "../version.js";
 
 declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      PgConditionArgumentPlugin: true;
+    }
+  }
+
   namespace GraphileBuild {
     interface Inflection {
       conditionType(this: Inflection, typeName: string): string;

--- a/graphile-build/graphile-build-pg/src/plugins/PgConditionCustomFieldsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgConditionCustomFieldsPlugin.ts
@@ -11,6 +11,12 @@ import { EXPORTABLE } from "graphile-build";
 import { version } from "../version.js";
 
 declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      PgConditionCustomFieldsPlugin: true;
+    }
+  }
+
   namespace GraphileBuild {
     interface ScopeInputObjectFieldsField {
       isPgConnectionConditionInputField?: boolean;

--- a/graphile-build/graphile-build-pg/src/plugins/PgConnectionArgOrderByDefaultValuePlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgConnectionArgOrderByDefaultValuePlugin.ts
@@ -5,6 +5,14 @@ import type { GraphQLEnumType } from "grafast/graphql";
 
 import { version } from "../version.js";
 
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      PgConnectionArgOrderByDefaultValuePlugin: true;
+    }
+  }
+}
+
 export const PgConnectionArgOrderByDefaultValuePlugin: GraphileConfig.Plugin = {
   name: "PgConnectionArgOrderByDefaultValuePlugin",
   description: "Sets the default 'orderBy' for a table",

--- a/graphile-build/graphile-build-pg/src/plugins/PgConnectionArgOrderByPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgConnectionArgOrderByPlugin.ts
@@ -20,6 +20,12 @@ import { inspect } from "util";
 import { version } from "../version.js";
 
 declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      PgConnectionArgOrderByPlugin: true;
+    }
+  }
+
   namespace GraphileBuild {
     interface Inflection {
       orderByType(this: Inflection, typeName: string): string;

--- a/graphile-build/graphile-build-pg/src/plugins/PgConnectionTotalCountPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgConnectionTotalCountPlugin.ts
@@ -15,6 +15,12 @@ import { EXPORTABLE } from "graphile-build";
 import { version } from "../version.js";
 
 declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      PgConnectionTotalCountPlugin: true;
+    }
+  }
+
   namespace GraphileBuild {
     interface ScopeObjectFieldsField {
       /**

--- a/graphile-build/graphile-build-pg/src/plugins/PgCustomTypeFieldPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgCustomTypeFieldPlugin.ts
@@ -54,6 +54,12 @@ const $$rootMutation = Symbol("PgCustomTypeFieldPluginRootMutationSources");
 const $$computed = Symbol("PgCustomTypeFieldPluginComputedSources");
 
 declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      PgCustomTypeFieldPlugin: true;
+    }
+  }
+
   namespace GraphileBuild {
     interface Build {
       pgGetArgDetailsFromParameters(

--- a/graphile-build/graphile-build-pg/src/plugins/PgEnumTablesPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgEnumTablesPlugin.ts
@@ -14,6 +14,10 @@ import { version } from "../version.js";
 
 declare global {
   namespace GraphileConfig {
+    interface Plugins {
+      PgEnumTablesPlugin: true;
+    }
+
     interface GatherHelpers {
       pgEnumTables: {
         isEnumConstraint(pgConstraint: PgConstraint): boolean;

--- a/graphile-build/graphile-build-pg/src/plugins/PgFakeConstraintsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgFakeConstraintsPlugin.ts
@@ -14,6 +14,10 @@ import { version } from "../version.js";
 
 declare global {
   namespace GraphileConfig {
+    interface Plugins {
+      PgFakeConstraintsPlugin: true;
+    }
+
     interface GatherHelpers {
       pgFakeConstraints: Record<string, never>;
     }

--- a/graphile-build/graphile-build-pg/src/plugins/PgFirstLastBeforeAfterArgsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgFirstLastBeforeAfterArgsPlugin.ts
@@ -12,6 +12,12 @@ import { EXPORTABLE } from "graphile-build";
 import { version } from "../version.js";
 
 declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      PgFirstLastBeforeAfterArgsPlugin: true;
+    }
+  }
+
   namespace GraphileBuild {
     interface Inflection {
       conditionType(this: Inflection, typeName: string): string;

--- a/graphile-build/graphile-build-pg/src/plugins/PgIndexBehaviorsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgIndexBehaviorsPlugin.ts
@@ -1,5 +1,13 @@
 import { addBehaviorToTags } from "../utils.js";
 
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      PgIndexBehaviorsPlugin: true;
+    }
+  }
+}
+
 export const PgIndexBehaviorsPlugin: GraphileConfig.Plugin = {
   name: "PgIndexBehaviorsPlugin",
   version: "0.0.0",

--- a/graphile-build/graphile-build-pg/src/plugins/PgInterfaceModeUnionAllRowsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgInterfaceModeUnionAllRowsPlugin.ts
@@ -14,6 +14,12 @@ import { EXPORTABLE } from "graphile-build";
 import { version } from "../version.js";
 
 declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      PgInterfaceModeUnionAllRowsPlugin: true;
+    }
+  }
+
   namespace GraphileBuild {
     interface Inflection {
       /**

--- a/graphile-build/graphile-build-pg/src/plugins/PgIntrospectionPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgIntrospectionPlugin.ts
@@ -61,6 +61,10 @@ declare global {
   }
 
   namespace GraphileConfig {
+    interface Plugins {
+      PgIntrospectionPlugin: true;
+    }
+
     interface GatherHelpers {
       pgIntrospection: {
         getIntrospection(): PromiseOrDirect<IntrospectionResults>;

--- a/graphile-build/graphile-build-pg/src/plugins/PgJWTPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgJWTPlugin.ts
@@ -42,6 +42,10 @@ declare global {
 
 declare global {
   namespace GraphileConfig {
+    interface Plugins {
+      PgJWTPlugin: true;
+    }
+
     interface GatherHelpers {
       pgJWT: Record<string, never>;
     }

--- a/graphile-build/graphile-build-pg/src/plugins/PgLtreePlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgLtreePlugin.ts
@@ -10,6 +10,14 @@ interface State {
   ltreeArrayCodec: PgCodec;
 }
 
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      PgLtreePlugin: true;
+    }
+  }
+}
+
 export const PgLtreePlugin: GraphileConfig.Plugin = {
   name: "PgLtreePlugin",
   version,

--- a/graphile-build/graphile-build-pg/src/plugins/PgMutationCreatePlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgMutationCreatePlugin.ts
@@ -11,6 +11,12 @@ import { tagToString } from "../utils.js";
 import { version } from "../version.js";
 
 declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      PgMutationCreatePlugin: true;
+    }
+  }
+
   namespace GraphileBuild {
     interface ScopeObject {
       isPgCreatePayloadType?: boolean;

--- a/graphile-build/graphile-build-pg/src/plugins/PgMutationPayloadEdgePlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgMutationPayloadEdgePlugin.ts
@@ -16,6 +16,12 @@ import { version } from "../version.js";
 import { applyOrderToPlan } from "./PgConnectionArgOrderByPlugin.js";
 
 declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      PgMutationPayloadEdgePlugin: true;
+    }
+  }
+
   namespace GraphileBuild {
     interface Inflection {
       tableEdgeField(this: Inflection, codec: PgCodecWithAttributes): string;

--- a/graphile-build/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgMutationUpdateDeletePlugin.ts
@@ -27,6 +27,12 @@ import { tagToString } from "../utils.js";
 import { version } from "../version.js";
 
 declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      PgMutationUpdateDeletePlugin: true;
+    }
+  }
+
   namespace GraphileBuild {
     interface ScopeObject {
       isPgUpdatePayloadType?: boolean;

--- a/graphile-build/graphile-build-pg/src/plugins/PgNodeIdAttributesPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgNodeIdAttributesPlugin.ts
@@ -15,6 +15,12 @@ import { EXPORTABLE } from "graphile-build";
 import { version } from "../version.js";
 
 declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      PgNodeIdAttributesPlugin: true;
+    }
+  }
+
   namespace GraphileBuild {
     interface Inflection {
       /**

--- a/graphile-build/graphile-build-pg/src/plugins/PgOrderAllAttributesPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgOrderAllAttributesPlugin.ts
@@ -10,6 +10,11 @@ import { EXPORTABLE } from "graphile-build";
 import { version } from "../version.js";
 
 declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      PgOrderAllAttributesPlugin: true;
+    }
+  }
   namespace GraphileBuild {
     interface Inflection {
       orderByAttributeEnum(

--- a/graphile-build/graphile-build-pg/src/plugins/PgOrderByPrimaryKeyPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgOrderByPrimaryKeyPlugin.ts
@@ -11,6 +11,12 @@ import { EXPORTABLE } from "graphile-build";
 import { version } from "../version.js";
 
 declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      PgOrderByPrimaryKeyPlugin: true;
+    }
+  }
+
   namespace GraphileBuild {
     interface SchemaOptions {
       pgOrderByNullsLast?: boolean;

--- a/graphile-build/graphile-build-pg/src/plugins/PgOrderCustomFieldsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgOrderCustomFieldsPlugin.ts
@@ -12,6 +12,12 @@ import { version } from "../version.js";
 import { isSimpleScalarComputedColumnLike } from "./PgConditionCustomFieldsPlugin.js";
 
 declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      PgOrderCustomFieldsPlugin: true;
+    }
+  }
+
   namespace GraphileBuild {
     interface Inflection {
       computedAttributeOrder(

--- a/graphile-build/graphile-build-pg/src/plugins/PgPolymorphismOnlyArgumentPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgPolymorphismOnlyArgumentPlugin.ts
@@ -15,6 +15,12 @@ import type { GraphQLFieldConfigArgumentMap } from "graphql";
 import { version } from "../version.js";
 
 declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      PgPolymorphismOnlyArgumentPlugin: true;
+    }
+  }
+
   namespace GraphileBuild {
     interface Inflection {
       pgPolymorphismEnumType(pgCodec: PgCodec): string;

--- a/graphile-build/graphile-build-pg/src/plugins/PgPolymorphismPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgPolymorphismPlugin.ts
@@ -61,6 +61,10 @@ function isNotNullish<T>(v: T | null | undefined): v is T {
 
 declare global {
   namespace GraphileConfig {
+    interface Plugins {
+      PgPolymorphismPlugin: true;
+    }
+
     interface GatherHelpers {
       pgPolymorphism: Record<string, never>;
     }

--- a/graphile-build/graphile-build-pg/src/plugins/PgProceduresPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgProceduresPlugin.ts
@@ -59,6 +59,10 @@ declare global {
   }
 
   namespace GraphileConfig {
+    interface Plugins {
+      PgProceduresPlugin: true;
+    }
+
     interface GatherHelpers {
       pgProcedures: {
         getResourceOptions(

--- a/graphile-build/graphile-build-pg/src/plugins/PgRBACPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgRBACPlugin.ts
@@ -8,6 +8,10 @@ import { version } from "../version.js";
 
 declare global {
   namespace GraphileConfig {
+    interface Plugins {
+      PgRBACPlugin: true;
+    }
+
     interface GatherHelpers {
       pgRBAC: Record<string, never>;
     }

--- a/graphile-build/graphile-build-pg/src/plugins/PgRefsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgRefsPlugin.ts
@@ -20,6 +20,10 @@ import { version } from "../version.js";
 
 declare global {
   namespace GraphileConfig {
+    interface Plugins {
+      PgRefsPlugin: true;
+    }
+
     interface GatherHelpers {
       pgRefs: Record<string, never>;
     }

--- a/graphile-build/graphile-build-pg/src/plugins/PgRegistryPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgRegistryPlugin.ts
@@ -8,6 +8,10 @@ import { version } from "../version.js";
 
 declare global {
   namespace GraphileConfig {
+    interface Plugins {
+      PgRegistryPlugin: true;
+    }
+
     interface GatherHelpers {
       pgRegistry: {
         getRegistryBuilder(): PromiseOrDirect<PgRegistryBuilder<any, any, any>>;

--- a/graphile-build/graphile-build-pg/src/plugins/PgRelationsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgRelationsPlugin.ts
@@ -107,6 +107,10 @@ declare global {
   }
 
   namespace GraphileConfig {
+    interface Plugins {
+      PgRelationsPlugin: true;
+    }
+
     interface GatherHelpers {
       pgRelations: {
         addRelation(

--- a/graphile-build/graphile-build-pg/src/plugins/PgRemoveExtensionResourcesPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgRemoveExtensionResourcesPlugin.ts
@@ -7,6 +7,10 @@ import { version } from "../version.js";
 
 declare global {
   namespace GraphileConfig {
+    interface Plugins {
+      PgRemoveExtensionResourcesPlugin: true;
+    }
+
     interface GatherHelpers {
       pgRemoveExtensionResources: Record<string, never>;
     }

--- a/graphile-build/graphile-build-pg/src/plugins/PgRowByUniquePlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgRowByUniquePlugin.ts
@@ -14,6 +14,12 @@ import { tagToString } from "../utils.js";
 import { version } from "../version.js";
 
 declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      PgRowByUniquePlugin: true;
+    }
+  }
+
   namespace GraphileBuild {
     interface Inflection {
       rowByUnique(

--- a/graphile-build/graphile-build-pg/src/plugins/PgTableNodePlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgTableNodePlugin.ts
@@ -15,6 +15,12 @@ import { tagToString } from "../utils.js";
 import { version } from "../version.js";
 
 declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      PgTableNodePlugin: true;
+    }
+  }
+
   namespace GraphileBuild {
     interface SchemaOptions {
       pgV4UseTableNameForNodeIdentifier?: boolean;

--- a/graphile-build/graphile-build-pg/src/plugins/PgTablesPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgTablesPlugin.ts
@@ -160,10 +160,12 @@ declare global {
       isPgFieldSimpleCollection?: boolean;
     }
   }
-}
 
-declare global {
   namespace GraphileConfig {
+    interface Plugins {
+      PgTablesPlugin: true;
+    }
+
     interface GatherHelpers {
       pgTables: {
         getResourceOptions(

--- a/graphile-build/graphile-build-pg/src/plugins/PgTypesPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgTypesPlugin.ts
@@ -10,6 +10,11 @@ import { EXPORTABLE } from "graphile-build";
 import { version } from "../version.js";
 
 declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      PgTypesPlugin: true;
+    }
+  }
   namespace GraphileBuild {
     interface ScopeObject {
       isPgIntervalType?: boolean;

--- a/graphile-build/graphile-build-pg/src/plugins/PgTypesPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgTypesPlugin.ts
@@ -14,6 +14,10 @@ declare global {
     interface Plugins {
       PgTypesPlugin: true;
     }
+
+    interface Provides {
+      "pg-standard-types": true;
+    }
   }
   namespace GraphileBuild {
     interface ScopeObject {

--- a/graphile-build/graphile-build/src/examples/README-1.ts
+++ b/graphile-build/graphile-build/src/examples/README-1.ts
@@ -17,6 +17,12 @@ import { buildSchema, defaultPreset, EXPORTABLE } from "../index.js";
  */
 
 declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      MyRandomFieldPlugin: true;
+    }
+  }
+
   namespace GraphileBuild {
     interface SchemaOptions {
       myDefaultMin?: number;

--- a/graphile-build/graphile-build/src/index.ts
+++ b/graphile-build/graphile-build/src/index.ts
@@ -701,6 +701,11 @@ export { version } from "./version.js";
 
 declare global {
   namespace GraphileConfig {
+    interface Provides {
+      default: true;
+      inferred: true;
+      override: true;
+    }
     interface Preset {
       /**
        * The inflection phase is the first phase that occurs when building a

--- a/graphile-build/graphile-build/src/plugins/AddNodeInterfaceToSuitableTypesPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/AddNodeInterfaceToSuitableTypesPlugin.ts
@@ -7,6 +7,14 @@ import type { GraphQLInterfaceType } from "grafast/graphql";
 import { EXPORTABLE } from "../utils.js";
 import { NODE_ID_CODECS, NODE_ID_HANDLER_BY_TYPE_NAME } from "./NodePlugin.js";
 
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      AddNodeInterfaceToSuitableTypesPlugin: true;
+    }
+  }
+}
+
 export const AddNodeInterfaceToSuitableTypesPlugin: GraphileConfig.Plugin = {
   name: "AddNodeInterfaceToSuitableTypesPlugin",
   version: "1.0.0",

--- a/graphile-build/graphile-build/src/plugins/BuiltinScalarConnectionsPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/BuiltinScalarConnectionsPlugin.ts
@@ -3,6 +3,14 @@ import "graphile-config";
 
 import { version } from "../version.js";
 
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      BuiltinScalarConnectionsPlugin: true;
+    }
+  }
+}
+
 export const BuiltinScalarConnectionsPlugin: GraphileConfig.Plugin = {
   name: "BuiltinScalarConnectionsPlugin",
   description: "Adds connection types for builtin scalars",

--- a/graphile-build/graphile-build/src/plugins/ClientMutationIdDescriptionPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/ClientMutationIdDescriptionPlugin.ts
@@ -1,5 +1,13 @@
 import { version } from "../version.js";
 
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      ClientMutationIdDescriptionPlugin: true;
+    }
+  }
+}
+
 /**
  * Adds generic descriptions (where not already present) to:
  *

--- a/graphile-build/graphile-build/src/plugins/ClientMutationIdDescriptionPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/ClientMutationIdDescriptionPlugin.ts
@@ -5,6 +5,10 @@ declare global {
     interface Plugins {
       ClientMutationIdDescriptionPlugin: true;
     }
+
+    interface Provides {
+      ClientMutationIdDescription: true;
+    }
   }
 }
 

--- a/graphile-build/graphile-build/src/plugins/CommonTypesPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/CommonTypesPlugin.ts
@@ -9,6 +9,12 @@ import { EXPORTABLE } from "../utils.js";
 import { version } from "../version.js";
 
 declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      CommonTypesPlugin: true;
+    }
+  }
+
   namespace GraphileBuild {
     interface ScopeScalar {}
     interface SchemaOptions {

--- a/graphile-build/graphile-build/src/plugins/ConnectionPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/ConnectionPlugin.ts
@@ -11,6 +11,12 @@ import { EXPORTABLE } from "../utils.js";
 import { version } from "../version.js";
 
 declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      ConnectionPlugin: true;
+    }
+  }
+
   namespace GraphileBuild {
     interface RegisterCursorConnectionOptions {
       typeName: string;

--- a/graphile-build/graphile-build/src/plugins/CursorTypePlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/CursorTypePlugin.ts
@@ -4,6 +4,12 @@ import { stringTypeSpec } from "../utils.js";
 import { version } from "../version.js";
 
 declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      CursorTypePlugin: true;
+    }
+  }
+
   namespace GraphileBuild {
     interface ScopeScalar extends Scope {
       isCursorType?: boolean;

--- a/graphile-build/graphile-build/src/plugins/CursorTypePlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/CursorTypePlugin.ts
@@ -8,6 +8,10 @@ declare global {
     interface Plugins {
       CursorTypePlugin: true;
     }
+
+    interface Provides {
+      Cursor: true;
+    }
   }
 
   namespace GraphileBuild {

--- a/graphile-build/graphile-build/src/plugins/MutationPayloadQueryPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/MutationPayloadQueryPlugin.ts
@@ -10,6 +10,10 @@ declare global {
     interface Plugins {
       MutationPayloadQueryPlugin: true;
     }
+
+    interface Provides {
+      MutationPayloadQuery: true;
+    }
   }
 }
 

--- a/graphile-build/graphile-build/src/plugins/MutationPayloadQueryPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/MutationPayloadQueryPlugin.ts
@@ -5,6 +5,14 @@ import { rootValue } from "grafast";
 import { EXPORTABLE } from "../utils.js";
 import { version } from "../version.js";
 
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      MutationPayloadQueryPlugin: true;
+    }
+  }
+}
+
 /**
  * Adds a 'query' field to each mutation payload object type; this often turns
  * out to be quite helpful but if you don't want it in your schema then it's

--- a/graphile-build/graphile-build/src/plugins/MutationPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/MutationPlugin.ts
@@ -10,6 +10,9 @@ declare global {
     interface Plugins {
       MutationPlugin: true;
     }
+    interface Provides {
+      Mutation: true;
+    }
   }
 }
 

--- a/graphile-build/graphile-build/src/plugins/MutationPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/MutationPlugin.ts
@@ -5,6 +5,14 @@ import { __ValueStep } from "grafast";
 import { isValidObjectType } from "../utils.js";
 import { version } from "../version.js";
 
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      MutationPlugin: true;
+    }
+  }
+}
+
 /**
  * This plugin registers the operation type for the 'mutation' operation, and
  * if that type adds at least one field then it will be added to the GraphQL

--- a/graphile-build/graphile-build/src/plugins/NodeAccessorPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/NodeAccessorPlugin.ts
@@ -7,6 +7,12 @@ import { EXPORTABLE } from "../utils.js";
 import { version } from "../version.js";
 
 declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      NodeAccessorPlugin: true;
+    }
+  }
+
   namespace GraphileBuild {
     type NodeFetcher = {
       ($nodeId: ExecutableStep<string>): ExecutableStep<any>;

--- a/graphile-build/graphile-build/src/plugins/NodeIdCodecBase64JSONPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/NodeIdCodecBase64JSONPlugin.ts
@@ -1,5 +1,13 @@
 import "graphile-config";
 
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      NodeIdCodecBase64JSONPlugin: true;
+    }
+  }
+}
+
 export const NodeIdCodecBase64JSONPlugin: GraphileConfig.Plugin = {
   name: "NodeIdCodecBase64JSONPlugin",
   version: "1.0.0",

--- a/graphile-build/graphile-build/src/plugins/NodeIdCodecPipeStringPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/NodeIdCodecPipeStringPlugin.ts
@@ -1,5 +1,13 @@
 import "graphile-config";
 
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      NodeIdCodecPipeStringPlugin: true;
+    }
+  }
+}
+
 function pipeStringEncode(value: any): string | null {
   return Array.isArray(value) ? value.join("|") : null;
 }

--- a/graphile-build/graphile-build/src/plugins/NodePlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/NodePlugin.ts
@@ -7,6 +7,11 @@ import type { GraphQLObjectType } from "grafast/graphql";
 import { EXPORTABLE } from "../utils.js";
 
 declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      NodePlugin: true;
+    }
+  }
   namespace GraphileBuild {
     interface Inflection {
       nodeIdFieldName(this: Inflection): string;

--- a/graphile-build/graphile-build/src/plugins/PageInfoStartEndCursorPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/PageInfoStartEndCursorPlugin.ts
@@ -6,6 +6,12 @@ import { EXPORTABLE } from "../utils.js";
 import { version } from "../version.js";
 
 declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      PageInfoStartEndCursorPlugin: true;
+    }
+  }
+
   namespace GraphileBuild {
     interface ScopeObjectFieldsField {
       isPageInfoStartCursorField?: boolean;

--- a/graphile-build/graphile-build/src/plugins/QueryPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/QueryPlugin.ts
@@ -9,6 +9,9 @@ declare global {
     interface Plugins {
       QueryPlugin: true;
     }
+    interface Provides {
+      Query: true;
+    }
   }
 }
 

--- a/graphile-build/graphile-build/src/plugins/QueryPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/QueryPlugin.ts
@@ -4,6 +4,14 @@ import { __ValueStep } from "grafast";
 
 import { isValidObjectType } from "../utils.js";
 
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      QueryPlugin: true;
+    }
+  }
+}
+
 /**
  * This plugin registers the operation type for the 'query' operation; the
  * GraphQL spec current requires GraphQL schemas to have an object type for the

--- a/graphile-build/graphile-build/src/plugins/QueryQueryPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/QueryQueryPlugin.ts
@@ -5,6 +5,14 @@ import { rootValue } from "grafast";
 import { EXPORTABLE } from "../utils.js";
 import { version } from "../version.js";
 
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      QueryQueryPlugin: true;
+    }
+  }
+}
+
 /**
  * Adds the Query.query field to the Query type for Relay 1 compatibility. This
  * is a vestigial field, you probably don't want it.

--- a/graphile-build/graphile-build/src/plugins/RegisterQueryNodePlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/RegisterQueryNodePlugin.ts
@@ -4,6 +4,14 @@ import { constant, rootValue } from "grafast";
 
 import { EXPORTABLE } from "../utils.js";
 
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      RegisterQueryNodePlugin: true;
+    }
+  }
+}
+
 export const RegisterQueryNodePlugin: GraphileConfig.Plugin = {
   name: "RegisterQueryNodePlugin",
   version: "1.0.0",

--- a/graphile-build/graphile-build/src/plugins/StreamDeferPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/StreamDeferPlugin.ts
@@ -1,5 +1,13 @@
 import "graphile-config";
 
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      StreamDeferPlugin: true;
+    }
+  }
+}
+
 /**
  * Enables stream/defer on the schema.
  *

--- a/graphile-build/graphile-build/src/plugins/SubscriptionPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/SubscriptionPlugin.ts
@@ -10,6 +10,10 @@ declare global {
     interface Plugins {
       SubscriptionPlugin: true;
     }
+
+    interface Provides {
+      Subscription: true;
+    }
   }
 }
 

--- a/graphile-build/graphile-build/src/plugins/SubscriptionPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/SubscriptionPlugin.ts
@@ -5,6 +5,14 @@ import { __ValueStep } from "grafast";
 import { isValidObjectType } from "../utils.js";
 import { version } from "../version.js";
 
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      SubscriptionPlugin: true;
+    }
+  }
+}
+
 /**
  * This plugin registers the operation type for the 'subscription' operation, and
  * if that type adds at least one field then it will be added to the GraphQL

--- a/graphile-build/graphile-build/src/plugins/SwallowErrorsPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/SwallowErrorsPlugin.ts
@@ -8,6 +8,10 @@ declare global {
     interface Plugins {
       SwallowErrorsPlugin: true;
     }
+
+    interface Provides {
+      SwallowErrors: true;
+    }
   }
 }
 

--- a/graphile-build/graphile-build/src/plugins/SwallowErrorsPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/SwallowErrorsPlugin.ts
@@ -3,6 +3,14 @@ import "graphile-config";
 import swallowError from "../swallowError.js";
 import { version } from "../version.js";
 
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      SwallowErrorsPlugin: true;
+    }
+  }
+}
+
 /**
  * This plugin changes the default handling for "recoverable" errors from
  * throwing the error to instead logging it and carrying on.  We do not

--- a/graphile-build/graphile-build/src/plugins/TrimEmptyDescriptionsPlugin.ts
+++ b/graphile-build/graphile-build/src/plugins/TrimEmptyDescriptionsPlugin.ts
@@ -7,6 +7,14 @@ import type {
   GraphQLInputFieldConfig,
 } from "grafast/graphql";
 
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      TrimEmptyDescriptionsPlugin: true;
+    }
+  }
+}
+
 /**
  * Sets the 'description' attribute to null if it's the empty string; useful
  * for cleaning up the schema as printing a schema with a lot of empty string

--- a/graphile-build/graphile-simplify-inflection/src/index.ts
+++ b/graphile-build/graphile-simplify-inflection/src/index.ts
@@ -3,6 +3,14 @@ import type {} from "graphile-build";
 import type {} from "graphile-build-pg";
 import type { GraphileConfig } from "graphile-config";
 
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      PgSimplifyInflectionPlugin: true;
+    }
+  }
+}
+
 /**
  * Returns true if array1 and array2 have the same length, and every pair of
  * values within them pass the `comparator` check (which defaults to `===`).

--- a/graphile-build/graphile-utils/src/makePgSmartTagsPlugin.ts
+++ b/graphile-build/graphile-utils/src/makePgSmartTagsPlugin.ts
@@ -580,7 +580,7 @@ export function makeJSONPgSmartTagsPlugin(
 
 export const makePgSmartTagsFromFilePlugin = (
   tagsFile = process.cwd() + "/postgraphile.tags.json5",
-  name?: string,
+  name?: keyof GraphileConfig.Plugins,
 ): GraphileConfig.Plugin => {
   /*
    * We're wrapping the `smartTagsPlugin` defined below with a plugin wrapper
@@ -640,3 +640,11 @@ export const TagsFilePlugin = makePgSmartTagsFromFilePlugin(
   undefined,
   "TagsFilePlugin",
 );
+
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      TagsFilePlugin: true;
+    }
+  }
+}

--- a/postgraphile/postgraphile/src/plugins/PgV4BehaviorPlugin.ts
+++ b/postgraphile/postgraphile/src/plugins/PgV4BehaviorPlugin.ts
@@ -7,6 +7,10 @@ import { inspect } from "util";
 
 declare global {
   namespace GraphileConfig {
+    interface Plugins {
+      PgV4BehaviorPlugin: true;
+    }
+
     interface GatherHelpers {
       pgV4SmartTags: Record<string, never>;
     }

--- a/postgraphile/postgraphile/src/plugins/PgV4InflectionPlugin.ts
+++ b/postgraphile/postgraphile/src/plugins/PgV4InflectionPlugin.ts
@@ -3,6 +3,9 @@ import "graphile-build-pg";
 
 declare global {
   namespace GraphileConfig {
+    interface Plugins {
+      PgV4InflectionPlugin: true;
+    }
     interface GatherHelpers {
       pgV4SmartTags: Record<string, never>;
     }

--- a/postgraphile/postgraphile/src/plugins/PgV4SmartTagsPlugin.ts
+++ b/postgraphile/postgraphile/src/plugins/PgV4SmartTagsPlugin.ts
@@ -9,6 +9,11 @@ declare global {
     interface Plugins {
       PgV4SmartTagsPlugin: true;
     }
+
+    interface Provides {
+      "smart-tags": true;
+    }
+
     interface GatherHelpers {
       pgV4SmartTags: Record<string, never>;
     }

--- a/postgraphile/postgraphile/src/plugins/PgV4SmartTagsPlugin.ts
+++ b/postgraphile/postgraphile/src/plugins/PgV4SmartTagsPlugin.ts
@@ -6,6 +6,9 @@ import { inspect } from "util";
 
 declare global {
   namespace GraphileConfig {
+    interface Plugins {
+      PgV4SmartTagsPlugin: true;
+    }
     interface GatherHelpers {
       pgV4SmartTags: Record<string, never>;
     }

--- a/postgraphile/postgraphile/src/presets/lazy-jwt.ts
+++ b/postgraphile/postgraphile/src/presets/lazy-jwt.ts
@@ -21,6 +21,14 @@ declare global {
   }
 }
 
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      GrafservPgJWTPlugin: true;
+    }
+  }
+}
+
 const GrafservPgJWTPlugin: GraphileConfig.Plugin = {
   name: "GrafservPgJWTPlugin",
   version,

--- a/postgraphile/postgraphile/src/presets/relay.ts
+++ b/postgraphile/postgraphile/src/presets/relay.ts
@@ -13,6 +13,14 @@ const RELAY_HIDDEN_COLUMN_BEHAVIORS = [
   "-orderBy",
 ] as const;
 
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      PgRelayPlugin: true;
+    }
+  }
+}
+
 /** @experimental */
 export const PgRelayPlugin: GraphileConfig.Plugin = {
   name: "PgRelayPlugin",

--- a/utils/graphile-config/src/functionality.ts
+++ b/utils/graphile-config/src/functionality.ts
@@ -27,9 +27,9 @@ export function orderedApply<
   type FullFunctionalitySpec = {
     id: string;
     plugin: GraphileConfig.Plugin;
-    provides: string[];
-    before: string[];
-    after: string[];
+    provides: (keyof GraphileConfig.Plugins | keyof GraphileConfig.Provides)[];
+    before: (keyof GraphileConfig.Plugins | keyof GraphileConfig.Provides)[];
+    after: (keyof GraphileConfig.Plugins | keyof GraphileConfig.Provides)[];
     callback: UnwrapCallback<TFunctionality[keyof TFunctionality]>;
   };
   // Normalize all the hooks and gather them into collections

--- a/utils/graphile-config/src/index.ts
+++ b/utils/graphile-config/src/index.ts
@@ -38,6 +38,7 @@ declare global {
      * auto-completion of plugin names in the relevant places.
      */
     interface Plugins {
+      // eslint-disable-next-line @typescript-eslint/ban-types
       [key: string & {}]: true;
     }
 
@@ -46,6 +47,7 @@ declare global {
      * auto-completion of things that plugins can provide.
      */
     interface Provides {
+      // eslint-disable-next-line @typescript-eslint/ban-types
       [key: string & {}]: true;
     }
 

--- a/utils/graphile-config/src/index.ts
+++ b/utils/graphile-config/src/index.ts
@@ -45,7 +45,7 @@ declare global {
      * Expand this through declaration merging to get TypeScript
      * auto-completion of things that plugins can provide.
      */
-    interface PluginProvides {
+    interface Provides {
       [key: string & {}]: true;
     }
 
@@ -56,16 +56,10 @@ declare global {
       description?: string;
       provides?: (
         | keyof GraphileConfig.Plugins
-        | keyof GraphileConfig.PluginProvides
+        | keyof GraphileConfig.Provides
       )[];
-      after?: (
-        | keyof GraphileConfig.Plugins
-        | keyof GraphileConfig.PluginProvides
-      )[];
-      before?: (
-        | keyof GraphileConfig.Plugins
-        | keyof GraphileConfig.PluginProvides
-      )[];
+      after?: (keyof GraphileConfig.Plugins | keyof GraphileConfig.Provides)[];
+      before?: (keyof GraphileConfig.Plugins | keyof GraphileConfig.Provides)[];
     }
 
     /**

--- a/utils/graphile-config/src/index.ts
+++ b/utils/graphile-config/src/index.ts
@@ -33,14 +33,39 @@ export function sortedPlugins(
 
 declare global {
   namespace GraphileConfig {
+    /**
+     * Expand this through declaration merging to get TypeScript
+     * auto-completion of plugin names in the relevant places.
+     */
+    interface Plugins {
+      [key: string & {}]: true;
+    }
+
+    /**
+     * Expand this through declaration merging to get TypeScript
+     * auto-completion of things that plugins can provide.
+     */
+    interface PluginProvides {
+      [key: string & {}]: true;
+    }
+
     interface Plugin {
-      name: string;
+      name: keyof GraphileConfig.Plugins;
       version: string;
       experimental?: boolean;
       description?: string;
-      provides?: string[];
-      after?: string[];
-      before?: string[];
+      provides?: (
+        | keyof GraphileConfig.Plugins
+        | keyof GraphileConfig.PluginProvides
+      )[];
+      after?: (
+        | keyof GraphileConfig.Plugins
+        | keyof GraphileConfig.PluginProvides
+      )[];
+      before?: (
+        | keyof GraphileConfig.Plugins
+        | keyof GraphileConfig.PluginProvides
+      )[];
     }
 
     /**
@@ -51,7 +76,10 @@ declare global {
     interface Preset {
       extends?: ReadonlyArray<Preset>;
       plugins?: Plugin[];
-      disablePlugins?: ReadonlyArray<string>;
+      disablePlugins?: ReadonlyArray<keyof GraphileConfig.Plugins>;
+
+      // These are to explicitly forbid options used in PostGraphile V4 for
+      // legacy reasons.
       appendPlugins?: never;
       prependPlugins?: never;
       skipPlugins?: never;
@@ -63,7 +91,7 @@ declare global {
       // As Preset, except extends is an empty array and plugins is definitely set.
       extends?: ReadonlyArray<never>;
       plugins?: Plugin[];
-      disablePlugins?: ReadonlyArray<string>;
+      disablePlugins?: ReadonlyArray<keyof GraphileConfig.Plugins>;
     }
   }
 }

--- a/utils/graphile-config/src/interfaces.ts
+++ b/utils/graphile-config/src/interfaces.ts
@@ -1,9 +1,9 @@
 export type AnyCallback = (...args: any[]) => any;
 
 export type CallbackDescriptor<T extends AnyCallback> = {
-  provides?: string[];
-  before?: string[];
-  after?: string[];
+  provides?: (keyof GraphileConfig.Plugins | keyof GraphileConfig.Provides)[];
+  before?: (keyof GraphileConfig.Plugins | keyof GraphileConfig.Provides)[];
+  after?: (keyof GraphileConfig.Plugins | keyof GraphileConfig.Provides)[];
   callback: T;
 };
 


### PR DESCRIPTION
## Description

When you define a plugin, declare you've done so:

```ts
declare global {
  namespace GraphileConfig {
    interface Plugins {
      MyPlugin: true
    }
  }
}

const plugin: GraphileConfig.Plugin = {
  name: "MyPlugin",
```

Then the plugin will show up in the TypeScript auto-complete:

![image](https://github.com/user-attachments/assets/f25701fc-00a0-48f6-a03d-6d950d26be83)


Fixes graphile/crystal-pre-merge#174

## Performance impact

None.

## Security impact

None.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~~I've added tests for the new feature, and `yarn test` passes.~~
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] ~~If this is a breaking change I've explained why.~~

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
