### PR TITLE
Add Documentation for ApplyTransforms, and Add Resources to Each and PgSelect Docs

### DIFF
--- a/grafast/website/grafast/step-library/dataplan-pg/pgSelect.md
+++ b/grafast/website/grafast/step-library/dataplan-pg/pgSelect.md
@@ -431,7 +431,7 @@ steps such as:
   `const $admins = filter($users, $user => $user.get('is_admin'))`
 - [`first`](../standard-steps/first.md) / [`last`](../standard-steps/last.md) -
   get the first/last entry from the list:
-  `const $firstUser = first($users);`
+  `const $firstUser = $users.row(first($users));`
 - [`groupBy`](../standard-steps/groupBy.md) - group the records into a map
   containing sub-lists keyed by a shared value, for example "posts by author":
   `const $postsByUser = groupBy($posts, $post => $post.get('author_id'))`

--- a/grafast/website/grafast/step-library/dataplan-pg/pgSelect.md
+++ b/grafast/website/grafast/step-library/dataplan-pg/pgSelect.md
@@ -397,18 +397,50 @@ Equivalent to `pgSelectFromRecord(resource, $record).single()`.
 
 `pgSelect` and `pgSelectSingle` are what we call "opaque steps" - that is you
 are not intended to use their underlying data directly, instead you use their
-methods to extract the data you need to use with other steps.
+methods to extract the data you need to use with other steps - for example
+`$user.get('username')` to extract the username, or `$user.record()` to turn a
+pgSelectSingle step into a step representing a record object.
+
+:::info Opaque step specifics
 
 Currently a `pgSelectSingle` doesn't use the object representation you might
 expect, instead it uses a tuple with entries for each of the selected
 attributes. The makeup of this tuple will vary depending on which attributes
-you requested, and in which order, so you must not rely on its structure. To
-get an attribute you should use `$pgSelectSingle.get(attr)` or similar
+you requested, and in which order, so you must not rely on its structure; this
+approach makes pgSelectSingle very efficient, but it can cause confusion for
+people trying to "print out" a user object and just seeing an array containing
+some assorted values. Use `$pgSelectSingle.get(attrName)` or
+`$pgSelectSingle.record()` to get a step representing a value more suitable for
+logging/debugging.
 
-## Using the Underlying Data of a PgSelect Step
+:::
 
-Although PgSelect is an opaque step, there are a few ways to modify the keys and values of that are returned in the plan.
+### Transforming the results from a PgSelect step
 
-For altering the returned keys of the object, see the documentation for [`each`](../standard-steps/each.md)
+A PgSelect step represents a collection of opaque tuples; sometimes you may
+want to transform these in some way, which you can do with list manipulation
+steps such as:
 
-For altering the values of the returned object, see the documentation for [`applyTransforms`](../standard-steps/applyTransforms.md)
+- [`each`](../standard-steps/each.md) - maps over the list and builds a new
+  representation of each item (e.g. turning a list of users into a list of
+  usernames: `const $usernames = each($users, $user => $user.get('username'))`)
+- [`filter`](../standard-steps/filter.md) - reduces the number of items in the
+  list by performing filtering in your JavaScript runtime; typically you'd want
+  to use `$pgSelect.where(...)` instead in order to filter on the database side
+  for efficiency, but `filter()` can be useful:
+  `const $admins = filter($users, $user => $user.get('is_admin'))`
+- [`first`](../standard-steps/first.md) / [`last`](../standard-steps/last.md) -
+  get the first/last entry from the list:
+  `const $firstUser = first($users);`
+- [`groupBy`](../standard-steps/groupBy.md) - group the records into a map
+  containing sub-lists keyed by a shared value, for example "posts by author":
+  `const $postsByUser = groupBy($posts, $post => $post.get('author_id'))`
+
+Note that if you perform this kind of transformation, it does not always take
+place immediately - sometimes the transforms are only applied when the step is
+paginated over. If you then use this step as a dependency of another step, you
+may get the raw (untransformed) values, causing confusion and bugs. To solve
+this, for now, you should use
+[`applyTransforms`](../standard-steps/applyTransforms.md) to force the
+transform to take place at the current level, such that depending on the
+transformed values is safe.

--- a/grafast/website/grafast/step-library/dataplan-pg/pgSelect.md
+++ b/grafast/website/grafast/step-library/dataplan-pg/pgSelect.md
@@ -404,3 +404,14 @@ expect, instead it uses a tuple with entries for each of the selected
 attributes. The makeup of this tuple will vary depending on which attributes
 you requested, and in which order, so you must not rely on its structure. To
 get an attribute you should use `$pgSelectSingle.get(attr)` or similar
+
+## Using the Underlying Data of a PgSelect Step
+
+Although PgSelect is an opaque step, there are a few ways to modify the keys and values of that are returned in the plan. 
+
+For altering the returned keys of the object, see the documentation for [`each`](../standard-steps/each.md)
+
+For altering the values of the returned object, see the documentation for [`applyTransforms`](../standard-steps/applyTransforms.md)
+
+
+

