### PR TITLE
Enable stabilization of objects/lists going through loadMany/loadOne multistep

### DIFF
--- a/.changeset/famous-birds-promise.md
+++ b/.changeset/famous-birds-promise.md
@@ -1,0 +1,7 @@
+---
+"@dataplan/pg": patch
+"grafast": patch
+---
+
+Add support for stable deduplication of object/list arguments to
+loadOne/loadMany, reducing redundant fetches.

--- a/grafast/grafast/__tests__/loadOne-test.ts
+++ b/grafast/grafast/__tests__/loadOne-test.ts
@@ -209,7 +209,8 @@ const makeSchema = (useStreamableStep = false) => {
           const $orgId = context().get("orgId");
           return loadOne(
             [$orgId, $regNo],
-            ["orgId", "orgRegNo"],
+            // Deliberately not using ioEquivalence here to test stable object/tuple creation
+            //["orgId", "orgRegNo"],
             loadThingByOrgIdRegNoTuples,
           );
         },
@@ -217,7 +218,8 @@ const makeSchema = (useStreamableStep = false) => {
           const $orgId = context().get("orgId");
           return loadOne(
             { orgId: $orgId, regNo: $regNo },
-            { orgId: "orgId", regNo: "orgRegNo" },
+            // Deliberately not using ioEquivalence here to test stable object/tuple creation
+            //{ orgId: "orgId", regNo: "orgRegNo" },
             loadThingByOrgIdRegNoObjs,
           );
         },
@@ -544,7 +546,7 @@ it("uses stable identifiers to avoid the need for double-fetches (tuple)", async
     },
   });
   expect(CALLS).to.have.length(1);
-  expect(CALLS[0].attributes).to.deep.equal(["id", "name"]);
+  expect(CALLS[0].attributes).to.deep.equal(["id", "name", "orgId"]);
 });
 
 it("uses stable identifiers to avoid the need for double-fetches (obj)", async () => {
@@ -593,5 +595,5 @@ it("uses stable identifiers to avoid the need for double-fetches (obj)", async (
     },
   });
   expect(CALLS).to.have.length(1);
-  expect(CALLS[0].attributes).to.deep.equal(["id", "name"]);
+  expect(CALLS[0].attributes).to.deep.equal(["id", "name", "orgId"]);
 });

--- a/grafast/grafast/__tests__/loadOne-test.ts
+++ b/grafast/grafast/__tests__/loadOne-test.ts
@@ -2,32 +2,70 @@ import { expect } from "chai";
 import type { ExecutionResult } from "graphql";
 import { it } from "mocha";
 
