### PR TITLE
docs: update express-jwt auth property name in examples

### DIFF
--- a/postgraphile/website/postgraphile/jwk-verification.md
+++ b/postgraphile/website/postgraphile/jwk-verification.md
@@ -151,8 +151,8 @@ app.use(
   postgraphile(process.env.DATABASE_URL, process.env.DB_SCHEMA, {
     pgSettings: (req) => {
       const settings = {};
-      if (req.user) {
-        settings["user.permissions"] = req.user.scopes;
+      if (req.auth) {
+        settings["user.permissions"] = req.auth.scope;
       }
       return settings;
     },

--- a/postgraphile/website/versioned_docs/version-4.x/jwk-verification.md
+++ b/postgraphile/website/versioned_docs/version-4.x/jwk-verification.md
@@ -145,7 +145,7 @@ app.use(
     pgSettings: (req) => {
       const settings = {};
       if (req.auth) {
-        settings["user.permissions"] = req.auth.scopes;
+        settings["user.permissions"] = req.auth.scope;
       }
       return settings;
     },


### PR DESCRIPTION
## Description

<!-- If this PR adds a feature, what does it add and what was the motivation for it? -->
<!-- If this PR fixes an issue, what is the issue? -->
<!-- Please link to the relevant GitHub issues/Discord discussion/etc as appropriate -->
In recent versions of [`express-jwt`](https://www.npmjs.com/package/express-jwt) the name of the property in the request object where the JWT payload is set defaults to `req.auth`

This PR also renames the `scope` claim to better align with the decoded JWT payload example in the documentation proceeding it.

## Performance impact

<!-- Detail any impact on performance of this PR, or put 'unknown' if not known -->
N/A

## Security impact

<!-- Detail any impact on security of this PR, or put 'unknown' if not known -->
N/A

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
