### PR TITLE
V4 preset should use Amber preset

### DIFF
--- a/.changeset/nine-ladybugs-guess.md
+++ b/.changeset/nine-ladybugs-guess.md
@@ -1,0 +1,6 @@
+---
+"postgraphile": patch
+---
+
+PostGraphile V4 preset should automatically include the Amber preset on which it
+relies.

--- a/.changeset/nine-ladybugs-guess.md
+++ b/.changeset/nine-ladybugs-guess.md
@@ -2,5 +2,5 @@
 "postgraphile": patch
 ---
 
-PostGraphile V4 preset should automatically include the Amber preset on which it
+PostGraphile V4 preset now automatically includes the Amber preset on which it
 relies.

--- a/.changeset/polite-cherries-exercise.md
+++ b/.changeset/polite-cherries-exercise.md
@@ -1,0 +1,8 @@
+---
+"graphile-build-pg": patch
+"postgraphile": patch
+"graphile-config": patch
+---
+
+Overhaul the way in which `graphile-config` presets work such that including a
+preset at two different layers shouldn't result in unexpected behavior.

--- a/postgraphile/postgraphile/src/presets/v4.ts
+++ b/postgraphile/postgraphile/src/presets/v4.ts
@@ -8,6 +8,7 @@ import { PgV4BehaviorPlugin } from "../plugins/PgV4BehaviorPlugin.js";
 import { PgV4InflectionPlugin } from "../plugins/PgV4InflectionPlugin.js";
 import { PgV4SimpleSubscriptionsPlugin } from "../plugins/PgV4SimpleSubscriptionsPlugin.js";
 import { PgV4SmartTagsPlugin } from "../plugins/PgV4SmartTagsPlugin.js";
+import PostGraphileAmberPreset from "./amber.js";
 
 export {
   PgV4BehaviorPlugin,
@@ -214,6 +215,7 @@ export const makeV4Preset = (
   const graphiqlPath = options.graphiqlRoute ?? "/graphiql";
   const eventStreamPath = options.eventStreamRoute ?? `${graphqlPath}/stream`;
   return {
+    extends: [PostGraphileAmberPreset],
     plugins: [
       PgV4InflectionPlugin,
       PgV4SmartTagsPlugin,

--- a/utils/graphile-config/src/resolvePresets.ts
+++ b/utils/graphile-config/src/resolvePresets.ts
@@ -103,12 +103,14 @@ function resolvePresetsInternal(
     );
     mergePreset(finalPreset, resolvedPreset, seenPluginNames, depth);
   }
+
   if (finalPreset.plugins) {
     finalPreset.plugins = sortWithBeforeAfterProvides(
       finalPreset.plugins,
       "name",
     );
   }
+
   return finalPreset;
 }
 
@@ -227,7 +229,10 @@ function resolvePresetInternal(
     }
   } catch (e) {
     throw new Error(
-      `Error occurred when resolving preset: ${e}\nPreset: ${inspect(preset)}`,
+      `Error occurred when resolving preset:\n  ${String(e).replace(
+        /\n/g,
+        "\n  ",
+      )}\nPreset: ${inspect(preset)}`,
     );
   }
 
@@ -243,7 +248,10 @@ function resolvePresetInternal(
     return basePreset;
   } catch (e) {
     throw new Error(
-      `Error occurred when resolving preset: ${e}\nPreset: ${inspect(preset)}`,
+      `Error occurred when resolving preset:\n  ${String(e).replace(
+        /\n/g,
+        "\n  ",
+      )}\nPreset: ${inspect(preset)}`,
     );
   }
 }

--- a/utils/graphile-config/src/resolvePresets.ts
+++ b/utils/graphile-config/src/resolvePresets.ts
@@ -257,6 +257,7 @@ function mergePreset(
   const sourcePluginNames: string[] = [];
   if (sourcePreset.plugins) {
     for (const plugin of sourcePreset.plugins) {
+      assertPlugin(plugin);
       seenPlugins.add(plugin);
       sourcePluginNames.push(plugin.name);
     }

--- a/utils/graphile-config/src/resolvePresets.ts
+++ b/utils/graphile-config/src/resolvePresets.ts
@@ -67,12 +67,6 @@ export function resolvePresets(presets: ReadonlyArray<GraphileConfig.Preset>) {
 
   const seenPlugins = new Set<GraphileConfig.Plugin>();
   const resolvedPreset = resolvePresetsInternal(presets, seenPlugins, 0);
-  if (resolvedPreset.plugins) {
-    resolvedPreset.plugins = sortWithBeforeAfterProvides(
-      resolvedPreset.plugins,
-      "name",
-    );
-  }
 
   const seenNames = [...seenPlugins].map((p) => p.name);
   const disabledButNotSeen = resolvedPreset.disablePlugins?.filter(
@@ -104,6 +98,12 @@ function resolvePresetsInternal(
       depth + 1,
     );
     mergePreset(finalPreset, resolvedPreset, seenPlugins, depth);
+  }
+  if (finalPreset.plugins) {
+    finalPreset.plugins = sortWithBeforeAfterProvides(
+      finalPreset.plugins,
+      "name",
+    );
   }
   return finalPreset;
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/graphile/crystal-pre-merge/issues/415

Some subtle issues with plugin/preset ordering/etc may be surfaced, plus this fixes a bug so anyone relying on the bug may have their configuration's tweaked - recommend fingerprinting your schema before and after this change and look for differences.

## Performance impact

Startup costs increased.

## Security impact

None known.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