--- a/grafast/website/grafast/step-library/dataplan-pg/pgSelect.md
+++ b/grafast/website/grafast/step-library/dataplan-pg/pgSelect.md
@@ -407,11 +407,8 @@ get an attribute you should use `$pgSelectSingle.get(attr)` or similar
 
 ## Using the Underlying Data of a PgSelect Step
 
-Although PgSelect is an opaque step, there are a few ways to modify the keys and values of that are returned in the plan. 
+Although PgSelect is an opaque step, there are a few ways to modify the keys and values of that are returned in the plan.
 
 For altering the returned keys of the object, see the documentation for [`each`](../standard-steps/each.md)
 
 For altering the values of the returned object, see the documentation for [`applyTransforms`](../standard-steps/applyTransforms.md)
-
-
-

--- a/grafast/website/grafast/step-library/standard-steps/applyTransforms.md
+++ b/grafast/website/grafast/step-library/standard-steps/applyTransforms.md
@@ -3,19 +3,17 @@
 Takes a step as the first argument and returns a step that guarantees all `listItem` transforms have occurred.
 
 This step is useful for when you need all of:
- * the `listItem` transforms to have already taken place (e.g. you're going to
- * send the result to an external service) rather than processing them through
- * the GraphQL response
 
- This is very useful for modifying the values of an opaque step!
+- the `listItem` transforms to have already taken place (e.g. you're going to
+- send the result to an external service) rather than processing them through
+- the GraphQL response
 
+This is very useful for modifying the values of an opaque step!
 
 ## Type
 
 ```ts
-function applyTransforms(
-  $step: ExecutableStep
-): ExecutableStep<any>;
+function applyTransforms($step: ExecutableStep): ExecutableStep<any>;
 ```
 
 ### Example
@@ -27,12 +25,16 @@ const $users = usersResource.find();
 const tbl = $users.alias;
 $users.where(sql`${tbl}.username = 'Benjie'`);
 // Options that could be used here include: loadOne, loadMany, lambda
-return lambda($users, (users) => {
-    return users.map(user => ({
-        username: 'USER-' + user.username,
-        ...user,
-    }))
-}, true);
+return lambda(
+  $users,
+  (users) => {
+    return users.map((user) => ({
+      username: "USER-" + user.username,
+      ...user,
+    }));
+  },
+  true,
+);
 ```
 
 Due to `PgSelect` being an opaque step, this will not work! The values of `$users` will not be loaded by the time the `lambda` step is run. In order to guarantee that those values are available, you can wrap the `$users` step in an `applyTransforms`!
@@ -42,10 +44,14 @@ const $users = usersResource.find();
 const tbl = $users.alias;
 $users.where(sql`${tbl}.username = 'Benjie'`);
 // By using applyTransforms, it guarantees these values will be available
-return lambda(applyTransforms($users), (users) => {
-    return users.map(user => ({
-        username: 'USER-' + user.username,
-        ...user,
-    }))
-}, true);
+return lambda(
+  applyTransforms($users),
+  (users) => {
+    return users.map((user) => ({
+      username: "USER-" + user.username,
+      ...user,
+    }));
+  },
+  true,
+);
 ```

--- a/grafast/website/grafast/step-library/standard-steps/applyTransforms.md
+++ b/grafast/website/grafast/step-library/standard-steps/applyTransforms.md
@@ -1,0 +1,51 @@
+# applyTransforms
+
+Takes a step as the first argument and returns a step that guarantees all `listItem` transforms have occurred.
+
+This step is useful for when you need all of:
+ * the `listItem` transforms to have already taken place (e.g. you're going to
+ * send the result to an external service) rather than processing them through
+ * the GraphQL response
+
+ This is very useful for modifying the values of an opaque step!
+
+
+## Type
+
+```ts
+function applyTransforms(
+  $step: ExecutableStep
+): ExecutableStep<any>;
+```
+
+### Example
+
+Let's say you have a `PgSelect` step and you want to apply logic to the values of said step. You may be inclined to do something like this:
+
+```ts
+const $users = usersResource.find();
+const tbl = $users.alias;
+$users.where(sql`${tbl}.username = 'Benjie'`);
+// Options that could be used here include: loadOne, loadMany, lambda
+return lambda($users, (users) => {
+    return users.map(user => ({
+        username: 'USER-' + user.username,
+        ...user,
+    }))
+}, true);
+```
+
+Due to `PgSelect` being an opaque step, this will not work! The values of `$users` will not be loaded by the time the `lambda` step is run. In order to guarantee that those values are available, you can wrap the `$users` step in an `applyTransforms`!
+
+```ts
+const $users = usersResource.find();
+const tbl = $users.alias;
+$users.where(sql`${tbl}.username = 'Benjie'`);
+// By using applyTransforms, it guarantees these values will be available
+return lambda(applyTransforms($users), (users) => {
+    return users.map(user => ({
+        username: 'USER-' + user.username,
+        ...user,
+    }))
+}, true);
+```

