### PR TITLE
docs: documentation for at() and get() methods

### DIFF
--- a/grafast/website/README.md
+++ b/grafast/website/README.md
@@ -18,6 +18,14 @@ $ yarn start
 This command starts a local development server and opens up a browser window.
 Most changes are reflected live without having to restart the server.
 
+### Lint Fix
+
+```
+$ yarn lint:fix
+```
+
+Please run `lint:fix` before your pull request.
+
 ### Build
 
 ```

--- a/grafast/website/grafast/step-classes.md
+++ b/grafast/website/grafast/step-classes.md
@@ -159,6 +159,54 @@ console.log("$a = " + $a.toString());
 You may override this to add additional data to the `toString` method (the data
 that would occur between the triangular brackets).
 
+## Access methods
+
+When writing a step class, you should implement either `.at()` or `.get()` depending on
+if the step represents a list, array, or an objet.
+
+### at
+
+Implement `.at()` if your step represents a list or an array. It should accept a single argument, an
+integer, which represents the index within the list-like value which should be accessed.
+
+Usage:
+
+```ts
+const $abTuple = list([$a, $b]);
+
+// abTuple.at(0) returns $a
+```
+
+### get
+
+Implement `.get()` if your step represents an object. It should accept a single argument, a
+string, which represents an attribute to access an object-like value.
+
+### access
+
+If optimization isn't a concern, you can defer to `access` while implementing `get` or `at`. This
+means you can refactor and optimize at a later stage without affecting code using that step class.
+
+```ts
+class MyStep extends ExecutableStep {
+  // ...
+
+  // For steps representing objects:
+  get(key) { return access(this, key); }
+
+  // For steps representing lists:
+  at(index) { return access(this, index); }
+```
+
+:::caution
+
+If your step implements `.at()` or `.get()`, make sure it conforms to the expectations of
+those methods: ie it correctly accepts a single argument of either an integer or string.
+&ZeroWidthSpace;<grafast /> relies on these assumptions; unanticipated behaviours may result
+from steps which don't adhere to these expectations.
+
+:::
+
 ## Lifecycle methods
 
 ### execute

--- a/grafast/website/grafast/step-classes.md
+++ b/grafast/website/grafast/step-classes.md
@@ -50,6 +50,72 @@ inherit directly from `ExecutableStep`.
 
 :::
 
+## Conventions
+
+Your step may implement any additional methods that it needs; however certain methods
+have special meaning. For example, if your step represents an object then it should
+implement the `.get(key)` method; and if the step represents an array/list then it
+should implement the `.at(index)` method.
+
+These conventions are still evolving, and more may be added as common usage patterns are
+detected. Functions that have special meanings/expectations can be found below:
+
+### at
+
+Implement `.at()` if your step represents a list or an array. It should accept a single argument, an
+integer, which represents the index within the list-like value which should be accessed.
+
+Usage:
+
+```ts
+import { access } from "grafast";
+
+class MyListStep extends ExecutableStep {
+  // ...
+
+  at(index) {
+    // Your step may implement a more optimized solution here.
+    return access(this, index);
+  }
+}
+```
+
+:::caution
+
+If your step implements `.at()`, make sure it meets the expectations:
+ie it correctly accepts a single argument an integer.
+&ZeroWidthSpace;<grafast /> relies on this assumption; unanticipated behaviours may result
+from steps which don't adhere to these expectations.
+
+:::
+
+### get
+
+Implement `.get()` if your step represents an object. It should accept a single argument, a
+string, which represents an attribute to access an object-like value.
+
+```ts
+import { access } from "grafast";
+
+class MyObjectStep extends ExecutableStep {
+  // ...
+
+  get(key) {
+    // Your step may implement a more optimized solution here.
+    return access(this, key);
+  }
+}
+```
+
+:::caution
+
+If your step implements `.get()`, make sure it meets the expectations:
+ie it correctly accepts a single argument of a string.
+&ZeroWidthSpace;<grafast /> relies on this assumption; unanticipated behaviours may result
+from steps which don't adhere to these expectations.
+
+:::
+
 ## Built in methods
 
 Your custom step class will have access to all the built-in methods that come
@@ -158,72 +224,6 @@ console.log("$a = " + $a.toString());
 
 You may override this to add additional data to the `toString` method (the data
 that would occur between the triangular brackets).
-
-## Conventions
-
-Your step may implement any additional methods that it needs; however certain methods
-have special meaning. For example, if your step represents an object then it should
-implement the `.get(key)` method; and if the step represents an array/list then it
-should implement the `.at(index)` method.
-
-These conventions are still evolving, and more may be added as common usage patterns are
-detected. Functions that have special meanings/expectations can be found below:
-
-### at
-
-Implement `.at()` if your step represents a list or an array. It should accept a single argument, an
-integer, which represents the index within the list-like value which should be accessed.
-
-Usage:
-
-```ts
-import { access } from "grafast";
-
-class MyListStep extends ExecutableStep {
-  // ...
-
-  at(index) {
-    // Your step may implement a more optimized solution here.
-    return access(this, index);
-  }
-}
-```
-
-:::caution
-
-If your step implements `.at()`, make sure it meets the expectations:
-ie it correctly accepts a single argument an integer.
-&ZeroWidthSpace;<grafast /> relies on this assumption; unanticipated behaviours may result
-from steps which don't adhere to these expectations.
-
-:::
-
-### get
-
-Implement `.get()` if your step represents an object. It should accept a single argument, a
-string, which represents an attribute to access an object-like value.
-
-```ts
-import { access } from "grafast";
-
-class MyObjectStep extends ExecutableStep {
-  // ...
-
-  get(key) {
-    // Your step may implement a more optimized solution here.
-    return access(this, key);
-  }
-}
-```
-
-:::caution
-
-If your step implements `.get()`, make sure it meets the expectations:
-ie it correctly accepts a single argument of a string.
-&ZeroWidthSpace;<grafast /> relies on this assumption; unanticipated behaviours may result
-from steps which don't adhere to these expectations.
-
-:::
 
 ## Lifecycle methods
 

--- a/grafast/website/grafast/step-classes.md
+++ b/grafast/website/grafast/step-classes.md
@@ -172,9 +172,16 @@ integer, which represents the index within the list-like value which should be a
 Usage:
 
 ```ts
-const $abTuple = list([$a, $b]);
+import { access } from 'grafast';
 
-// abTuple.at(0) returns $a
+class MyListStep extends ExecutableStep {
+  // ...
+
+  at(index) {
+    // Your step may implement a more optimized solution here.
+    return access(this, index);
+  }
+}
 ```
 
 ### get
@@ -182,21 +189,19 @@ const $abTuple = list([$a, $b]);
 Implement `.get()` if your step represents an object. It should accept a single argument, a
 string, which represents an attribute to access an object-like value.
 
-### access
-
-If optimization isn't a concern, you can defer to `access` while implementing `get` or `at`. This
-means you can refactor and optimize at a later stage without affecting code using that step class.
-
 ```ts
-class MyStep extends ExecutableStep {
+import { access } from 'grafast';
+
+class MyObjectStep extends ExecutableStep {
   // ...
 
-  // For steps representing objects:
-  get(key) { return access(this, key); }
-
-  // For steps representing lists:
-  at(index) { return access(this, index); }
+  get(key) {
+    // Your step may implement a more optimized solution here.
+    return access(this, key);
+  }
+}
 ```
+
 
 :::caution
 

--- a/grafast/website/grafast/step-classes.md
+++ b/grafast/website/grafast/step-classes.md
@@ -159,10 +159,15 @@ console.log("$a = " + $a.toString());
 You may override this to add additional data to the `toString` method (the data
 that would occur between the triangular brackets).
 
-## Access methods
+## Conventions
 
-When writing a step class, you should implement either `.at()` or `.get()` depending on
-if the step represents a list, array, or an objet.
+Your step may implement any additional methods that it needs; however certain methods 
+have special meaning. For example, if your step represents an object then it should
+implement the `.get(key)` method; and if the step represents an array/list then it
+should implement the `.at(index)` method.
+
+These conventions are still evolving, and more may be added as common usage patterns are
+detected. Functions that have special meanings/expectations can be found below:
 
 ### at
 

--- a/grafast/website/grafast/step-classes.md
+++ b/grafast/website/grafast/step-classes.md
@@ -432,7 +432,7 @@ class MyObjectStep extends ExecutableStep {
 :::caution
 
 If your step implements `.get()`, make sure it meets the expectations:
-ie it correctly accepts a single argument of a string.
+i.e. it correctly accepts a single argument of a string.
 &ZeroWidthSpace;<grafast /> relies on this assumption; unanticipated behaviours may result
 from steps which don't adhere to these expectations.
 

--- a/grafast/website/grafast/step-classes.md
+++ b/grafast/website/grafast/step-classes.md
@@ -161,7 +161,7 @@ that would occur between the triangular brackets).
 
 ## Conventions
 
-Your step may implement any additional methods that it needs; however certain methods 
+Your step may implement any additional methods that it needs; however certain methods
 have special meaning. For example, if your step represents an object then it should
 implement the `.get(key)` method; and if the step represents an array/list then it
 should implement the `.at(index)` method.
@@ -177,7 +177,7 @@ integer, which represents the index within the list-like value which should be a
 Usage:
 
 ```ts
-import { access } from 'grafast';
+import { access } from "grafast";
 
 class MyListStep extends ExecutableStep {
   // ...
@@ -189,13 +189,22 @@ class MyListStep extends ExecutableStep {
 }
 ```
 
+:::caution
+
+If your step implements `.at()`, make sure it meets the expectations:
+ie it correctly accepts a single argument an integer.
+&ZeroWidthSpace;<grafast /> relies on this assumption; unanticipated behaviours may result
+from steps which don't adhere to these expectations.
+
+:::
+
 ### get
 
 Implement `.get()` if your step represents an object. It should accept a single argument, a
 string, which represents an attribute to access an object-like value.
 
 ```ts
-import { access } from 'grafast';
+import { access } from "grafast";
 
 class MyObjectStep extends ExecutableStep {
   // ...
@@ -207,12 +216,11 @@ class MyObjectStep extends ExecutableStep {
 }
 ```
 
-
 :::caution
 
-If your step implements `.at()` or `.get()`, make sure it conforms to the expectations of
-those methods: ie it correctly accepts a single argument of either an integer or string.
-&ZeroWidthSpace;<grafast /> relies on these assumptions; unanticipated behaviours may result
+If your step implements `.get()`, make sure it meets the expectations:
+ie it correctly accepts a single argument of a string.
+&ZeroWidthSpace;<grafast /> relies on this assumption; unanticipated behaviours may result
 from steps which don't adhere to these expectations.
 
 :::

--- a/grafast/website/grafast/step-classes.md
+++ b/grafast/website/grafast/step-classes.md
@@ -316,7 +316,7 @@ equivalent of `SELECT *` - it can be more selective). However, since
 can simply replace itself during `optimize` with its parent step (typically an
 `__ItemStep`).
 
-The builtin `each` step uses `optimize` to replace itself with the underlying
+The built-in `each` step uses `optimize` to replace itself with the underlying
 list where possible.
 
 #### Optimize: simplification
@@ -528,7 +528,7 @@ const $b = this.getDep(1);
 
 _EXPERIMENTAL_
 
-Like `getDep`, but skips over `__ItemStep` and similar builtin intermediary
+Like `getDep`, but skips over `__ItemStep` and similar built-in intermediary
 steps to try and get to the original source. Typically useful if you have a
 step representing an entry from a collection (e.g. a database "row") and you
 want to get the step representing the entire collection (e.g. a database

--- a/grafast/website/grafast/step-classes.md
+++ b/grafast/website/grafast/step-classes.md
@@ -368,11 +368,7 @@ should use the `optimize` method to do so.
 
 :::
 
-## Custom Methods
-
-conventions blurb, list of likely future keywords (import, export, defer, filter, order, merge)
-
-### Conventions
+## Custom methods and conventions
 
 Your step may implement any additional methods that it needs; however certain methods
 have special meaning. For example, if your step represents an object then it should
@@ -380,7 +376,11 @@ implement the `.get(key)` method; and if the step represents an array/list then 
 should implement the `.at(index)` method.
 
 These conventions are still evolving, and more may be added as common usage patterns are
-detected. Functions that have special meanings/expectations can be found below:
+detected. Some likely candidates for future reserved methods include: import, export,
+defer, filter, order and merge. To avoid conflicts with built in and future methods,
+consider using a prefix when naming custom methods.
+
+Functions that have special meanings/expectations can be found below:
 
 ### at
 

--- a/grafast/website/grafast/step-library/dataplan-pg/registry/codecs.md
+++ b/grafast/website/grafast/step-library/dataplan-pg/registry/codecs.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 # Codecs
 
 A `PgCodec` ("codec") represents a type (data type) in the database. There are
-loads of built in codecs for dealing with the builtin types in Postgres made
+loads of built in codecs for dealing with the built-in types in Postgres made
 available via the [`TYPES` export](#TYPES), but you can also create your own
 codecs for other types using the various helpers.
 
@@ -25,7 +25,7 @@ import { TYPES } from "@dataplan/pg";
 const intCodec = TYPES.int;
 ```
 
-The `TYPES` object comprises a number of builtin codecs for common types in your
+The `TYPES` object comprises a number of built-in codecs for common types in your
 database; the following keys on `TYPES` represent the similarly named database
 types (e.g. `TYPES.boolean` represents the `bool` type):
 

--- a/grafast/website/grafast/step-library/index.md
+++ b/grafast/website/grafast/step-library/index.md
@@ -5,9 +5,9 @@ A step class is a JavaScript class that extends `ExecutableStep` with an
 methods, and add other accessors and similar that child field plans may call.
 For more information see [step classes](../step-classes).
 
-A number of builtin standard step classes are provided for schemas to
+A number of built-in standard step classes are provided for schemas to
 accomplish common tasks, these are documented in [Standard
-steps](./standard-steps). Often these builtin steps are enough for your schemas
+steps](./standard-steps). Often these built-in steps are enough for your schemas
 needs, especially when integrating with an existing business logic layer via
 steps such as [loadOne][] and [loadMany][].
 

--- a/grafast/website/grafast/step-library/standard-steps/index.mdx
+++ b/grafast/website/grafast/step-library/standard-steps/index.mdx
@@ -6,7 +6,7 @@ sidebar_position: 6
 
 The following are built-in standard steps, provided to accomplish common tasks.
 Many of them are thin wrappers around an underlying step class, for example
-`loadOne` and `loadMany` both call in to the underlying `load` step class. These
+`loadOne` and `loadMany` both call in to the underlying `LoadStep` step class. These
 standard steps can be used as a foundation for your project, and are often
 sufficient enough for a schema's needs - particularly when integrating with an existing
 business logic layer.

--- a/grafast/website/grafast/step-library/standard-steps/index.mdx
+++ b/grafast/website/grafast/step-library/standard-steps/index.mdx
@@ -4,6 +4,13 @@ sidebar_position: 6
 
 # Standard steps
 
+The following are built-in standard steps, provided to accomplish common tasks.
+Many of them are thin wrappers around an underlying step class, for example
+`loadOne` and `loadMany` both call in to the underlying `load` step class. These
+standard steps can be used as a foundation for your project, and are often
+sufficient enough for a schema's needs - particularly when integrating with an existing
+business logic layer.
+
 ## Loading data
 
 - [loadOne][]: similar to DataLoader.load, batch loading of single values

--- a/grafast/website/grafast/step-library/standard-steps/lambda.md
+++ b/grafast/website/grafast/step-library/standard-steps/lambda.md
@@ -17,7 +17,7 @@ If you are 100% certain that your callback function:
 3. will not throw an error
 
 then for the very best performance, you can pass the third argument,
-`isSyncAndSafe`, as the value `true`. Do not do this unless you are certain!
+[`isSyncAndSafe`](../../step-classes.md#issyncandsafe), as the value `true`. Do not do this unless you are certain!
 
 ## Single dependency version
 

--- a/grafast/website/grafast/step-library/standard-steps/list.md
+++ b/grafast/website/grafast/step-library/standard-steps/list.md
@@ -9,8 +9,8 @@ Usage:
 const $abTuple = list([$a, $b]);
 ```
 
-```ts
-abTuple.at(0); // returns $a
-abTuple.first(); // returns $a
-abTuple.last(); // returns $b
-```
+A ListStep has the following methods:
+
+- `.at(index)` - gets the value at `index` (`abTuple.at(0)` returns `$a`).
+- `.first()` - returns the first value in the list (`abTuple.first` returns `$a`).
+- `.last()` - returns the last value in the list (`abTuple.last()` returns `$b`).

--- a/grafast/website/grafast/step-library/standard-steps/list.md
+++ b/grafast/website/grafast/step-library/standard-steps/list.md
@@ -8,3 +8,9 @@ Usage:
 ```ts
 const $abTuple = list([$a, $b]);
 ```
+
+```ts
+abTuple.at(0); // returns $a
+abTuple.first(); // returns $a
+abTuple.last(); // returns $b
+```

--- a/grafast/website/grafast/step-library/standard-steps/list.md
+++ b/grafast/website/grafast/step-library/standard-steps/list.md
@@ -6,11 +6,11 @@ of their values.
 Usage:
 
 ```ts
-const $abTuple = list([$a, $b]);
+const $abTuple = list([$a, $b, $c]);
 ```
 
 A ListStep has the following methods:
 
-- `.at(index)` - gets the value at `index` (`abTuple.at(0)` returns `$a`).
-- `.first()` - returns the first value in the list (`abTuple.first` returns `$a`).
-- `.last()` - returns the last value in the list (`abTuple.last()` returns `$b`).
+- `.at(index)` - gets the value at `index` (`$abTuple.at(1)` returns `$b`).
+- `.first()` - returns the first value in the list (`$abTuple.first()` returns `$a`).
+- `.last()` - returns the last value in the list (`$abTuple.last()` returns `$c`).

--- a/grafast/website/grafast/step-library/standard-steps/list.md
+++ b/grafast/website/grafast/step-library/standard-steps/list.md
@@ -6,11 +6,11 @@ of their values.
 Usage:
 
 ```ts
-const $abTuple = list([$a, $b, $c]);
+const $abcTuple = list([$a, $b, $c]);
 ```
 
 A ListStep has the following methods:
 
-- `.at(index)` - gets the value at `index` (`$abTuple.at(1)` returns `$b`).
-- `.first()` - returns the first value in the list (`$abTuple.first()` returns `$a`).
-- `.last()` - returns the last value in the list (`$abTuple.last()` returns `$c`).
+- `.at(index)` - gets the value at `index` (`$abcTuple.at(1)` returns `$b`).
+- `.first()` - returns the first value in the list (`$abcTuple.first()` returns `$a`).
+- `.last()` - returns the last value in the list (`$abcTuple.last()` returns `$c`).

--- a/grafast/website/grafserv/servers/index.mdx
+++ b/grafast/website/grafserv/servers/index.mdx
@@ -5,7 +5,7 @@ import Mermaid from "@theme/Mermaid";
 Grafserv has support for a number of Node.js webservers built in, and you can
 build an adaptor to make Grafserv compatible with your server of choice.
 
-Please see the subpages for the builtin webserver support.
+Please see the subpages for the built-in webserver support.
 
 ## Sequence diagram
 


### PR DESCRIPTION
## Description

Needs review! 

- detail on implementing `at` and `get` added under the header "Access methods" 
- added missing detail about the methods a ListStep can accept
- Saw a missing link while reviewing the methods for a Lambda step

Closes https://github.com/graphile/crystal-pre-merge/issues/497
