### PR TITLE
Remove default filter from WellKnownMap

### DIFF
--- a/.changeset/quiet-items-divide.md
+++ b/.changeset/quiet-items-divide.md
@@ -1,0 +1,7 @@
+---
+"graphile-export": patch
+---
+
+Fix bug in graphile-export handing modules where default export
+(`import mod from 'mod'`) differed from wildcard export
+(`import * as mod from 'mod'`).

--- a/utils/graphile-export/src/wellKnown.ts
+++ b/utils/graphile-export/src/wellKnown.ts
@@ -21,7 +21,7 @@ function makeWellKnownFromOptions(options: ExportOptions) {
     preferViaDefault = false,
   ) {
     for (const exportName of Object.keys(obj)) {
-      if (exportName !== "default" && !wellKnownMap.has(obj[exportName])) {
+      if (!wellKnownMap.has(obj[exportName])) {
         /**
          * ESM is still a bit flaky, so though `import { foo } from 'bar';` may
          * work in some contexts, in raw Node it's often required to do

--- a/utils/graphile-export/src/wellKnown.ts
+++ b/utils/graphile-export/src/wellKnown.ts
@@ -11,6 +11,7 @@ interface $$Export {
 }
 
 function makeWellKnownFromOptions(options: ExportOptions) {
+  const namespaces = Object.create(null);
   const wellKnownMap = new Map<unknown, $$Export>();
 
   function exportAll(
@@ -18,6 +19,7 @@ function makeWellKnownFromOptions(options: ExportOptions) {
     moduleName: string,
     preferViaDefault = false,
   ) {
+    namespaces[moduleName] = moduleStar;
     for (const exportName of Object.keys(moduleStar)) {
       if (!wellKnownMap.has(moduleStar[exportName])) {
         /**
@@ -62,13 +64,10 @@ function makeWellKnownFromOptions(options: ExportOptions) {
     }
   }
 
-  const namespaces = Object.assign(Object.create(null), { crypto: _crypto });
-
   // Now process options
   if (options.modules) {
     for (const [moduleName, moduleStar] of Object.entries(options.modules)) {
       exportAll(moduleStar, moduleName, true);
-      namespaces[moduleName] = moduleStar;
     }
   }
 

--- a/utils/graphile-export/src/wellKnown.ts
+++ b/utils/graphile-export/src/wellKnown.ts
@@ -1,9 +1,7 @@
-import crypto from "crypto";
-// eslint-disable-next-line import/no-duplicates
-import * as _crypto from "crypto";
+import * as cryptoStar from "crypto";
 import * as grafastStar from "grafast";
 import * as graphqlStar from "grafast/graphql";
-import util, * as utilStar from "util";
+import * as utilStar from "util";
 
 import type { ExportOptions } from "./interfaces.js";
 
@@ -16,12 +14,12 @@ function makeWellKnownFromOptions(options: ExportOptions) {
   const wellKnownMap = new Map<unknown, $$Export>();
 
   function exportAll(
-    obj: Record<string, any>,
+    moduleStar: Record<string, any>,
     moduleName: string,
     preferViaDefault = false,
   ) {
-    for (const exportName of Object.keys(obj)) {
-      if (!wellKnownMap.has(obj[exportName])) {
+    for (const exportName of Object.keys(moduleStar)) {
+      if (!wellKnownMap.has(moduleStar[exportName])) {
         /**
          * ESM is still a bit flaky, so though `import { foo } from 'bar';` may
          * work in some contexts, in raw Node it's often required to do
@@ -29,17 +27,21 @@ function makeWellKnownFromOptions(options: ExportOptions) {
          * if this latter approach is desired.
          */
         const viaDefault =
-          preferViaDefault && obj[exportName] === obj["default"]?.[exportName];
-        wellKnownMap.set(obj[exportName], {
+          preferViaDefault &&
+          exportName !== "default" &&
+          moduleStar[exportName] === moduleStar["default"]?.[exportName];
+        wellKnownMap.set(moduleStar[exportName], {
           moduleName,
           exportName: viaDefault ? ["default", exportName] : exportName,
         });
       }
     }
+    if (!wellKnownMap.has(moduleStar)) {
+      wellKnownMap.set(moduleStar, { moduleName, exportName: "*" });
+    }
   }
 
-  wellKnownMap.set(crypto, { moduleName: "crypto", exportName: "default" });
-  wellKnownMap.set(util, { moduleName: "util", exportName: "default" });
+  exportAll(cryptoStar, "crypto");
   exportAll(grafastStar, "grafast");
   exportAll(graphqlStar, "graphql");
   exportAll(utilStar, "util");


### PR DESCRIPTION
## Description

I noticed an issue where some modules weren't being exported properly. [Full discord discussion here](https://discord.com/channels/489127045289476126/498852330754801666/1286380009379856465).


### Problem
My source code has:

```ts
import CityTimezones from 'city-timezones';
import snakeCase from 'lodash/snakeCase';

...
export const pgInsert = EXPORTABLE((snakeCase) => async (pgClient, table, data) => {
  const columns = Object.keys(data).map(snakeCase).join(', ');
  ...
}, [snakeCase]);
```

and I'm exporting modules like:

```ts
import * as CityTimezones from 'city-timezones';
import * as lodashSnakeCase from 'lodash/snakeCase';

...
  await exportSchema(schema, exportFileLocation, {
    mode: "typeDefs",
    modules: {
      'city-timezones': CityTimezones,
      'lodash/snakeCase': lodashSnakeCase,
    }
  });
```

But my exported schema has `snakeCase` undefined:

```js
const pgInsert2 = async (pgClient, table, data) => {
  const columns = Object.keys(data).map(undefined).join(", ");
  // !! Note how snakeCase has become undefined /\
```

### Resolution
After [this line](https://github.com/graphile/crystal/blob/d9d175b23a0abaed2aa620440cc7959f4c1e8837/utils/graphile-export/src/wellKnown.ts#L24) I added the following:

```ts
  console.log({ moduleName, exportName, exp: obj[exportName] });
  console.log(exportName !== "default");
  console.log(!wellKnownMap.has(obj[exportName]));
```

and noticed

```ts
{
  moduleName: 'city-timezones',
  exportName: 'lookupViaCity',
  exp: [Function: lookupViaCity]
}
true
true
{
  moduleName: 'lodash/snakeCase',
  exportName: 'default',
  exp: [Function (anonymous)]
}
false
true
```

So, for now, I'm simply removing the `exportName !== "default"` conditional and my schema seems to be exported as expected, but I don't know why that was there in the first place or the other downstream effects.

## Performance impact

unknown, likely none.

## Security impact

unknown, likely none.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.