-import type { ExecutableStep, LoadOneCallback } from "../dist/index.js";
-import {
-  grafast,
-  list,
-  loadOne,
-  makeGrafastSchema,
-  object,
+import type {
+  ExecutableStep,
+  LoadedRecordStep,
+  LoadOneCallback,
 } from "../dist/index.js";
+import { context, grafast, loadOne, makeGrafastSchema } from "../dist/index.js";
 
 interface Thing {
   id: number;
+  orgId: number;
+  orgRegNo: number;
   name: string;
   reallyLongBio: string;
 }
 const THINGS: Thing[] = [
   {
     id: 1,
+    orgId: 27,
+    orgRegNo: 93,
     name: "Eyedee Won",
     reallyLongBio: "Really long bio. ".repeat(1000),
   },
   {
     id: 2,
+    orgId: 42,
+    orgRegNo: 120,
     name: "Idee Too",
     reallyLongBio: "Super long bio. ".repeat(1000),
   },
+  {
+    id: 2003,
+    orgId: 27,
+    orgRegNo: 987,
+    name: "Eye D. Tree",
+    reallyLongBio: "Somewhat long bio. ".repeat(1000),
+  },
+  {
+    id: 2004,
+    orgId: 42,
+    orgRegNo: 987,
+    name: "I.D. Phwoar",
+    reallyLongBio: "Quite long bio. ".repeat(1000),
+  },
 ];
+
+interface Org {
+  id: number;
+}
+const ORGS: Org[] = [
+  {
+    id: 27,
+  },
+  {
+    id: 42,
+  },
+];
+
+declare global {
+  namespace Grafast {
+    interface Context {
+      orgId: number;
+    }
+  }
+}
 
 function pick<T extends object, K extends keyof T>(
   obj: T,
@@ -39,7 +77,13 @@ function pick<T extends object, K extends keyof T>(
 }
 
 let CALLS: {
-  specs: readonly (number | { identifier: number } | readonly number[])[];
+  specs: ReadonlyArray<
+    | number
+    | { identifier: number }
+    | readonly [identifier: number]
+    | { orgId: number; regNo: number }
+    | readonly [orgId: number, regNo: number]
+  >;
   result: object;
   attributes: readonly (keyof Thing)[] | null;
   params: object;
@@ -80,6 +124,45 @@ const loadThingByIdentifierLists: LoadOneCallback<
   return result;
 };
 
+const loadThingByOrgIdRegNoObjs: LoadOneCallback<
+  { orgId: number; regNo: number },
+  Thing,
+  Record<string, never>
+> = (specs, { attributes, params }) => {
+  const result = specs
+    .map((spec) =>
+      THINGS.find((t) => t.orgId === spec.orgId && t.orgRegNo === spec.regNo),
+    )
+    .map((t) => (t && attributes ? pick(t, attributes) : t));
+  CALLS.push({ specs, result, attributes, params });
+  return result;
+};
+
+const loadThingByOrgIdRegNoTuples: LoadOneCallback<
+  readonly [orgId: number, regNo: number],
+  Thing,
+  Record<string, never>
+> = (specs, { attributes, params }) => {
+  const result = specs
+    .map((spec) =>
+      THINGS.find((t) => t.orgId === spec[0] && t.orgRegNo === spec[1]),
+    )
+    .map((t) => (t && attributes ? pick(t, attributes) : t));
+  CALLS.push({ specs, result, attributes, params });
+  return result;
+};
+
+const loadOrgByIds: LoadOneCallback<number, Org, Record<string, never>> = (
+  specs,
+  { attributes, params },
+) => {
+  const result = specs
+    .map((id) => ORGS.find((t) => t.id === id))
+    .map((t) => (t && attributes ? pick(t, attributes) : t));
+  // CALLS.push({ specs, result, attributes, params });
+  return result;
+};
+
 const makeSchema = (useStreamableStep = false) => {
   return makeGrafastSchema({
     typeDefs: /* GraphQL */ `
@@ -87,11 +170,20 @@ const makeSchema = (useStreamableStep = false) => {
         id: Int!
         name: String!
         reallyLongBio: String!
+        org: Org!
+        orgRegNo: Int!
+      }
+      type Org {
+        id: Int!
+        thingByTuple(regNo: Int!): Thing
+        thingByObj(regNo: Int!): Thing
       }
       type Query {
         thingById(id: Int!): Thing
         thingByIdObj(id: Int!): Thing
         thingByIdList(id: Int!): Thing
+        thingByOrgIdRegNoTuple(regNo: Int!): Thing
+        thingByOrgIdRegNoObj(regNo: Int!): Thing
       }
     `,
     plans: {
@@ -111,6 +203,45 @@ const makeSchema = (useStreamableStep = false) => {
             [$id as ExecutableStep<number>],
             ["id"],
             loadThingByIdentifierLists,
+          );
+        },
+        thingByOrgIdRegNoTuple(_, { $regNo }) {
+          const $orgId = context().get("orgId");
+          return loadOne(
+            [$orgId, $regNo],
+            ["orgId", "orgRegNo"],
+            loadThingByOrgIdRegNoTuples,
+          );
+        },
+        thingByOrgIdRegNoObj(_, { $regNo }) {
+          const $orgId = context().get("orgId");
+          return loadOne(
+            { orgId: $orgId, regNo: $regNo },
+            { orgId: "orgId", regNo: "orgRegNo" },
+            loadThingByOrgIdRegNoObjs,
+          );
+        },
+      },
+      Thing: {
+        org($thing: LoadedRecordStep<Thing>) {
+          return loadOne($thing.get("orgId"), "id", loadOrgByIds);
+        },
+      },
+      Org: {
+        thingByTuple($org: LoadedRecordStep<Org>, { $regNo }) {
+          const $orgId = $org.get("id");
+          return loadOne(
+            [$orgId, $regNo],
+            ["orgId", "orgRegNo"],
+            loadThingByOrgIdRegNoTuples,
+          );
+        },
+        thingByObj($org: LoadedRecordStep<Org>, { $regNo }) {
+          const $orgId = $org.get("id");
+          return loadOne(
+            { orgId: $orgId, regNo: $regNo },
+            { orgId: "orgId", regNo: "orgRegNo" },
+            loadThingByOrgIdRegNoObjs,
           );
         },
       },
@@ -365,4 +496,53 @@ it("supports no ioEquivalence", async () => {
   expect(CALLS[1].attributes).to.deep.equal(["name"]);
   expect(CALLS[2].specs).to.deep.equal([[1]]);
   expect(CALLS[2].attributes).to.deep.equal(["name"]);
+});
+
+it("uses stable identifiers to avoid the need for double-fetches", async () => {
+  const source = /* GraphQL */ `
+    {
+      t1: thingByOrgIdRegNoTuple(regNo: 987) {
+        id
+        name
+        org {
+          id
+          t1: thingByTuple(regNo: 987) {
+            id
+            name
+          }
+        }
+      }
+    }
+  `;
+  const schema = makeSchema(false);
+
+  CALLS = [];
+  const result = (await grafast(
+    {
+      schema,
+      source,
+      contextValue: {
+        orgId: 27,
+      },
+    },
+    {},
+    {},
+  )) as ExecutionResult;
+  expect(result).to.deep.equal({
+    data: {
+      t1: {
+        id: 2003,
+        name: "Eye D. Tree",
+        org: {
+          id: 27,
+          t1: {
+            id: 2003,
+            name: "Eye D. Tree",
+          },
+        },
+      },
+    },
+  });
+  expect(CALLS).to.have.length(1);
+  expect(CALLS[0].attributes).to.deep.equal(["id", "name"]);
 });

--- a/grafast/grafast/__tests__/loadOne-test.ts
+++ b/grafast/grafast/__tests__/loadOne-test.ts
@@ -498,7 +498,7 @@ it("supports no ioEquivalence", async () => {
   expect(CALLS[2].attributes).to.deep.equal(["name"]);
 });
 
-it("uses stable identifiers to avoid the need for double-fetches", async () => {
+it("uses stable identifiers to avoid the need for double-fetches (tuple)", async () => {
   const source = /* GraphQL */ `
     {
       t1: thingByOrgIdRegNoTuple(regNo: 987) {
@@ -507,6 +507,55 @@ it("uses stable identifiers to avoid the need for double-fetches", async () => {
         org {
           id
           t1: thingByTuple(regNo: 987) {
+            id
+            name
+          }
+        }
+      }
+    }
+  `;
+  const schema = makeSchema(false);
+
+  CALLS = [];
+  const result = (await grafast(
+    {
+      schema,
+      source,
+      contextValue: {
+        orgId: 27,
+      },
+    },
+    {},
+    {},
+  )) as ExecutionResult;
+  expect(result).to.deep.equal({
+    data: {
+      t1: {
+        id: 2003,
+        name: "Eye D. Tree",
+        org: {
+          id: 27,
+          t1: {
+            id: 2003,
+            name: "Eye D. Tree",
+          },
+        },
+      },
+    },
+  });
+  expect(CALLS).to.have.length(1);
+  expect(CALLS[0].attributes).to.deep.equal(["id", "name"]);
+});
+
+it("uses stable identifiers to avoid the need for double-fetches (obj)", async () => {
+  const source = /* GraphQL */ `
+    {
+      t1: thingByOrgIdRegNoObj(regNo: 987) {
+        id
+        name
+        org {
+          id
+          t1: thingByObj(regNo: 987) {
             id
             name
           }

--- a/grafast/grafast/src/multistep.ts
+++ b/grafast/grafast/src/multistep.ts
@@ -54,7 +54,7 @@ export function multistep<const TMultistepSpec extends Multistep>(
   } else if (isTuple(spec)) {
     const config =
       stable === true
-        ? { identifier: `multistep-list` }
+        ? { identifier: `multistep` }
         : typeof stable === "string"
         ? { identifier: stable }
         : stable;
@@ -63,7 +63,7 @@ export function multistep<const TMultistepSpec extends Multistep>(
   } else {
     const config =
       stable === true
-        ? { identifier: `multistep-obj` }
+        ? { identifier: `multistep` }
         : typeof stable === "string"
         ? { identifier: stable }
         : stable;

--- a/grafast/grafast/src/multistep.ts
+++ b/grafast/grafast/src/multistep.ts
@@ -38,29 +38,36 @@ export type UnwrapMultistep<TMultistepSpec extends Multistep> =
           : never;
       };
 
+interface MultistepCacheConfig {
+  identifier: string;
+  cacheSize: number;
+}
+
 export function multistep<const TMultistepSpec extends Multistep>(
   spec: TMultistepSpec,
-  stable?: string | true,
+  stable?: string | true | MultistepCacheConfig,
 ): ExecutableStep<UnwrapMultistep<TMultistepSpec>> {
   if (spec == null) {
     return constant(spec) as any;
   } else if (spec instanceof ExecutableStep) {
     return spec;
   } else if (isTuple(spec)) {
-    const $step = list(spec);
-    if (typeof stable === "string") {
-      $step.metaKey = `${stable}|list|${spec.length}`;
-    } else if (stable === true) {
-      $step.metaKey = `multistep|list|${spec.length}`;
-    }
+    const config =
+      stable === true
+        ? { identifier: `multistep-list` }
+        : typeof stable === "string"
+        ? { identifier: stable }
+        : stable;
+    const $step = list(spec, config);
     return $step as any;
   } else {
-    const $step = object(spec);
-    if (typeof stable === "string") {
-      $step.metaKey = `${stable}|object|${JSON.stringify(Object.keys(spec))}`;
-    } else if (stable === true) {
-      $step.metaKey = `multistep|object|${JSON.stringify(Object.keys(spec))}`;
-    }
+    const config =
+      stable === true
+        ? { identifier: `multistep-obj` }
+        : typeof stable === "string"
+        ? { identifier: stable }
+        : stable;
+    const $step = object(spec, config);
     return $step as any;
   }
 }

--- a/grafast/grafast/src/multistep.ts
+++ b/grafast/grafast/src/multistep.ts
@@ -40,15 +40,28 @@ export type UnwrapMultistep<TMultistepSpec extends Multistep> =
 
 export function multistep<const TMultistepSpec extends Multistep>(
   spec: TMultistepSpec,
+  stable?: string | true,
 ): ExecutableStep<UnwrapMultistep<TMultistepSpec>> {
   if (spec == null) {
     return constant(spec) as any;
   } else if (spec instanceof ExecutableStep) {
     return spec;
   } else if (isTuple(spec)) {
-    return list(spec) as any;
+    const $step = list(spec);
+    if (typeof stable === "string") {
+      $step.metaKey = `${stable}|list|${spec.length}`;
+    } else if (stable === true) {
+      $step.metaKey = `multistep|list|${spec.length}`;
+    }
+    return $step as any;
   } else {
-    return object(spec) as any;
+    const $step = object(spec);
+    if (typeof stable === "string") {
+      $step.metaKey = `${stable}|object|${JSON.stringify(Object.keys(spec))}`;
+    } else if (stable === true) {
+      $step.metaKey = `multistep|object|${JSON.stringify(Object.keys(spec))}`;
+    }
+    return $step as any;
   }
 }
 

--- a/grafast/grafast/src/steps/list.ts
+++ b/grafast/grafast/src/steps/list.ts
@@ -8,6 +8,8 @@ import type { ExecutableStep } from "../step.js";
 import { UnbatchedExecutableStep } from "../step.js";
 import { constant, ConstantStep } from "./constant.js";
 
+const DEFAULT_CACHE_SIZE = 100;
+
 interface ListStepCacheConfig {
   identifier?: string;
   cacheSize?: number;
@@ -24,13 +26,20 @@ export class ListStep<
   allowMultipleOptimizations = true;
   optimizeMetaKey = "ListStep";
   private cacheSize: number;
+  private valueCount: number;
 
   constructor(list: TPlanTuple, cacheConfig?: ListStepCacheConfig) {
     super();
-    this.metaKey = cacheConfig?.identifier
-      ? `list|${list.length}|${cacheConfig.identifier}`
-      : this.id;
-    this.cacheSize = cacheConfig?.cacheSize ?? 10;
+    this.valueCount = list.length;
+    this.cacheSize =
+      cacheConfig?.cacheSize ??
+      (cacheConfig?.identifier ? DEFAULT_CACHE_SIZE : 0);
+    this.metaKey =
+      this.cacheSize <= 0
+        ? undefined
+        : cacheConfig?.identifier
+        ? `list|${list.length}|${cacheConfig.identifier}`
+        : this.id;
     for (let i = 0, l = list.length; i < l; i++) {
       this.addDependency({ step: list[i], skipDeduplication: true });
     }
@@ -52,6 +61,35 @@ export class ListStep<
     _extra: UnbatchedExecutionExtra,
     ...values: any[] //UnwrapPlanTuple<TPlanTuple>,
   ): UnwrapPlanTuple<TPlanTuple> {
+    return values as any;
+  }
+
+  deduplicatedUnbatchedExecute(
+    { meta: inMeta }: UnbatchedExecutionExtra,
+    ...values: any[] //UnwrapPlanTuple<TPlanTuple>,
+  ): UnwrapPlanTuple<TPlanTuple> {
+    const meta = inMeta as {
+      nextIndex: number | undefined;
+      results: Array<any[]>;
+    };
+    if (meta.nextIndex !== undefined) {
+      outer: for (let i = 0, l = meta.results.length; i < l; i++) {
+        const cachedValues = meta.results[i];
+        for (let j = 0, c = this.valueCount; j < c; j++) {
+          if (values[j] !== cachedValues[j]) {
+            continue outer;
+          }
+        }
+        return cachedValues as any;
+      }
+    } else {
+      meta.nextIndex = 0;
+      meta.results = [];
+    }
+    meta.results[meta.nextIndex] = values;
+    // Only cache this.cacheSize results, use a round-robin
+    const maxIndex = this.cacheSize - 1;
+    meta.nextIndex = meta.nextIndex === maxIndex ? 0 : meta.nextIndex + 1;
     return values as any;
   }
 
@@ -87,6 +125,13 @@ export class ListStep<
       }
     }
     return this;
+  }
+
+  finalize() {
+    if (this.cacheSize > 0) {
+      this.unbatchedExecute = this.deduplicatedUnbatchedExecute;
+    }
+    super.finalize();
   }
 
   /**

--- a/grafast/grafast/src/steps/load.ts
+++ b/grafast/grafast/src/steps/load.ts
@@ -208,9 +208,10 @@ export class LoadStep<
     >,
   ) {
     super();
-    const $spec = multistep(spec);
+    const $spec = multistep(spec, "load");
     this.addDependency($spec);
-    const $unarySpec = unarySpec == null ? null : multistep(unarySpec);
+    const $unarySpec =
+      unarySpec == null ? null : multistep(unarySpec, "loadUnary");
     if ($unarySpec) {
       this.unaryDepId = this.addUnaryDependency($unarySpec);
     }

--- a/grafast/grafast/src/steps/load.ts
+++ b/grafast/grafast/src/steps/load.ts
@@ -97,7 +97,7 @@ let loadCounter = 0;
  */
 export class LoadedRecordStep<
   TItem,
-  TParams extends Record<string, any>,
+  TParams extends Record<string, any> = Record<string, any>,
 > extends ExecutableStep<TItem> {
   static $$export = {
     moduleName: "grafast",


### PR DESCRIPTION
## Description

Fixes https://github.com/graphile/crystal/issues/2170

## Performance impact

Marginal performance cost for loadOne/loadMany calls that accept object/list specs.

## Security impact

Generally an improvement I hope, though there's a risk of memory exhaustion attacks if this is not used sensibly.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