--- a/grafast/website/grafast/step-library/standard-steps/each.md
+++ b/grafast/website/grafast/step-library/standard-steps/each.md
@@ -26,12 +26,12 @@ const $derivatives = each($list, ($item) =>
 return $derivatives;
 ```
 
-:::warn `applyTransforms()` if passing to another step
+:::warning Remember: `applyTransforms()` if passing to another step
 
 If you aren't returning the result of `each()` from a plan resolver, but are
 instead feeding it into another step, you will likely need to perform
 `applyTransforms()` to force the list transforms to take place before the
 dependent step receives the resulting values. Read more in
-[applyTransforms()](./applyTransforms.md).
+[`applyTransforms()`](./applyTransforms.md).
 
 :::

--- a/grafast/website/grafast/step-library/standard-steps/each.md
+++ b/grafast/website/grafast/step-library/standard-steps/each.md
@@ -8,35 +8,30 @@ Usage:
 const $newList = each($oldList, ($listItem) => doSomethingWith($listItem));
 ```
 
-## Extended Usage with `object`
+## Example generating a list of objects
 
-You may end up in a scenario where you need to alter the return value of an opaque step. For example, when using a `PgSelect` step, you may end up with something like this in your plan:
-
-```ts
-const $users = usersResource.find();
-const tbl = $users.alias;
-$users.where(sql`${tbl}.username = 'Benjie'`);
-return $users;
-```
-
-For this example, lets say you have a field you want to resolve to with a type that does not match the schema of the DB:
-
-```graphql
-type UsernameMapping {
-  currentUsername: String!;
-  currentEmail: String!;
-}
-
-```
-
-In order to map these values to new keys, you could use something like this:
+Sometimes you have a step representing a collection of resources, `$list`, and
+you need to build a list of derivative objects from them. For example, the
+items in your collection might have `x` and `y` properties, and you might want
+to turn them into `lng` and `lat` attributes; which might look like this:
 
 ```ts
-// return $users;
-return each($users, ($user) =>
+const $derivatives = each($list, ($item) =>
   object({
-    currentUsername: $user.get("username"),
-    currentEmail: $user.get("email"),
+    name: $item.get("name"),
+    lng: $item.get("x"),
+    lat: $item.get("y"),
   }),
 );
+return $derivatives;
 ```
+
+:::warn `applyTransforms()` if passing to another step
+
+If you aren't returning the result of `each()` from a plan resolver, but are
+instead feeding it into another step, you will likely need to perform
+`applyTransforms()` to force the list transforms to take place before the
+dependent step receives the resulting values. Read more in
+[applyTransforms()](./applyTransforms.md).
+
+:::

--- a/grafast/website/grafast/step-library/standard-steps/each.md
+++ b/grafast/website/grafast/step-library/standard-steps/each.md
@@ -33,10 +33,10 @@ In order to map these values to new keys, you could use something like this:
 
 ```ts
 // return $users;
-return each($users, ($user) => 
-    object({
-        currentUsername: $user.get('username'),
-        currentEmail: $user.get('email')
-    })
-)
+return each($users, ($user) =>
+  object({
+    currentUsername: $user.get("username"),
+    currentEmail: $user.get("email"),
+  }),
+);
 ```

--- a/grafast/website/grafast/step-library/standard-steps/each.md
+++ b/grafast/website/grafast/step-library/standard-steps/each.md
@@ -7,3 +7,36 @@ Usage:
 ```ts
 const $newList = each($oldList, ($listItem) => doSomethingWith($listItem));
 ```
+
+## Extended Usage with `object`
+
+You may end up in a scenario where you need to alter the return value of an opaque step. For example, when using a `PgSelect` step, you may end up with something like this in your plan:
+
+```ts
+const $users = usersResource.find();
+const tbl = $users.alias;
+$users.where(sql`${tbl}.username = 'Benjie'`);
+return $users;
+```
+
+For this example, lets say you have a field you want to resolve to with a type that does not match the schema of the DB:
+
+```graphql
+type UsernameMapping {
+  currentUsername: String!;
+  currentEmail: String!;
+}
+
+```
+
+In order to map these values to new keys, you could use something like this:
+
+```ts
+// return $users;
+return each($users, ($user) => 
+    object({
+        currentUsername: $user.get('username'),
+        currentEmail: $user.get('email')
+    })
+)
+```


### PR DESCRIPTION
## Description

In my usage of Grafast at my workplace for the past few months, I've fallen in love with it. I've also obtained some learnings that I wish I had read in the docs. This is focused mainly around modifying the keys/values returned from a `PgSelect`. We have been working through the unique case of having to support a legacy GraphQL schema while not wanting that to affect our database design. This meant writing plans to resolve fields that required changing the returned keys and values from the DB a lot. 

Hopefully, these changes might help others that run into similar use-cases.

- Add a new docs page for the ApplyTransforms step 
- Add a new section in the each step docs with more example usage
- Add a new section in PgSelect to link to each and applyTransforms to describe additional behavior a user may be interested in

Question that prompted this: https://github.com/graphile/crystal/issues/2161

## Performance impact

- None

## Security impact

- None

## Checklist

- None (Doc changes)
