### PR TITLE
Fix optional arguments in scalar computed column functions

### DIFF
--- a/.changeset/curly-tigers-glow.md
+++ b/.changeset/curly-tigers-glow.md
@@ -1,0 +1,6 @@
+---
+"graphile-build-pg": patch
+"postgraphile": patch
+---
+
+Fixes bug handling optional arguments to computed column functions.

--- a/graphile-build/graphile-build-pg/src/plugins/PgCustomTypeFieldPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgCustomTypeFieldPlugin.ts
@@ -1102,7 +1102,13 @@ function modFields(
                   ) {
                     // This is a scalar computed attribute, let's inline the expression
                     const newSelectArgs = selectArgs.map(
-                      (arg, i): PgSelectArgumentDigest => {
+                      (
+                        arg,
+                        i,
+                      ): PgSelectArgumentDigest & {
+                        // We _MUST_ set `name` if we're told one
+                        name: string | undefined;
+                      } => {
                         const { name } = arg;
                         if (i === 0) {
                           return {

--- a/graphile-build/graphile-build-pg/src/plugins/PgCustomTypeFieldPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgCustomTypeFieldPlugin.ts
@@ -12,6 +12,7 @@ import type {
   PgInsertSingleStep,
   PgResource,
   PgResourceParameter,
+  PgSelectArgumentDigest,
   PgSelectArgumentSpec,
   PgSelectStep,
   PgTypedExecutableStep,
@@ -1100,25 +1101,36 @@ function modFields(
                     typeof resource.from === "function"
                   ) {
                     // This is a scalar computed attribute, let's inline the expression
-                    const placeholders = selectArgs.map((arg, i) => {
-                      if (i === 0) {
-                        return $row.getClassStep().alias;
-                      } else if ("pgCodec" in arg && arg.pgCodec) {
-                        return $row.placeholder(arg.step, arg.pgCodec);
-                      } else {
-                        return $row.placeholder(
-                          arg.step as PgTypedExecutableStep<any>,
-                        );
-                      }
-                    });
+                    const newSelectArgs = selectArgs.map(
+                      (arg, i): PgSelectArgumentDigest => {
+                        const { name } = arg;
+                        if (i === 0) {
+                          return {
+                            name,
+                            placeholder: $row.getClassStep().alias,
+                          };
+                        } else if ("pgCodec" in arg && arg.pgCodec) {
+                          return {
+                            name,
+                            placeholder: $row.placeholder(
+                              arg.step,
+                              arg.pgCodec,
+                            ),
+                          };
+                        } else {
+                          return {
+                            name,
+                            placeholder: $row.placeholder(
+                              arg.step as PgTypedExecutableStep<any>,
+                            ),
+                          };
+                        }
+                      },
+                    );
                     return pgClassExpression(
                       $row,
                       resource.codec,
-                    )`${resource.from(
-                      ...placeholders.map((placeholder) => ({
-                        placeholder,
-                      })),
-                    )}`;
+                    )`${resource.from(...newSelectArgs)}`;
                   }
                   // PERF: or here, if scalar add select to `$row`?
                   return resource.execute(selectArgs);

--- a/postgraphile/postgraphile/__tests__/kitchen-sink-schema.sql
+++ b/postgraphile/postgraphile/__tests__/kitchen-sink-schema.sql
@@ -402,6 +402,14 @@ create function c.person_friends(person c.person) returns setof c.person as $$ s
 comment on function c.person_friends(c.person) is E'@sortable';
 create function c.person_first_post(person c.person) returns a.post as $$ select * from a.post where a.post.author_id = person.id order by id asc limit 1 $$ language sql stable;
 comment on function c.person_first_post(c.person) is 'The first post by the person.';
+
+-- Same as optional_missing_middle_* functions above, but computed column
+create function c.person_optional_missing_middle_1(p c.person, int, b int default 2, c int default 3) returns int as $$ select $2 + $3 + $4 $$ language sql immutable strict;
+create function c.person_optional_missing_middle_2(p c.person, a int, b int default 2, c int default 3) returns int as $$ select $2 + $3 + $4 $$ language sql immutable strict;
+create function c.person_optional_missing_middle_3(p c.person, a int, int default 2, c int default 3) returns int as $$ select $2 + $3 + $4 $$ language sql immutable strict;
+create function c.person_optional_missing_middle_4(p c.person, int, b int default 2, int default 3) returns int as $$ select $2 + $3 + $4 $$ language sql immutable strict;
+create function c.person_optional_missing_middle_5(p c.person, a int, int default 2, int default 3) returns int as $$ select $2 + $3 + $4 $$ language sql immutable strict;
+
 create function c.compound_type_computed_field(compound_type c.compound_type) returns integer as $$ select compound_type.a + compound_type.foo_bar $$ language sql stable;
 create function a.post_headline_trimmed(post a.post, length int default 10, omission text default '…') returns text as $$ select substr(post.headline, 0, length) || omission $$ language sql stable;
 create function a.post_headline_trimmed_strict(post a.post, length int default 10, omission text default '…') returns text as $$ select substr(post.headline, 0, length) || omission $$ language sql stable strict;

--- a/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields.json5
+++ b/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields.json5
@@ -1633,4 +1633,12 @@
       },
     ],
   },
+  personById: {
+    optionalMissingMiddle1: 10,
+    optionalMissingMiddle1_2: 16,
+    optionalMissingMiddle2: 10,
+    optionalMissingMiddle3: 10,
+    optionalMissingMiddle4: null,
+    optionalMissingMiddle5: null,
+  },
 }

--- a/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields.mermaid
@@ -9,13 +9,23 @@ graph TD
 
 
     %% plan dependencies
+    PgSelect334[["PgSelect[334∈0] ➊<br />ᐸpersonᐳ"]]:::plan
     Object17{{"Object[17∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    Constant432{{"Constant[432∈0] ➊<br />ᐸ1ᐳ"}}:::plan
+    Constant435{{"Constant[435∈0] ➊<br />ᐸ7ᐳ"}}:::plan
+    Constant431{{"Constant[431∈0] ➊<br />ᐸ8ᐳ"}}:::plan
+    Constant145{{"Constant[145∈0] ➊<br />ᐸnullᐳ"}}:::plan
+    Object17 & Constant432 & Constant432 & Constant435 & Constant432 & Constant431 & Constant435 & Constant432 & Constant435 & Constant432 & Constant435 & Constant432 & Constant145 & Constant435 & Constant432 & Constant435 --> PgSelect334
     Access15{{"Access[15∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access16{{"Access[16∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
     Access15 & Access16 --> Object17
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access15
     __Value2 --> Access16
+    First338{{"First[338∈0] ➊"}}:::plan
+    PgSelect334 --> First338
+    PgSelectSingle339{{"PgSelectSingle[339∈0] ➊<br />ᐸpersonᐳ"}}:::plan
+    First338 --> PgSelectSingle339
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     Connection18{{"Connection[18∈0] ➊<br />ᐸ14ᐳ"}}:::plan
     Connection114{{"Connection[114∈0] ➊<br />ᐸ110ᐳ"}}:::plan
@@ -37,23 +47,23 @@ graph TD
     PgClassExpression32{{"PgClassExpression[32∈3]<br />ᐸ”c”.”compo...nd_type__)ᐳ"}}:::plan
     PgSelectSingle28 --> PgClassExpression32
     PgSelectSingle39{{"PgSelectSingle[39∈3]<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys339{{"RemapKeys[339∈3]<br />ᐸ21:{”0”:4,”1”:5,”2”:6,”3”:7,”4”:8,”5”:9,”6”:10,”7”:11,”8”:12}ᐳ"}}:::plan
-    RemapKeys339 --> PgSelectSingle39
+    RemapKeys392{{"RemapKeys[392∈3]<br />ᐸ21:{”0”:4,”1”:5,”2”:6,”3”:7,”4”:8,”5”:9,”6”:10,”7”:11,”8”:12}ᐳ"}}:::plan
+    RemapKeys392 --> PgSelectSingle39
     PgSelectSingle46{{"PgSelectSingle[46∈3]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle39 --> PgSelectSingle46
     PgSelectSingle57{{"PgSelectSingle[57∈3]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys337{{"RemapKeys[337∈3]<br />ᐸ39:{”0”:4,”1”:5,”2”:6,”3”:7}ᐳ"}}:::plan
-    RemapKeys337 --> PgSelectSingle57
+    RemapKeys390{{"RemapKeys[390∈3]<br />ᐸ39:{”0”:4,”1”:5,”2”:6,”3”:7}ᐳ"}}:::plan
+    RemapKeys390 --> PgSelectSingle57
     PgSelectSingle68{{"PgSelectSingle[68∈3]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys341{{"RemapKeys[341∈3]<br />ᐸ21:{”0”:13,”1”:14,”2”:15,”3”:16}ᐳ"}}:::plan
-    RemapKeys341 --> PgSelectSingle68
+    RemapKeys394{{"RemapKeys[394∈3]<br />ᐸ21:{”0”:13,”1”:14,”2”:15,”3”:16}ᐳ"}}:::plan
+    RemapKeys394 --> PgSelectSingle68
     PgSelectSingle79{{"PgSelectSingle[79∈3]<br />ᐸfrmcdc_nestedCompoundTypeᐳ"}}:::plan
-    RemapKeys347{{"RemapKeys[347∈3]<br />ᐸ21:{”0”:17,”1”:18,”2”:19,”3”:20,”4”:21,”5”:22,”6”:23,”7”:24,”8”:25}ᐳ"}}:::plan
-    RemapKeys347 --> PgSelectSingle79
-    PgSelectSingle39 --> RemapKeys337
-    PgSelectSingle21 --> RemapKeys339
-    PgSelectSingle21 --> RemapKeys341
-    PgSelectSingle21 --> RemapKeys347
+    RemapKeys400{{"RemapKeys[400∈3]<br />ᐸ21:{”0”:17,”1”:18,”2”:19,”3”:20,”4”:21,”5”:22,”6”:23,”7”:24,”8”:25}ᐳ"}}:::plan
+    RemapKeys400 --> PgSelectSingle79
+    PgSelectSingle39 --> RemapKeys390
+    PgSelectSingle21 --> RemapKeys392
+    PgSelectSingle21 --> RemapKeys394
+    PgSelectSingle21 --> RemapKeys400
     PgClassExpression47{{"PgClassExpression[47∈4]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle46 --> PgClassExpression47
     PgClassExpression48{{"PgClassExpression[48∈4]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
@@ -75,9 +85,9 @@ graph TD
     PgSelectSingle86{{"PgSelectSingle[86∈7]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
     PgSelectSingle79 --> PgSelectSingle86
     PgSelectSingle97{{"PgSelectSingle[97∈7]<br />ᐸfrmcdc_compoundTypeᐳ"}}:::plan
-    RemapKeys345{{"RemapKeys[345∈7]<br />ᐸ79:{”0”:4,”1”:5,”2”:6,”3”:7}ᐳ"}}:::plan
-    RemapKeys345 --> PgSelectSingle97
-    PgSelectSingle79 --> RemapKeys345
+    RemapKeys398{{"RemapKeys[398∈7]<br />ᐸ79:{”0”:4,”1”:5,”2”:6,”3”:7}ᐳ"}}:::plan
+    RemapKeys398 --> PgSelectSingle97
+    PgSelectSingle79 --> RemapKeys398
     PgClassExpression87{{"PgClassExpression[87∈8]<br />ᐸ__frmcdc_c...type__.”a”ᐳ"}}:::plan
     PgSelectSingle86 --> PgClassExpression87
     PgClassExpression88{{"PgClassExpression[88∈8]<br />ᐸ__frmcdc_c....”foo_bar”ᐳ"}}:::plan
@@ -91,12 +101,11 @@ graph TD
     PgClassExpression101{{"PgClassExpression[101∈9]<br />ᐸ”c”.”compo...nd_type__)ᐳ"}}:::plan
     PgSelectSingle97 --> PgClassExpression101
     PgSelect115[["PgSelect[115∈10] ➊<br />ᐸpostᐳ"]]:::plan
-    Constant359{{"Constant[359∈10] ➊<br />ᐸ15ᐳ"}}:::plan
-    Constant360{{"Constant[360∈10] ➊<br />ᐸ20ᐳ"}}:::plan
-    Constant361{{"Constant[361∈10] ➊<br />ᐸ'[...]'ᐳ"}}:::plan
-    Constant145{{"Constant[145∈10] ➊<br />ᐸnullᐳ"}}:::plan
-    Constant377{{"Constant[377∈10] ➊<br />ᐸ[Object: null prototype] {   a: 419,   b: 'easy cheesy bakedᐳ"}}:::plan
-    Object17 & Connection114 & Constant359 & Constant360 & Constant361 & Constant359 & Constant360 & Constant361 & Constant360 & Constant361 & Constant359 & Constant145 & Constant377 --> PgSelect115
+    Constant416{{"Constant[416∈10] ➊<br />ᐸ15ᐳ"}}:::plan
+    Constant417{{"Constant[417∈10] ➊<br />ᐸ20ᐳ"}}:::plan
+    Constant418{{"Constant[418∈10] ➊<br />ᐸ'[...]'ᐳ"}}:::plan
+    Constant448{{"Constant[448∈10] ➊<br />ᐸ[Object: null prototype] {   a: 419,   b: 'easy cheesy bakedᐳ"}}:::plan
+    Object17 & Connection114 & Constant416 & Constant417 & Constant418 & Constant416 & Constant417 & Constant418 & Constant417 & Constant418 & Constant416 & Constant145 & Constant448 --> PgSelect115
     __Item116[/"__Item[116∈11]<br />ᐸ115ᐳ"\]:::itemplan
     PgSelect115 ==> __Item116
     PgSelectSingle117{{"PgSelectSingle[117∈11]<br />ᐸpostᐳ"}}:::plan
@@ -116,8 +125,8 @@ graph TD
     PgClassExpression142{{"PgClassExpression[142∈12]<br />ᐸ”a”.”post_...lder! */<br />)ᐳ"}}:::plan
     PgSelectSingle117 --> PgClassExpression142
     PgSelectSingle152{{"PgSelectSingle[152∈12]<br />ᐸpostᐳ"}}:::plan
-    RemapKeys349{{"RemapKeys[349∈12]<br />ᐸ117:{”0”:1,”1”:2}ᐳ"}}:::plan
-    RemapKeys349 --> PgSelectSingle152
+    RemapKeys402{{"RemapKeys[402∈12]<br />ᐸ117:{”0”:1,”1”:2}ᐳ"}}:::plan
+    RemapKeys402 --> PgSelectSingle152
     PgClassExpression154{{"PgClassExpression[154∈12]<br />ᐸ”a”.”post_...lder! */<br />)ᐳ"}}:::plan
     PgSelectSingle152 --> PgClassExpression154
     PgClassExpression158{{"PgClassExpression[158∈12]<br />ᐸ”a”.”post_...lder! */<br />)ᐳ"}}:::plan
@@ -127,16 +136,16 @@ graph TD
     PgClassExpression205{{"PgClassExpression[205∈12]<br />ᐸ”a”.”post_...(__post__)ᐳ"}}:::plan
     PgSelectSingle117 --> PgClassExpression205
     __ListTransform235[["__ListTransform[235∈12]<br />ᐸeach:234ᐳ"]]:::plan
-    Access354{{"Access[354∈12]<br />ᐸ116.4ᐳ"}}:::plan
-    Access354 --> __ListTransform235
-    PgSelectSingle117 --> RemapKeys349
-    Access351{{"Access[351∈12]<br />ᐸ352.0ᐳ"}}:::plan
-    RemapKeys352{{"RemapKeys[352∈12]<br />ᐸ117:{”0”:3}ᐳ"}}:::plan
-    RemapKeys352 --> Access351
-    PgSelectSingle117 --> RemapKeys352
-    __Item116 --> Access354
-    __Item188[/"__Item[188∈13]<br />ᐸ351ᐳ"\]:::itemplan
-    Access351 ==> __Item188
+    Access407{{"Access[407∈12]<br />ᐸ116.4ᐳ"}}:::plan
+    Access407 --> __ListTransform235
+    PgSelectSingle117 --> RemapKeys402
+    Access404{{"Access[404∈12]<br />ᐸ405.0ᐳ"}}:::plan
+    RemapKeys405{{"RemapKeys[405∈12]<br />ᐸ117:{”0”:3}ᐳ"}}:::plan
+    RemapKeys405 --> Access404
+    PgSelectSingle117 --> RemapKeys405
+    __Item116 --> Access407
+    __Item188[/"__Item[188∈13]<br />ᐸ404ᐳ"\]:::itemplan
+    Access404 ==> __Item188
     PgSelectSingle189{{"PgSelectSingle[189∈13]<br />ᐸpost_computed_compound_type_arrayᐳ"}}:::plan
     __Item188 --> PgSelectSingle189
     PgClassExpression190{{"PgClassExpression[190∈14]<br />ᐸ__post_com...rray__.”a”ᐳ"}}:::plan
@@ -159,14 +168,14 @@ graph TD
     PgClassExpression202 ==> __Item203
     __Item206[/"__Item[206∈17]<br />ᐸ205ᐳ"\]:::itemplan
     PgClassExpression205 ==> __Item206
-    __Item225[/"__Item[225∈19]<br />ᐸ354ᐳ"\]:::itemplan
-    Access354 ==> __Item225
+    __Item225[/"__Item[225∈19]<br />ᐸ407ᐳ"\]:::itemplan
+    Access407 ==> __Item225
     PgSelectSingle226{{"PgSelectSingle[226∈19]<br />ᐸpost_computed_interval_setᐳ"}}:::plan
     __Item225 --> PgSelectSingle226
     PgClassExpression227{{"PgClassExpression[227∈19]<br />ᐸ__post_com...al_set__.vᐳ"}}:::plan
     PgSelectSingle226 --> PgClassExpression227
-    __Item236[/"__Item[236∈21]<br />ᐸ354ᐳ"\]:::itemplan
-    Access354 -.-> __Item236
+    __Item236[/"__Item[236∈21]<br />ᐸ407ᐳ"\]:::itemplan
+    Access407 -.-> __Item236
     PgSelectSingle237{{"PgSelectSingle[237∈21]<br />ᐸpost_computed_interval_setᐳ"}}:::plan
     __Item236 --> PgSelectSingle237
     PgClassExpression238{{"PgClassExpression[238∈21]<br />ᐸ__post_com...al_set__.vᐳ"}}:::plan
@@ -188,8 +197,7 @@ graph TD
     PgSelect262[["PgSelect[262∈25] ➊<br />ᐸpersonᐳ"]]:::plan
     Object17 & Connection261 --> PgSelect262
     Connection297{{"Connection[297∈25] ➊<br />ᐸ293ᐳ"}}:::plan
-    Constant375{{"Constant[375∈25] ➊<br />ᐸ1ᐳ"}}:::plan
-    Constant375 --> Connection297
+    Constant432 --> Connection297
     Connection279{{"Connection[279∈25] ➊<br />ᐸ275ᐳ"}}:::plan
     __Item263[/"__Item[263∈26]<br />ᐸ262ᐳ"\]:::itemplan
     PgSelect262 ==> __Item263
@@ -200,23 +208,23 @@ graph TD
     PgClassExpression267{{"PgClassExpression[267∈27]<br />ᐸ”c”.”perso..._person__)ᐳ"}}:::plan
     PgSelectSingle264 --> PgClassExpression267
     PgSelectSingle310{{"PgSelectSingle[310∈27]<br />ᐸperson_first_postᐳ"}}:::plan
-    RemapKeys357{{"RemapKeys[357∈27]<br />ᐸ264:{”0”:2,”1”:3}ᐳ"}}:::plan
-    RemapKeys357 --> PgSelectSingle310
-    Access356{{"Access[356∈27]<br />ᐸ263.1ᐳ"}}:::plan
-    __Item263 --> Access356
-    PgSelectSingle264 --> RemapKeys357
-    __Item281[/"__Item[281∈28]<br />ᐸ356ᐳ"\]:::itemplan
-    Access356 ==> __Item281
+    RemapKeys410{{"RemapKeys[410∈27]<br />ᐸ264:{”0”:2,”1”:3}ᐳ"}}:::plan
+    RemapKeys410 --> PgSelectSingle310
+    Access409{{"Access[409∈27]<br />ᐸ263.1ᐳ"}}:::plan
+    __Item263 --> Access409
+    PgSelectSingle264 --> RemapKeys410
+    __Item281[/"__Item[281∈28]<br />ᐸ409ᐳ"\]:::itemplan
+    Access409 ==> __Item281
     PgSelectSingle282{{"PgSelectSingle[282∈28]<br />ᐸperson_friendsᐳ"}}:::plan
     __Item281 --> PgSelectSingle282
     PgClassExpression283{{"PgClassExpression[283∈29]<br />ᐸ__person_f...full_name”ᐳ"}}:::plan
     PgSelectSingle282 --> PgClassExpression283
     PgClassExpression285{{"PgClassExpression[285∈29]<br />ᐸ”c”.”perso...friends__)ᐳ"}}:::plan
     PgSelectSingle282 --> PgClassExpression285
-    Access355{{"Access[355∈29]<br />ᐸ281.1ᐳ"}}:::plan
-    __Item281 --> Access355
-    __Item299[/"__Item[299∈30]<br />ᐸ355ᐳ"\]:::itemplan
-    Access355 ==> __Item299
+    Access408{{"Access[408∈29]<br />ᐸ281.1ᐳ"}}:::plan
+    __Item281 --> Access408
+    __Item299[/"__Item[299∈30]<br />ᐸ408ᐳ"\]:::itemplan
+    Access408 ==> __Item299
     PgSelectSingle300{{"PgSelectSingle[300∈30]<br />ᐸperson_friendsᐳ"}}:::plan
     __Item299 --> PgSelectSingle300
     PgClassExpression301{{"PgClassExpression[301∈31]<br />ᐸ__person_f...full_name”ᐳ"}}:::plan
@@ -239,13 +247,31 @@ graph TD
     PgSelectSingle328 --> PgClassExpression330
     PgClassExpression332{{"PgClassExpression[332∈35]<br />ᐸ”c”.”edge_...ge_case__)ᐳ"}}:::plan
     PgSelectSingle328 --> PgClassExpression332
+    PgClassExpression344{{"PgClassExpression[344∈36] ➊<br />ᐸ”c”.”perso...lder! */<br />)ᐳ"}}:::plan
+    PgSelectSingle339 --> PgClassExpression344
+    PgClassExpression349{{"PgClassExpression[349∈36] ➊<br />ᐸ”c”.”perso...lder! */<br />)ᐳ"}}:::plan
+    PgSelectSingle339 --> PgClassExpression349
+    PgClassExpression354{{"PgClassExpression[354∈36] ➊<br />ᐸ”c”.”perso...lder! */<br />)ᐳ"}}:::plan
+    PgSelectSingle339 --> PgClassExpression354
+    PgClassExpression359{{"PgClassExpression[359∈36] ➊<br />ᐸ”c”.”perso...lder! */<br />)ᐳ"}}:::plan
+    PgSelectSingle339 --> PgClassExpression359
+    PgSelectSingle370{{"PgSelectSingle[370∈36] ➊<br />ᐸpersonᐳ"}}:::plan
+    PgSelectSingle339 --> PgSelectSingle370
+    PgClassExpression372{{"PgClassExpression[372∈36] ➊<br />ᐸ”c”.”perso...lder! */<br />)ᐳ"}}:::plan
+    PgSelectSingle370 --> PgClassExpression372
+    PgSelectSingle383{{"PgSelectSingle[383∈36] ➊<br />ᐸpersonᐳ"}}:::plan
+    RemapKeys414{{"RemapKeys[414∈36] ➊<br />ᐸ339:{”0”:2,”1”:3}ᐳ"}}:::plan
+    RemapKeys414 --> PgSelectSingle383
+    PgClassExpression385{{"PgClassExpression[385∈36] ➊<br />ᐸ”c”.”perso...lder! */<br />)ᐳ"}}:::plan
+    PgSelectSingle383 --> PgClassExpression385
+    PgSelectSingle339 --> RemapKeys414
 
     %% define steps
 
     subgraph "Buckets for queries/v4/procedure-computed-fields"
-    Bucket0("Bucket 0 (root)"):::bucket
+    Bucket0("Bucket 0 (root)<br /><br />1: <br />ᐳ: 15, 16, 18, 114, 145, 223, 261, 325, 431, 432, 435, 17<br />2: PgSelect[334]<br />ᐳ: First[338], PgSelectSingle[339]"):::bucket
     classDef bucket0 stroke:#696969
-    class Bucket0,__Value2,__Value4,Access15,Access16,Object17,Connection18,Connection114,Connection223,Connection261,Connection325 bucket0
+    class Bucket0,__Value2,__Value4,Access15,Access16,Object17,Connection18,Connection114,Constant145,Connection223,Connection261,Connection325,PgSelect334,First338,PgSelectSingle339,Constant431,Constant432,Constant435 bucket0
     Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 17, 18<br /><br />ROOT Connectionᐸ14ᐳ[18]"):::bucket
     classDef bucket1 stroke:#00bfff
     class Bucket1,PgSelect19 bucket1
@@ -254,7 +280,7 @@ graph TD
     class Bucket2,__Item20,PgSelectSingle21 bucket2
     Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 21<br /><br />ROOT PgSelectSingle{2}ᐸtypesᐳ[21]"):::bucket
     classDef bucket3 stroke:#ffa500
-    class Bucket3,PgSelectSingle28,PgClassExpression29,PgClassExpression30,PgClassExpression32,PgSelectSingle39,PgSelectSingle46,PgSelectSingle57,PgSelectSingle68,PgSelectSingle79,RemapKeys337,RemapKeys339,RemapKeys341,RemapKeys347 bucket3
+    class Bucket3,PgSelectSingle28,PgClassExpression29,PgClassExpression30,PgClassExpression32,PgSelectSingle39,PgSelectSingle46,PgSelectSingle57,PgSelectSingle68,PgSelectSingle79,RemapKeys390,RemapKeys392,RemapKeys394,RemapKeys400 bucket3
     Bucket4("Bucket 4 (nullableBoundary)<br />Deps: 46<br /><br />ROOT PgSelectSingle{3}ᐸfrmcdc_compoundTypeᐳ[46]"):::bucket
     classDef bucket4 stroke:#0000ff
     class Bucket4,PgClassExpression47,PgClassExpression48,PgClassExpression50 bucket4
@@ -266,23 +292,23 @@ graph TD
     class Bucket6,PgClassExpression69,PgClassExpression70,PgClassExpression72 bucket6
     Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 79<br /><br />ROOT PgSelectSingle{3}ᐸfrmcdc_nestedCompoundTypeᐳ[79]"):::bucket
     classDef bucket7 stroke:#808000
-    class Bucket7,PgSelectSingle86,PgSelectSingle97,RemapKeys345 bucket7
+    class Bucket7,PgSelectSingle86,PgSelectSingle97,RemapKeys398 bucket7
     Bucket8("Bucket 8 (nullableBoundary)<br />Deps: 86<br /><br />ROOT PgSelectSingle{7}ᐸfrmcdc_compoundTypeᐳ[86]"):::bucket
     classDef bucket8 stroke:#dda0dd
     class Bucket8,PgClassExpression87,PgClassExpression88,PgClassExpression90 bucket8
     Bucket9("Bucket 9 (nullableBoundary)<br />Deps: 97<br /><br />ROOT PgSelectSingle{7}ᐸfrmcdc_compoundTypeᐳ[97]"):::bucket
     classDef bucket9 stroke:#ff0000
     class Bucket9,PgClassExpression98,PgClassExpression99,PgClassExpression101 bucket9
-    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 17, 114, 223<br /><br />ROOT Connectionᐸ110ᐳ[114]<br />1: <br />ᐳ: 145, 359, 360, 361, 377<br />2: PgSelect[115]"):::bucket
+    Bucket10("Bucket 10 (nullableBoundary)<br />Deps: 17, 114, 145, 223<br /><br />ROOT Connectionᐸ110ᐳ[114]<br />1: <br />ᐳ: 416, 417, 418, 448<br />2: PgSelect[115]"):::bucket
     classDef bucket10 stroke:#ffff00
-    class Bucket10,PgSelect115,Constant145,Constant359,Constant360,Constant361,Constant377 bucket10
+    class Bucket10,PgSelect115,Constant416,Constant417,Constant418,Constant448 bucket10
     Bucket11("Bucket 11 (listItem)<br />Deps: 223<br /><br />ROOT __Item{11}ᐸ115ᐳ[116]"):::bucket
     classDef bucket11 stroke:#00ffff
     class Bucket11,__Item116,PgSelectSingle117 bucket11
-    Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 117, 116, 223<br /><br />ROOT PgSelectSingle{11}ᐸpostᐳ[117]<br />1: <br />ᐳ: 118, 122, 126, 130, 134, 138, 142, 158, 202, 205, 349, 352, 354, 152, 154, 351<br />2: __ListTransform[235]"):::bucket
+    Bucket12("Bucket 12 (nullableBoundary)<br />Deps: 117, 116, 223<br /><br />ROOT PgSelectSingle{11}ᐸpostᐳ[117]<br />1: <br />ᐳ: 118, 122, 126, 130, 134, 138, 142, 158, 202, 205, 402, 405, 407, 152, 154, 404<br />2: __ListTransform[235]"):::bucket
     classDef bucket12 stroke:#4169e1
-    class Bucket12,PgClassExpression118,PgClassExpression122,PgClassExpression126,PgClassExpression130,PgClassExpression134,PgClassExpression138,PgClassExpression142,PgSelectSingle152,PgClassExpression154,PgClassExpression158,PgClassExpression202,PgClassExpression205,__ListTransform235,RemapKeys349,Access351,RemapKeys352,Access354 bucket12
-    Bucket13("Bucket 13 (listItem)<br /><br />ROOT __Item{13}ᐸ351ᐳ[188]"):::bucket
+    class Bucket12,PgClassExpression118,PgClassExpression122,PgClassExpression126,PgClassExpression130,PgClassExpression134,PgClassExpression138,PgClassExpression142,PgSelectSingle152,PgClassExpression154,PgClassExpression158,PgClassExpression202,PgClassExpression205,__ListTransform235,RemapKeys402,Access404,RemapKeys405,Access407 bucket12
+    Bucket13("Bucket 13 (listItem)<br /><br />ROOT __Item{13}ᐸ404ᐳ[188]"):::bucket
     classDef bucket13 stroke:#3cb371
     class Bucket13,__Item188,PgSelectSingle189 bucket13
     Bucket14("Bucket 14 (nullableBoundary)<br />Deps: 189<br /><br />ROOT PgSelectSingle{13}ᐸpost_computed_compound_type_arrayᐳ[189]"):::bucket
@@ -300,7 +326,7 @@ graph TD
     Bucket18("Bucket 18 (nullableBoundary)<br />Deps: 206<br /><br />ROOT __Item{17}ᐸ205ᐳ[206]"):::bucket
     classDef bucket18 stroke:#00bfff
     class Bucket18 bucket18
-    Bucket19("Bucket 19 (listItem)<br /><br />ROOT __Item{19}ᐸ354ᐳ[225]"):::bucket
+    Bucket19("Bucket 19 (listItem)<br /><br />ROOT __Item{19}ᐸ407ᐳ[225]"):::bucket
     classDef bucket19 stroke:#7f007f
     class Bucket19,__Item225,PgSelectSingle226,PgClassExpression227 bucket19
     Bucket20("Bucket 20 (nullableBoundary)<br />Deps: 227<br /><br />ROOT PgClassExpression{19}ᐸ__post_com...al_set__.vᐳ[227]"):::bucket
@@ -318,22 +344,22 @@ graph TD
     Bucket24("Bucket 24 (nullableBoundary)<br />Deps: 241<br /><br />ROOT PgClassExpression{22}ᐸ__post_com...al_set__.vᐳ[241]"):::bucket
     classDef bucket24 stroke:#808000
     class Bucket24 bucket24
-    Bucket25("Bucket 25 (nullableBoundary)<br />Deps: 17, 261<br /><br />ROOT Connectionᐸ257ᐳ[261]"):::bucket
+    Bucket25("Bucket 25 (nullableBoundary)<br />Deps: 17, 261, 432<br /><br />ROOT Connectionᐸ257ᐳ[261]"):::bucket
     classDef bucket25 stroke:#dda0dd
-    class Bucket25,PgSelect262,Connection279,Connection297,Constant375 bucket25
+    class Bucket25,PgSelect262,Connection279,Connection297 bucket25
     Bucket26("Bucket 26 (listItem)<br />Deps: 279, 297<br /><br />ROOT __Item{26}ᐸ262ᐳ[263]"):::bucket
     classDef bucket26 stroke:#ff0000
     class Bucket26,__Item263,PgSelectSingle264 bucket26
     Bucket27("Bucket 27 (nullableBoundary)<br />Deps: 264, 263, 279, 297<br /><br />ROOT PgSelectSingle{26}ᐸpersonᐳ[264]"):::bucket
     classDef bucket27 stroke:#ffff00
-    class Bucket27,PgClassExpression265,PgClassExpression267,PgSelectSingle310,Access356,RemapKeys357 bucket27
-    Bucket28("Bucket 28 (listItem)<br />Deps: 297<br /><br />ROOT __Item{28}ᐸ356ᐳ[281]"):::bucket
+    class Bucket27,PgClassExpression265,PgClassExpression267,PgSelectSingle310,Access409,RemapKeys410 bucket27
+    Bucket28("Bucket 28 (listItem)<br />Deps: 297<br /><br />ROOT __Item{28}ᐸ409ᐳ[281]"):::bucket
     classDef bucket28 stroke:#00ffff
     class Bucket28,__Item281,PgSelectSingle282 bucket28
     Bucket29("Bucket 29 (nullableBoundary)<br />Deps: 282, 281, 297<br /><br />ROOT PgSelectSingle{28}ᐸperson_friendsᐳ[282]"):::bucket
     classDef bucket29 stroke:#4169e1
-    class Bucket29,PgClassExpression283,PgClassExpression285,Access355 bucket29
-    Bucket30("Bucket 30 (listItem)<br /><br />ROOT __Item{30}ᐸ355ᐳ[299]"):::bucket
+    class Bucket29,PgClassExpression283,PgClassExpression285,Access408 bucket29
+    Bucket30("Bucket 30 (listItem)<br /><br />ROOT __Item{30}ᐸ408ᐳ[299]"):::bucket
     classDef bucket30 stroke:#3cb371
     class Bucket30,__Item299,PgSelectSingle300 bucket30
     Bucket31("Bucket 31 (nullableBoundary)<br />Deps: 300<br /><br />ROOT PgSelectSingle{30}ᐸperson_friendsᐳ[300]"):::bucket
@@ -351,7 +377,10 @@ graph TD
     Bucket35("Bucket 35 (nullableBoundary)<br />Deps: 328<br /><br />ROOT PgSelectSingle{34}ᐸedge_caseᐳ[328]"):::bucket
     classDef bucket35 stroke:#00bfff
     class Bucket35,PgClassExpression329,PgClassExpression330,PgClassExpression332 bucket35
-    Bucket0 --> Bucket1 & Bucket10 & Bucket25 & Bucket33
+    Bucket36("Bucket 36 (nullableBoundary)<br />Deps: 339<br /><br />ROOT PgSelectSingleᐸpersonᐳ[339]"):::bucket
+    classDef bucket36 stroke:#7f007f
+    class Bucket36,PgClassExpression344,PgClassExpression349,PgClassExpression354,PgClassExpression359,PgSelectSingle370,PgClassExpression372,PgSelectSingle383,PgClassExpression385,RemapKeys414 bucket36
+    Bucket0 --> Bucket1 & Bucket10 & Bucket25 & Bucket33 & Bucket36
     Bucket1 --> Bucket2
     Bucket2 --> Bucket3
     Bucket3 --> Bucket4 & Bucket5 & Bucket6 & Bucket7

--- a/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields.sql
+++ b/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields.sql
@@ -1,3 +1,54 @@
+select __person_result__.*
+from (select 0 as idx, $1::"int4" as "id0", $2::"int4" as "id1", $3::"int4" as "id2", $4::"int4" as "id3", $5::"int4" as "id4", $6::"int4" as "id5", $7::"int4" as "id6", $8::"int4" as "id7", $9::"int4" as "id8", $10::"int4" as "id9", $11::"int4" as "id10", $12::"int4" as "id11", $13::"int4" as "id12", $14::"int4" as "id13", $15::"int4" as "id14") as __person_identifiers__,
+lateral (
+  select
+    ("c"."person_optional_missing_middle_4"(
+      __person__,
+      __person_identifiers__."id10",
+      __person_identifiers__."id11",
+      __person_identifiers__."id12"
+    ))::text as "0",
+    __person__."id"::text as "1",
+    ("c"."person_optional_missing_middle_5"(
+      __person_2,
+      __person_identifiers__."id13",
+      __person_identifiers__."id11",
+      __person_identifiers__."id14"
+    ))::text as "2",
+    __person_2."id"::text as "3",
+    ("c"."person_optional_missing_middle_1"(
+      __person_3,
+      __person_identifiers__."id1",
+      "c" := __person_identifiers__."id2"
+    ))::text as "4",
+    ("c"."person_optional_missing_middle_1"(
+      __person_3,
+      __person_identifiers__."id3",
+      __person_identifiers__."id4",
+      __person_identifiers__."id5"
+    ))::text as "5",
+    ("c"."person_optional_missing_middle_2"(
+      __person_3,
+      __person_identifiers__."id6",
+      "c" := __person_identifiers__."id7"
+    ))::text as "6",
+    ("c"."person_optional_missing_middle_3"(
+      __person_3,
+      __person_identifiers__."id8",
+      "c" := __person_identifiers__."id9"
+    ))::text as "7",
+    __person_3."id"::text as "8",
+    __person_identifiers__.idx as "9"
+  from "c"."person" as __person_3
+  left outer join lateral (select (__person_3).*) as __person__
+  on TRUE
+  left outer join lateral (select (__person_3).*) as __person_2
+  on TRUE
+  where (
+    __person_3."id" = __person_identifiers__."id0"
+  )
+) as __person_result__;
+
 select
   __frmcdc_compound_type__."a"::text as "0",
   __frmcdc_compound_type__."foo_bar"::text as "1",

--- a/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields.test.graphql
+++ b/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields.test.graphql
@@ -63,4 +63,12 @@ query {
       computed
     }
   }
+  personById(id: 1) {
+    optionalMissingMiddle1(arg0: 1, c: 7) # expect 10 (b defaults to 2)
+    optionalMissingMiddle1_2: optionalMissingMiddle1(arg0: 1, b: 8, c: 7) # expect 16
+    optionalMissingMiddle2(a: 1, c: 7) # expect 10 (b defaults to 2)
+    optionalMissingMiddle3(a: 1, c: 7) # expect 10 because we can specify $1 positionally and $3 via name, and b defaults to 2
+    optionalMissingMiddle4(arg0: 1, arg2: 7) # expect null because we can't specify $3 without specifying $2 (= null)
+    optionalMissingMiddle5(a: 1, arg2: 7) # expect null because we can't specify $3 without specifying $2 (= null)
+  }
 }

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.export.mjs
@@ -3494,6 +3494,11 @@ const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_compu
 const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
 const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
 const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const person_optional_missing_middle_1FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_1");
+const person_optional_missing_middle_2FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_2");
+const person_optional_missing_middle_3FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_3");
+const person_optional_missing_middle_4FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_4");
+const person_optional_missing_middle_5FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_5");
 const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
 const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
 const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
@@ -7383,6 +7388,216 @@ const registry = makeRegistry({
           serviceName: "main",
           schemaName: "c",
           name: "person_computed_first_arg_inout_out"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_1: {
+      executor,
+      name: "person_optional_missing_middle_1",
+      identifier: "main.c.person_optional_missing_middle_1(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_1"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_2: {
+      executor,
+      name: "person_optional_missing_middle_2",
+      identifier: "main.c.person_optional_missing_middle_2(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_2"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_3: {
+      executor,
+      name: "person_optional_missing_middle_3",
+      identifier: "main.c.person_optional_missing_middle_3(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_3"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_4: {
+      executor,
+      name: "person_optional_missing_middle_4",
+      identifier: "main.c.person_optional_missing_middle_4(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_4"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_5: {
+      executor,
+      name: "person_optional_missing_middle_5",
+      identifier: "main.c.person_optional_missing_middle_5(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_5FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_5"
         },
         tags: {}
       },
@@ -11870,22 +12085,28 @@ const makeArgs56 = (args, path = []) => {
 };
 const resource_person_computed_first_arg_inout_outPgResource = registry.pgResources["person_computed_first_arg_inout_out"];
 const argDetailsSimple57 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
+  graphqlArgName: "arg0",
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
   graphqlArgName: "b",
   postgresArgName: "b",
-  pgCodec: TYPES.text,
-  required: true,
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
   fetcher: null
 }];
 const makeArgs57 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11896,7 +12117,7 @@ const makeArgs57 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 1 - 1) {
         skipped = true;
         continue;
       } else {
@@ -11926,12 +12147,30 @@ const makeArgs57 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
-const argDetailsSimple58 = [];
+const resource_person_optional_missing_middle_1PgResource = registry.pgResources["person_optional_missing_middle_1"];
+const argDetailsSimple58 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs58 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11972,12 +12211,30 @@ const makeArgs58 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
-const argDetailsSimple59 = [];
+const resource_person_optional_missing_middle_2PgResource = registry.pgResources["person_optional_missing_middle_2"];
+const argDetailsSimple59 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs59 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11988,7 +12245,7 @@ const makeArgs59 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 2 - 1) {
         skipped = true;
         continue;
       } else {
@@ -12018,12 +12275,30 @@ const makeArgs59 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
-const argDetailsSimple60 = [];
+const resource_person_optional_missing_middle_3PgResource = registry.pgResources["person_optional_missing_middle_3"];
+const argDetailsSimple60 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs60 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12034,7 +12309,7 @@ const makeArgs60 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -12064,46 +12339,30 @@ const makeArgs60 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_friendsPgResource = registry.pgResources["person_friends"];
-const getSelectPlanFromParentAndArgs15 = ($in, args, _info) => {
-  if (!hasRecord($in)) {
-    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-  }
-  const extraSelectArgs = makeArgs60(args);
-  /**
-   * An optimisation - if all our dependencies are
-   * compatible with the expression's class plan then we
-   * can inline ourselves into that, otherwise we must
-   * issue the query separately.
-   */
-  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-  const selectArgs = [{
-    step: $row.record()
-  }, ...extraSelectArgs];
-  if (resource_person_friendsPgResource.isUnique && !resource_person_friendsPgResource.codec.attributes && typeof resource_person_friendsPgResource.from === "function") {
-    // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
-      if (i === 0) {
-        return $row.getClassStep().alias;
-      } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
-      } else {
-        return $row.placeholder(arg.step);
-      }
-    });
-    return pgClassExpression($row, resource_person_friendsPgResource.codec)`${resource_person_friendsPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
-  }
-  // PERF: or here, if scalar add select to `$row`?
-  return resource_person_friendsPgResource.execute(selectArgs);
-};
-const argDetailsSimple61 = [];
+const resource_person_optional_missing_middle_4PgResource = registry.pgResources["person_optional_missing_middle_4"];
+const argDetailsSimple61 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs61 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12114,7 +12373,7 @@ const makeArgs61 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -12144,52 +12403,24 @@ const makeArgs61 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
-const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
-  if (!hasRecord($in)) {
-    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-  }
-  const extraSelectArgs = makeArgs61(args);
-  /**
-   * An optimisation - if all our dependencies are
-   * compatible with the expression's class plan then we
-   * can inline ourselves into that, otherwise we must
-   * issue the query separately.
-   */
-  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-  const selectArgs = [{
-    step: $row.record()
-  }, ...extraSelectArgs];
-  if (resource_person_type_function_connectionPgResource.isUnique && !resource_person_type_function_connectionPgResource.codec.attributes && typeof resource_person_type_function_connectionPgResource.from === "function") {
-    // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
-      if (i === 0) {
-        return $row.getClassStep().alias;
-      } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
-      } else {
-        return $row.placeholder(arg.step);
-      }
-    });
-    return pgClassExpression($row, resource_person_type_function_connectionPgResource.codec)`${resource_person_type_function_connectionPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
-  }
-  // PERF: or here, if scalar add select to `$row`?
-  return resource_person_type_function_connectionPgResource.execute(selectArgs);
-};
+const resource_person_optional_missing_middle_5PgResource = registry.pgResources["person_optional_missing_middle_5"];
 const argDetailsSimple62 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs62 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12230,7 +12461,7 @@ const makeArgs62 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
+const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
 const argDetailsSimple63 = [];
 const makeArgs63 = (args, path = []) => {
   const selectArgs = [];
@@ -12276,9 +12507,7 @@ const makeArgs63 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
-const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
-const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
+const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
 const argDetailsSimple64 = [];
 const makeArgs64 = (args, path = []) => {
   const selectArgs = [];
@@ -12324,16 +12553,7 @@ const makeArgs64 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
-function UUIDSerialize(value) {
-  return "" + value;
-}
-const coerce = string => {
-  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
-    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
-  }
-  return string;
-};
+const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -12379,8 +12599,8 @@ const makeArgs65 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_interval_setPgResource = registry.pgResources["post_computed_interval_set"];
-const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
+const resource_person_friendsPgResource = registry.pgResources["person_friends"];
+const getSelectPlanFromParentAndArgs15 = ($in, args, _info) => {
   if (!hasRecord($in)) {
     throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
   }
@@ -12396,23 +12616,33 @@ const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
   const selectArgs = [{
     step: $row.record()
   }, ...extraSelectArgs];
-  if (resource_post_computed_interval_setPgResource.isUnique && !resource_post_computed_interval_setPgResource.codec.attributes && typeof resource_post_computed_interval_setPgResource.from === "function") {
+  if (resource_person_friendsPgResource.isUnique && !resource_person_friendsPgResource.codec.attributes && typeof resource_person_friendsPgResource.from === "function") {
     // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
       if (i === 0) {
-        return $row.getClassStep().alias;
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
       } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
       } else {
-        return $row.placeholder(arg.step);
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
       }
     });
-    return pgClassExpression($row, resource_post_computed_interval_setPgResource.codec)`${resource_post_computed_interval_setPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
+    return pgClassExpression($row, resource_person_friendsPgResource.codec)`${resource_person_friendsPgResource.from(...newSelectArgs)}`;
   }
   // PERF: or here, if scalar add select to `$row`?
-  return resource_post_computed_interval_setPgResource.execute(selectArgs);
+  return resource_person_friendsPgResource.execute(selectArgs);
 };
 const argDetailsSimple66 = [];
 const makeArgs66 = (args, path = []) => {
@@ -12459,12 +12689,62 @@ const makeArgs66 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_interval_arrayPgResource = registry.pgResources["post_computed_interval_array"];
-const argDetailsSimple67 = [];
+const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
+const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
+  if (!hasRecord($in)) {
+    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+  }
+  const extraSelectArgs = makeArgs66(args);
+  /**
+   * An optimisation - if all our dependencies are
+   * compatible with the expression's class plan then we
+   * can inline ourselves into that, otherwise we must
+   * issue the query separately.
+   */
+  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+  const selectArgs = [{
+    step: $row.record()
+  }, ...extraSelectArgs];
+  if (resource_person_type_function_connectionPgResource.isUnique && !resource_person_type_function_connectionPgResource.codec.attributes && typeof resource_person_type_function_connectionPgResource.from === "function") {
+    // This is a scalar computed attribute, let's inline the expression
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
+      if (i === 0) {
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
+      } else if ("pgCodec" in arg && arg.pgCodec) {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
+      } else {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
+      }
+    });
+    return pgClassExpression($row, resource_person_type_function_connectionPgResource.codec)`${resource_person_type_function_connectionPgResource.from(...newSelectArgs)}`;
+  }
+  // PERF: or here, if scalar add select to `$row`?
+  return resource_person_type_function_connectionPgResource.execute(selectArgs);
+};
+const argDetailsSimple67 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs67 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12505,18 +12785,12 @@ const makeArgs67 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_text_arrayPgResource = registry.pgResources["post_computed_text_array"];
-const argDetailsSimple68 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: false,
-  fetcher: null
-}];
+const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
+const argDetailsSimple68 = [];
 const makeArgs68 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12557,18 +12831,14 @@ const makeArgs68 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_with_optional_argPgResource = registry.pgResources["post_computed_with_optional_arg"];
-const argDetailsSimple69 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
+const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
+const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
+const argDetailsSimple69 = [];
 const makeArgs69 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12609,24 +12879,21 @@ const makeArgs69 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_with_required_argPgResource = registry.pgResources["post_computed_with_required_arg"];
-const argDetailsSimple70 = [{
-  graphqlArgName: "length",
-  postgresArgName: "length",
-  pgCodec: TYPES.int,
-  required: false,
-  fetcher: null
-}, {
-  graphqlArgName: "omission",
-  postgresArgName: "omission",
-  pgCodec: TYPES.text,
-  required: false,
-  fetcher: null
-}];
+const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
+function UUIDSerialize(value) {
+  return "" + value;
+}
+const coerce = string => {
+  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
+    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
+  }
+  return string;
+};
+const argDetailsSimple70 = [];
 const makeArgs70 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12667,24 +12934,56 @@ const makeArgs70 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmedPgResource = registry.pgResources["post_headline_trimmed"];
-const argDetailsSimple71 = [{
-  graphqlArgName: "length",
-  postgresArgName: "length",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "omission",
-  postgresArgName: "omission",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_post_computed_interval_setPgResource = registry.pgResources["post_computed_interval_set"];
+const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
+  if (!hasRecord($in)) {
+    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+  }
+  const extraSelectArgs = makeArgs70(args);
+  /**
+   * An optimisation - if all our dependencies are
+   * compatible with the expression's class plan then we
+   * can inline ourselves into that, otherwise we must
+   * issue the query separately.
+   */
+  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+  const selectArgs = [{
+    step: $row.record()
+  }, ...extraSelectArgs];
+  if (resource_post_computed_interval_setPgResource.isUnique && !resource_post_computed_interval_setPgResource.codec.attributes && typeof resource_post_computed_interval_setPgResource.from === "function") {
+    // This is a scalar computed attribute, let's inline the expression
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
+      if (i === 0) {
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
+      } else if ("pgCodec" in arg && arg.pgCodec) {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
+      } else {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
+      }
+    });
+    return pgClassExpression($row, resource_post_computed_interval_setPgResource.codec)`${resource_post_computed_interval_setPgResource.from(...newSelectArgs)}`;
+  }
+  // PERF: or here, if scalar add select to `$row`?
+  return resource_post_computed_interval_setPgResource.execute(selectArgs);
+};
+const argDetailsSimple71 = [];
 const makeArgs71 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12725,24 +13024,12 @@ const makeArgs71 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmed_no_defaultsPgResource = registry.pgResources["post_headline_trimmed_no_defaults"];
-const argDetailsSimple72 = [{
-  graphqlArgName: "length",
-  postgresArgName: "length",
-  pgCodec: TYPES.int,
-  required: false,
-  fetcher: null
-}, {
-  graphqlArgName: "omission",
-  postgresArgName: "omission",
-  pgCodec: TYPES.text,
-  required: false,
-  fetcher: null
-}];
+const resource_post_computed_interval_arrayPgResource = registry.pgResources["post_computed_interval_array"];
+const argDetailsSimple72 = [];
 const makeArgs72 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12783,12 +13070,12 @@ const makeArgs72 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmed_strictPgResource = registry.pgResources["post_headline_trimmed_strict"];
+const resource_post_computed_text_arrayPgResource = registry.pgResources["post_computed_text_array"];
 const argDetailsSimple73 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
-  required: true,
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: false,
   fetcher: null
 }];
 const makeArgs73 = (args, path = []) => {
@@ -12802,6 +13089,284 @@ const makeArgs73 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple73[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_computed_with_optional_argPgResource = registry.pgResources["post_computed_with_optional_arg"];
+const argDetailsSimple74 = [{
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs74 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple74[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_computed_with_required_argPgResource = registry.pgResources["post_computed_with_required_arg"];
+const argDetailsSimple75 = [{
+  graphqlArgName: "length",
+  postgresArgName: "length",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "omission",
+  postgresArgName: "omission",
+  pgCodec: TYPES.text,
+  required: false,
+  fetcher: null
+}];
+const makeArgs75 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple75[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_headline_trimmedPgResource = registry.pgResources["post_headline_trimmed"];
+const argDetailsSimple76 = [{
+  graphqlArgName: "length",
+  postgresArgName: "length",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "omission",
+  postgresArgName: "omission",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
+const makeArgs76 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple76[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_headline_trimmed_no_defaultsPgResource = registry.pgResources["post_headline_trimmed_no_defaults"];
+const argDetailsSimple77 = [{
+  graphqlArgName: "length",
+  postgresArgName: "length",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "omission",
+  postgresArgName: "omission",
+  pgCodec: TYPES.text,
+  required: false,
+  fetcher: null
+}];
+const makeArgs77 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple77[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_headline_trimmed_strictPgResource = registry.pgResources["post_headline_trimmed_strict"];
+const argDetailsSimple78 = [{
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
+  required: true,
+  fetcher: null
+}];
+const makeArgs78 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple78[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -12892,236 +13457,6 @@ const parseValueLiteral = (ast, variables) => {
       return undefined;
   }
 };
-const argDetailsSimple74 = [];
-const makeArgs74 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple74[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
-const argDetailsSimple75 = [];
-const makeArgs75 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple75[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
-const argDetailsSimple76 = [];
-const makeArgs76 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple76[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
-const argDetailsSimple77 = [];
-const makeArgs77 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple77[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
-const argDetailsSimple78 = [];
-const makeArgs78 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple78[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
 const argDetailsSimple79 = [];
 const makeArgs79 = (args, path = []) => {
   const selectArgs = [];
@@ -13167,7 +13502,7 @@ const makeArgs79 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
+const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
 const argDetailsSimple80 = [];
 const makeArgs80 = (args, path = []) => {
   const selectArgs = [];
@@ -13213,18 +13548,12 @@ const makeArgs80 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
-const argDetailsSimple81 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
+const argDetailsSimple81 = [];
 const makeArgs81 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13265,18 +13594,12 @@ const makeArgs81 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
-const argDetailsSimple82 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
+const argDetailsSimple82 = [];
 const makeArgs82 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13317,18 +13640,12 @@ const makeArgs82 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
-const argDetailsSimple83 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
+const argDetailsSimple83 = [];
 const makeArgs83 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13369,18 +13686,12 @@ const makeArgs83 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
-const argDetailsSimple84 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
+const argDetailsSimple84 = [];
 const makeArgs84 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13421,18 +13732,12 @@ const makeArgs84 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
-const argDetailsSimple85 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
+const argDetailsSimple85 = [];
 const makeArgs85 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13473,12 +13778,12 @@ const makeArgs85 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
+const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
 const argDetailsSimple86 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: false,
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
   fetcher: null
 }];
 const makeArgs86 = (args, path = []) => {
@@ -13525,16 +13830,10 @@ const makeArgs86 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
+const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
 const argDetailsSimple87 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: null,
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "arg1",
-  postgresArgName: null,
+  graphqlArgName: "i",
+  postgresArgName: "i",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -13542,7 +13841,7 @@ const argDetailsSimple87 = [{
 const makeArgs87 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13553,7 +13852,7 @@ const makeArgs87 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 2 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13583,24 +13882,18 @@ const makeArgs87 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
+const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
 const argDetailsSimple88 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.json,
   required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.int,
-  required: false,
   fetcher: null
 }];
 const makeArgs88 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13641,24 +13934,18 @@ const makeArgs88 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
+const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
 const argDetailsSimple89 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "arg1",
-  postgresArgName: "",
-  pgCodec: TYPES.int,
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.jsonb,
   required: true,
   fetcher: null
 }];
 const makeArgs89 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13669,7 +13956,7 @@ const makeArgs89 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 2 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13699,24 +13986,18 @@ const makeArgs89 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
+const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
 const argDetailsSimple90 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: "",
-  pgCodec: TYPES.int,
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
   required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.int,
-  required: false,
   fetcher: null
 }];
 const makeArgs90 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13727,7 +14008,7 @@ const makeArgs90 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 1 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13757,24 +14038,18 @@ const makeArgs90 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
+const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
 const argDetailsSimple91 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: "",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.int,
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
   required: false,
   fetcher: null
 }];
 const makeArgs91 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13785,7 +14060,7 @@ const makeArgs91 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 1 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13815,7 +14090,7 @@ const makeArgs91 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
+const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
 const argDetailsSimple92 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -13873,18 +14148,18 @@ const makeArgs92 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_1PgResource = registry.pgResources["mult_1"];
+const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
 const argDetailsSimple93 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: null,
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "arg1",
-  postgresArgName: null,
+  graphqlArgName: "b",
+  postgresArgName: "b",
   pgCodec: TYPES.int,
-  required: true,
+  required: false,
   fetcher: null
 }];
 const makeArgs93 = (args, path = []) => {
@@ -13901,7 +14176,7 @@ const makeArgs93 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 2 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13931,16 +14206,16 @@ const makeArgs93 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_2PgResource = registry.pgResources["mult_2"];
+const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
 const argDetailsSimple94 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: null,
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
   graphqlArgName: "arg1",
-  postgresArgName: null,
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -13989,18 +14264,18 @@ const makeArgs94 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_3PgResource = registry.pgResources["mult_3"];
+const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
 const argDetailsSimple95 = [{
   graphqlArgName: "arg0",
-  postgresArgName: null,
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "arg1",
-  postgresArgName: null,
+  graphqlArgName: "b",
+  postgresArgName: "b",
   pgCodec: TYPES.int,
-  required: true,
+  required: false,
   fetcher: null
 }];
 const makeArgs95 = (args, path = []) => {
@@ -14014,6 +14289,296 @@ const makeArgs95 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple95[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 1 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
+const argDetailsSimple96 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
+const makeArgs96 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple96[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 1 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
+const argDetailsSimple97 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs97 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple97[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 2 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mult_1PgResource = registry.pgResources["mult_1"];
+const argDetailsSimple98 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs98 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple98[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 2 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mult_2PgResource = registry.pgResources["mult_2"];
+const argDetailsSimple99 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs99 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple99[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 2 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mult_3PgResource = registry.pgResources["mult_3"];
+const argDetailsSimple100 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs100 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple100[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -14048,7 +14613,7 @@ const makeArgs95 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_4PgResource = registry.pgResources["mult_4"];
-const argDetailsSimple96 = [{
+const argDetailsSimple101 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
   pgCodec: TYPES.int,
@@ -14061,258 +14626,10 @@ const argDetailsSimple96 = [{
   required: true,
   fetcher: null
 }];
-const makeArgs96 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 2; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple96[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
-const argDetailsSimple97 = [];
-const makeArgs97 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple97[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
-const argDetailsSimple98 = [];
-const makeArgs98 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple98[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
-const argDetailsSimple99 = [];
-const makeArgs99 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple99[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
-const argDetailsSimple100 = [{
-  graphqlArgName: "x",
-  postgresArgName: "x",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "y",
-  postgresArgName: "y",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "z",
-  postgresArgName: "z",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
-const makeArgs100 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 3; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple100[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
-const argDetailsSimple101 = [];
 const makeArgs101 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14353,18 +14670,12 @@ const makeArgs101 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
-const argDetailsSimple102 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
+const argDetailsSimple102 = [];
 const makeArgs102 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14405,18 +14716,12 @@ const makeArgs102 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
-const argDetailsSimple103 = [{
-  graphqlArgName: "g",
-  postgresArgName: "g",
-  pgCodec: guidCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
+const argDetailsSimple103 = [];
 const makeArgs103 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14457,7 +14762,7 @@ const makeArgs103 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_guid_fnPgResource = registry.pgResources["guid_fn"];
+const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
 const argDetailsSimple104 = [];
 const makeArgs104 = (args, path = []) => {
   const selectArgs = [];
@@ -14503,12 +14808,30 @@ const makeArgs104 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
-const argDetailsSimple105 = [];
+const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
+const argDetailsSimple105 = [{
+  graphqlArgName: "x",
+  postgresArgName: "x",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "y",
+  postgresArgName: "y",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "z",
+  postgresArgName: "z",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs105 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14549,30 +14872,12 @@ const makeArgs105 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
-const argDetailsSimple106 = [{
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: textArrayCodec,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "d",
-  postgresArgName: "d",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "e",
-  postgresArgName: "e",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
+const argDetailsSimple106 = [];
 const makeArgs106 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14613,12 +14918,18 @@ const makeArgs106 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_list_bde_mutationPgResource = registry.pgResources["list_bde_mutation"];
-const argDetailsSimple107 = [];
+const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
+const argDetailsSimple107 = [{
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs107 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14659,30 +14970,18 @@ const makeArgs107 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_failPgResource = registry.pgResources["authenticate_fail"];
+const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
 const argDetailsSimple108 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.numeric,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.bigint,
+  graphqlArgName: "g",
+  postgresArgName: "g",
+  pgCodec: guidCodec,
   required: true,
   fetcher: null
 }];
 const makeArgs108 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14723,18 +15022,12 @@ const makeArgs108 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticatePgResource = registry.pgResources["authenticate"];
-const argDetailsSimple109 = [{
-  graphqlArgName: "leftArm",
-  postgresArgName: "left_arm",
-  pgCodec: leftArmCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_guid_fnPgResource = registry.pgResources["guid_fn"];
+const argDetailsSimple109 = [];
 const makeArgs109 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14775,7 +15068,7 @@ const makeArgs109 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
+const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
 const argDetailsSimple110 = [];
 const makeArgs110 = (args, path = []) => {
   const selectArgs = [];
@@ -14821,12 +15114,30 @@ const makeArgs110 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
-const argDetailsSimple111 = [];
+const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
+const argDetailsSimple111 = [{
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: textArrayCodec,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "d",
+  postgresArgName: "d",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "e",
+  postgresArgName: "e",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
 const makeArgs111 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14867,30 +15178,12 @@ const makeArgs111 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
-const argDetailsSimple112 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.numeric,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.bigint,
-  required: true,
-  fetcher: null
-}];
+const resource_list_bde_mutationPgResource = registry.pgResources["list_bde_mutation"];
+const argDetailsSimple112 = [];
 const makeArgs112 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14931,7 +15224,7 @@ const makeArgs112 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_manyPgResource = registry.pgResources["authenticate_many"];
+const resource_authenticate_failPgResource = registry.pgResources["authenticate_fail"];
 const argDetailsSimple113 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -14995,48 +15288,18 @@ const makeArgs113 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_payloadPgResource = registry.pgResources["authenticate_payload"];
+const resource_authenticatePgResource = registry.pgResources["authenticate"];
 const argDetailsSimple114 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.bigint,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.boolean,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.varchar,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "d",
-  postgresArgName: "d",
-  pgCodec: int4ArrayCodec,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "e",
-  postgresArgName: "e",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "f",
-  postgresArgName: "f",
-  pgCodec: floatrangeCodec,
+  graphqlArgName: "leftArm",
+  postgresArgName: "left_arm",
+  pgCodec: leftArmCodec,
   required: true,
   fetcher: null
 }];
 const makeArgs114 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 6; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15077,18 +15340,12 @@ const makeArgs114 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
-const argDetailsSimple115 = [{
-  graphqlArgName: "i1",
-  postgresArgName: "i1",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
+const argDetailsSimple115 = [];
 const makeArgs115 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15129,18 +15386,12 @@ const makeArgs115 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
-const argDetailsSimple116 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
+const argDetailsSimple116 = [];
 const makeArgs116 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15181,18 +15432,30 @@ const makeArgs116 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_mutationPgResource = registry.pgResources["compound_type_mutation"];
+const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
 const argDetailsSimple117 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.numeric,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.bigint,
   required: true,
   fetcher: null
 }];
 const makeArgs117 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15233,18 +15496,30 @@ const makeArgs117 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
+const resource_authenticate_manyPgResource = registry.pgResources["authenticate_many"];
 const argDetailsSimple118 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.numeric,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.bigint,
   required: true,
   fetcher: null
 }];
 const makeArgs118 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15285,24 +15560,48 @@ const makeArgs118 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
+const resource_authenticate_payloadPgResource = registry.pgResources["authenticate_payload"];
 const argDetailsSimple119 = [{
-  graphqlArgName: "post",
-  postgresArgName: "post",
-  pgCodec: postCodec,
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.bigint,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "suffix",
-  postgresArgName: "suffix",
-  pgCodec: TYPES.text,
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.boolean,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.varchar,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "d",
+  postgresArgName: "d",
+  pgCodec: int4ArrayCodec,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "e",
+  postgresArgName: "e",
+  pgCodec: TYPES.json,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "f",
+  postgresArgName: "f",
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
 const makeArgs119 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 6; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15343,11 +15642,11 @@ const makeArgs119 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_with_suffixPgResource = registry.pgResources["post_with_suffix"];
+const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
 const argDetailsSimple120 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
+  graphqlArgName: "i1",
+  postgresArgName: "i1",
+  pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }];
@@ -15395,7 +15694,7 @@ const makeArgs120 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
+const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
 const argDetailsSimple121 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -15447,11 +15746,11 @@ const makeArgs121 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_array_mutationPgResource = registry.pgResources["compound_type_array_mutation"];
+const resource_compound_type_mutationPgResource = registry.pgResources["compound_type_mutation"];
 const argDetailsSimple122 = [{
-  graphqlArgName: "posts",
-  postgresArgName: "posts",
-  pgCodec: postArrayCodec,
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -15499,24 +15798,18 @@ const makeArgs122 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_manyPgResource = registry.pgResources["post_many"];
+const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
 const argDetailsSimple123 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
+  graphqlArgName: "id",
+  postgresArgName: "id",
   pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs123 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15557,16 +15850,16 @@ const makeArgs123 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
+const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
 const argDetailsSimple124 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
+  graphqlArgName: "post",
+  postgresArgName: "post",
+  pgCodec: postCodec,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
+  graphqlArgName: "suffix",
+  postgresArgName: "suffix",
   pgCodec: TYPES.text,
   required: true,
   fetcher: null
@@ -15615,12 +15908,18 @@ const makeArgs124 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
-const argDetailsSimple125 = [];
+const resource_post_with_suffixPgResource = registry.pgResources["post_with_suffix"];
+const argDetailsSimple125 = [{
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs125 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15661,12 +15960,18 @@ const makeArgs125 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
-const argDetailsSimple126 = [];
+const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
+const argDetailsSimple126 = [{
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs126 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15707,12 +16012,18 @@ const makeArgs126 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
-const argDetailsSimple127 = [];
+const resource_compound_type_array_mutationPgResource = registry.pgResources["compound_type_array_mutation"];
+const argDetailsSimple127 = [{
+  graphqlArgName: "posts",
+  postgresArgName: "posts",
+  pgCodec: postArrayCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs127 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15753,12 +16064,24 @@ const makeArgs127 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
-const argDetailsSimple128 = [];
+const resource_post_manyPgResource = registry.pgResources["post_many"];
+const argDetailsSimple128 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
 const makeArgs128 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15799,18 +16122,24 @@ const makeArgs128 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_type_function_connection_mutationPgResource = registry.pgResources["type_function_connection_mutation"];
+const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
 const argDetailsSimple129 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs129 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15851,7 +16180,7 @@ const makeArgs129 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_type_function_mutationPgResource = registry.pgResources["type_function_mutation"];
+const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
 const argDetailsSimple130 = [];
 const makeArgs130 = (args, path = []) => {
   const selectArgs = [];
@@ -15864,6 +16193,242 @@ const makeArgs130 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple130[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
+const argDetailsSimple131 = [];
+const makeArgs131 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple131[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
+const argDetailsSimple132 = [];
+const makeArgs132 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple132[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
+const argDetailsSimple133 = [];
+const makeArgs133 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple133[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_type_function_connection_mutationPgResource = registry.pgResources["type_function_connection_mutation"];
+const argDetailsSimple134 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs134 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple134[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_type_function_mutationPgResource = registry.pgResources["type_function_mutation"];
+const argDetailsSimple135 = [];
+const makeArgs135 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple135[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -17460,6 +18025,11 @@ type Person implements Node {
   computedInoutOut(ino: String): PersonComputedInoutOutRecord
   exists(email: Email): Boolean @deprecated(reason: "This is deprecated (comment on function c.person_exists).")
   computedFirstArgInoutOut: PersonComputedFirstArgInoutOutRecord
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, b: Int, arg2: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
   computedComplex(a: Int, b: String): PersonComputedComplexRecord
 
   """The first post by the person."""
@@ -28938,18 +29508,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_outPgResource.isUnique && !resource_person_computed_outPgResource.codec.attributes && typeof resource_person_computed_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_outPgResource.codec)`${resource_person_computed_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_outPgResource.codec)`${resource_person_computed_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_outPgResource.execute(selectArgs);
@@ -28972,18 +29552,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_first_namePgResource.isUnique && !resource_person_first_namePgResource.codec.attributes && typeof resource_person_first_namePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_first_namePgResource.codec)`${resource_person_first_namePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_first_namePgResource.codec)`${resource_person_first_namePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_first_namePgResource.execute(selectArgs);
@@ -29006,18 +29596,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_out_outPgResource.isUnique && !resource_person_computed_out_outPgResource.codec.attributes && typeof resource_person_computed_out_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_out_outPgResource.codec)`${resource_person_computed_out_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_out_outPgResource.codec)`${resource_person_computed_out_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_out_outPgResource.execute(selectArgs);
@@ -29041,18 +29641,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_computed_inoutPgResource.isUnique && !resource_person_computed_inoutPgResource.codec.attributes && typeof resource_person_computed_inoutPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_inoutPgResource.codec)`${resource_person_computed_inoutPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_computed_inoutPgResource.codec)`${resource_person_computed_inoutPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_inoutPgResource.execute(selectArgs);
@@ -29080,18 +29690,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_computed_inout_outPgResource.isUnique && !resource_person_computed_inout_outPgResource.codec.attributes && typeof resource_person_computed_inout_outPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_inout_outPgResource.codec)`${resource_person_computed_inout_outPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_computed_inout_outPgResource.codec)`${resource_person_computed_inout_outPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_inout_outPgResource.execute(selectArgs);
@@ -29119,18 +29739,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_existsPgResource.isUnique && !resource_person_existsPgResource.codec.attributes && typeof resource_person_existsPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_existsPgResource.codec)`${resource_person_existsPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_existsPgResource.codec)`${resource_person_existsPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_existsPgResource.execute(selectArgs);
@@ -29157,23 +29787,33 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_first_arg_inout_outPgResource.isUnique && !resource_person_computed_first_arg_inout_outPgResource.codec.attributes && typeof resource_person_computed_first_arg_inout_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_first_arg_inout_outPgResource.codec)`${resource_person_computed_first_arg_inout_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_first_arg_inout_outPgResource.codec)`${resource_person_computed_first_arg_inout_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_first_arg_inout_outPgResource.execute(selectArgs);
     },
-    computedComplex: {
+    optionalMissingMiddle1: {
       plan($in, args, _info) {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -29190,20 +29830,285 @@ export const plans = {
         const selectArgs = [{
           step: $row.record()
         }, ...extraSelectArgs];
-        if (resource_person_computed_complexPgResource.isUnique && !resource_person_computed_complexPgResource.codec.attributes && typeof resource_person_computed_complexPgResource.from === "function") {
+        if (resource_person_optional_missing_middle_1PgResource.isUnique && !resource_person_optional_missing_middle_1PgResource.codec.attributes && typeof resource_person_optional_missing_middle_1PgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_complexPgResource.codec)`${resource_person_computed_complexPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_optional_missing_middle_1PgResource.codec)`${resource_person_optional_missing_middle_1PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_1PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle2: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs58(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_2PgResource.isUnique && !resource_person_optional_missing_middle_2PgResource.codec.attributes && typeof resource_person_optional_missing_middle_2PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_2PgResource.codec)`${resource_person_optional_missing_middle_2PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_2PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        b: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle3: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs59(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_3PgResource.isUnique && !resource_person_optional_missing_middle_3PgResource.codec.attributes && typeof resource_person_optional_missing_middle_3PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_3PgResource.codec)`${resource_person_optional_missing_middle_3PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_3PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle4: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs60(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_4PgResource.isUnique && !resource_person_optional_missing_middle_4PgResource.codec.attributes && typeof resource_person_optional_missing_middle_4PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_4PgResource.codec)`${resource_person_optional_missing_middle_4PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_4PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        arg2: undefined
+      }
+    },
+    optionalMissingMiddle5: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs61(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_5PgResource.isUnique && !resource_person_optional_missing_middle_5PgResource.codec.attributes && typeof resource_person_optional_missing_middle_5PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_5PgResource.codec)`${resource_person_optional_missing_middle_5PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_5PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        arg2: undefined
+      }
+    },
+    computedComplex: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs62(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_computed_complexPgResource.isUnique && !resource_person_computed_complexPgResource.codec.attributes && typeof resource_person_computed_complexPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_computed_complexPgResource.codec)`${resource_person_computed_complexPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_complexPgResource.execute(selectArgs);
@@ -29217,7 +30122,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs58(args);
+      const extraSelectArgs = makeArgs63(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29231,18 +30136,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_first_postPgResource.isUnique && !resource_person_first_postPgResource.codec.attributes && typeof resource_person_first_postPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_first_postPgResource.codec)`${resource_person_first_postPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_first_postPgResource.codec)`${resource_person_first_postPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_first_postPgResource.execute(selectArgs);
@@ -29251,7 +30166,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs59(args);
+      const extraSelectArgs = makeArgs64(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29265,18 +30180,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_first_arg_inoutPgResource.isUnique && !resource_person_computed_first_arg_inoutPgResource.codec.attributes && typeof resource_person_computed_first_arg_inoutPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_first_arg_inoutPgResource.codec)`${resource_person_computed_first_arg_inoutPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_first_arg_inoutPgResource.codec)`${resource_person_computed_first_arg_inoutPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_first_arg_inoutPgResource.execute(selectArgs);
@@ -29381,7 +30306,7 @@ export const plans = {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
         }
-        const extraSelectArgs = makeArgs62(args);
+        const extraSelectArgs = makeArgs67(args);
         /**
          * An optimisation - if all our dependencies are
          * compatible with the expression's class plan then we
@@ -29395,18 +30320,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_type_functionPgResource.isUnique && !resource_person_type_functionPgResource.codec.attributes && typeof resource_person_type_functionPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_type_functionPgResource.codec)`${resource_person_type_functionPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_type_functionPgResource.codec)`${resource_person_type_functionPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_type_functionPgResource.execute(selectArgs);
@@ -29419,7 +30354,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs63(args);
+      const extraSelectArgs = makeArgs68(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29433,18 +30368,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_type_function_listPgResource.isUnique && !resource_person_type_function_listPgResource.codec.attributes && typeof resource_person_type_function_listPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_type_function_listPgResource.codec)`${resource_person_type_function_listPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_type_function_listPgResource.codec)`${resource_person_type_function_listPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_type_function_listPgResource.execute(selectArgs);
@@ -29791,7 +30736,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs64(args);
+      const extraSelectArgs = makeArgs69(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29805,18 +30750,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_compound_type_computed_fieldPgResource.isUnique && !resource_compound_type_computed_fieldPgResource.codec.attributes && typeof resource_compound_type_computed_fieldPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_compound_type_computed_fieldPgResource.codec)`${resource_compound_type_computed_fieldPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_compound_type_computed_fieldPgResource.codec)`${resource_compound_type_computed_fieldPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_compound_type_computed_fieldPgResource.execute(selectArgs);
@@ -29960,7 +30915,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs66(args);
+      const extraSelectArgs = makeArgs71(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29974,18 +30929,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_post_computed_interval_arrayPgResource.isUnique && !resource_post_computed_interval_arrayPgResource.codec.attributes && typeof resource_post_computed_interval_arrayPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_post_computed_interval_arrayPgResource.codec)`${resource_post_computed_interval_arrayPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_post_computed_interval_arrayPgResource.codec)`${resource_post_computed_interval_arrayPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_post_computed_interval_arrayPgResource.execute(selectArgs);
@@ -29994,7 +30959,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs67(args);
+      const extraSelectArgs = makeArgs72(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -30008,221 +30973,33 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_post_computed_text_arrayPgResource.isUnique && !resource_post_computed_text_arrayPgResource.codec.attributes && typeof resource_post_computed_text_arrayPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_post_computed_text_arrayPgResource.codec)`${resource_post_computed_text_arrayPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_post_computed_text_arrayPgResource.codec)`${resource_post_computed_text_arrayPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_post_computed_text_arrayPgResource.execute(selectArgs);
     },
     computedWithOptionalArg: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs68(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_computed_with_optional_argPgResource.isUnique && !resource_post_computed_with_optional_argPgResource.codec.attributes && typeof resource_post_computed_with_optional_argPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_computed_with_optional_argPgResource.codec)`${resource_post_computed_with_optional_argPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_computed_with_optional_argPgResource.execute(selectArgs);
-      },
-      args: {
-        i: undefined
-      }
-    },
-    computedWithRequiredArg: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs69(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_computed_with_required_argPgResource.isUnique && !resource_post_computed_with_required_argPgResource.codec.attributes && typeof resource_post_computed_with_required_argPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_computed_with_required_argPgResource.codec)`${resource_post_computed_with_required_argPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_computed_with_required_argPgResource.execute(selectArgs);
-      },
-      args: {
-        i: undefined
-      }
-    },
-    headlineTrimmed: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs70(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_headline_trimmedPgResource.isUnique && !resource_post_headline_trimmedPgResource.codec.attributes && typeof resource_post_headline_trimmedPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_headline_trimmedPgResource.codec)`${resource_post_headline_trimmedPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_headline_trimmedPgResource.execute(selectArgs);
-      },
-      args: {
-        length: undefined,
-        omission: undefined
-      }
-    },
-    headlineTrimmedNoDefaults: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs71(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_headline_trimmed_no_defaultsPgResource.isUnique && !resource_post_headline_trimmed_no_defaultsPgResource.codec.attributes && typeof resource_post_headline_trimmed_no_defaultsPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_headline_trimmed_no_defaultsPgResource.codec)`${resource_post_headline_trimmed_no_defaultsPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_headline_trimmed_no_defaultsPgResource.execute(selectArgs);
-      },
-      args: {
-        length: undefined,
-        omission: undefined
-      }
-    },
-    headlineTrimmedStrict: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs72(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_headline_trimmed_strictPgResource.isUnique && !resource_post_headline_trimmed_strictPgResource.codec.attributes && typeof resource_post_headline_trimmed_strictPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_headline_trimmed_strictPgResource.codec)`${resource_post_headline_trimmed_strictPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_headline_trimmed_strictPgResource.execute(selectArgs);
-      },
-      args: {
-        length: undefined,
-        omission: undefined
-      }
-    },
-    computedCompoundTypeArray: {
       plan($in, args, _info) {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -30239,20 +31016,278 @@ export const plans = {
         const selectArgs = [{
           step: $row.record()
         }, ...extraSelectArgs];
-        if (resource_post_computed_compound_type_arrayPgResource.isUnique && !resource_post_computed_compound_type_arrayPgResource.codec.attributes && typeof resource_post_computed_compound_type_arrayPgResource.from === "function") {
+        if (resource_post_computed_with_optional_argPgResource.isUnique && !resource_post_computed_with_optional_argPgResource.codec.attributes && typeof resource_post_computed_with_optional_argPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_post_computed_compound_type_arrayPgResource.codec)`${resource_post_computed_compound_type_arrayPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_post_computed_with_optional_argPgResource.codec)`${resource_post_computed_with_optional_argPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_computed_with_optional_argPgResource.execute(selectArgs);
+      },
+      args: {
+        i: undefined
+      }
+    },
+    computedWithRequiredArg: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs74(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_computed_with_required_argPgResource.isUnique && !resource_post_computed_with_required_argPgResource.codec.attributes && typeof resource_post_computed_with_required_argPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_computed_with_required_argPgResource.codec)`${resource_post_computed_with_required_argPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_computed_with_required_argPgResource.execute(selectArgs);
+      },
+      args: {
+        i: undefined
+      }
+    },
+    headlineTrimmed: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs75(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_headline_trimmedPgResource.isUnique && !resource_post_headline_trimmedPgResource.codec.attributes && typeof resource_post_headline_trimmedPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_headline_trimmedPgResource.codec)`${resource_post_headline_trimmedPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_headline_trimmedPgResource.execute(selectArgs);
+      },
+      args: {
+        length: undefined,
+        omission: undefined
+      }
+    },
+    headlineTrimmedNoDefaults: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs76(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_headline_trimmed_no_defaultsPgResource.isUnique && !resource_post_headline_trimmed_no_defaultsPgResource.codec.attributes && typeof resource_post_headline_trimmed_no_defaultsPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_headline_trimmed_no_defaultsPgResource.codec)`${resource_post_headline_trimmed_no_defaultsPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_headline_trimmed_no_defaultsPgResource.execute(selectArgs);
+      },
+      args: {
+        length: undefined,
+        omission: undefined
+      }
+    },
+    headlineTrimmedStrict: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs77(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_headline_trimmed_strictPgResource.isUnique && !resource_post_headline_trimmed_strictPgResource.codec.attributes && typeof resource_post_headline_trimmed_strictPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_headline_trimmed_strictPgResource.codec)`${resource_post_headline_trimmed_strictPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_headline_trimmed_strictPgResource.execute(selectArgs);
+      },
+      args: {
+        length: undefined,
+        omission: undefined
+      }
+    },
+    computedCompoundTypeArray: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs78(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_computed_compound_type_arrayPgResource.isUnique && !resource_post_computed_compound_type_arrayPgResource.codec.attributes && typeof resource_post_computed_compound_type_arrayPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_computed_compound_type_arrayPgResource.codec)`${resource_post_computed_compound_type_arrayPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_post_computed_compound_type_arrayPgResource.execute(selectArgs);
@@ -38594,7 +39629,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs74(args);
+      const extraSelectArgs = makeArgs79(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -38608,18 +39643,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_edge_case_computedPgResource.isUnique && !resource_edge_case_computedPgResource.codec.attributes && typeof resource_edge_case_computedPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_edge_case_computedPgResource.codec)`${resource_edge_case_computedPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_edge_case_computedPgResource.codec)`${resource_edge_case_computedPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_edge_case_computedPgResource.execute(selectArgs);
@@ -39295,7 +40340,7 @@ export const plans = {
     __assertStep: __ValueStep,
     mutationOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs75(args, ["input"]);
+        const selectArgs = makeArgs80(args, ["input"]);
         const $result = resource_mutation_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39312,7 +40357,7 @@ export const plans = {
     },
     mutationOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs76(args, ["input"]);
+        const selectArgs = makeArgs81(args, ["input"]);
         const $result = resource_mutation_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39329,7 +40374,7 @@ export const plans = {
     },
     mutationOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs77(args, ["input"]);
+        const selectArgs = makeArgs82(args, ["input"]);
         const $result = resource_mutation_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39346,7 +40391,7 @@ export const plans = {
     },
     noArgsMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs78(args, ["input"]);
+        const selectArgs = makeArgs83(args, ["input"]);
         const $result = resource_no_args_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39363,7 +40408,7 @@ export const plans = {
     },
     returnVoidMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs79(args, ["input"]);
+        const selectArgs = makeArgs84(args, ["input"]);
         const $result = resource_return_void_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39380,7 +40425,7 @@ export const plans = {
     },
     mutationIntervalSet: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs80(args, ["input"]);
+        const selectArgs = makeArgs85(args, ["input"]);
         const $result = resource_mutation_interval_setPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39397,7 +40442,7 @@ export const plans = {
     },
     mutationInOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs81(args, ["input"]);
+        const selectArgs = makeArgs86(args, ["input"]);
         const $result = resource_mutation_in_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39414,7 +40459,7 @@ export const plans = {
     },
     mutationReturnsTableOneCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs82(args, ["input"]);
+        const selectArgs = makeArgs87(args, ["input"]);
         const $result = resource_mutation_returns_table_one_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39431,7 +40476,7 @@ export const plans = {
     },
     jsonIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs83(args, ["input"]);
+        const selectArgs = makeArgs88(args, ["input"]);
         const $result = resource_json_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39448,7 +40493,7 @@ export const plans = {
     },
     jsonbIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs84(args, ["input"]);
+        const selectArgs = makeArgs89(args, ["input"]);
         const $result = resource_jsonb_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39465,7 +40510,7 @@ export const plans = {
     },
     jsonbIdentityMutationPlpgsql: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs85(args, ["input"]);
+        const selectArgs = makeArgs90(args, ["input"]);
         const $result = resource_jsonb_identity_mutation_plpgsqlPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39482,7 +40527,7 @@ export const plans = {
     },
     jsonbIdentityMutationPlpgsqlWithDefault: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs86(args, ["input"]);
+        const selectArgs = makeArgs91(args, ["input"]);
         const $result = resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39499,7 +40544,7 @@ export const plans = {
     },
     add1Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs87(args, ["input"]);
+        const selectArgs = makeArgs92(args, ["input"]);
         const $result = resource_add_1_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39516,7 +40561,7 @@ export const plans = {
     },
     add2Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs88(args, ["input"]);
+        const selectArgs = makeArgs93(args, ["input"]);
         const $result = resource_add_2_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39533,7 +40578,7 @@ export const plans = {
     },
     add3Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs89(args, ["input"]);
+        const selectArgs = makeArgs94(args, ["input"]);
         const $result = resource_add_3_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39550,7 +40595,7 @@ export const plans = {
     },
     add4Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs90(args, ["input"]);
+        const selectArgs = makeArgs95(args, ["input"]);
         const $result = resource_add_4_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39567,7 +40612,7 @@ export const plans = {
     },
     add4MutationError: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs91(args, ["input"]);
+        const selectArgs = makeArgs96(args, ["input"]);
         const $result = resource_add_4_mutation_errorPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39584,7 +40629,7 @@ export const plans = {
     },
     mult1: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs92(args, ["input"]);
+        const selectArgs = makeArgs97(args, ["input"]);
         const $result = resource_mult_1PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39601,7 +40646,7 @@ export const plans = {
     },
     mult2: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs93(args, ["input"]);
+        const selectArgs = makeArgs98(args, ["input"]);
         const $result = resource_mult_2PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39618,7 +40663,7 @@ export const plans = {
     },
     mult3: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs94(args, ["input"]);
+        const selectArgs = makeArgs99(args, ["input"]);
         const $result = resource_mult_3PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39635,7 +40680,7 @@ export const plans = {
     },
     mult4: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs95(args, ["input"]);
+        const selectArgs = makeArgs100(args, ["input"]);
         const $result = resource_mult_4PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39652,7 +40697,7 @@ export const plans = {
     },
     mutationInInout: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs96(args, ["input"]);
+        const selectArgs = makeArgs101(args, ["input"]);
         const $result = resource_mutation_in_inoutPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39669,7 +40714,7 @@ export const plans = {
     },
     mutationOutOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs97(args, ["input"]);
+        const selectArgs = makeArgs102(args, ["input"]);
         const $result = resource_mutation_out_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39686,7 +40731,7 @@ export const plans = {
     },
     mutationOutOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs98(args, ["input"]);
+        const selectArgs = makeArgs103(args, ["input"]);
         const $result = resource_mutation_out_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39703,7 +40748,7 @@ export const plans = {
     },
     mutationOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs99(args, ["input"]);
+        const selectArgs = makeArgs104(args, ["input"]);
         const $result = resource_mutation_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39720,7 +40765,7 @@ export const plans = {
     },
     intSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs100(args, ["input"]);
+        const selectArgs = makeArgs105(args, ["input"]);
         const $result = resource_int_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39737,7 +40782,7 @@ export const plans = {
     },
     mutationOutUnnamedOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs101(args, ["input"]);
+        const selectArgs = makeArgs106(args, ["input"]);
         const $result = resource_mutation_out_unnamed_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39754,7 +40799,7 @@ export const plans = {
     },
     mutationReturnsTableMultiCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs102(args, ["input"]);
+        const selectArgs = makeArgs107(args, ["input"]);
         const $result = resource_mutation_returns_table_multi_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39771,7 +40816,7 @@ export const plans = {
     },
     guidFn: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs103(args, ["input"]);
+        const selectArgs = makeArgs108(args, ["input"]);
         const $result = resource_guid_fnPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39788,7 +40833,7 @@ export const plans = {
     },
     mutationIntervalArray: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs104(args, ["input"]);
+        const selectArgs = makeArgs109(args, ["input"]);
         const $result = resource_mutation_interval_arrayPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39805,7 +40850,7 @@ export const plans = {
     },
     mutationTextArray: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs105(args, ["input"]);
+        const selectArgs = makeArgs110(args, ["input"]);
         const $result = resource_mutation_text_arrayPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39822,7 +40867,7 @@ export const plans = {
     },
     listBdeMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs106(args, ["input"]);
+        const selectArgs = makeArgs111(args, ["input"]);
         const $result = resource_list_bde_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39839,7 +40884,7 @@ export const plans = {
     },
     authenticateFail: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs107(args, ["input"]);
+        const selectArgs = makeArgs112(args, ["input"]);
         const $result = resource_authenticate_failPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39856,7 +40901,7 @@ export const plans = {
     },
     authenticate: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs108(args, ["input"]);
+        const selectArgs = makeArgs113(args, ["input"]);
         const $result = resource_authenticatePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39873,7 +40918,7 @@ export const plans = {
     },
     leftArmIdentity: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs109(args, ["input"]);
+        const selectArgs = makeArgs114(args, ["input"]);
         const $result = resource_left_arm_identityPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39890,7 +40935,7 @@ export const plans = {
     },
     issue756Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs110(args, ["input"]);
+        const selectArgs = makeArgs115(args, ["input"]);
         const $result = resource_issue756_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39907,7 +40952,7 @@ export const plans = {
     },
     issue756SetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs111(args, ["input"]);
+        const selectArgs = makeArgs116(args, ["input"]);
         const $result = resource_issue756_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39924,7 +40969,7 @@ export const plans = {
     },
     authenticateMany: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs112(args, ["input"]);
+        const selectArgs = makeArgs117(args, ["input"]);
         const $result = resource_authenticate_manyPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39941,7 +40986,7 @@ export const plans = {
     },
     authenticatePayload: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs113(args, ["input"]);
+        const selectArgs = makeArgs118(args, ["input"]);
         const $result = resource_authenticate_payloadPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39958,7 +41003,7 @@ export const plans = {
     },
     typesMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs114(args, ["input"]);
+        const selectArgs = makeArgs119(args, ["input"]);
         const $result = resource_types_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39975,7 +41020,7 @@ export const plans = {
     },
     mutationOutOutCompoundType: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs115(args, ["input"]);
+        const selectArgs = makeArgs120(args, ["input"]);
         const $result = resource_mutation_out_out_compound_typePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39992,7 +41037,7 @@ export const plans = {
     },
     compoundTypeMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs116(args, ["input"]);
+        const selectArgs = makeArgs121(args, ["input"]);
         const $result = resource_compound_type_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40009,7 +41054,7 @@ export const plans = {
     },
     compoundTypeSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs117(args, ["input"]);
+        const selectArgs = makeArgs122(args, ["input"]);
         const $result = resource_compound_type_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40026,7 +41071,7 @@ export const plans = {
     },
     tableMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs118(args, ["input"]);
+        const selectArgs = makeArgs123(args, ["input"]);
         const $result = resource_table_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40043,7 +41088,7 @@ export const plans = {
     },
     postWithSuffix: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs119(args, ["input"]);
+        const selectArgs = makeArgs124(args, ["input"]);
         const $result = resource_post_with_suffixPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40060,7 +41105,7 @@ export const plans = {
     },
     mutationCompoundTypeArray: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs120(args, ["input"]);
+        const selectArgs = makeArgs125(args, ["input"]);
         const $result = resource_mutation_compound_type_arrayPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40077,7 +41122,7 @@ export const plans = {
     },
     compoundTypeArrayMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs121(args, ["input"]);
+        const selectArgs = makeArgs126(args, ["input"]);
         const $result = resource_compound_type_array_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40094,7 +41139,7 @@ export const plans = {
     },
     postMany: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs122(args, ["input"]);
+        const selectArgs = makeArgs127(args, ["input"]);
         const $result = resource_post_manyPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40111,7 +41156,7 @@ export const plans = {
     },
     mutationOutComplex: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs123(args, ["input"]);
+        const selectArgs = makeArgs128(args, ["input"]);
         const $result = resource_mutation_out_complexPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40128,7 +41173,7 @@ export const plans = {
     },
     mutationOutComplexSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs124(args, ["input"]);
+        const selectArgs = makeArgs129(args, ["input"]);
         const $result = resource_mutation_out_complex_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40145,7 +41190,7 @@ export const plans = {
     },
     mutationOutTable: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs125(args, ["input"]);
+        const selectArgs = makeArgs130(args, ["input"]);
         const $result = resource_mutation_out_tablePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40162,7 +41207,7 @@ export const plans = {
     },
     mutationOutTableSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs126(args, ["input"]);
+        const selectArgs = makeArgs131(args, ["input"]);
         const $result = resource_mutation_out_table_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40179,7 +41224,7 @@ export const plans = {
     },
     tableSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs127(args, ["input"]);
+        const selectArgs = makeArgs132(args, ["input"]);
         const $result = resource_table_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40196,7 +41241,7 @@ export const plans = {
     },
     typeFunctionConnectionMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs128(args, ["input"]);
+        const selectArgs = makeArgs133(args, ["input"]);
         const $result = resource_type_function_connection_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40213,7 +41258,7 @@ export const plans = {
     },
     typeFunctionMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs129(args, ["input"]);
+        const selectArgs = makeArgs134(args, ["input"]);
         const $result = resource_type_function_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40230,7 +41275,7 @@ export const plans = {
     },
     typeFunctionListMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs130(args, ["input"]);
+        const selectArgs = makeArgs135(args, ["input"]);
         const $result = resource_type_function_list_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.graphql
@@ -5903,6 +5903,11 @@ type Person implements Node {
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, arg2: Int, b: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
 
   """This `Person`'s `PersonSecret`."""
   personSecretByPersonId: PersonSecret @deprecated(reason: "This is deprecated (comment on table c.person_secret).")

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.export.mjs
@@ -3494,6 +3494,11 @@ const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_compu
 const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
 const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
 const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const person_optional_missing_middle_1FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_1");
+const person_optional_missing_middle_2FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_2");
+const person_optional_missing_middle_3FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_3");
+const person_optional_missing_middle_4FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_4");
+const person_optional_missing_middle_5FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_5");
 const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
 const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
 const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
@@ -7383,6 +7388,216 @@ const registry = makeRegistry({
           serviceName: "main",
           schemaName: "c",
           name: "person_computed_first_arg_inout_out"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_1: {
+      executor,
+      name: "person_optional_missing_middle_1",
+      identifier: "main.c.person_optional_missing_middle_1(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_1"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_2: {
+      executor,
+      name: "person_optional_missing_middle_2",
+      identifier: "main.c.person_optional_missing_middle_2(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_2"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_3: {
+      executor,
+      name: "person_optional_missing_middle_3",
+      identifier: "main.c.person_optional_missing_middle_3(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_3"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_4: {
+      executor,
+      name: "person_optional_missing_middle_4",
+      identifier: "main.c.person_optional_missing_middle_4(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_4"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_5: {
+      executor,
+      name: "person_optional_missing_middle_5",
+      identifier: "main.c.person_optional_missing_middle_5(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_5FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_5"
         },
         tags: {}
       },
@@ -11870,22 +12085,28 @@ const makeArgs56 = (args, path = []) => {
 };
 const resource_person_computed_first_arg_inout_outPgResource = registry.pgResources["person_computed_first_arg_inout_out"];
 const argDetailsSimple57 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
+  graphqlArgName: "arg0",
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
   graphqlArgName: "b",
   postgresArgName: "b",
-  pgCodec: TYPES.text,
-  required: true,
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
   fetcher: null
 }];
 const makeArgs57 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11896,7 +12117,7 @@ const makeArgs57 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 1 - 1) {
         skipped = true;
         continue;
       } else {
@@ -11926,12 +12147,30 @@ const makeArgs57 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
-const argDetailsSimple58 = [];
+const resource_person_optional_missing_middle_1PgResource = registry.pgResources["person_optional_missing_middle_1"];
+const argDetailsSimple58 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs58 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11972,12 +12211,30 @@ const makeArgs58 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
-const argDetailsSimple59 = [];
+const resource_person_optional_missing_middle_2PgResource = registry.pgResources["person_optional_missing_middle_2"];
+const argDetailsSimple59 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs59 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11988,7 +12245,7 @@ const makeArgs59 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 2 - 1) {
         skipped = true;
         continue;
       } else {
@@ -12018,12 +12275,30 @@ const makeArgs59 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
-const argDetailsSimple60 = [];
+const resource_person_optional_missing_middle_3PgResource = registry.pgResources["person_optional_missing_middle_3"];
+const argDetailsSimple60 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs60 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12034,7 +12309,7 @@ const makeArgs60 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -12064,46 +12339,30 @@ const makeArgs60 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_friendsPgResource = registry.pgResources["person_friends"];
-const getSelectPlanFromParentAndArgs15 = ($in, args, _info) => {
-  if (!hasRecord($in)) {
-    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-  }
-  const extraSelectArgs = makeArgs60(args);
-  /**
-   * An optimisation - if all our dependencies are
-   * compatible with the expression's class plan then we
-   * can inline ourselves into that, otherwise we must
-   * issue the query separately.
-   */
-  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-  const selectArgs = [{
-    step: $row.record()
-  }, ...extraSelectArgs];
-  if (resource_person_friendsPgResource.isUnique && !resource_person_friendsPgResource.codec.attributes && typeof resource_person_friendsPgResource.from === "function") {
-    // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
-      if (i === 0) {
-        return $row.getClassStep().alias;
-      } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
-      } else {
-        return $row.placeholder(arg.step);
-      }
-    });
-    return pgClassExpression($row, resource_person_friendsPgResource.codec)`${resource_person_friendsPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
-  }
-  // PERF: or here, if scalar add select to `$row`?
-  return resource_person_friendsPgResource.execute(selectArgs);
-};
-const argDetailsSimple61 = [];
+const resource_person_optional_missing_middle_4PgResource = registry.pgResources["person_optional_missing_middle_4"];
+const argDetailsSimple61 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs61 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12114,7 +12373,7 @@ const makeArgs61 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -12144,52 +12403,24 @@ const makeArgs61 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
-const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
-  if (!hasRecord($in)) {
-    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-  }
-  const extraSelectArgs = makeArgs61(args);
-  /**
-   * An optimisation - if all our dependencies are
-   * compatible with the expression's class plan then we
-   * can inline ourselves into that, otherwise we must
-   * issue the query separately.
-   */
-  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-  const selectArgs = [{
-    step: $row.record()
-  }, ...extraSelectArgs];
-  if (resource_person_type_function_connectionPgResource.isUnique && !resource_person_type_function_connectionPgResource.codec.attributes && typeof resource_person_type_function_connectionPgResource.from === "function") {
-    // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
-      if (i === 0) {
-        return $row.getClassStep().alias;
-      } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
-      } else {
-        return $row.placeholder(arg.step);
-      }
-    });
-    return pgClassExpression($row, resource_person_type_function_connectionPgResource.codec)`${resource_person_type_function_connectionPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
-  }
-  // PERF: or here, if scalar add select to `$row`?
-  return resource_person_type_function_connectionPgResource.execute(selectArgs);
-};
+const resource_person_optional_missing_middle_5PgResource = registry.pgResources["person_optional_missing_middle_5"];
 const argDetailsSimple62 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs62 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12230,7 +12461,7 @@ const makeArgs62 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
+const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
 const argDetailsSimple63 = [];
 const makeArgs63 = (args, path = []) => {
   const selectArgs = [];
@@ -12276,9 +12507,7 @@ const makeArgs63 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
-const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
-const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
+const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
 const argDetailsSimple64 = [];
 const makeArgs64 = (args, path = []) => {
   const selectArgs = [];
@@ -12324,16 +12553,7 @@ const makeArgs64 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
-function UUIDSerialize(value) {
-  return "" + value;
-}
-const coerce = string => {
-  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
-    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
-  }
-  return string;
-};
+const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -12379,8 +12599,8 @@ const makeArgs65 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_interval_setPgResource = registry.pgResources["post_computed_interval_set"];
-const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
+const resource_person_friendsPgResource = registry.pgResources["person_friends"];
+const getSelectPlanFromParentAndArgs15 = ($in, args, _info) => {
   if (!hasRecord($in)) {
     throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
   }
@@ -12396,23 +12616,33 @@ const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
   const selectArgs = [{
     step: $row.record()
   }, ...extraSelectArgs];
-  if (resource_post_computed_interval_setPgResource.isUnique && !resource_post_computed_interval_setPgResource.codec.attributes && typeof resource_post_computed_interval_setPgResource.from === "function") {
+  if (resource_person_friendsPgResource.isUnique && !resource_person_friendsPgResource.codec.attributes && typeof resource_person_friendsPgResource.from === "function") {
     // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
       if (i === 0) {
-        return $row.getClassStep().alias;
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
       } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
       } else {
-        return $row.placeholder(arg.step);
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
       }
     });
-    return pgClassExpression($row, resource_post_computed_interval_setPgResource.codec)`${resource_post_computed_interval_setPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
+    return pgClassExpression($row, resource_person_friendsPgResource.codec)`${resource_person_friendsPgResource.from(...newSelectArgs)}`;
   }
   // PERF: or here, if scalar add select to `$row`?
-  return resource_post_computed_interval_setPgResource.execute(selectArgs);
+  return resource_person_friendsPgResource.execute(selectArgs);
 };
 const argDetailsSimple66 = [];
 const makeArgs66 = (args, path = []) => {
@@ -12459,12 +12689,62 @@ const makeArgs66 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_interval_arrayPgResource = registry.pgResources["post_computed_interval_array"];
-const argDetailsSimple67 = [];
+const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
+const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
+  if (!hasRecord($in)) {
+    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+  }
+  const extraSelectArgs = makeArgs66(args);
+  /**
+   * An optimisation - if all our dependencies are
+   * compatible with the expression's class plan then we
+   * can inline ourselves into that, otherwise we must
+   * issue the query separately.
+   */
+  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+  const selectArgs = [{
+    step: $row.record()
+  }, ...extraSelectArgs];
+  if (resource_person_type_function_connectionPgResource.isUnique && !resource_person_type_function_connectionPgResource.codec.attributes && typeof resource_person_type_function_connectionPgResource.from === "function") {
+    // This is a scalar computed attribute, let's inline the expression
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
+      if (i === 0) {
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
+      } else if ("pgCodec" in arg && arg.pgCodec) {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
+      } else {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
+      }
+    });
+    return pgClassExpression($row, resource_person_type_function_connectionPgResource.codec)`${resource_person_type_function_connectionPgResource.from(...newSelectArgs)}`;
+  }
+  // PERF: or here, if scalar add select to `$row`?
+  return resource_person_type_function_connectionPgResource.execute(selectArgs);
+};
+const argDetailsSimple67 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs67 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12505,18 +12785,12 @@ const makeArgs67 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_text_arrayPgResource = registry.pgResources["post_computed_text_array"];
-const argDetailsSimple68 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: false,
-  fetcher: null
-}];
+const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
+const argDetailsSimple68 = [];
 const makeArgs68 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12557,18 +12831,14 @@ const makeArgs68 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_with_optional_argPgResource = registry.pgResources["post_computed_with_optional_arg"];
-const argDetailsSimple69 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
+const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
+const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
+const argDetailsSimple69 = [];
 const makeArgs69 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12609,24 +12879,21 @@ const makeArgs69 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_with_required_argPgResource = registry.pgResources["post_computed_with_required_arg"];
-const argDetailsSimple70 = [{
-  graphqlArgName: "length",
-  postgresArgName: "length",
-  pgCodec: TYPES.int,
-  required: false,
-  fetcher: null
-}, {
-  graphqlArgName: "omission",
-  postgresArgName: "omission",
-  pgCodec: TYPES.text,
-  required: false,
-  fetcher: null
-}];
+const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
+function UUIDSerialize(value) {
+  return "" + value;
+}
+const coerce = string => {
+  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
+    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
+  }
+  return string;
+};
+const argDetailsSimple70 = [];
 const makeArgs70 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12667,24 +12934,56 @@ const makeArgs70 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmedPgResource = registry.pgResources["post_headline_trimmed"];
-const argDetailsSimple71 = [{
-  graphqlArgName: "length",
-  postgresArgName: "length",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "omission",
-  postgresArgName: "omission",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_post_computed_interval_setPgResource = registry.pgResources["post_computed_interval_set"];
+const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
+  if (!hasRecord($in)) {
+    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+  }
+  const extraSelectArgs = makeArgs70(args);
+  /**
+   * An optimisation - if all our dependencies are
+   * compatible with the expression's class plan then we
+   * can inline ourselves into that, otherwise we must
+   * issue the query separately.
+   */
+  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+  const selectArgs = [{
+    step: $row.record()
+  }, ...extraSelectArgs];
+  if (resource_post_computed_interval_setPgResource.isUnique && !resource_post_computed_interval_setPgResource.codec.attributes && typeof resource_post_computed_interval_setPgResource.from === "function") {
+    // This is a scalar computed attribute, let's inline the expression
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
+      if (i === 0) {
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
+      } else if ("pgCodec" in arg && arg.pgCodec) {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
+      } else {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
+      }
+    });
+    return pgClassExpression($row, resource_post_computed_interval_setPgResource.codec)`${resource_post_computed_interval_setPgResource.from(...newSelectArgs)}`;
+  }
+  // PERF: or here, if scalar add select to `$row`?
+  return resource_post_computed_interval_setPgResource.execute(selectArgs);
+};
+const argDetailsSimple71 = [];
 const makeArgs71 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12725,24 +13024,12 @@ const makeArgs71 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmed_no_defaultsPgResource = registry.pgResources["post_headline_trimmed_no_defaults"];
-const argDetailsSimple72 = [{
-  graphqlArgName: "length",
-  postgresArgName: "length",
-  pgCodec: TYPES.int,
-  required: false,
-  fetcher: null
-}, {
-  graphqlArgName: "omission",
-  postgresArgName: "omission",
-  pgCodec: TYPES.text,
-  required: false,
-  fetcher: null
-}];
+const resource_post_computed_interval_arrayPgResource = registry.pgResources["post_computed_interval_array"];
+const argDetailsSimple72 = [];
 const makeArgs72 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12783,12 +13070,12 @@ const makeArgs72 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmed_strictPgResource = registry.pgResources["post_headline_trimmed_strict"];
+const resource_post_computed_text_arrayPgResource = registry.pgResources["post_computed_text_array"];
 const argDetailsSimple73 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
-  required: true,
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: false,
   fetcher: null
 }];
 const makeArgs73 = (args, path = []) => {
@@ -12802,6 +13089,284 @@ const makeArgs73 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple73[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_computed_with_optional_argPgResource = registry.pgResources["post_computed_with_optional_arg"];
+const argDetailsSimple74 = [{
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs74 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple74[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_computed_with_required_argPgResource = registry.pgResources["post_computed_with_required_arg"];
+const argDetailsSimple75 = [{
+  graphqlArgName: "length",
+  postgresArgName: "length",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "omission",
+  postgresArgName: "omission",
+  pgCodec: TYPES.text,
+  required: false,
+  fetcher: null
+}];
+const makeArgs75 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple75[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_headline_trimmedPgResource = registry.pgResources["post_headline_trimmed"];
+const argDetailsSimple76 = [{
+  graphqlArgName: "length",
+  postgresArgName: "length",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "omission",
+  postgresArgName: "omission",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
+const makeArgs76 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple76[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_headline_trimmed_no_defaultsPgResource = registry.pgResources["post_headline_trimmed_no_defaults"];
+const argDetailsSimple77 = [{
+  graphqlArgName: "length",
+  postgresArgName: "length",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "omission",
+  postgresArgName: "omission",
+  pgCodec: TYPES.text,
+  required: false,
+  fetcher: null
+}];
+const makeArgs77 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple77[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_headline_trimmed_strictPgResource = registry.pgResources["post_headline_trimmed_strict"];
+const argDetailsSimple78 = [{
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
+  required: true,
+  fetcher: null
+}];
+const makeArgs78 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple78[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -12892,236 +13457,6 @@ const parseValueLiteral = (ast, variables) => {
       return undefined;
   }
 };
-const argDetailsSimple74 = [];
-const makeArgs74 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple74[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
-const argDetailsSimple75 = [];
-const makeArgs75 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple75[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
-const argDetailsSimple76 = [];
-const makeArgs76 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple76[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
-const argDetailsSimple77 = [];
-const makeArgs77 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple77[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
-const argDetailsSimple78 = [];
-const makeArgs78 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple78[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
 const argDetailsSimple79 = [];
 const makeArgs79 = (args, path = []) => {
   const selectArgs = [];
@@ -13167,7 +13502,7 @@ const makeArgs79 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
+const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
 const argDetailsSimple80 = [];
 const makeArgs80 = (args, path = []) => {
   const selectArgs = [];
@@ -13213,18 +13548,12 @@ const makeArgs80 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
-const argDetailsSimple81 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
+const argDetailsSimple81 = [];
 const makeArgs81 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13265,18 +13594,12 @@ const makeArgs81 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
-const argDetailsSimple82 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
+const argDetailsSimple82 = [];
 const makeArgs82 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13317,18 +13640,12 @@ const makeArgs82 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
-const argDetailsSimple83 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
+const argDetailsSimple83 = [];
 const makeArgs83 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13369,18 +13686,12 @@ const makeArgs83 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
-const argDetailsSimple84 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
+const argDetailsSimple84 = [];
 const makeArgs84 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13421,18 +13732,12 @@ const makeArgs84 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
-const argDetailsSimple85 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
+const argDetailsSimple85 = [];
 const makeArgs85 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13473,12 +13778,12 @@ const makeArgs85 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
+const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
 const argDetailsSimple86 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: false,
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
   fetcher: null
 }];
 const makeArgs86 = (args, path = []) => {
@@ -13525,16 +13830,10 @@ const makeArgs86 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
+const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
 const argDetailsSimple87 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: null,
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "arg1",
-  postgresArgName: null,
+  graphqlArgName: "i",
+  postgresArgName: "i",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -13542,7 +13841,7 @@ const argDetailsSimple87 = [{
 const makeArgs87 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13553,7 +13852,7 @@ const makeArgs87 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 2 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13583,24 +13882,18 @@ const makeArgs87 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
+const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
 const argDetailsSimple88 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.json,
   required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.int,
-  required: false,
   fetcher: null
 }];
 const makeArgs88 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13641,24 +13934,18 @@ const makeArgs88 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
+const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
 const argDetailsSimple89 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "arg1",
-  postgresArgName: "",
-  pgCodec: TYPES.int,
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.jsonb,
   required: true,
   fetcher: null
 }];
 const makeArgs89 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13669,7 +13956,7 @@ const makeArgs89 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 2 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13699,24 +13986,18 @@ const makeArgs89 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
+const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
 const argDetailsSimple90 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: "",
-  pgCodec: TYPES.int,
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
   required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.int,
-  required: false,
   fetcher: null
 }];
 const makeArgs90 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13727,7 +14008,7 @@ const makeArgs90 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 1 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13757,24 +14038,18 @@ const makeArgs90 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
+const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
 const argDetailsSimple91 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: "",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.int,
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
   required: false,
   fetcher: null
 }];
 const makeArgs91 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13785,7 +14060,7 @@ const makeArgs91 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 1 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13815,7 +14090,7 @@ const makeArgs91 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
+const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
 const argDetailsSimple92 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -13873,18 +14148,18 @@ const makeArgs92 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_1PgResource = registry.pgResources["mult_1"];
+const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
 const argDetailsSimple93 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: null,
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "arg1",
-  postgresArgName: null,
+  graphqlArgName: "b",
+  postgresArgName: "b",
   pgCodec: TYPES.int,
-  required: true,
+  required: false,
   fetcher: null
 }];
 const makeArgs93 = (args, path = []) => {
@@ -13901,7 +14176,7 @@ const makeArgs93 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 2 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13931,16 +14206,16 @@ const makeArgs93 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_2PgResource = registry.pgResources["mult_2"];
+const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
 const argDetailsSimple94 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: null,
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
   graphqlArgName: "arg1",
-  postgresArgName: null,
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -13989,18 +14264,18 @@ const makeArgs94 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_3PgResource = registry.pgResources["mult_3"];
+const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
 const argDetailsSimple95 = [{
   graphqlArgName: "arg0",
-  postgresArgName: null,
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "arg1",
-  postgresArgName: null,
+  graphqlArgName: "b",
+  postgresArgName: "b",
   pgCodec: TYPES.int,
-  required: true,
+  required: false,
   fetcher: null
 }];
 const makeArgs95 = (args, path = []) => {
@@ -14014,6 +14289,296 @@ const makeArgs95 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple95[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 1 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
+const argDetailsSimple96 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
+const makeArgs96 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple96[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 1 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
+const argDetailsSimple97 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs97 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple97[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 2 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mult_1PgResource = registry.pgResources["mult_1"];
+const argDetailsSimple98 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs98 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple98[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 2 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mult_2PgResource = registry.pgResources["mult_2"];
+const argDetailsSimple99 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs99 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple99[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 2 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mult_3PgResource = registry.pgResources["mult_3"];
+const argDetailsSimple100 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs100 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple100[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -14048,7 +14613,7 @@ const makeArgs95 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_4PgResource = registry.pgResources["mult_4"];
-const argDetailsSimple96 = [{
+const argDetailsSimple101 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
   pgCodec: TYPES.int,
@@ -14061,258 +14626,10 @@ const argDetailsSimple96 = [{
   required: true,
   fetcher: null
 }];
-const makeArgs96 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 2; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple96[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
-const argDetailsSimple97 = [];
-const makeArgs97 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple97[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
-const argDetailsSimple98 = [];
-const makeArgs98 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple98[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
-const argDetailsSimple99 = [];
-const makeArgs99 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple99[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
-const argDetailsSimple100 = [{
-  graphqlArgName: "x",
-  postgresArgName: "x",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "y",
-  postgresArgName: "y",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "z",
-  postgresArgName: "z",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
-const makeArgs100 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 3; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple100[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
-const argDetailsSimple101 = [];
 const makeArgs101 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14353,18 +14670,12 @@ const makeArgs101 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
-const argDetailsSimple102 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
+const argDetailsSimple102 = [];
 const makeArgs102 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14405,18 +14716,12 @@ const makeArgs102 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
-const argDetailsSimple103 = [{
-  graphqlArgName: "g",
-  postgresArgName: "g",
-  pgCodec: guidCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
+const argDetailsSimple103 = [];
 const makeArgs103 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14457,7 +14762,7 @@ const makeArgs103 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_guid_fnPgResource = registry.pgResources["guid_fn"];
+const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
 const argDetailsSimple104 = [];
 const makeArgs104 = (args, path = []) => {
   const selectArgs = [];
@@ -14503,12 +14808,30 @@ const makeArgs104 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
-const argDetailsSimple105 = [];
+const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
+const argDetailsSimple105 = [{
+  graphqlArgName: "x",
+  postgresArgName: "x",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "y",
+  postgresArgName: "y",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "z",
+  postgresArgName: "z",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs105 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14549,30 +14872,12 @@ const makeArgs105 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
-const argDetailsSimple106 = [{
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: textArrayCodec,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "d",
-  postgresArgName: "d",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "e",
-  postgresArgName: "e",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
+const argDetailsSimple106 = [];
 const makeArgs106 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14613,12 +14918,18 @@ const makeArgs106 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_list_bde_mutationPgResource = registry.pgResources["list_bde_mutation"];
-const argDetailsSimple107 = [];
+const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
+const argDetailsSimple107 = [{
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs107 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14659,30 +14970,18 @@ const makeArgs107 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_failPgResource = registry.pgResources["authenticate_fail"];
+const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
 const argDetailsSimple108 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.numeric,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.bigint,
+  graphqlArgName: "g",
+  postgresArgName: "g",
+  pgCodec: guidCodec,
   required: true,
   fetcher: null
 }];
 const makeArgs108 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14723,18 +15022,12 @@ const makeArgs108 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticatePgResource = registry.pgResources["authenticate"];
-const argDetailsSimple109 = [{
-  graphqlArgName: "leftArm",
-  postgresArgName: "left_arm",
-  pgCodec: leftArmCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_guid_fnPgResource = registry.pgResources["guid_fn"];
+const argDetailsSimple109 = [];
 const makeArgs109 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14775,7 +15068,7 @@ const makeArgs109 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
+const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
 const argDetailsSimple110 = [];
 const makeArgs110 = (args, path = []) => {
   const selectArgs = [];
@@ -14821,12 +15114,30 @@ const makeArgs110 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
-const argDetailsSimple111 = [];
+const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
+const argDetailsSimple111 = [{
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: textArrayCodec,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "d",
+  postgresArgName: "d",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "e",
+  postgresArgName: "e",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
 const makeArgs111 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14867,30 +15178,12 @@ const makeArgs111 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
-const argDetailsSimple112 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.numeric,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.bigint,
-  required: true,
-  fetcher: null
-}];
+const resource_list_bde_mutationPgResource = registry.pgResources["list_bde_mutation"];
+const argDetailsSimple112 = [];
 const makeArgs112 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14931,7 +15224,7 @@ const makeArgs112 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_manyPgResource = registry.pgResources["authenticate_many"];
+const resource_authenticate_failPgResource = registry.pgResources["authenticate_fail"];
 const argDetailsSimple113 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -14995,48 +15288,18 @@ const makeArgs113 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_payloadPgResource = registry.pgResources["authenticate_payload"];
+const resource_authenticatePgResource = registry.pgResources["authenticate"];
 const argDetailsSimple114 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.bigint,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.boolean,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.varchar,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "d",
-  postgresArgName: "d",
-  pgCodec: int4ArrayCodec,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "e",
-  postgresArgName: "e",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "f",
-  postgresArgName: "f",
-  pgCodec: floatrangeCodec,
+  graphqlArgName: "leftArm",
+  postgresArgName: "left_arm",
+  pgCodec: leftArmCodec,
   required: true,
   fetcher: null
 }];
 const makeArgs114 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 6; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15077,18 +15340,12 @@ const makeArgs114 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
-const argDetailsSimple115 = [{
-  graphqlArgName: "i1",
-  postgresArgName: "i1",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
+const argDetailsSimple115 = [];
 const makeArgs115 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15129,18 +15386,12 @@ const makeArgs115 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
-const argDetailsSimple116 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
+const argDetailsSimple116 = [];
 const makeArgs116 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15181,18 +15432,30 @@ const makeArgs116 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_mutationPgResource = registry.pgResources["compound_type_mutation"];
+const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
 const argDetailsSimple117 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.numeric,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.bigint,
   required: true,
   fetcher: null
 }];
 const makeArgs117 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15233,18 +15496,30 @@ const makeArgs117 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
+const resource_authenticate_manyPgResource = registry.pgResources["authenticate_many"];
 const argDetailsSimple118 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.numeric,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.bigint,
   required: true,
   fetcher: null
 }];
 const makeArgs118 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15285,24 +15560,48 @@ const makeArgs118 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
+const resource_authenticate_payloadPgResource = registry.pgResources["authenticate_payload"];
 const argDetailsSimple119 = [{
-  graphqlArgName: "post",
-  postgresArgName: "post",
-  pgCodec: postCodec,
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.bigint,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "suffix",
-  postgresArgName: "suffix",
-  pgCodec: TYPES.text,
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.boolean,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.varchar,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "d",
+  postgresArgName: "d",
+  pgCodec: int4ArrayCodec,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "e",
+  postgresArgName: "e",
+  pgCodec: TYPES.json,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "f",
+  postgresArgName: "f",
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
 const makeArgs119 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 6; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15343,11 +15642,11 @@ const makeArgs119 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_with_suffixPgResource = registry.pgResources["post_with_suffix"];
+const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
 const argDetailsSimple120 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
+  graphqlArgName: "i1",
+  postgresArgName: "i1",
+  pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }];
@@ -15395,7 +15694,7 @@ const makeArgs120 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
+const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
 const argDetailsSimple121 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -15447,11 +15746,11 @@ const makeArgs121 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_array_mutationPgResource = registry.pgResources["compound_type_array_mutation"];
+const resource_compound_type_mutationPgResource = registry.pgResources["compound_type_mutation"];
 const argDetailsSimple122 = [{
-  graphqlArgName: "posts",
-  postgresArgName: "posts",
-  pgCodec: postArrayCodec,
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -15499,24 +15798,18 @@ const makeArgs122 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_manyPgResource = registry.pgResources["post_many"];
+const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
 const argDetailsSimple123 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
+  graphqlArgName: "id",
+  postgresArgName: "id",
   pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs123 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15557,16 +15850,16 @@ const makeArgs123 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
+const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
 const argDetailsSimple124 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
+  graphqlArgName: "post",
+  postgresArgName: "post",
+  pgCodec: postCodec,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
+  graphqlArgName: "suffix",
+  postgresArgName: "suffix",
   pgCodec: TYPES.text,
   required: true,
   fetcher: null
@@ -15615,12 +15908,18 @@ const makeArgs124 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
-const argDetailsSimple125 = [];
+const resource_post_with_suffixPgResource = registry.pgResources["post_with_suffix"];
+const argDetailsSimple125 = [{
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs125 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15661,12 +15960,18 @@ const makeArgs125 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
-const argDetailsSimple126 = [];
+const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
+const argDetailsSimple126 = [{
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs126 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15707,12 +16012,18 @@ const makeArgs126 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
-const argDetailsSimple127 = [];
+const resource_compound_type_array_mutationPgResource = registry.pgResources["compound_type_array_mutation"];
+const argDetailsSimple127 = [{
+  graphqlArgName: "posts",
+  postgresArgName: "posts",
+  pgCodec: postArrayCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs127 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15753,12 +16064,24 @@ const makeArgs127 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
-const argDetailsSimple128 = [];
+const resource_post_manyPgResource = registry.pgResources["post_many"];
+const argDetailsSimple128 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
 const makeArgs128 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15799,18 +16122,24 @@ const makeArgs128 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_type_function_connection_mutationPgResource = registry.pgResources["type_function_connection_mutation"];
+const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
 const argDetailsSimple129 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs129 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15851,7 +16180,7 @@ const makeArgs129 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_type_function_mutationPgResource = registry.pgResources["type_function_mutation"];
+const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
 const argDetailsSimple130 = [];
 const makeArgs130 = (args, path = []) => {
   const selectArgs = [];
@@ -15864,6 +16193,242 @@ const makeArgs130 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple130[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
+const argDetailsSimple131 = [];
+const makeArgs131 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple131[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
+const argDetailsSimple132 = [];
+const makeArgs132 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple132[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
+const argDetailsSimple133 = [];
+const makeArgs133 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple133[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_type_function_connection_mutationPgResource = registry.pgResources["type_function_connection_mutation"];
+const argDetailsSimple134 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs134 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple134[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_type_function_mutationPgResource = registry.pgResources["type_function_mutation"];
+const argDetailsSimple135 = [];
+const makeArgs135 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple135[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -17460,6 +18025,11 @@ type Person implements Node {
   computedInoutOut(ino: String): PersonComputedInoutOutRecord
   exists(email: Email): Boolean @deprecated(reason: "This is deprecated (comment on function c.person_exists).")
   computedFirstArgInoutOut: PersonComputedFirstArgInoutOutRecord
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, b: Int, arg2: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
   computedComplex(a: Int, b: String): PersonComputedComplexRecord
 
   """The first post by the person."""
@@ -28938,18 +29508,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_outPgResource.isUnique && !resource_person_computed_outPgResource.codec.attributes && typeof resource_person_computed_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_outPgResource.codec)`${resource_person_computed_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_outPgResource.codec)`${resource_person_computed_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_outPgResource.execute(selectArgs);
@@ -28972,18 +29552,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_first_namePgResource.isUnique && !resource_person_first_namePgResource.codec.attributes && typeof resource_person_first_namePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_first_namePgResource.codec)`${resource_person_first_namePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_first_namePgResource.codec)`${resource_person_first_namePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_first_namePgResource.execute(selectArgs);
@@ -29006,18 +29596,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_out_outPgResource.isUnique && !resource_person_computed_out_outPgResource.codec.attributes && typeof resource_person_computed_out_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_out_outPgResource.codec)`${resource_person_computed_out_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_out_outPgResource.codec)`${resource_person_computed_out_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_out_outPgResource.execute(selectArgs);
@@ -29041,18 +29641,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_computed_inoutPgResource.isUnique && !resource_person_computed_inoutPgResource.codec.attributes && typeof resource_person_computed_inoutPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_inoutPgResource.codec)`${resource_person_computed_inoutPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_computed_inoutPgResource.codec)`${resource_person_computed_inoutPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_inoutPgResource.execute(selectArgs);
@@ -29080,18 +29690,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_computed_inout_outPgResource.isUnique && !resource_person_computed_inout_outPgResource.codec.attributes && typeof resource_person_computed_inout_outPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_inout_outPgResource.codec)`${resource_person_computed_inout_outPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_computed_inout_outPgResource.codec)`${resource_person_computed_inout_outPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_inout_outPgResource.execute(selectArgs);
@@ -29119,18 +29739,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_existsPgResource.isUnique && !resource_person_existsPgResource.codec.attributes && typeof resource_person_existsPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_existsPgResource.codec)`${resource_person_existsPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_existsPgResource.codec)`${resource_person_existsPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_existsPgResource.execute(selectArgs);
@@ -29157,23 +29787,33 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_first_arg_inout_outPgResource.isUnique && !resource_person_computed_first_arg_inout_outPgResource.codec.attributes && typeof resource_person_computed_first_arg_inout_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_first_arg_inout_outPgResource.codec)`${resource_person_computed_first_arg_inout_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_first_arg_inout_outPgResource.codec)`${resource_person_computed_first_arg_inout_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_first_arg_inout_outPgResource.execute(selectArgs);
     },
-    computedComplex: {
+    optionalMissingMiddle1: {
       plan($in, args, _info) {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -29190,20 +29830,285 @@ export const plans = {
         const selectArgs = [{
           step: $row.record()
         }, ...extraSelectArgs];
-        if (resource_person_computed_complexPgResource.isUnique && !resource_person_computed_complexPgResource.codec.attributes && typeof resource_person_computed_complexPgResource.from === "function") {
+        if (resource_person_optional_missing_middle_1PgResource.isUnique && !resource_person_optional_missing_middle_1PgResource.codec.attributes && typeof resource_person_optional_missing_middle_1PgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_complexPgResource.codec)`${resource_person_computed_complexPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_optional_missing_middle_1PgResource.codec)`${resource_person_optional_missing_middle_1PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_1PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle2: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs58(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_2PgResource.isUnique && !resource_person_optional_missing_middle_2PgResource.codec.attributes && typeof resource_person_optional_missing_middle_2PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_2PgResource.codec)`${resource_person_optional_missing_middle_2PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_2PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        b: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle3: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs59(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_3PgResource.isUnique && !resource_person_optional_missing_middle_3PgResource.codec.attributes && typeof resource_person_optional_missing_middle_3PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_3PgResource.codec)`${resource_person_optional_missing_middle_3PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_3PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle4: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs60(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_4PgResource.isUnique && !resource_person_optional_missing_middle_4PgResource.codec.attributes && typeof resource_person_optional_missing_middle_4PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_4PgResource.codec)`${resource_person_optional_missing_middle_4PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_4PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        arg2: undefined
+      }
+    },
+    optionalMissingMiddle5: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs61(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_5PgResource.isUnique && !resource_person_optional_missing_middle_5PgResource.codec.attributes && typeof resource_person_optional_missing_middle_5PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_5PgResource.codec)`${resource_person_optional_missing_middle_5PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_5PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        arg2: undefined
+      }
+    },
+    computedComplex: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs62(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_computed_complexPgResource.isUnique && !resource_person_computed_complexPgResource.codec.attributes && typeof resource_person_computed_complexPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_computed_complexPgResource.codec)`${resource_person_computed_complexPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_complexPgResource.execute(selectArgs);
@@ -29217,7 +30122,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs58(args);
+      const extraSelectArgs = makeArgs63(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29231,18 +30136,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_first_postPgResource.isUnique && !resource_person_first_postPgResource.codec.attributes && typeof resource_person_first_postPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_first_postPgResource.codec)`${resource_person_first_postPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_first_postPgResource.codec)`${resource_person_first_postPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_first_postPgResource.execute(selectArgs);
@@ -29251,7 +30166,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs59(args);
+      const extraSelectArgs = makeArgs64(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29265,18 +30180,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_first_arg_inoutPgResource.isUnique && !resource_person_computed_first_arg_inoutPgResource.codec.attributes && typeof resource_person_computed_first_arg_inoutPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_first_arg_inoutPgResource.codec)`${resource_person_computed_first_arg_inoutPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_first_arg_inoutPgResource.codec)`${resource_person_computed_first_arg_inoutPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_first_arg_inoutPgResource.execute(selectArgs);
@@ -29381,7 +30306,7 @@ export const plans = {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
         }
-        const extraSelectArgs = makeArgs62(args);
+        const extraSelectArgs = makeArgs67(args);
         /**
          * An optimisation - if all our dependencies are
          * compatible with the expression's class plan then we
@@ -29395,18 +30320,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_type_functionPgResource.isUnique && !resource_person_type_functionPgResource.codec.attributes && typeof resource_person_type_functionPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_type_functionPgResource.codec)`${resource_person_type_functionPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_type_functionPgResource.codec)`${resource_person_type_functionPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_type_functionPgResource.execute(selectArgs);
@@ -29419,7 +30354,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs63(args);
+      const extraSelectArgs = makeArgs68(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29433,18 +30368,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_type_function_listPgResource.isUnique && !resource_person_type_function_listPgResource.codec.attributes && typeof resource_person_type_function_listPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_type_function_listPgResource.codec)`${resource_person_type_function_listPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_type_function_listPgResource.codec)`${resource_person_type_function_listPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_type_function_listPgResource.execute(selectArgs);
@@ -29791,7 +30736,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs64(args);
+      const extraSelectArgs = makeArgs69(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29805,18 +30750,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_compound_type_computed_fieldPgResource.isUnique && !resource_compound_type_computed_fieldPgResource.codec.attributes && typeof resource_compound_type_computed_fieldPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_compound_type_computed_fieldPgResource.codec)`${resource_compound_type_computed_fieldPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_compound_type_computed_fieldPgResource.codec)`${resource_compound_type_computed_fieldPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_compound_type_computed_fieldPgResource.execute(selectArgs);
@@ -29960,7 +30915,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs66(args);
+      const extraSelectArgs = makeArgs71(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29974,18 +30929,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_post_computed_interval_arrayPgResource.isUnique && !resource_post_computed_interval_arrayPgResource.codec.attributes && typeof resource_post_computed_interval_arrayPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_post_computed_interval_arrayPgResource.codec)`${resource_post_computed_interval_arrayPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_post_computed_interval_arrayPgResource.codec)`${resource_post_computed_interval_arrayPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_post_computed_interval_arrayPgResource.execute(selectArgs);
@@ -29994,7 +30959,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs67(args);
+      const extraSelectArgs = makeArgs72(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -30008,221 +30973,33 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_post_computed_text_arrayPgResource.isUnique && !resource_post_computed_text_arrayPgResource.codec.attributes && typeof resource_post_computed_text_arrayPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_post_computed_text_arrayPgResource.codec)`${resource_post_computed_text_arrayPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_post_computed_text_arrayPgResource.codec)`${resource_post_computed_text_arrayPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_post_computed_text_arrayPgResource.execute(selectArgs);
     },
     computedWithOptionalArg: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs68(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_computed_with_optional_argPgResource.isUnique && !resource_post_computed_with_optional_argPgResource.codec.attributes && typeof resource_post_computed_with_optional_argPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_computed_with_optional_argPgResource.codec)`${resource_post_computed_with_optional_argPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_computed_with_optional_argPgResource.execute(selectArgs);
-      },
-      args: {
-        i: undefined
-      }
-    },
-    computedWithRequiredArg: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs69(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_computed_with_required_argPgResource.isUnique && !resource_post_computed_with_required_argPgResource.codec.attributes && typeof resource_post_computed_with_required_argPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_computed_with_required_argPgResource.codec)`${resource_post_computed_with_required_argPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_computed_with_required_argPgResource.execute(selectArgs);
-      },
-      args: {
-        i: undefined
-      }
-    },
-    headlineTrimmed: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs70(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_headline_trimmedPgResource.isUnique && !resource_post_headline_trimmedPgResource.codec.attributes && typeof resource_post_headline_trimmedPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_headline_trimmedPgResource.codec)`${resource_post_headline_trimmedPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_headline_trimmedPgResource.execute(selectArgs);
-      },
-      args: {
-        length: undefined,
-        omission: undefined
-      }
-    },
-    headlineTrimmedNoDefaults: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs71(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_headline_trimmed_no_defaultsPgResource.isUnique && !resource_post_headline_trimmed_no_defaultsPgResource.codec.attributes && typeof resource_post_headline_trimmed_no_defaultsPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_headline_trimmed_no_defaultsPgResource.codec)`${resource_post_headline_trimmed_no_defaultsPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_headline_trimmed_no_defaultsPgResource.execute(selectArgs);
-      },
-      args: {
-        length: undefined,
-        omission: undefined
-      }
-    },
-    headlineTrimmedStrict: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs72(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_headline_trimmed_strictPgResource.isUnique && !resource_post_headline_trimmed_strictPgResource.codec.attributes && typeof resource_post_headline_trimmed_strictPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_headline_trimmed_strictPgResource.codec)`${resource_post_headline_trimmed_strictPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_headline_trimmed_strictPgResource.execute(selectArgs);
-      },
-      args: {
-        length: undefined,
-        omission: undefined
-      }
-    },
-    computedCompoundTypeArray: {
       plan($in, args, _info) {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -30239,20 +31016,278 @@ export const plans = {
         const selectArgs = [{
           step: $row.record()
         }, ...extraSelectArgs];
-        if (resource_post_computed_compound_type_arrayPgResource.isUnique && !resource_post_computed_compound_type_arrayPgResource.codec.attributes && typeof resource_post_computed_compound_type_arrayPgResource.from === "function") {
+        if (resource_post_computed_with_optional_argPgResource.isUnique && !resource_post_computed_with_optional_argPgResource.codec.attributes && typeof resource_post_computed_with_optional_argPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_post_computed_compound_type_arrayPgResource.codec)`${resource_post_computed_compound_type_arrayPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_post_computed_with_optional_argPgResource.codec)`${resource_post_computed_with_optional_argPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_computed_with_optional_argPgResource.execute(selectArgs);
+      },
+      args: {
+        i: undefined
+      }
+    },
+    computedWithRequiredArg: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs74(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_computed_with_required_argPgResource.isUnique && !resource_post_computed_with_required_argPgResource.codec.attributes && typeof resource_post_computed_with_required_argPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_computed_with_required_argPgResource.codec)`${resource_post_computed_with_required_argPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_computed_with_required_argPgResource.execute(selectArgs);
+      },
+      args: {
+        i: undefined
+      }
+    },
+    headlineTrimmed: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs75(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_headline_trimmedPgResource.isUnique && !resource_post_headline_trimmedPgResource.codec.attributes && typeof resource_post_headline_trimmedPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_headline_trimmedPgResource.codec)`${resource_post_headline_trimmedPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_headline_trimmedPgResource.execute(selectArgs);
+      },
+      args: {
+        length: undefined,
+        omission: undefined
+      }
+    },
+    headlineTrimmedNoDefaults: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs76(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_headline_trimmed_no_defaultsPgResource.isUnique && !resource_post_headline_trimmed_no_defaultsPgResource.codec.attributes && typeof resource_post_headline_trimmed_no_defaultsPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_headline_trimmed_no_defaultsPgResource.codec)`${resource_post_headline_trimmed_no_defaultsPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_headline_trimmed_no_defaultsPgResource.execute(selectArgs);
+      },
+      args: {
+        length: undefined,
+        omission: undefined
+      }
+    },
+    headlineTrimmedStrict: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs77(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_headline_trimmed_strictPgResource.isUnique && !resource_post_headline_trimmed_strictPgResource.codec.attributes && typeof resource_post_headline_trimmed_strictPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_headline_trimmed_strictPgResource.codec)`${resource_post_headline_trimmed_strictPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_headline_trimmed_strictPgResource.execute(selectArgs);
+      },
+      args: {
+        length: undefined,
+        omission: undefined
+      }
+    },
+    computedCompoundTypeArray: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs78(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_computed_compound_type_arrayPgResource.isUnique && !resource_post_computed_compound_type_arrayPgResource.codec.attributes && typeof resource_post_computed_compound_type_arrayPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_computed_compound_type_arrayPgResource.codec)`${resource_post_computed_compound_type_arrayPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_post_computed_compound_type_arrayPgResource.execute(selectArgs);
@@ -38594,7 +39629,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs74(args);
+      const extraSelectArgs = makeArgs79(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -38608,18 +39643,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_edge_case_computedPgResource.isUnique && !resource_edge_case_computedPgResource.codec.attributes && typeof resource_edge_case_computedPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_edge_case_computedPgResource.codec)`${resource_edge_case_computedPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_edge_case_computedPgResource.codec)`${resource_edge_case_computedPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_edge_case_computedPgResource.execute(selectArgs);
@@ -39295,7 +40340,7 @@ export const plans = {
     __assertStep: __ValueStep,
     mutationOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs75(args, ["input"]);
+        const selectArgs = makeArgs80(args, ["input"]);
         const $result = resource_mutation_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39312,7 +40357,7 @@ export const plans = {
     },
     mutationOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs76(args, ["input"]);
+        const selectArgs = makeArgs81(args, ["input"]);
         const $result = resource_mutation_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39329,7 +40374,7 @@ export const plans = {
     },
     mutationOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs77(args, ["input"]);
+        const selectArgs = makeArgs82(args, ["input"]);
         const $result = resource_mutation_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39346,7 +40391,7 @@ export const plans = {
     },
     noArgsMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs78(args, ["input"]);
+        const selectArgs = makeArgs83(args, ["input"]);
         const $result = resource_no_args_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39363,7 +40408,7 @@ export const plans = {
     },
     returnVoidMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs79(args, ["input"]);
+        const selectArgs = makeArgs84(args, ["input"]);
         const $result = resource_return_void_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39380,7 +40425,7 @@ export const plans = {
     },
     mutationIntervalSet: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs80(args, ["input"]);
+        const selectArgs = makeArgs85(args, ["input"]);
         const $result = resource_mutation_interval_setPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39397,7 +40442,7 @@ export const plans = {
     },
     mutationInOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs81(args, ["input"]);
+        const selectArgs = makeArgs86(args, ["input"]);
         const $result = resource_mutation_in_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39414,7 +40459,7 @@ export const plans = {
     },
     mutationReturnsTableOneCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs82(args, ["input"]);
+        const selectArgs = makeArgs87(args, ["input"]);
         const $result = resource_mutation_returns_table_one_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39431,7 +40476,7 @@ export const plans = {
     },
     jsonIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs83(args, ["input"]);
+        const selectArgs = makeArgs88(args, ["input"]);
         const $result = resource_json_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39448,7 +40493,7 @@ export const plans = {
     },
     jsonbIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs84(args, ["input"]);
+        const selectArgs = makeArgs89(args, ["input"]);
         const $result = resource_jsonb_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39465,7 +40510,7 @@ export const plans = {
     },
     jsonbIdentityMutationPlpgsql: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs85(args, ["input"]);
+        const selectArgs = makeArgs90(args, ["input"]);
         const $result = resource_jsonb_identity_mutation_plpgsqlPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39482,7 +40527,7 @@ export const plans = {
     },
     jsonbIdentityMutationPlpgsqlWithDefault: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs86(args, ["input"]);
+        const selectArgs = makeArgs91(args, ["input"]);
         const $result = resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39499,7 +40544,7 @@ export const plans = {
     },
     add1Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs87(args, ["input"]);
+        const selectArgs = makeArgs92(args, ["input"]);
         const $result = resource_add_1_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39516,7 +40561,7 @@ export const plans = {
     },
     add2Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs88(args, ["input"]);
+        const selectArgs = makeArgs93(args, ["input"]);
         const $result = resource_add_2_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39533,7 +40578,7 @@ export const plans = {
     },
     add3Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs89(args, ["input"]);
+        const selectArgs = makeArgs94(args, ["input"]);
         const $result = resource_add_3_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39550,7 +40595,7 @@ export const plans = {
     },
     add4Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs90(args, ["input"]);
+        const selectArgs = makeArgs95(args, ["input"]);
         const $result = resource_add_4_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39567,7 +40612,7 @@ export const plans = {
     },
     add4MutationError: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs91(args, ["input"]);
+        const selectArgs = makeArgs96(args, ["input"]);
         const $result = resource_add_4_mutation_errorPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39584,7 +40629,7 @@ export const plans = {
     },
     mult1: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs92(args, ["input"]);
+        const selectArgs = makeArgs97(args, ["input"]);
         const $result = resource_mult_1PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39601,7 +40646,7 @@ export const plans = {
     },
     mult2: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs93(args, ["input"]);
+        const selectArgs = makeArgs98(args, ["input"]);
         const $result = resource_mult_2PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39618,7 +40663,7 @@ export const plans = {
     },
     mult3: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs94(args, ["input"]);
+        const selectArgs = makeArgs99(args, ["input"]);
         const $result = resource_mult_3PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39635,7 +40680,7 @@ export const plans = {
     },
     mult4: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs95(args, ["input"]);
+        const selectArgs = makeArgs100(args, ["input"]);
         const $result = resource_mult_4PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39652,7 +40697,7 @@ export const plans = {
     },
     mutationInInout: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs96(args, ["input"]);
+        const selectArgs = makeArgs101(args, ["input"]);
         const $result = resource_mutation_in_inoutPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39669,7 +40714,7 @@ export const plans = {
     },
     mutationOutOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs97(args, ["input"]);
+        const selectArgs = makeArgs102(args, ["input"]);
         const $result = resource_mutation_out_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39686,7 +40731,7 @@ export const plans = {
     },
     mutationOutOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs98(args, ["input"]);
+        const selectArgs = makeArgs103(args, ["input"]);
         const $result = resource_mutation_out_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39703,7 +40748,7 @@ export const plans = {
     },
     mutationOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs99(args, ["input"]);
+        const selectArgs = makeArgs104(args, ["input"]);
         const $result = resource_mutation_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39720,7 +40765,7 @@ export const plans = {
     },
     intSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs100(args, ["input"]);
+        const selectArgs = makeArgs105(args, ["input"]);
         const $result = resource_int_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39737,7 +40782,7 @@ export const plans = {
     },
     mutationOutUnnamedOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs101(args, ["input"]);
+        const selectArgs = makeArgs106(args, ["input"]);
         const $result = resource_mutation_out_unnamed_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39754,7 +40799,7 @@ export const plans = {
     },
     mutationReturnsTableMultiCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs102(args, ["input"]);
+        const selectArgs = makeArgs107(args, ["input"]);
         const $result = resource_mutation_returns_table_multi_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39771,7 +40816,7 @@ export const plans = {
     },
     guidFn: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs103(args, ["input"]);
+        const selectArgs = makeArgs108(args, ["input"]);
         const $result = resource_guid_fnPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39788,7 +40833,7 @@ export const plans = {
     },
     mutationIntervalArray: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs104(args, ["input"]);
+        const selectArgs = makeArgs109(args, ["input"]);
         const $result = resource_mutation_interval_arrayPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39805,7 +40850,7 @@ export const plans = {
     },
     mutationTextArray: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs105(args, ["input"]);
+        const selectArgs = makeArgs110(args, ["input"]);
         const $result = resource_mutation_text_arrayPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39822,7 +40867,7 @@ export const plans = {
     },
     listBdeMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs106(args, ["input"]);
+        const selectArgs = makeArgs111(args, ["input"]);
         const $result = resource_list_bde_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39839,7 +40884,7 @@ export const plans = {
     },
     authenticateFail: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs107(args, ["input"]);
+        const selectArgs = makeArgs112(args, ["input"]);
         const $result = resource_authenticate_failPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39856,7 +40901,7 @@ export const plans = {
     },
     authenticate: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs108(args, ["input"]);
+        const selectArgs = makeArgs113(args, ["input"]);
         const $result = resource_authenticatePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39873,7 +40918,7 @@ export const plans = {
     },
     leftArmIdentity: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs109(args, ["input"]);
+        const selectArgs = makeArgs114(args, ["input"]);
         const $result = resource_left_arm_identityPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39890,7 +40935,7 @@ export const plans = {
     },
     issue756Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs110(args, ["input"]);
+        const selectArgs = makeArgs115(args, ["input"]);
         const $result = resource_issue756_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39907,7 +40952,7 @@ export const plans = {
     },
     issue756SetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs111(args, ["input"]);
+        const selectArgs = makeArgs116(args, ["input"]);
         const $result = resource_issue756_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39924,7 +40969,7 @@ export const plans = {
     },
     authenticateMany: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs112(args, ["input"]);
+        const selectArgs = makeArgs117(args, ["input"]);
         const $result = resource_authenticate_manyPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39941,7 +40986,7 @@ export const plans = {
     },
     authenticatePayload: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs113(args, ["input"]);
+        const selectArgs = makeArgs118(args, ["input"]);
         const $result = resource_authenticate_payloadPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39958,7 +41003,7 @@ export const plans = {
     },
     typesMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs114(args, ["input"]);
+        const selectArgs = makeArgs119(args, ["input"]);
         const $result = resource_types_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39975,7 +41020,7 @@ export const plans = {
     },
     mutationOutOutCompoundType: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs115(args, ["input"]);
+        const selectArgs = makeArgs120(args, ["input"]);
         const $result = resource_mutation_out_out_compound_typePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39992,7 +41037,7 @@ export const plans = {
     },
     compoundTypeMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs116(args, ["input"]);
+        const selectArgs = makeArgs121(args, ["input"]);
         const $result = resource_compound_type_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40009,7 +41054,7 @@ export const plans = {
     },
     compoundTypeSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs117(args, ["input"]);
+        const selectArgs = makeArgs122(args, ["input"]);
         const $result = resource_compound_type_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40026,7 +41071,7 @@ export const plans = {
     },
     tableMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs118(args, ["input"]);
+        const selectArgs = makeArgs123(args, ["input"]);
         const $result = resource_table_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40043,7 +41088,7 @@ export const plans = {
     },
     postWithSuffix: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs119(args, ["input"]);
+        const selectArgs = makeArgs124(args, ["input"]);
         const $result = resource_post_with_suffixPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40060,7 +41105,7 @@ export const plans = {
     },
     mutationCompoundTypeArray: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs120(args, ["input"]);
+        const selectArgs = makeArgs125(args, ["input"]);
         const $result = resource_mutation_compound_type_arrayPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40077,7 +41122,7 @@ export const plans = {
     },
     compoundTypeArrayMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs121(args, ["input"]);
+        const selectArgs = makeArgs126(args, ["input"]);
         const $result = resource_compound_type_array_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40094,7 +41139,7 @@ export const plans = {
     },
     postMany: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs122(args, ["input"]);
+        const selectArgs = makeArgs127(args, ["input"]);
         const $result = resource_post_manyPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40111,7 +41156,7 @@ export const plans = {
     },
     mutationOutComplex: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs123(args, ["input"]);
+        const selectArgs = makeArgs128(args, ["input"]);
         const $result = resource_mutation_out_complexPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40128,7 +41173,7 @@ export const plans = {
     },
     mutationOutComplexSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs124(args, ["input"]);
+        const selectArgs = makeArgs129(args, ["input"]);
         const $result = resource_mutation_out_complex_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40145,7 +41190,7 @@ export const plans = {
     },
     mutationOutTable: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs125(args, ["input"]);
+        const selectArgs = makeArgs130(args, ["input"]);
         const $result = resource_mutation_out_tablePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40162,7 +41207,7 @@ export const plans = {
     },
     mutationOutTableSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs126(args, ["input"]);
+        const selectArgs = makeArgs131(args, ["input"]);
         const $result = resource_mutation_out_table_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40179,7 +41224,7 @@ export const plans = {
     },
     tableSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs127(args, ["input"]);
+        const selectArgs = makeArgs132(args, ["input"]);
         const $result = resource_table_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40196,7 +41241,7 @@ export const plans = {
     },
     typeFunctionConnectionMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs128(args, ["input"]);
+        const selectArgs = makeArgs133(args, ["input"]);
         const $result = resource_type_function_connection_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40213,7 +41258,7 @@ export const plans = {
     },
     typeFunctionMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs129(args, ["input"]);
+        const selectArgs = makeArgs134(args, ["input"]);
         const $result = resource_type_function_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40230,7 +41275,7 @@ export const plans = {
     },
     typeFunctionListMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs130(args, ["input"]);
+        const selectArgs = makeArgs135(args, ["input"]);
         const $result = resource_type_function_list_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.graphql
@@ -5903,6 +5903,11 @@ type Person implements Node {
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, arg2: Int, b: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
 
   """This `Person`'s `PersonSecret`."""
   personSecretByPersonId: PersonSecret @deprecated(reason: "This is deprecated (comment on table c.person_secret).")

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.export.mjs
@@ -2504,6 +2504,11 @@ const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_compu
 const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
 const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
 const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const person_optional_missing_middle_1FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_1");
+const person_optional_missing_middle_2FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_2");
+const person_optional_missing_middle_3FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_3");
+const person_optional_missing_middle_4FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_4");
+const person_optional_missing_middle_5FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_5");
 const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
 const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
 const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
@@ -4303,6 +4308,216 @@ const registry = makeRegistry({
           serviceName: "main",
           schemaName: "c",
           name: "person_computed_first_arg_inout_out"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_1: {
+      executor,
+      name: "person_optional_missing_middle_1",
+      identifier: "main.c.person_optional_missing_middle_1(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_1"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_2: {
+      executor,
+      name: "person_optional_missing_middle_2",
+      identifier: "main.c.person_optional_missing_middle_2(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_2"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_3: {
+      executor,
+      name: "person_optional_missing_middle_3",
+      identifier: "main.c.person_optional_missing_middle_3(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_3"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_4: {
+      executor,
+      name: "person_optional_missing_middle_4",
+      identifier: "main.c.person_optional_missing_middle_4(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_4"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_5: {
+      executor,
+      name: "person_optional_missing_middle_5",
+      identifier: "main.c.person_optional_missing_middle_5(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_5FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_5"
         },
         tags: {}
       },
@@ -7134,22 +7349,28 @@ const makeArgs37 = (args, path = []) => {
 };
 const resource_person_computed_first_arg_inout_outPgResource = registry.pgResources["person_computed_first_arg_inout_out"];
 const argDetailsSimple38 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
+  graphqlArgName: "arg0",
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
   graphqlArgName: "b",
   postgresArgName: "b",
-  pgCodec: TYPES.text,
-  required: true,
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
   fetcher: null
 }];
 const makeArgs38 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7160,7 +7381,7 @@ const makeArgs38 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 1 - 1) {
         skipped = true;
         continue;
       } else {
@@ -7190,12 +7411,30 @@ const makeArgs38 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
-const argDetailsSimple39 = [];
+const resource_person_optional_missing_middle_1PgResource = registry.pgResources["person_optional_missing_middle_1"];
+const argDetailsSimple39 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs39 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7236,12 +7475,30 @@ const makeArgs39 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
-const argDetailsSimple40 = [];
+const resource_person_optional_missing_middle_2PgResource = registry.pgResources["person_optional_missing_middle_2"];
+const argDetailsSimple40 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs40 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7252,7 +7509,7 @@ const makeArgs40 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 2 - 1) {
         skipped = true;
         continue;
       } else {
@@ -7282,12 +7539,30 @@ const makeArgs40 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
-const argDetailsSimple41 = [];
+const resource_person_optional_missing_middle_3PgResource = registry.pgResources["person_optional_missing_middle_3"];
+const argDetailsSimple41 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs41 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7298,7 +7573,7 @@ const makeArgs41 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -7328,46 +7603,30 @@ const makeArgs41 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_friendsPgResource = registry.pgResources["person_friends"];
-const getSelectPlanFromParentAndArgs12 = ($in, args, _info) => {
-  if (!hasRecord($in)) {
-    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-  }
-  const extraSelectArgs = makeArgs41(args);
-  /**
-   * An optimisation - if all our dependencies are
-   * compatible with the expression's class plan then we
-   * can inline ourselves into that, otherwise we must
-   * issue the query separately.
-   */
-  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-  const selectArgs = [{
-    step: $row.record()
-  }, ...extraSelectArgs];
-  if (resource_person_friendsPgResource.isUnique && !resource_person_friendsPgResource.codec.attributes && typeof resource_person_friendsPgResource.from === "function") {
-    // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
-      if (i === 0) {
-        return $row.getClassStep().alias;
-      } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
-      } else {
-        return $row.placeholder(arg.step);
-      }
-    });
-    return pgClassExpression($row, resource_person_friendsPgResource.codec)`${resource_person_friendsPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
-  }
-  // PERF: or here, if scalar add select to `$row`?
-  return resource_person_friendsPgResource.execute(selectArgs);
-};
-const argDetailsSimple42 = [];
+const resource_person_optional_missing_middle_4PgResource = registry.pgResources["person_optional_missing_middle_4"];
+const argDetailsSimple42 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs42 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7378,7 +7637,7 @@ const makeArgs42 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -7408,52 +7667,24 @@ const makeArgs42 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
-const getSelectPlanFromParentAndArgs13 = ($in, args, _info) => {
-  if (!hasRecord($in)) {
-    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-  }
-  const extraSelectArgs = makeArgs42(args);
-  /**
-   * An optimisation - if all our dependencies are
-   * compatible with the expression's class plan then we
-   * can inline ourselves into that, otherwise we must
-   * issue the query separately.
-   */
-  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-  const selectArgs = [{
-    step: $row.record()
-  }, ...extraSelectArgs];
-  if (resource_person_type_function_connectionPgResource.isUnique && !resource_person_type_function_connectionPgResource.codec.attributes && typeof resource_person_type_function_connectionPgResource.from === "function") {
-    // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
-      if (i === 0) {
-        return $row.getClassStep().alias;
-      } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
-      } else {
-        return $row.placeholder(arg.step);
-      }
-    });
-    return pgClassExpression($row, resource_person_type_function_connectionPgResource.codec)`${resource_person_type_function_connectionPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
-  }
-  // PERF: or here, if scalar add select to `$row`?
-  return resource_person_type_function_connectionPgResource.execute(selectArgs);
-};
+const resource_person_optional_missing_middle_5PgResource = registry.pgResources["person_optional_missing_middle_5"];
 const argDetailsSimple43 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs43 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7494,7 +7725,7 @@ const makeArgs43 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
+const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
 const argDetailsSimple44 = [];
 const makeArgs44 = (args, path = []) => {
   const selectArgs = [];
@@ -7540,9 +7771,7 @@ const makeArgs44 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
-const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
-const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
+const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
 const argDetailsSimple45 = [];
 const makeArgs45 = (args, path = []) => {
   const selectArgs = [];
@@ -7555,6 +7784,332 @@ const makeArgs45 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple45[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
+const argDetailsSimple46 = [];
+const makeArgs46 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple46[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_person_friendsPgResource = registry.pgResources["person_friends"];
+const getSelectPlanFromParentAndArgs12 = ($in, args, _info) => {
+  if (!hasRecord($in)) {
+    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+  }
+  const extraSelectArgs = makeArgs46(args);
+  /**
+   * An optimisation - if all our dependencies are
+   * compatible with the expression's class plan then we
+   * can inline ourselves into that, otherwise we must
+   * issue the query separately.
+   */
+  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+  const selectArgs = [{
+    step: $row.record()
+  }, ...extraSelectArgs];
+  if (resource_person_friendsPgResource.isUnique && !resource_person_friendsPgResource.codec.attributes && typeof resource_person_friendsPgResource.from === "function") {
+    // This is a scalar computed attribute, let's inline the expression
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
+      if (i === 0) {
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
+      } else if ("pgCodec" in arg && arg.pgCodec) {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
+      } else {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
+      }
+    });
+    return pgClassExpression($row, resource_person_friendsPgResource.codec)`${resource_person_friendsPgResource.from(...newSelectArgs)}`;
+  }
+  // PERF: or here, if scalar add select to `$row`?
+  return resource_person_friendsPgResource.execute(selectArgs);
+};
+const argDetailsSimple47 = [];
+const makeArgs47 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple47[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
+const getSelectPlanFromParentAndArgs13 = ($in, args, _info) => {
+  if (!hasRecord($in)) {
+    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+  }
+  const extraSelectArgs = makeArgs47(args);
+  /**
+   * An optimisation - if all our dependencies are
+   * compatible with the expression's class plan then we
+   * can inline ourselves into that, otherwise we must
+   * issue the query separately.
+   */
+  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+  const selectArgs = [{
+    step: $row.record()
+  }, ...extraSelectArgs];
+  if (resource_person_type_function_connectionPgResource.isUnique && !resource_person_type_function_connectionPgResource.codec.attributes && typeof resource_person_type_function_connectionPgResource.from === "function") {
+    // This is a scalar computed attribute, let's inline the expression
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
+      if (i === 0) {
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
+      } else if ("pgCodec" in arg && arg.pgCodec) {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
+      } else {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
+      }
+    });
+    return pgClassExpression($row, resource_person_type_function_connectionPgResource.codec)`${resource_person_type_function_connectionPgResource.from(...newSelectArgs)}`;
+  }
+  // PERF: or here, if scalar add select to `$row`?
+  return resource_person_type_function_connectionPgResource.execute(selectArgs);
+};
+const argDetailsSimple48 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs48 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple48[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
+const argDetailsSimple49 = [];
+const makeArgs49 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple49[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
+const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
+const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
+const argDetailsSimple50 = [];
+const makeArgs50 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple50[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -7655,247 +8210,11 @@ const parseValueLiteral = (ast, variables) => {
   }
 };
 const resource_frmcdc_postPgResource = registry.pgResources["frmcdc_post"];
-const argDetailsSimple46 = [];
-const makeArgs46 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple46[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
-const argDetailsSimple47 = [];
-const makeArgs47 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple47[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
-const argDetailsSimple48 = [];
-const makeArgs48 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple48[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
-const argDetailsSimple49 = [];
-const makeArgs49 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple49[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
-const argDetailsSimple50 = [];
-const makeArgs50 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple50[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
-const argDetailsSimple51 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const argDetailsSimple51 = [];
 const makeArgs51 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7936,18 +8255,12 @@ const makeArgs51 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
-const argDetailsSimple52 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
+const argDetailsSimple52 = [];
 const makeArgs52 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7988,18 +8301,12 @@ const makeArgs52 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
-const argDetailsSimple53 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
+const argDetailsSimple53 = [];
 const makeArgs53 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8040,18 +8347,12 @@ const makeArgs53 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
-const argDetailsSimple54 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
+const argDetailsSimple54 = [];
 const makeArgs54 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8092,18 +8393,12 @@ const makeArgs54 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
-const argDetailsSimple55 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
+const argDetailsSimple55 = [];
 const makeArgs55 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8144,12 +8439,12 @@ const makeArgs55 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
+const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
 const argDetailsSimple56 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: false,
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
   fetcher: null
 }];
 const makeArgs56 = (args, path = []) => {
@@ -8196,16 +8491,10 @@ const makeArgs56 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
+const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
 const argDetailsSimple57 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "ino",
-  postgresArgName: "ino",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -8213,7 +8502,7 @@ const argDetailsSimple57 = [{
 const makeArgs57 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8254,12 +8543,18 @@ const makeArgs57 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
-const argDetailsSimple58 = [];
+const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
+const argDetailsSimple58 = [{
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.json,
+  required: true,
+  fetcher: null
+}];
 const makeArgs58 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8300,12 +8595,18 @@ const makeArgs58 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
-const argDetailsSimple59 = [];
+const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
+const argDetailsSimple59 = [{
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.jsonb,
+  required: true,
+  fetcher: null
+}];
 const makeArgs59 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8346,12 +8647,18 @@ const makeArgs59 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
-const argDetailsSimple60 = [];
+const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
+const argDetailsSimple60 = [{
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
+  required: true,
+  fetcher: null
+}];
 const makeArgs60 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8392,30 +8699,18 @@ const makeArgs60 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
+const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
 const argDetailsSimple61 = [{
-  graphqlArgName: "x",
-  postgresArgName: "x",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "y",
-  postgresArgName: "y",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "z",
-  postgresArgName: "z",
-  pgCodec: TYPES.int,
-  required: true,
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
+  required: false,
   fetcher: null
 }];
 const makeArgs61 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8456,12 +8751,24 @@ const makeArgs61 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
-const argDetailsSimple62 = [];
+const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
+const argDetailsSimple62 = [{
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "ino",
+  postgresArgName: "ino",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs62 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8502,18 +8809,12 @@ const makeArgs62 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
-const argDetailsSimple63 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
+const argDetailsSimple63 = [];
 const makeArgs63 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8554,18 +8855,12 @@ const makeArgs63 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
-const argDetailsSimple64 = [{
-  graphqlArgName: "leftArm",
-  postgresArgName: "left_arm",
-  pgCodec: leftArmCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
+const argDetailsSimple64 = [];
 const makeArgs64 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8606,7 +8901,7 @@ const makeArgs64 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
+const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -8652,12 +8947,30 @@ const makeArgs65 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
-const argDetailsSimple66 = [];
+const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
+const argDetailsSimple66 = [{
+  graphqlArgName: "x",
+  postgresArgName: "x",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "y",
+  postgresArgName: "y",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "z",
+  postgresArgName: "z",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs66 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8698,48 +9011,12 @@ const makeArgs66 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
-const argDetailsSimple67 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.bigint,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.boolean,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.varchar,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "d",
-  postgresArgName: "d",
-  pgCodec: int4ArrayCodec,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "e",
-  postgresArgName: "e",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "f",
-  postgresArgName: "f",
-  pgCodec: floatrangeCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
+const argDetailsSimple67 = [];
 const makeArgs67 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 6; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8780,10 +9057,10 @@ const makeArgs67 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
+const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
 const argDetailsSimple68 = [{
-  graphqlArgName: "i1",
-  postgresArgName: "i1",
+  graphqlArgName: "i",
+  postgresArgName: "i",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -8832,11 +9109,11 @@ const makeArgs68 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
+const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
 const argDetailsSimple69 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
-  pgCodec: TYPES.int,
+  graphqlArgName: "leftArm",
+  postgresArgName: "left_arm",
+  pgCodec: leftArmCodec,
   required: true,
   fetcher: null
 }];
@@ -8884,24 +9161,12 @@ const makeArgs69 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
-const argDetailsSimple70 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
+const argDetailsSimple70 = [];
 const makeArgs70 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8942,24 +9207,12 @@ const makeArgs70 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
-const argDetailsSimple71 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
+const argDetailsSimple71 = [];
 const makeArgs71 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -9000,12 +9253,48 @@ const makeArgs71 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
-const argDetailsSimple72 = [];
+const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
+const argDetailsSimple72 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.bigint,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.boolean,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.varchar,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "d",
+  postgresArgName: "d",
+  pgCodec: int4ArrayCodec,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "e",
+  postgresArgName: "e",
+  pgCodec: TYPES.json,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "f",
+  postgresArgName: "f",
+  pgCodec: floatrangeCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs72 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 6; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -9046,12 +9335,18 @@ const makeArgs72 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
-const argDetailsSimple73 = [];
+const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
+const argDetailsSimple73 = [{
+  graphqlArgName: "i1",
+  postgresArgName: "i1",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs73 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -9092,9 +9387,177 @@ const makeArgs73 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
-const argDetailsSimple74 = [];
+const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
+const argDetailsSimple74 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs74 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple74[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
+const argDetailsSimple75 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
+const makeArgs75 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple75[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
+const argDetailsSimple76 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
+const makeArgs76 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple76[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
+const argDetailsSimple77 = [];
+const makeArgs77 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
   for (let i = 0; i < 0; i++) {
@@ -9104,7 +9567,99 @@ const makeArgs74 = (args, path = []) => {
       pgCodec,
       required,
       fetcher
-    } = argDetailsSimple74[i];
+    } = argDetailsSimple77[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
+const argDetailsSimple78 = [];
+const makeArgs78 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple78[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
+const argDetailsSimple79 = [];
+const makeArgs79 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple79[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -9856,6 +10411,11 @@ type Person implements Node {
   computedInoutOut(ino: String): PersonComputedInoutOutRecord
   exists(email: Email): Boolean @deprecated(reason: "This is deprecated (comment on function c.person_exists).")
   computedFirstArgInoutOut: PersonComputedFirstArgInoutOutRecord
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, b: Int, arg2: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
   computedComplex(a: Int, b: String): PersonComputedComplexRecord
 
   """The first post by the person."""
@@ -15020,18 +15580,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_outPgResource.isUnique && !resource_person_computed_outPgResource.codec.attributes && typeof resource_person_computed_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_outPgResource.codec)`${resource_person_computed_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_outPgResource.codec)`${resource_person_computed_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_outPgResource.execute(selectArgs);
@@ -15054,18 +15624,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_first_namePgResource.isUnique && !resource_person_first_namePgResource.codec.attributes && typeof resource_person_first_namePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_first_namePgResource.codec)`${resource_person_first_namePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_first_namePgResource.codec)`${resource_person_first_namePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_first_namePgResource.execute(selectArgs);
@@ -15088,18 +15668,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_out_outPgResource.isUnique && !resource_person_computed_out_outPgResource.codec.attributes && typeof resource_person_computed_out_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_out_outPgResource.codec)`${resource_person_computed_out_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_out_outPgResource.codec)`${resource_person_computed_out_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_out_outPgResource.execute(selectArgs);
@@ -15123,18 +15713,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_computed_inoutPgResource.isUnique && !resource_person_computed_inoutPgResource.codec.attributes && typeof resource_person_computed_inoutPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_inoutPgResource.codec)`${resource_person_computed_inoutPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_computed_inoutPgResource.codec)`${resource_person_computed_inoutPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_inoutPgResource.execute(selectArgs);
@@ -15162,18 +15762,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_computed_inout_outPgResource.isUnique && !resource_person_computed_inout_outPgResource.codec.attributes && typeof resource_person_computed_inout_outPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_inout_outPgResource.codec)`${resource_person_computed_inout_outPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_computed_inout_outPgResource.codec)`${resource_person_computed_inout_outPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_inout_outPgResource.execute(selectArgs);
@@ -15201,18 +15811,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_existsPgResource.isUnique && !resource_person_existsPgResource.codec.attributes && typeof resource_person_existsPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_existsPgResource.codec)`${resource_person_existsPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_existsPgResource.codec)`${resource_person_existsPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_existsPgResource.execute(selectArgs);
@@ -15239,23 +15859,33 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_first_arg_inout_outPgResource.isUnique && !resource_person_computed_first_arg_inout_outPgResource.codec.attributes && typeof resource_person_computed_first_arg_inout_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_first_arg_inout_outPgResource.codec)`${resource_person_computed_first_arg_inout_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_first_arg_inout_outPgResource.codec)`${resource_person_computed_first_arg_inout_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_first_arg_inout_outPgResource.execute(selectArgs);
     },
-    computedComplex: {
+    optionalMissingMiddle1: {
       plan($in, args, _info) {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -15272,20 +15902,285 @@ export const plans = {
         const selectArgs = [{
           step: $row.record()
         }, ...extraSelectArgs];
-        if (resource_person_computed_complexPgResource.isUnique && !resource_person_computed_complexPgResource.codec.attributes && typeof resource_person_computed_complexPgResource.from === "function") {
+        if (resource_person_optional_missing_middle_1PgResource.isUnique && !resource_person_optional_missing_middle_1PgResource.codec.attributes && typeof resource_person_optional_missing_middle_1PgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_complexPgResource.codec)`${resource_person_computed_complexPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_optional_missing_middle_1PgResource.codec)`${resource_person_optional_missing_middle_1PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_1PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle2: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs39(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_2PgResource.isUnique && !resource_person_optional_missing_middle_2PgResource.codec.attributes && typeof resource_person_optional_missing_middle_2PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_2PgResource.codec)`${resource_person_optional_missing_middle_2PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_2PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        b: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle3: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs40(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_3PgResource.isUnique && !resource_person_optional_missing_middle_3PgResource.codec.attributes && typeof resource_person_optional_missing_middle_3PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_3PgResource.codec)`${resource_person_optional_missing_middle_3PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_3PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle4: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs41(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_4PgResource.isUnique && !resource_person_optional_missing_middle_4PgResource.codec.attributes && typeof resource_person_optional_missing_middle_4PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_4PgResource.codec)`${resource_person_optional_missing_middle_4PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_4PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        arg2: undefined
+      }
+    },
+    optionalMissingMiddle5: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs42(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_5PgResource.isUnique && !resource_person_optional_missing_middle_5PgResource.codec.attributes && typeof resource_person_optional_missing_middle_5PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_5PgResource.codec)`${resource_person_optional_missing_middle_5PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_5PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        arg2: undefined
+      }
+    },
+    computedComplex: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs43(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_computed_complexPgResource.isUnique && !resource_person_computed_complexPgResource.codec.attributes && typeof resource_person_computed_complexPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_computed_complexPgResource.codec)`${resource_person_computed_complexPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_complexPgResource.execute(selectArgs);
@@ -15299,7 +16194,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs39(args);
+      const extraSelectArgs = makeArgs44(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -15313,18 +16208,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_first_postPgResource.isUnique && !resource_person_first_postPgResource.codec.attributes && typeof resource_person_first_postPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_first_postPgResource.codec)`${resource_person_first_postPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_first_postPgResource.codec)`${resource_person_first_postPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_first_postPgResource.execute(selectArgs);
@@ -15333,7 +16238,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs40(args);
+      const extraSelectArgs = makeArgs45(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -15347,18 +16252,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_first_arg_inoutPgResource.isUnique && !resource_person_computed_first_arg_inoutPgResource.codec.attributes && typeof resource_person_computed_first_arg_inoutPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_first_arg_inoutPgResource.codec)`${resource_person_computed_first_arg_inoutPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_first_arg_inoutPgResource.codec)`${resource_person_computed_first_arg_inoutPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_first_arg_inoutPgResource.execute(selectArgs);
@@ -15463,7 +16378,7 @@ export const plans = {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
         }
-        const extraSelectArgs = makeArgs43(args);
+        const extraSelectArgs = makeArgs48(args);
         /**
          * An optimisation - if all our dependencies are
          * compatible with the expression's class plan then we
@@ -15477,18 +16392,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_type_functionPgResource.isUnique && !resource_person_type_functionPgResource.codec.attributes && typeof resource_person_type_functionPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_type_functionPgResource.codec)`${resource_person_type_functionPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_type_functionPgResource.codec)`${resource_person_type_functionPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_type_functionPgResource.execute(selectArgs);
@@ -15501,7 +16426,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs44(args);
+      const extraSelectArgs = makeArgs49(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -15515,18 +16440,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_type_function_listPgResource.isUnique && !resource_person_type_function_listPgResource.codec.attributes && typeof resource_person_type_function_listPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_type_function_listPgResource.codec)`${resource_person_type_function_listPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_type_function_listPgResource.codec)`${resource_person_type_function_listPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_type_function_listPgResource.execute(selectArgs);
@@ -15817,7 +16752,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs45(args);
+      const extraSelectArgs = makeArgs50(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -15831,18 +16766,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_compound_type_computed_fieldPgResource.isUnique && !resource_compound_type_computed_fieldPgResource.codec.attributes && typeof resource_compound_type_computed_fieldPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_compound_type_computed_fieldPgResource.codec)`${resource_compound_type_computed_fieldPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_compound_type_computed_fieldPgResource.codec)`${resource_compound_type_computed_fieldPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_compound_type_computed_fieldPgResource.execute(selectArgs);
@@ -18577,7 +19522,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs46(args);
+      const extraSelectArgs = makeArgs51(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -18591,18 +19536,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_edge_case_computedPgResource.isUnique && !resource_edge_case_computedPgResource.codec.attributes && typeof resource_edge_case_computedPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_edge_case_computedPgResource.codec)`${resource_edge_case_computedPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_edge_case_computedPgResource.codec)`${resource_edge_case_computedPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_edge_case_computedPgResource.execute(selectArgs);
@@ -19278,7 +20233,7 @@ export const plans = {
     __assertStep: __ValueStep,
     mutationOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs47(args, ["input"]);
+        const selectArgs = makeArgs52(args, ["input"]);
         const $result = resource_mutation_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19295,7 +20250,7 @@ export const plans = {
     },
     mutationOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs48(args, ["input"]);
+        const selectArgs = makeArgs53(args, ["input"]);
         const $result = resource_mutation_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19312,7 +20267,7 @@ export const plans = {
     },
     mutationOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs49(args, ["input"]);
+        const selectArgs = makeArgs54(args, ["input"]);
         const $result = resource_mutation_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19329,7 +20284,7 @@ export const plans = {
     },
     noArgsMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs50(args, ["input"]);
+        const selectArgs = makeArgs55(args, ["input"]);
         const $result = resource_no_args_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19346,7 +20301,7 @@ export const plans = {
     },
     mutationInOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs51(args, ["input"]);
+        const selectArgs = makeArgs56(args, ["input"]);
         const $result = resource_mutation_in_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19363,7 +20318,7 @@ export const plans = {
     },
     mutationReturnsTableOneCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs52(args, ["input"]);
+        const selectArgs = makeArgs57(args, ["input"]);
         const $result = resource_mutation_returns_table_one_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19380,7 +20335,7 @@ export const plans = {
     },
     jsonIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs53(args, ["input"]);
+        const selectArgs = makeArgs58(args, ["input"]);
         const $result = resource_json_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19397,7 +20352,7 @@ export const plans = {
     },
     jsonbIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs54(args, ["input"]);
+        const selectArgs = makeArgs59(args, ["input"]);
         const $result = resource_jsonb_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19414,7 +20369,7 @@ export const plans = {
     },
     jsonbIdentityMutationPlpgsql: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs55(args, ["input"]);
+        const selectArgs = makeArgs60(args, ["input"]);
         const $result = resource_jsonb_identity_mutation_plpgsqlPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19431,7 +20386,7 @@ export const plans = {
     },
     jsonbIdentityMutationPlpgsqlWithDefault: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs56(args, ["input"]);
+        const selectArgs = makeArgs61(args, ["input"]);
         const $result = resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19448,7 +20403,7 @@ export const plans = {
     },
     mutationInInout: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs57(args, ["input"]);
+        const selectArgs = makeArgs62(args, ["input"]);
         const $result = resource_mutation_in_inoutPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19465,7 +20420,7 @@ export const plans = {
     },
     mutationOutOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs58(args, ["input"]);
+        const selectArgs = makeArgs63(args, ["input"]);
         const $result = resource_mutation_out_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19482,7 +20437,7 @@ export const plans = {
     },
     mutationOutOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs59(args, ["input"]);
+        const selectArgs = makeArgs64(args, ["input"]);
         const $result = resource_mutation_out_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19499,7 +20454,7 @@ export const plans = {
     },
     mutationOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs60(args, ["input"]);
+        const selectArgs = makeArgs65(args, ["input"]);
         const $result = resource_mutation_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19516,7 +20471,7 @@ export const plans = {
     },
     intSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs61(args, ["input"]);
+        const selectArgs = makeArgs66(args, ["input"]);
         const $result = resource_int_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19533,7 +20488,7 @@ export const plans = {
     },
     mutationOutUnnamedOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs62(args, ["input"]);
+        const selectArgs = makeArgs67(args, ["input"]);
         const $result = resource_mutation_out_unnamed_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19550,7 +20505,7 @@ export const plans = {
     },
     mutationReturnsTableMultiCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs63(args, ["input"]);
+        const selectArgs = makeArgs68(args, ["input"]);
         const $result = resource_mutation_returns_table_multi_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19567,7 +20522,7 @@ export const plans = {
     },
     leftArmIdentity: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs64(args, ["input"]);
+        const selectArgs = makeArgs69(args, ["input"]);
         const $result = resource_left_arm_identityPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19584,7 +20539,7 @@ export const plans = {
     },
     issue756Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs65(args, ["input"]);
+        const selectArgs = makeArgs70(args, ["input"]);
         const $result = resource_issue756_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19601,7 +20556,7 @@ export const plans = {
     },
     issue756SetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs66(args, ["input"]);
+        const selectArgs = makeArgs71(args, ["input"]);
         const $result = resource_issue756_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19618,7 +20573,7 @@ export const plans = {
     },
     typesMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs67(args, ["input"]);
+        const selectArgs = makeArgs72(args, ["input"]);
         const $result = resource_types_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19635,7 +20590,7 @@ export const plans = {
     },
     mutationOutOutCompoundType: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs68(args, ["input"]);
+        const selectArgs = makeArgs73(args, ["input"]);
         const $result = resource_mutation_out_out_compound_typePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19652,7 +20607,7 @@ export const plans = {
     },
     tableMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs69(args, ["input"]);
+        const selectArgs = makeArgs74(args, ["input"]);
         const $result = resource_table_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19669,7 +20624,7 @@ export const plans = {
     },
     mutationOutComplex: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs70(args, ["input"]);
+        const selectArgs = makeArgs75(args, ["input"]);
         const $result = resource_mutation_out_complexPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19686,7 +20641,7 @@ export const plans = {
     },
     mutationOutComplexSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs71(args, ["input"]);
+        const selectArgs = makeArgs76(args, ["input"]);
         const $result = resource_mutation_out_complex_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19703,7 +20658,7 @@ export const plans = {
     },
     mutationOutTable: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs72(args, ["input"]);
+        const selectArgs = makeArgs77(args, ["input"]);
         const $result = resource_mutation_out_tablePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19720,7 +20675,7 @@ export const plans = {
     },
     mutationOutTableSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs73(args, ["input"]);
+        const selectArgs = makeArgs78(args, ["input"]);
         const $result = resource_mutation_out_table_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19737,7 +20692,7 @@ export const plans = {
     },
     tableSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs74(args, ["input"]);
+        const selectArgs = makeArgs79(args, ["input"]);
         const $result = resource_table_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.graphql
@@ -2993,6 +2993,11 @@ type Person implements Node {
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, arg2: Int, b: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
 
   """This `Person`'s `PersonSecret`."""
   personSecretByPersonId: PersonSecret @deprecated(reason: "This is deprecated (comment on table c.person_secret).")

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-good.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-good.1.export.mjs
@@ -2504,6 +2504,11 @@ const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_compu
 const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
 const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
 const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const person_optional_missing_middle_1FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_1");
+const person_optional_missing_middle_2FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_2");
+const person_optional_missing_middle_3FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_3");
+const person_optional_missing_middle_4FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_4");
+const person_optional_missing_middle_5FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_5");
 const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
 const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
 const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
@@ -4301,6 +4306,216 @@ const registry = makeRegistry({
           serviceName: "main",
           schemaName: "c",
           name: "person_computed_first_arg_inout_out"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_1: {
+      executor,
+      name: "person_optional_missing_middle_1",
+      identifier: "main.c.person_optional_missing_middle_1(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_1"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_2: {
+      executor,
+      name: "person_optional_missing_middle_2",
+      identifier: "main.c.person_optional_missing_middle_2(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_2"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_3: {
+      executor,
+      name: "person_optional_missing_middle_3",
+      identifier: "main.c.person_optional_missing_middle_3(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_3"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_4: {
+      executor,
+      name: "person_optional_missing_middle_4",
+      identifier: "main.c.person_optional_missing_middle_4(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_4"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_5: {
+      executor,
+      name: "person_optional_missing_middle_5",
+      identifier: "main.c.person_optional_missing_middle_5(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_5FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_5"
         },
         tags: {}
       },
@@ -7132,22 +7347,28 @@ const makeArgs37 = (args, path = []) => {
 };
 const resource_person_computed_first_arg_inout_outPgResource = registry.pgResources["person_computed_first_arg_inout_out"];
 const argDetailsSimple38 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
+  graphqlArgName: "arg0",
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
   graphqlArgName: "b",
   postgresArgName: "b",
-  pgCodec: TYPES.text,
-  required: true,
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
   fetcher: null
 }];
 const makeArgs38 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7158,7 +7379,7 @@ const makeArgs38 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 1 - 1) {
         skipped = true;
         continue;
       } else {
@@ -7188,12 +7409,30 @@ const makeArgs38 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
-const argDetailsSimple39 = [];
+const resource_person_optional_missing_middle_1PgResource = registry.pgResources["person_optional_missing_middle_1"];
+const argDetailsSimple39 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs39 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7234,12 +7473,30 @@ const makeArgs39 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
-const argDetailsSimple40 = [];
+const resource_person_optional_missing_middle_2PgResource = registry.pgResources["person_optional_missing_middle_2"];
+const argDetailsSimple40 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs40 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7250,7 +7507,7 @@ const makeArgs40 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 2 - 1) {
         skipped = true;
         continue;
       } else {
@@ -7280,12 +7537,30 @@ const makeArgs40 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
-const argDetailsSimple41 = [];
+const resource_person_optional_missing_middle_3PgResource = registry.pgResources["person_optional_missing_middle_3"];
+const argDetailsSimple41 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs41 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7296,7 +7571,7 @@ const makeArgs41 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -7326,46 +7601,30 @@ const makeArgs41 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_friendsPgResource = registry.pgResources["person_friends"];
-const getSelectPlanFromParentAndArgs12 = ($in, args, _info) => {
-  if (!hasRecord($in)) {
-    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-  }
-  const extraSelectArgs = makeArgs41(args);
-  /**
-   * An optimisation - if all our dependencies are
-   * compatible with the expression's class plan then we
-   * can inline ourselves into that, otherwise we must
-   * issue the query separately.
-   */
-  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-  const selectArgs = [{
-    step: $row.record()
-  }, ...extraSelectArgs];
-  if (resource_person_friendsPgResource.isUnique && !resource_person_friendsPgResource.codec.attributes && typeof resource_person_friendsPgResource.from === "function") {
-    // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
-      if (i === 0) {
-        return $row.getClassStep().alias;
-      } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
-      } else {
-        return $row.placeholder(arg.step);
-      }
-    });
-    return pgClassExpression($row, resource_person_friendsPgResource.codec)`${resource_person_friendsPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
-  }
-  // PERF: or here, if scalar add select to `$row`?
-  return resource_person_friendsPgResource.execute(selectArgs);
-};
-const argDetailsSimple42 = [];
+const resource_person_optional_missing_middle_4PgResource = registry.pgResources["person_optional_missing_middle_4"];
+const argDetailsSimple42 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs42 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7376,7 +7635,7 @@ const makeArgs42 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -7406,52 +7665,24 @@ const makeArgs42 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
-const getSelectPlanFromParentAndArgs13 = ($in, args, _info) => {
-  if (!hasRecord($in)) {
-    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-  }
-  const extraSelectArgs = makeArgs42(args);
-  /**
-   * An optimisation - if all our dependencies are
-   * compatible with the expression's class plan then we
-   * can inline ourselves into that, otherwise we must
-   * issue the query separately.
-   */
-  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-  const selectArgs = [{
-    step: $row.record()
-  }, ...extraSelectArgs];
-  if (resource_person_type_function_connectionPgResource.isUnique && !resource_person_type_function_connectionPgResource.codec.attributes && typeof resource_person_type_function_connectionPgResource.from === "function") {
-    // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
-      if (i === 0) {
-        return $row.getClassStep().alias;
-      } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
-      } else {
-        return $row.placeholder(arg.step);
-      }
-    });
-    return pgClassExpression($row, resource_person_type_function_connectionPgResource.codec)`${resource_person_type_function_connectionPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
-  }
-  // PERF: or here, if scalar add select to `$row`?
-  return resource_person_type_function_connectionPgResource.execute(selectArgs);
-};
+const resource_person_optional_missing_middle_5PgResource = registry.pgResources["person_optional_missing_middle_5"];
 const argDetailsSimple43 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs43 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7492,7 +7723,7 @@ const makeArgs43 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
+const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
 const argDetailsSimple44 = [];
 const makeArgs44 = (args, path = []) => {
   const selectArgs = [];
@@ -7538,9 +7769,7 @@ const makeArgs44 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
-const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
-const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
+const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
 const argDetailsSimple45 = [];
 const makeArgs45 = (args, path = []) => {
   const selectArgs = [];
@@ -7553,6 +7782,332 @@ const makeArgs45 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple45[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
+const argDetailsSimple46 = [];
+const makeArgs46 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple46[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_person_friendsPgResource = registry.pgResources["person_friends"];
+const getSelectPlanFromParentAndArgs12 = ($in, args, _info) => {
+  if (!hasRecord($in)) {
+    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+  }
+  const extraSelectArgs = makeArgs46(args);
+  /**
+   * An optimisation - if all our dependencies are
+   * compatible with the expression's class plan then we
+   * can inline ourselves into that, otherwise we must
+   * issue the query separately.
+   */
+  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+  const selectArgs = [{
+    step: $row.record()
+  }, ...extraSelectArgs];
+  if (resource_person_friendsPgResource.isUnique && !resource_person_friendsPgResource.codec.attributes && typeof resource_person_friendsPgResource.from === "function") {
+    // This is a scalar computed attribute, let's inline the expression
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
+      if (i === 0) {
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
+      } else if ("pgCodec" in arg && arg.pgCodec) {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
+      } else {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
+      }
+    });
+    return pgClassExpression($row, resource_person_friendsPgResource.codec)`${resource_person_friendsPgResource.from(...newSelectArgs)}`;
+  }
+  // PERF: or here, if scalar add select to `$row`?
+  return resource_person_friendsPgResource.execute(selectArgs);
+};
+const argDetailsSimple47 = [];
+const makeArgs47 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple47[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
+const getSelectPlanFromParentAndArgs13 = ($in, args, _info) => {
+  if (!hasRecord($in)) {
+    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+  }
+  const extraSelectArgs = makeArgs47(args);
+  /**
+   * An optimisation - if all our dependencies are
+   * compatible with the expression's class plan then we
+   * can inline ourselves into that, otherwise we must
+   * issue the query separately.
+   */
+  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+  const selectArgs = [{
+    step: $row.record()
+  }, ...extraSelectArgs];
+  if (resource_person_type_function_connectionPgResource.isUnique && !resource_person_type_function_connectionPgResource.codec.attributes && typeof resource_person_type_function_connectionPgResource.from === "function") {
+    // This is a scalar computed attribute, let's inline the expression
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
+      if (i === 0) {
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
+      } else if ("pgCodec" in arg && arg.pgCodec) {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
+      } else {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
+      }
+    });
+    return pgClassExpression($row, resource_person_type_function_connectionPgResource.codec)`${resource_person_type_function_connectionPgResource.from(...newSelectArgs)}`;
+  }
+  // PERF: or here, if scalar add select to `$row`?
+  return resource_person_type_function_connectionPgResource.execute(selectArgs);
+};
+const argDetailsSimple48 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs48 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple48[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
+const argDetailsSimple49 = [];
+const makeArgs49 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple49[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
+const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
+const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
+const argDetailsSimple50 = [];
+const makeArgs50 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple50[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -7653,247 +8208,11 @@ const parseValueLiteral = (ast, variables) => {
   }
 };
 const resource_frmcdc_postPgResource = registry.pgResources["frmcdc_post"];
-const argDetailsSimple46 = [];
-const makeArgs46 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple46[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
-const argDetailsSimple47 = [];
-const makeArgs47 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple47[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
-const argDetailsSimple48 = [];
-const makeArgs48 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple48[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
-const argDetailsSimple49 = [];
-const makeArgs49 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple49[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
-const argDetailsSimple50 = [];
-const makeArgs50 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple50[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
-const argDetailsSimple51 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const argDetailsSimple51 = [];
 const makeArgs51 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7934,18 +8253,12 @@ const makeArgs51 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
-const argDetailsSimple52 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
+const argDetailsSimple52 = [];
 const makeArgs52 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7986,18 +8299,12 @@ const makeArgs52 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
-const argDetailsSimple53 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
+const argDetailsSimple53 = [];
 const makeArgs53 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8038,18 +8345,12 @@ const makeArgs53 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
-const argDetailsSimple54 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
+const argDetailsSimple54 = [];
 const makeArgs54 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8090,18 +8391,12 @@ const makeArgs54 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
-const argDetailsSimple55 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
+const argDetailsSimple55 = [];
 const makeArgs55 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8142,12 +8437,12 @@ const makeArgs55 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
+const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
 const argDetailsSimple56 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: false,
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
   fetcher: null
 }];
 const makeArgs56 = (args, path = []) => {
@@ -8194,16 +8489,10 @@ const makeArgs56 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
+const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
 const argDetailsSimple57 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "ino",
-  postgresArgName: "ino",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -8211,7 +8500,7 @@ const argDetailsSimple57 = [{
 const makeArgs57 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8252,12 +8541,18 @@ const makeArgs57 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
-const argDetailsSimple58 = [];
+const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
+const argDetailsSimple58 = [{
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.json,
+  required: true,
+  fetcher: null
+}];
 const makeArgs58 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8298,12 +8593,18 @@ const makeArgs58 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
-const argDetailsSimple59 = [];
+const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
+const argDetailsSimple59 = [{
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.jsonb,
+  required: true,
+  fetcher: null
+}];
 const makeArgs59 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8344,12 +8645,18 @@ const makeArgs59 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
-const argDetailsSimple60 = [];
+const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
+const argDetailsSimple60 = [{
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
+  required: true,
+  fetcher: null
+}];
 const makeArgs60 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8390,30 +8697,18 @@ const makeArgs60 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
+const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
 const argDetailsSimple61 = [{
-  graphqlArgName: "x",
-  postgresArgName: "x",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "y",
-  postgresArgName: "y",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "z",
-  postgresArgName: "z",
-  pgCodec: TYPES.int,
-  required: true,
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
+  required: false,
   fetcher: null
 }];
 const makeArgs61 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8454,12 +8749,24 @@ const makeArgs61 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
-const argDetailsSimple62 = [];
+const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
+const argDetailsSimple62 = [{
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "ino",
+  postgresArgName: "ino",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs62 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8500,18 +8807,12 @@ const makeArgs62 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
-const argDetailsSimple63 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
+const argDetailsSimple63 = [];
 const makeArgs63 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8552,18 +8853,12 @@ const makeArgs63 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
-const argDetailsSimple64 = [{
-  graphqlArgName: "leftArm",
-  postgresArgName: "left_arm",
-  pgCodec: leftArmCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
+const argDetailsSimple64 = [];
 const makeArgs64 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8604,7 +8899,7 @@ const makeArgs64 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
+const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -8650,12 +8945,30 @@ const makeArgs65 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
-const argDetailsSimple66 = [];
+const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
+const argDetailsSimple66 = [{
+  graphqlArgName: "x",
+  postgresArgName: "x",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "y",
+  postgresArgName: "y",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "z",
+  postgresArgName: "z",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs66 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8696,48 +9009,12 @@ const makeArgs66 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
-const argDetailsSimple67 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.bigint,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.boolean,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.varchar,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "d",
-  postgresArgName: "d",
-  pgCodec: int4ArrayCodec,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "e",
-  postgresArgName: "e",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "f",
-  postgresArgName: "f",
-  pgCodec: floatrangeCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
+const argDetailsSimple67 = [];
 const makeArgs67 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 6; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8778,10 +9055,10 @@ const makeArgs67 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
+const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
 const argDetailsSimple68 = [{
-  graphqlArgName: "i1",
-  postgresArgName: "i1",
+  graphqlArgName: "i",
+  postgresArgName: "i",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -8830,11 +9107,11 @@ const makeArgs68 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
+const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
 const argDetailsSimple69 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
-  pgCodec: TYPES.int,
+  graphqlArgName: "leftArm",
+  postgresArgName: "left_arm",
+  pgCodec: leftArmCodec,
   required: true,
   fetcher: null
 }];
@@ -8882,24 +9159,12 @@ const makeArgs69 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
-const argDetailsSimple70 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
+const argDetailsSimple70 = [];
 const makeArgs70 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8940,24 +9205,12 @@ const makeArgs70 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
-const argDetailsSimple71 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
+const argDetailsSimple71 = [];
 const makeArgs71 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8998,12 +9251,48 @@ const makeArgs71 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
-const argDetailsSimple72 = [];
+const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
+const argDetailsSimple72 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.bigint,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.boolean,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.varchar,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "d",
+  postgresArgName: "d",
+  pgCodec: int4ArrayCodec,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "e",
+  postgresArgName: "e",
+  pgCodec: TYPES.json,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "f",
+  postgresArgName: "f",
+  pgCodec: floatrangeCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs72 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 6; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -9044,12 +9333,18 @@ const makeArgs72 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
-const argDetailsSimple73 = [];
+const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
+const argDetailsSimple73 = [{
+  graphqlArgName: "i1",
+  postgresArgName: "i1",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs73 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -9090,9 +9385,177 @@ const makeArgs73 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
-const argDetailsSimple74 = [];
+const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
+const argDetailsSimple74 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs74 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple74[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
+const argDetailsSimple75 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
+const makeArgs75 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple75[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
+const argDetailsSimple76 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
+const makeArgs76 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple76[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
+const argDetailsSimple77 = [];
+const makeArgs77 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
   for (let i = 0; i < 0; i++) {
@@ -9102,7 +9565,99 @@ const makeArgs74 = (args, path = []) => {
       pgCodec,
       required,
       fetcher
-    } = argDetailsSimple74[i];
+    } = argDetailsSimple77[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
+const argDetailsSimple78 = [];
+const makeArgs78 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple78[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
+const argDetailsSimple79 = [];
+const makeArgs79 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple79[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -9857,6 +10412,11 @@ type Person implements Node {
   computedInoutOut(ino: String): PersonComputedInoutOutRecord
   exists(email: Email): Boolean @deprecated(reason: "This is deprecated (comment on function c.person_exists).")
   computedFirstArgInoutOut: PersonComputedFirstArgInoutOutRecord
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, b: Int, arg2: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
   computedComplex(a: Int, b: String): PersonComputedComplexRecord
 
   """The first post by the person."""
@@ -15072,18 +15632,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_outPgResource.isUnique && !resource_person_computed_outPgResource.codec.attributes && typeof resource_person_computed_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_outPgResource.codec)`${resource_person_computed_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_outPgResource.codec)`${resource_person_computed_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_outPgResource.execute(selectArgs);
@@ -15106,18 +15676,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_first_namePgResource.isUnique && !resource_person_first_namePgResource.codec.attributes && typeof resource_person_first_namePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_first_namePgResource.codec)`${resource_person_first_namePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_first_namePgResource.codec)`${resource_person_first_namePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_first_namePgResource.execute(selectArgs);
@@ -15140,18 +15720,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_out_outPgResource.isUnique && !resource_person_computed_out_outPgResource.codec.attributes && typeof resource_person_computed_out_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_out_outPgResource.codec)`${resource_person_computed_out_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_out_outPgResource.codec)`${resource_person_computed_out_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_out_outPgResource.execute(selectArgs);
@@ -15175,18 +15765,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_computed_inoutPgResource.isUnique && !resource_person_computed_inoutPgResource.codec.attributes && typeof resource_person_computed_inoutPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_inoutPgResource.codec)`${resource_person_computed_inoutPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_computed_inoutPgResource.codec)`${resource_person_computed_inoutPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_inoutPgResource.execute(selectArgs);
@@ -15214,18 +15814,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_computed_inout_outPgResource.isUnique && !resource_person_computed_inout_outPgResource.codec.attributes && typeof resource_person_computed_inout_outPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_inout_outPgResource.codec)`${resource_person_computed_inout_outPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_computed_inout_outPgResource.codec)`${resource_person_computed_inout_outPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_inout_outPgResource.execute(selectArgs);
@@ -15253,18 +15863,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_existsPgResource.isUnique && !resource_person_existsPgResource.codec.attributes && typeof resource_person_existsPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_existsPgResource.codec)`${resource_person_existsPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_existsPgResource.codec)`${resource_person_existsPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_existsPgResource.execute(selectArgs);
@@ -15291,23 +15911,33 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_first_arg_inout_outPgResource.isUnique && !resource_person_computed_first_arg_inout_outPgResource.codec.attributes && typeof resource_person_computed_first_arg_inout_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_first_arg_inout_outPgResource.codec)`${resource_person_computed_first_arg_inout_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_first_arg_inout_outPgResource.codec)`${resource_person_computed_first_arg_inout_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_first_arg_inout_outPgResource.execute(selectArgs);
     },
-    computedComplex: {
+    optionalMissingMiddle1: {
       plan($in, args, _info) {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -15324,20 +15954,285 @@ export const plans = {
         const selectArgs = [{
           step: $row.record()
         }, ...extraSelectArgs];
-        if (resource_person_computed_complexPgResource.isUnique && !resource_person_computed_complexPgResource.codec.attributes && typeof resource_person_computed_complexPgResource.from === "function") {
+        if (resource_person_optional_missing_middle_1PgResource.isUnique && !resource_person_optional_missing_middle_1PgResource.codec.attributes && typeof resource_person_optional_missing_middle_1PgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_complexPgResource.codec)`${resource_person_computed_complexPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_optional_missing_middle_1PgResource.codec)`${resource_person_optional_missing_middle_1PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_1PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle2: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs39(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_2PgResource.isUnique && !resource_person_optional_missing_middle_2PgResource.codec.attributes && typeof resource_person_optional_missing_middle_2PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_2PgResource.codec)`${resource_person_optional_missing_middle_2PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_2PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        b: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle3: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs40(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_3PgResource.isUnique && !resource_person_optional_missing_middle_3PgResource.codec.attributes && typeof resource_person_optional_missing_middle_3PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_3PgResource.codec)`${resource_person_optional_missing_middle_3PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_3PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle4: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs41(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_4PgResource.isUnique && !resource_person_optional_missing_middle_4PgResource.codec.attributes && typeof resource_person_optional_missing_middle_4PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_4PgResource.codec)`${resource_person_optional_missing_middle_4PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_4PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        arg2: undefined
+      }
+    },
+    optionalMissingMiddle5: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs42(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_5PgResource.isUnique && !resource_person_optional_missing_middle_5PgResource.codec.attributes && typeof resource_person_optional_missing_middle_5PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_5PgResource.codec)`${resource_person_optional_missing_middle_5PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_5PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        arg2: undefined
+      }
+    },
+    computedComplex: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs43(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_computed_complexPgResource.isUnique && !resource_person_computed_complexPgResource.codec.attributes && typeof resource_person_computed_complexPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_computed_complexPgResource.codec)`${resource_person_computed_complexPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_complexPgResource.execute(selectArgs);
@@ -15351,7 +16246,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs39(args);
+      const extraSelectArgs = makeArgs44(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -15365,18 +16260,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_first_postPgResource.isUnique && !resource_person_first_postPgResource.codec.attributes && typeof resource_person_first_postPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_first_postPgResource.codec)`${resource_person_first_postPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_first_postPgResource.codec)`${resource_person_first_postPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_first_postPgResource.execute(selectArgs);
@@ -15385,7 +16290,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs40(args);
+      const extraSelectArgs = makeArgs45(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -15399,18 +16304,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_first_arg_inoutPgResource.isUnique && !resource_person_computed_first_arg_inoutPgResource.codec.attributes && typeof resource_person_computed_first_arg_inoutPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_first_arg_inoutPgResource.codec)`${resource_person_computed_first_arg_inoutPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_first_arg_inoutPgResource.codec)`${resource_person_computed_first_arg_inoutPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_first_arg_inoutPgResource.execute(selectArgs);
@@ -15515,7 +16430,7 @@ export const plans = {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
         }
-        const extraSelectArgs = makeArgs43(args);
+        const extraSelectArgs = makeArgs48(args);
         /**
          * An optimisation - if all our dependencies are
          * compatible with the expression's class plan then we
@@ -15529,18 +16444,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_type_functionPgResource.isUnique && !resource_person_type_functionPgResource.codec.attributes && typeof resource_person_type_functionPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_type_functionPgResource.codec)`${resource_person_type_functionPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_type_functionPgResource.codec)`${resource_person_type_functionPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_type_functionPgResource.execute(selectArgs);
@@ -15553,7 +16478,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs44(args);
+      const extraSelectArgs = makeArgs49(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -15567,18 +16492,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_type_function_listPgResource.isUnique && !resource_person_type_function_listPgResource.codec.attributes && typeof resource_person_type_function_listPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_type_function_listPgResource.codec)`${resource_person_type_function_listPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_type_function_listPgResource.codec)`${resource_person_type_function_listPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_type_function_listPgResource.execute(selectArgs);
@@ -15869,7 +16804,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs45(args);
+      const extraSelectArgs = makeArgs50(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -15883,18 +16818,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_compound_type_computed_fieldPgResource.isUnique && !resource_compound_type_computed_fieldPgResource.codec.attributes && typeof resource_compound_type_computed_fieldPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_compound_type_computed_fieldPgResource.codec)`${resource_compound_type_computed_fieldPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_compound_type_computed_fieldPgResource.codec)`${resource_compound_type_computed_fieldPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_compound_type_computed_fieldPgResource.execute(selectArgs);
@@ -18629,7 +19574,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs46(args);
+      const extraSelectArgs = makeArgs51(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -18643,18 +19588,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_edge_case_computedPgResource.isUnique && !resource_edge_case_computedPgResource.codec.attributes && typeof resource_edge_case_computedPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_edge_case_computedPgResource.codec)`${resource_edge_case_computedPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_edge_case_computedPgResource.codec)`${resource_edge_case_computedPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_edge_case_computedPgResource.execute(selectArgs);
@@ -19330,7 +20285,7 @@ export const plans = {
     __assertStep: __ValueStep,
     mutationOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs47(args, ["input"]);
+        const selectArgs = makeArgs52(args, ["input"]);
         const $result = resource_mutation_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19347,7 +20302,7 @@ export const plans = {
     },
     mutationOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs48(args, ["input"]);
+        const selectArgs = makeArgs53(args, ["input"]);
         const $result = resource_mutation_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19364,7 +20319,7 @@ export const plans = {
     },
     mutationOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs49(args, ["input"]);
+        const selectArgs = makeArgs54(args, ["input"]);
         const $result = resource_mutation_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19381,7 +20336,7 @@ export const plans = {
     },
     noArgsMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs50(args, ["input"]);
+        const selectArgs = makeArgs55(args, ["input"]);
         const $result = resource_no_args_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19398,7 +20353,7 @@ export const plans = {
     },
     mutationInOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs51(args, ["input"]);
+        const selectArgs = makeArgs56(args, ["input"]);
         const $result = resource_mutation_in_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19415,7 +20370,7 @@ export const plans = {
     },
     mutationReturnsTableOneCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs52(args, ["input"]);
+        const selectArgs = makeArgs57(args, ["input"]);
         const $result = resource_mutation_returns_table_one_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19432,7 +20387,7 @@ export const plans = {
     },
     jsonIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs53(args, ["input"]);
+        const selectArgs = makeArgs58(args, ["input"]);
         const $result = resource_json_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19449,7 +20404,7 @@ export const plans = {
     },
     jsonbIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs54(args, ["input"]);
+        const selectArgs = makeArgs59(args, ["input"]);
         const $result = resource_jsonb_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19466,7 +20421,7 @@ export const plans = {
     },
     jsonbIdentityMutationPlpgsql: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs55(args, ["input"]);
+        const selectArgs = makeArgs60(args, ["input"]);
         const $result = resource_jsonb_identity_mutation_plpgsqlPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19483,7 +20438,7 @@ export const plans = {
     },
     jsonbIdentityMutationPlpgsqlWithDefault: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs56(args, ["input"]);
+        const selectArgs = makeArgs61(args, ["input"]);
         const $result = resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19500,7 +20455,7 @@ export const plans = {
     },
     mutationInInout: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs57(args, ["input"]);
+        const selectArgs = makeArgs62(args, ["input"]);
         const $result = resource_mutation_in_inoutPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19517,7 +20472,7 @@ export const plans = {
     },
     mutationOutOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs58(args, ["input"]);
+        const selectArgs = makeArgs63(args, ["input"]);
         const $result = resource_mutation_out_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19534,7 +20489,7 @@ export const plans = {
     },
     mutationOutOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs59(args, ["input"]);
+        const selectArgs = makeArgs64(args, ["input"]);
         const $result = resource_mutation_out_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19551,7 +20506,7 @@ export const plans = {
     },
     mutationOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs60(args, ["input"]);
+        const selectArgs = makeArgs65(args, ["input"]);
         const $result = resource_mutation_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19568,7 +20523,7 @@ export const plans = {
     },
     intSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs61(args, ["input"]);
+        const selectArgs = makeArgs66(args, ["input"]);
         const $result = resource_int_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19585,7 +20540,7 @@ export const plans = {
     },
     mutationOutUnnamedOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs62(args, ["input"]);
+        const selectArgs = makeArgs67(args, ["input"]);
         const $result = resource_mutation_out_unnamed_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19602,7 +20557,7 @@ export const plans = {
     },
     mutationReturnsTableMultiCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs63(args, ["input"]);
+        const selectArgs = makeArgs68(args, ["input"]);
         const $result = resource_mutation_returns_table_multi_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19619,7 +20574,7 @@ export const plans = {
     },
     leftArmIdentity: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs64(args, ["input"]);
+        const selectArgs = makeArgs69(args, ["input"]);
         const $result = resource_left_arm_identityPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19636,7 +20591,7 @@ export const plans = {
     },
     issue756Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs65(args, ["input"]);
+        const selectArgs = makeArgs70(args, ["input"]);
         const $result = resource_issue756_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19653,7 +20608,7 @@ export const plans = {
     },
     issue756SetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs66(args, ["input"]);
+        const selectArgs = makeArgs71(args, ["input"]);
         const $result = resource_issue756_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19670,7 +20625,7 @@ export const plans = {
     },
     typesMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs67(args, ["input"]);
+        const selectArgs = makeArgs72(args, ["input"]);
         const $result = resource_types_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19687,7 +20642,7 @@ export const plans = {
     },
     mutationOutOutCompoundType: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs68(args, ["input"]);
+        const selectArgs = makeArgs73(args, ["input"]);
         const $result = resource_mutation_out_out_compound_typePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19704,7 +20659,7 @@ export const plans = {
     },
     tableMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs69(args, ["input"]);
+        const selectArgs = makeArgs74(args, ["input"]);
         const $result = resource_table_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19721,7 +20676,7 @@ export const plans = {
     },
     mutationOutComplex: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs70(args, ["input"]);
+        const selectArgs = makeArgs75(args, ["input"]);
         const $result = resource_mutation_out_complexPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19738,7 +20693,7 @@ export const plans = {
     },
     mutationOutComplexSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs71(args, ["input"]);
+        const selectArgs = makeArgs76(args, ["input"]);
         const $result = resource_mutation_out_complex_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19755,7 +20710,7 @@ export const plans = {
     },
     mutationOutTable: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs72(args, ["input"]);
+        const selectArgs = makeArgs77(args, ["input"]);
         const $result = resource_mutation_out_tablePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19772,7 +20727,7 @@ export const plans = {
     },
     mutationOutTableSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs73(args, ["input"]);
+        const selectArgs = makeArgs78(args, ["input"]);
         const $result = resource_mutation_out_table_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19789,7 +20744,7 @@ export const plans = {
     },
     tableSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs74(args, ["input"]);
+        const selectArgs = makeArgs79(args, ["input"]);
         const $result = resource_table_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-good.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-good.1.graphql
@@ -3020,6 +3020,11 @@ type Person implements Node {
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, arg2: Int, b: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
 
   """This `Person`'s `PersonSecret`."""
   personSecretByPersonId: PersonSecret @deprecated(reason: "This is deprecated (comment on table c.person_secret).")

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.export.mjs
@@ -3501,6 +3501,11 @@ const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_compu
 const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
 const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
 const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const person_optional_missing_middle_1FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_1");
+const person_optional_missing_middle_2FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_2");
+const person_optional_missing_middle_3FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_3");
+const person_optional_missing_middle_4FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_4");
+const person_optional_missing_middle_5FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_5");
 const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
 const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
 const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
@@ -7415,6 +7420,216 @@ const registry = makeRegistry({
           serviceName: "main",
           schemaName: "c",
           name: "person_computed_first_arg_inout_out"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_1: {
+      executor,
+      name: "person_optional_missing_middle_1",
+      identifier: "main.c.person_optional_missing_middle_1(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_1"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_2: {
+      executor,
+      name: "person_optional_missing_middle_2",
+      identifier: "main.c.person_optional_missing_middle_2(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_2"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_3: {
+      executor,
+      name: "person_optional_missing_middle_3",
+      identifier: "main.c.person_optional_missing_middle_3(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_3"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_4: {
+      executor,
+      name: "person_optional_missing_middle_4",
+      identifier: "main.c.person_optional_missing_middle_4(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_4"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_5: {
+      executor,
+      name: "person_optional_missing_middle_5",
+      identifier: "main.c.person_optional_missing_middle_5(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_5FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_5"
         },
         tags: {}
       },
@@ -11902,22 +12117,28 @@ const makeArgs56 = (args, path = []) => {
 };
 const resource_person_computed_first_arg_inout_outPgResource = registry.pgResources["person_computed_first_arg_inout_out"];
 const argDetailsSimple57 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
+  graphqlArgName: "arg0",
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
   graphqlArgName: "b",
   postgresArgName: "b",
-  pgCodec: TYPES.text,
-  required: true,
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
   fetcher: null
 }];
 const makeArgs57 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11928,7 +12149,7 @@ const makeArgs57 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 1 - 1) {
         skipped = true;
         continue;
       } else {
@@ -11958,12 +12179,30 @@ const makeArgs57 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
-const argDetailsSimple58 = [];
+const resource_person_optional_missing_middle_1PgResource = registry.pgResources["person_optional_missing_middle_1"];
+const argDetailsSimple58 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs58 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12004,12 +12243,30 @@ const makeArgs58 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
-const argDetailsSimple59 = [];
+const resource_person_optional_missing_middle_2PgResource = registry.pgResources["person_optional_missing_middle_2"];
+const argDetailsSimple59 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs59 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12020,7 +12277,7 @@ const makeArgs59 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 2 - 1) {
         skipped = true;
         continue;
       } else {
@@ -12050,12 +12307,30 @@ const makeArgs59 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
-const argDetailsSimple60 = [];
+const resource_person_optional_missing_middle_3PgResource = registry.pgResources["person_optional_missing_middle_3"];
+const argDetailsSimple60 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs60 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12066,7 +12341,7 @@ const makeArgs60 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -12096,46 +12371,30 @@ const makeArgs60 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_friendsPgResource = registry.pgResources["person_friends"];
-const getSelectPlanFromParentAndArgs15 = ($in, args, _info) => {
-  if (!hasRecord($in)) {
-    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-  }
-  const extraSelectArgs = makeArgs60(args);
-  /**
-   * An optimisation - if all our dependencies are
-   * compatible with the expression's class plan then we
-   * can inline ourselves into that, otherwise we must
-   * issue the query separately.
-   */
-  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-  const selectArgs = [{
-    step: $row.record()
-  }, ...extraSelectArgs];
-  if (resource_person_friendsPgResource.isUnique && !resource_person_friendsPgResource.codec.attributes && typeof resource_person_friendsPgResource.from === "function") {
-    // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
-      if (i === 0) {
-        return $row.getClassStep().alias;
-      } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
-      } else {
-        return $row.placeholder(arg.step);
-      }
-    });
-    return pgClassExpression($row, resource_person_friendsPgResource.codec)`${resource_person_friendsPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
-  }
-  // PERF: or here, if scalar add select to `$row`?
-  return resource_person_friendsPgResource.execute(selectArgs);
-};
-const argDetailsSimple61 = [];
+const resource_person_optional_missing_middle_4PgResource = registry.pgResources["person_optional_missing_middle_4"];
+const argDetailsSimple61 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs61 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12146,7 +12405,7 @@ const makeArgs61 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -12176,52 +12435,24 @@ const makeArgs61 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
-const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
-  if (!hasRecord($in)) {
-    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-  }
-  const extraSelectArgs = makeArgs61(args);
-  /**
-   * An optimisation - if all our dependencies are
-   * compatible with the expression's class plan then we
-   * can inline ourselves into that, otherwise we must
-   * issue the query separately.
-   */
-  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-  const selectArgs = [{
-    step: $row.record()
-  }, ...extraSelectArgs];
-  if (resource_person_type_function_connectionPgResource.isUnique && !resource_person_type_function_connectionPgResource.codec.attributes && typeof resource_person_type_function_connectionPgResource.from === "function") {
-    // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
-      if (i === 0) {
-        return $row.getClassStep().alias;
-      } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
-      } else {
-        return $row.placeholder(arg.step);
-      }
-    });
-    return pgClassExpression($row, resource_person_type_function_connectionPgResource.codec)`${resource_person_type_function_connectionPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
-  }
-  // PERF: or here, if scalar add select to `$row`?
-  return resource_person_type_function_connectionPgResource.execute(selectArgs);
-};
+const resource_person_optional_missing_middle_5PgResource = registry.pgResources["person_optional_missing_middle_5"];
 const argDetailsSimple62 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs62 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12262,7 +12493,7 @@ const makeArgs62 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
+const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
 const argDetailsSimple63 = [];
 const makeArgs63 = (args, path = []) => {
   const selectArgs = [];
@@ -12308,9 +12539,7 @@ const makeArgs63 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
-const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
-const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
+const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
 const argDetailsSimple64 = [];
 const makeArgs64 = (args, path = []) => {
   const selectArgs = [];
@@ -12356,16 +12585,7 @@ const makeArgs64 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
-function UUIDSerialize(value) {
-  return "" + value;
-}
-const coerce = string => {
-  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
-    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
-  }
-  return string;
-};
+const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -12411,8 +12631,8 @@ const makeArgs65 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_interval_setPgResource = registry.pgResources["post_computed_interval_set"];
-const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
+const resource_person_friendsPgResource = registry.pgResources["person_friends"];
+const getSelectPlanFromParentAndArgs15 = ($in, args, _info) => {
   if (!hasRecord($in)) {
     throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
   }
@@ -12428,23 +12648,33 @@ const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
   const selectArgs = [{
     step: $row.record()
   }, ...extraSelectArgs];
-  if (resource_post_computed_interval_setPgResource.isUnique && !resource_post_computed_interval_setPgResource.codec.attributes && typeof resource_post_computed_interval_setPgResource.from === "function") {
+  if (resource_person_friendsPgResource.isUnique && !resource_person_friendsPgResource.codec.attributes && typeof resource_person_friendsPgResource.from === "function") {
     // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
       if (i === 0) {
-        return $row.getClassStep().alias;
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
       } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
       } else {
-        return $row.placeholder(arg.step);
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
       }
     });
-    return pgClassExpression($row, resource_post_computed_interval_setPgResource.codec)`${resource_post_computed_interval_setPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
+    return pgClassExpression($row, resource_person_friendsPgResource.codec)`${resource_person_friendsPgResource.from(...newSelectArgs)}`;
   }
   // PERF: or here, if scalar add select to `$row`?
-  return resource_post_computed_interval_setPgResource.execute(selectArgs);
+  return resource_person_friendsPgResource.execute(selectArgs);
 };
 const argDetailsSimple66 = [];
 const makeArgs66 = (args, path = []) => {
@@ -12491,12 +12721,62 @@ const makeArgs66 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_interval_arrayPgResource = registry.pgResources["post_computed_interval_array"];
-const argDetailsSimple67 = [];
+const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
+const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
+  if (!hasRecord($in)) {
+    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+  }
+  const extraSelectArgs = makeArgs66(args);
+  /**
+   * An optimisation - if all our dependencies are
+   * compatible with the expression's class plan then we
+   * can inline ourselves into that, otherwise we must
+   * issue the query separately.
+   */
+  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+  const selectArgs = [{
+    step: $row.record()
+  }, ...extraSelectArgs];
+  if (resource_person_type_function_connectionPgResource.isUnique && !resource_person_type_function_connectionPgResource.codec.attributes && typeof resource_person_type_function_connectionPgResource.from === "function") {
+    // This is a scalar computed attribute, let's inline the expression
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
+      if (i === 0) {
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
+      } else if ("pgCodec" in arg && arg.pgCodec) {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
+      } else {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
+      }
+    });
+    return pgClassExpression($row, resource_person_type_function_connectionPgResource.codec)`${resource_person_type_function_connectionPgResource.from(...newSelectArgs)}`;
+  }
+  // PERF: or here, if scalar add select to `$row`?
+  return resource_person_type_function_connectionPgResource.execute(selectArgs);
+};
+const argDetailsSimple67 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs67 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12537,18 +12817,12 @@ const makeArgs67 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_text_arrayPgResource = registry.pgResources["post_computed_text_array"];
-const argDetailsSimple68 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: false,
-  fetcher: null
-}];
+const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
+const argDetailsSimple68 = [];
 const makeArgs68 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12589,18 +12863,14 @@ const makeArgs68 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_with_optional_argPgResource = registry.pgResources["post_computed_with_optional_arg"];
-const argDetailsSimple69 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
+const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
+const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
+const argDetailsSimple69 = [];
 const makeArgs69 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12641,24 +12911,21 @@ const makeArgs69 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_with_required_argPgResource = registry.pgResources["post_computed_with_required_arg"];
-const argDetailsSimple70 = [{
-  graphqlArgName: "length",
-  postgresArgName: "length",
-  pgCodec: TYPES.int,
-  required: false,
-  fetcher: null
-}, {
-  graphqlArgName: "omission",
-  postgresArgName: "omission",
-  pgCodec: TYPES.text,
-  required: false,
-  fetcher: null
-}];
+const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
+function UUIDSerialize(value) {
+  return "" + value;
+}
+const coerce = string => {
+  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
+    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
+  }
+  return string;
+};
+const argDetailsSimple70 = [];
 const makeArgs70 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12699,24 +12966,56 @@ const makeArgs70 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmedPgResource = registry.pgResources["post_headline_trimmed"];
-const argDetailsSimple71 = [{
-  graphqlArgName: "length",
-  postgresArgName: "length",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "omission",
-  postgresArgName: "omission",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_post_computed_interval_setPgResource = registry.pgResources["post_computed_interval_set"];
+const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
+  if (!hasRecord($in)) {
+    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+  }
+  const extraSelectArgs = makeArgs70(args);
+  /**
+   * An optimisation - if all our dependencies are
+   * compatible with the expression's class plan then we
+   * can inline ourselves into that, otherwise we must
+   * issue the query separately.
+   */
+  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+  const selectArgs = [{
+    step: $row.record()
+  }, ...extraSelectArgs];
+  if (resource_post_computed_interval_setPgResource.isUnique && !resource_post_computed_interval_setPgResource.codec.attributes && typeof resource_post_computed_interval_setPgResource.from === "function") {
+    // This is a scalar computed attribute, let's inline the expression
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
+      if (i === 0) {
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
+      } else if ("pgCodec" in arg && arg.pgCodec) {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
+      } else {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
+      }
+    });
+    return pgClassExpression($row, resource_post_computed_interval_setPgResource.codec)`${resource_post_computed_interval_setPgResource.from(...newSelectArgs)}`;
+  }
+  // PERF: or here, if scalar add select to `$row`?
+  return resource_post_computed_interval_setPgResource.execute(selectArgs);
+};
+const argDetailsSimple71 = [];
 const makeArgs71 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12757,24 +13056,12 @@ const makeArgs71 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmed_no_defaultsPgResource = registry.pgResources["post_headline_trimmed_no_defaults"];
-const argDetailsSimple72 = [{
-  graphqlArgName: "length",
-  postgresArgName: "length",
-  pgCodec: TYPES.int,
-  required: false,
-  fetcher: null
-}, {
-  graphqlArgName: "omission",
-  postgresArgName: "omission",
-  pgCodec: TYPES.text,
-  required: false,
-  fetcher: null
-}];
+const resource_post_computed_interval_arrayPgResource = registry.pgResources["post_computed_interval_array"];
+const argDetailsSimple72 = [];
 const makeArgs72 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12815,12 +13102,12 @@ const makeArgs72 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmed_strictPgResource = registry.pgResources["post_headline_trimmed_strict"];
+const resource_post_computed_text_arrayPgResource = registry.pgResources["post_computed_text_array"];
 const argDetailsSimple73 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
-  required: true,
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: false,
   fetcher: null
 }];
 const makeArgs73 = (args, path = []) => {
@@ -12834,6 +13121,284 @@ const makeArgs73 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple73[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_computed_with_optional_argPgResource = registry.pgResources["post_computed_with_optional_arg"];
+const argDetailsSimple74 = [{
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs74 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple74[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_computed_with_required_argPgResource = registry.pgResources["post_computed_with_required_arg"];
+const argDetailsSimple75 = [{
+  graphqlArgName: "length",
+  postgresArgName: "length",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "omission",
+  postgresArgName: "omission",
+  pgCodec: TYPES.text,
+  required: false,
+  fetcher: null
+}];
+const makeArgs75 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple75[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_headline_trimmedPgResource = registry.pgResources["post_headline_trimmed"];
+const argDetailsSimple76 = [{
+  graphqlArgName: "length",
+  postgresArgName: "length",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "omission",
+  postgresArgName: "omission",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
+const makeArgs76 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple76[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_headline_trimmed_no_defaultsPgResource = registry.pgResources["post_headline_trimmed_no_defaults"];
+const argDetailsSimple77 = [{
+  graphqlArgName: "length",
+  postgresArgName: "length",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "omission",
+  postgresArgName: "omission",
+  pgCodec: TYPES.text,
+  required: false,
+  fetcher: null
+}];
+const makeArgs77 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple77[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_headline_trimmed_strictPgResource = registry.pgResources["post_headline_trimmed_strict"];
+const argDetailsSimple78 = [{
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
+  required: true,
+  fetcher: null
+}];
+const makeArgs78 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple78[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -12924,236 +13489,6 @@ const parseValueLiteral = (ast, variables) => {
       return undefined;
   }
 };
-const argDetailsSimple74 = [];
-const makeArgs74 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple74[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
-const argDetailsSimple75 = [];
-const makeArgs75 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple75[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
-const argDetailsSimple76 = [];
-const makeArgs76 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple76[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
-const argDetailsSimple77 = [];
-const makeArgs77 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple77[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
-const argDetailsSimple78 = [];
-const makeArgs78 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple78[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
 const argDetailsSimple79 = [];
 const makeArgs79 = (args, path = []) => {
   const selectArgs = [];
@@ -13199,7 +13534,7 @@ const makeArgs79 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
+const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
 const argDetailsSimple80 = [];
 const makeArgs80 = (args, path = []) => {
   const selectArgs = [];
@@ -13245,18 +13580,12 @@ const makeArgs80 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
-const argDetailsSimple81 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
+const argDetailsSimple81 = [];
 const makeArgs81 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13297,18 +13626,12 @@ const makeArgs81 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
-const argDetailsSimple82 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
+const argDetailsSimple82 = [];
 const makeArgs82 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13349,18 +13672,12 @@ const makeArgs82 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
-const argDetailsSimple83 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
+const argDetailsSimple83 = [];
 const makeArgs83 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13401,18 +13718,12 @@ const makeArgs83 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
-const argDetailsSimple84 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
+const argDetailsSimple84 = [];
 const makeArgs84 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13453,18 +13764,12 @@ const makeArgs84 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
-const argDetailsSimple85 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
+const argDetailsSimple85 = [];
 const makeArgs85 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13505,12 +13810,12 @@ const makeArgs85 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
+const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
 const argDetailsSimple86 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: false,
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
   fetcher: null
 }];
 const makeArgs86 = (args, path = []) => {
@@ -13557,16 +13862,10 @@ const makeArgs86 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
+const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
 const argDetailsSimple87 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: null,
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "arg1",
-  postgresArgName: null,
+  graphqlArgName: "i",
+  postgresArgName: "i",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -13574,7 +13873,7 @@ const argDetailsSimple87 = [{
 const makeArgs87 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13585,7 +13884,7 @@ const makeArgs87 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 2 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13615,24 +13914,18 @@ const makeArgs87 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
+const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
 const argDetailsSimple88 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.json,
   required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.int,
-  required: false,
   fetcher: null
 }];
 const makeArgs88 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13673,24 +13966,18 @@ const makeArgs88 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
+const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
 const argDetailsSimple89 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "arg1",
-  postgresArgName: "",
-  pgCodec: TYPES.int,
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.jsonb,
   required: true,
   fetcher: null
 }];
 const makeArgs89 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13701,7 +13988,7 @@ const makeArgs89 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 2 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13731,24 +14018,18 @@ const makeArgs89 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
+const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
 const argDetailsSimple90 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: "",
-  pgCodec: TYPES.int,
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
   required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.int,
-  required: false,
   fetcher: null
 }];
 const makeArgs90 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13759,7 +14040,7 @@ const makeArgs90 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 1 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13789,24 +14070,18 @@ const makeArgs90 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
+const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
 const argDetailsSimple91 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: "",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.int,
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
   required: false,
   fetcher: null
 }];
 const makeArgs91 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13817,7 +14092,7 @@ const makeArgs91 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 1 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13847,7 +14122,7 @@ const makeArgs91 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
+const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
 const argDetailsSimple92 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -13905,18 +14180,18 @@ const makeArgs92 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_1PgResource = registry.pgResources["mult_1"];
+const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
 const argDetailsSimple93 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: null,
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "arg1",
-  postgresArgName: null,
+  graphqlArgName: "b",
+  postgresArgName: "b",
   pgCodec: TYPES.int,
-  required: true,
+  required: false,
   fetcher: null
 }];
 const makeArgs93 = (args, path = []) => {
@@ -13933,7 +14208,7 @@ const makeArgs93 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 2 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13963,16 +14238,16 @@ const makeArgs93 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_2PgResource = registry.pgResources["mult_2"];
+const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
 const argDetailsSimple94 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: null,
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
   graphqlArgName: "arg1",
-  postgresArgName: null,
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -14021,18 +14296,18 @@ const makeArgs94 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_3PgResource = registry.pgResources["mult_3"];
+const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
 const argDetailsSimple95 = [{
   graphqlArgName: "arg0",
-  postgresArgName: null,
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "arg1",
-  postgresArgName: null,
+  graphqlArgName: "b",
+  postgresArgName: "b",
   pgCodec: TYPES.int,
-  required: true,
+  required: false,
   fetcher: null
 }];
 const makeArgs95 = (args, path = []) => {
@@ -14046,6 +14321,296 @@ const makeArgs95 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple95[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 1 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
+const argDetailsSimple96 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
+const makeArgs96 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple96[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 1 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
+const argDetailsSimple97 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs97 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple97[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 2 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mult_1PgResource = registry.pgResources["mult_1"];
+const argDetailsSimple98 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs98 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple98[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 2 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mult_2PgResource = registry.pgResources["mult_2"];
+const argDetailsSimple99 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs99 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple99[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 2 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mult_3PgResource = registry.pgResources["mult_3"];
+const argDetailsSimple100 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs100 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple100[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -14080,7 +14645,7 @@ const makeArgs95 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_4PgResource = registry.pgResources["mult_4"];
-const argDetailsSimple96 = [{
+const argDetailsSimple101 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
   pgCodec: TYPES.int,
@@ -14093,258 +14658,10 @@ const argDetailsSimple96 = [{
   required: true,
   fetcher: null
 }];
-const makeArgs96 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 2; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple96[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
-const argDetailsSimple97 = [];
-const makeArgs97 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple97[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
-const argDetailsSimple98 = [];
-const makeArgs98 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple98[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
-const argDetailsSimple99 = [];
-const makeArgs99 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple99[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
-const argDetailsSimple100 = [{
-  graphqlArgName: "x",
-  postgresArgName: "x",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "y",
-  postgresArgName: "y",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "z",
-  postgresArgName: "z",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
-const makeArgs100 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 3; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple100[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
-const argDetailsSimple101 = [];
 const makeArgs101 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14385,18 +14702,12 @@ const makeArgs101 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
-const argDetailsSimple102 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
+const argDetailsSimple102 = [];
 const makeArgs102 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14437,18 +14748,12 @@ const makeArgs102 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
-const argDetailsSimple103 = [{
-  graphqlArgName: "g",
-  postgresArgName: "g",
-  pgCodec: guidCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
+const argDetailsSimple103 = [];
 const makeArgs103 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14489,7 +14794,7 @@ const makeArgs103 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_guid_fnPgResource = registry.pgResources["guid_fn"];
+const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
 const argDetailsSimple104 = [];
 const makeArgs104 = (args, path = []) => {
   const selectArgs = [];
@@ -14535,12 +14840,30 @@ const makeArgs104 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
-const argDetailsSimple105 = [];
+const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
+const argDetailsSimple105 = [{
+  graphqlArgName: "x",
+  postgresArgName: "x",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "y",
+  postgresArgName: "y",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "z",
+  postgresArgName: "z",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs105 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14581,30 +14904,12 @@ const makeArgs105 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
-const argDetailsSimple106 = [{
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: textArrayCodec,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "d",
-  postgresArgName: "d",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "e",
-  postgresArgName: "e",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
+const argDetailsSimple106 = [];
 const makeArgs106 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14645,12 +14950,18 @@ const makeArgs106 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_list_bde_mutationPgResource = registry.pgResources["list_bde_mutation"];
-const argDetailsSimple107 = [];
+const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
+const argDetailsSimple107 = [{
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs107 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14691,30 +15002,18 @@ const makeArgs107 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_failPgResource = registry.pgResources["authenticate_fail"];
+const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
 const argDetailsSimple108 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.numeric,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.bigint,
+  graphqlArgName: "g",
+  postgresArgName: "g",
+  pgCodec: guidCodec,
   required: true,
   fetcher: null
 }];
 const makeArgs108 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14755,18 +15054,12 @@ const makeArgs108 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticatePgResource = registry.pgResources["authenticate"];
-const argDetailsSimple109 = [{
-  graphqlArgName: "leftArm",
-  postgresArgName: "left_arm",
-  pgCodec: leftArmCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_guid_fnPgResource = registry.pgResources["guid_fn"];
+const argDetailsSimple109 = [];
 const makeArgs109 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14807,7 +15100,7 @@ const makeArgs109 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
+const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
 const argDetailsSimple110 = [];
 const makeArgs110 = (args, path = []) => {
   const selectArgs = [];
@@ -14853,12 +15146,30 @@ const makeArgs110 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
-const argDetailsSimple111 = [];
+const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
+const argDetailsSimple111 = [{
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: textArrayCodec,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "d",
+  postgresArgName: "d",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "e",
+  postgresArgName: "e",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
 const makeArgs111 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14899,30 +15210,12 @@ const makeArgs111 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
-const argDetailsSimple112 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.numeric,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.bigint,
-  required: true,
-  fetcher: null
-}];
+const resource_list_bde_mutationPgResource = registry.pgResources["list_bde_mutation"];
+const argDetailsSimple112 = [];
 const makeArgs112 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14963,7 +15256,7 @@ const makeArgs112 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_manyPgResource = registry.pgResources["authenticate_many"];
+const resource_authenticate_failPgResource = registry.pgResources["authenticate_fail"];
 const argDetailsSimple113 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -15027,48 +15320,18 @@ const makeArgs113 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_payloadPgResource = registry.pgResources["authenticate_payload"];
+const resource_authenticatePgResource = registry.pgResources["authenticate"];
 const argDetailsSimple114 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.bigint,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.boolean,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.varchar,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "d",
-  postgresArgName: "d",
-  pgCodec: int4ArrayCodec,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "e",
-  postgresArgName: "e",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "f",
-  postgresArgName: "f",
-  pgCodec: floatrangeCodec,
+  graphqlArgName: "leftArm",
+  postgresArgName: "left_arm",
+  pgCodec: leftArmCodec,
   required: true,
   fetcher: null
 }];
 const makeArgs114 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 6; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15109,18 +15372,12 @@ const makeArgs114 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
-const argDetailsSimple115 = [{
-  graphqlArgName: "i1",
-  postgresArgName: "i1",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
+const argDetailsSimple115 = [];
 const makeArgs115 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15161,18 +15418,12 @@ const makeArgs115 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
-const argDetailsSimple116 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
+const argDetailsSimple116 = [];
 const makeArgs116 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15213,18 +15464,30 @@ const makeArgs116 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_mutationPgResource = registry.pgResources["compound_type_mutation"];
+const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
 const argDetailsSimple117 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.numeric,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.bigint,
   required: true,
   fetcher: null
 }];
 const makeArgs117 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15265,18 +15528,30 @@ const makeArgs117 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
+const resource_authenticate_manyPgResource = registry.pgResources["authenticate_many"];
 const argDetailsSimple118 = [{
-  graphqlArgName: "t",
-  postgresArgName: "t",
-  pgCodec: TYPES.text,
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.numeric,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.bigint,
   required: true,
   fetcher: null
 }];
 const makeArgs118 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15317,18 +15592,48 @@ const makeArgs118 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_create_postPgResource = registry.pgResources["create_post"];
+const resource_authenticate_payloadPgResource = registry.pgResources["authenticate_payload"];
 const argDetailsSimple119 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
-  pgCodec: TYPES.int,
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.bigint,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.boolean,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.varchar,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "d",
+  postgresArgName: "d",
+  pgCodec: int4ArrayCodec,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "e",
+  postgresArgName: "e",
+  pgCodec: TYPES.json,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "f",
+  postgresArgName: "f",
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
 const makeArgs119 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 6; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15369,24 +15674,18 @@ const makeArgs119 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
+const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
 const argDetailsSimple120 = [{
-  graphqlArgName: "post",
-  postgresArgName: "post",
-  pgCodec: postCodec,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "suffix",
-  postgresArgName: "suffix",
-  pgCodec: TYPES.text,
+  graphqlArgName: "i1",
+  postgresArgName: "i1",
+  pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }];
 const makeArgs120 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15427,7 +15726,7 @@ const makeArgs120 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_with_suffixPgResource = registry.pgResources["post_with_suffix"];
+const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
 const argDetailsSimple121 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -15479,7 +15778,7 @@ const makeArgs121 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
+const resource_compound_type_mutationPgResource = registry.pgResources["compound_type_mutation"];
 const argDetailsSimple122 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -15531,11 +15830,11 @@ const makeArgs122 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_array_mutationPgResource = registry.pgResources["compound_type_array_mutation"];
+const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
 const argDetailsSimple123 = [{
-  graphqlArgName: "posts",
-  postgresArgName: "posts",
-  pgCodec: postArrayCodec,
+  graphqlArgName: "t",
+  postgresArgName: "t",
+  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
@@ -15583,24 +15882,18 @@ const makeArgs123 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_manyPgResource = registry.pgResources["post_many"];
+const resource_create_postPgResource = registry.pgResources["create_post"];
 const argDetailsSimple124 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
+  graphqlArgName: "id",
+  postgresArgName: "id",
   pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs124 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15641,16 +15934,16 @@ const makeArgs124 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
+const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
 const argDetailsSimple125 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
+  graphqlArgName: "post",
+  postgresArgName: "post",
+  pgCodec: postCodec,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
+  graphqlArgName: "suffix",
+  postgresArgName: "suffix",
   pgCodec: TYPES.text,
   required: true,
   fetcher: null
@@ -15699,12 +15992,18 @@ const makeArgs125 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
-const argDetailsSimple126 = [];
+const resource_post_with_suffixPgResource = registry.pgResources["post_with_suffix"];
+const argDetailsSimple126 = [{
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs126 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15745,12 +16044,18 @@ const makeArgs126 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
-const argDetailsSimple127 = [];
+const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
+const argDetailsSimple127 = [{
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs127 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15791,12 +16096,18 @@ const makeArgs127 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
-const argDetailsSimple128 = [];
+const resource_compound_type_array_mutationPgResource = registry.pgResources["compound_type_array_mutation"];
+const argDetailsSimple128 = [{
+  graphqlArgName: "posts",
+  postgresArgName: "posts",
+  pgCodec: postArrayCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs128 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15837,12 +16148,24 @@ const makeArgs128 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
-const argDetailsSimple129 = [];
+const resource_post_manyPgResource = registry.pgResources["post_many"];
+const argDetailsSimple129 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
 const makeArgs129 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15883,18 +16206,24 @@ const makeArgs129 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_type_function_connection_mutationPgResource = registry.pgResources["type_function_connection_mutation"];
+const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
 const argDetailsSimple130 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs130 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15935,7 +16264,7 @@ const makeArgs130 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_type_function_mutationPgResource = registry.pgResources["type_function_mutation"];
+const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
 const argDetailsSimple131 = [];
 const makeArgs131 = (args, path = []) => {
   const selectArgs = [];
@@ -15948,6 +16277,242 @@ const makeArgs131 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple131[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
+const argDetailsSimple132 = [];
+const makeArgs132 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple132[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
+const argDetailsSimple133 = [];
+const makeArgs133 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple133[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
+const argDetailsSimple134 = [];
+const makeArgs134 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple134[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_type_function_connection_mutationPgResource = registry.pgResources["type_function_connection_mutation"];
+const argDetailsSimple135 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs135 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple135[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_type_function_mutationPgResource = registry.pgResources["type_function_mutation"];
+const argDetailsSimple136 = [];
+const makeArgs136 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple136[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -17544,6 +18109,11 @@ type Person implements Node {
   computedInoutOut(ino: String): PersonComputedInoutOutRecord
   exists(email: Email): Boolean @deprecated(reason: "This is deprecated (comment on function c.person_exists).")
   computedFirstArgInoutOut: PersonComputedFirstArgInoutOutRecord
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, b: Int, arg2: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
   computedComplex(a: Int, b: String): PersonComputedComplexRecord
 
   """The first post by the person."""
@@ -29016,18 +29586,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_outPgResource.isUnique && !resource_person_computed_outPgResource.codec.attributes && typeof resource_person_computed_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_outPgResource.codec)`${resource_person_computed_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_outPgResource.codec)`${resource_person_computed_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_outPgResource.execute(selectArgs);
@@ -29050,18 +29630,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_first_namePgResource.isUnique && !resource_person_first_namePgResource.codec.attributes && typeof resource_person_first_namePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_first_namePgResource.codec)`${resource_person_first_namePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_first_namePgResource.codec)`${resource_person_first_namePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_first_namePgResource.execute(selectArgs);
@@ -29084,18 +29674,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_out_outPgResource.isUnique && !resource_person_computed_out_outPgResource.codec.attributes && typeof resource_person_computed_out_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_out_outPgResource.codec)`${resource_person_computed_out_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_out_outPgResource.codec)`${resource_person_computed_out_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_out_outPgResource.execute(selectArgs);
@@ -29119,18 +29719,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_computed_inoutPgResource.isUnique && !resource_person_computed_inoutPgResource.codec.attributes && typeof resource_person_computed_inoutPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_inoutPgResource.codec)`${resource_person_computed_inoutPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_computed_inoutPgResource.codec)`${resource_person_computed_inoutPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_inoutPgResource.execute(selectArgs);
@@ -29158,18 +29768,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_computed_inout_outPgResource.isUnique && !resource_person_computed_inout_outPgResource.codec.attributes && typeof resource_person_computed_inout_outPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_inout_outPgResource.codec)`${resource_person_computed_inout_outPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_computed_inout_outPgResource.codec)`${resource_person_computed_inout_outPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_inout_outPgResource.execute(selectArgs);
@@ -29197,18 +29817,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_existsPgResource.isUnique && !resource_person_existsPgResource.codec.attributes && typeof resource_person_existsPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_existsPgResource.codec)`${resource_person_existsPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_existsPgResource.codec)`${resource_person_existsPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_existsPgResource.execute(selectArgs);
@@ -29235,23 +29865,33 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_first_arg_inout_outPgResource.isUnique && !resource_person_computed_first_arg_inout_outPgResource.codec.attributes && typeof resource_person_computed_first_arg_inout_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_first_arg_inout_outPgResource.codec)`${resource_person_computed_first_arg_inout_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_first_arg_inout_outPgResource.codec)`${resource_person_computed_first_arg_inout_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_first_arg_inout_outPgResource.execute(selectArgs);
     },
-    computedComplex: {
+    optionalMissingMiddle1: {
       plan($in, args, _info) {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -29268,20 +29908,285 @@ export const plans = {
         const selectArgs = [{
           step: $row.record()
         }, ...extraSelectArgs];
-        if (resource_person_computed_complexPgResource.isUnique && !resource_person_computed_complexPgResource.codec.attributes && typeof resource_person_computed_complexPgResource.from === "function") {
+        if (resource_person_optional_missing_middle_1PgResource.isUnique && !resource_person_optional_missing_middle_1PgResource.codec.attributes && typeof resource_person_optional_missing_middle_1PgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_complexPgResource.codec)`${resource_person_computed_complexPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_optional_missing_middle_1PgResource.codec)`${resource_person_optional_missing_middle_1PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_1PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle2: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs58(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_2PgResource.isUnique && !resource_person_optional_missing_middle_2PgResource.codec.attributes && typeof resource_person_optional_missing_middle_2PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_2PgResource.codec)`${resource_person_optional_missing_middle_2PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_2PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        b: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle3: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs59(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_3PgResource.isUnique && !resource_person_optional_missing_middle_3PgResource.codec.attributes && typeof resource_person_optional_missing_middle_3PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_3PgResource.codec)`${resource_person_optional_missing_middle_3PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_3PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle4: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs60(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_4PgResource.isUnique && !resource_person_optional_missing_middle_4PgResource.codec.attributes && typeof resource_person_optional_missing_middle_4PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_4PgResource.codec)`${resource_person_optional_missing_middle_4PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_4PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        arg2: undefined
+      }
+    },
+    optionalMissingMiddle5: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs61(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_5PgResource.isUnique && !resource_person_optional_missing_middle_5PgResource.codec.attributes && typeof resource_person_optional_missing_middle_5PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_5PgResource.codec)`${resource_person_optional_missing_middle_5PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_5PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        arg2: undefined
+      }
+    },
+    computedComplex: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs62(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_computed_complexPgResource.isUnique && !resource_person_computed_complexPgResource.codec.attributes && typeof resource_person_computed_complexPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_computed_complexPgResource.codec)`${resource_person_computed_complexPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_complexPgResource.execute(selectArgs);
@@ -29295,7 +30200,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs58(args);
+      const extraSelectArgs = makeArgs63(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29309,18 +30214,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_first_postPgResource.isUnique && !resource_person_first_postPgResource.codec.attributes && typeof resource_person_first_postPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_first_postPgResource.codec)`${resource_person_first_postPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_first_postPgResource.codec)`${resource_person_first_postPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_first_postPgResource.execute(selectArgs);
@@ -29329,7 +30244,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs59(args);
+      const extraSelectArgs = makeArgs64(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29343,18 +30258,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_first_arg_inoutPgResource.isUnique && !resource_person_computed_first_arg_inoutPgResource.codec.attributes && typeof resource_person_computed_first_arg_inoutPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_first_arg_inoutPgResource.codec)`${resource_person_computed_first_arg_inoutPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_first_arg_inoutPgResource.codec)`${resource_person_computed_first_arg_inoutPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_first_arg_inoutPgResource.execute(selectArgs);
@@ -29459,7 +30384,7 @@ export const plans = {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
         }
-        const extraSelectArgs = makeArgs62(args);
+        const extraSelectArgs = makeArgs67(args);
         /**
          * An optimisation - if all our dependencies are
          * compatible with the expression's class plan then we
@@ -29473,18 +30398,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_type_functionPgResource.isUnique && !resource_person_type_functionPgResource.codec.attributes && typeof resource_person_type_functionPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_type_functionPgResource.codec)`${resource_person_type_functionPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_type_functionPgResource.codec)`${resource_person_type_functionPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_type_functionPgResource.execute(selectArgs);
@@ -29497,7 +30432,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs63(args);
+      const extraSelectArgs = makeArgs68(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29511,18 +30446,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_type_function_listPgResource.isUnique && !resource_person_type_function_listPgResource.codec.attributes && typeof resource_person_type_function_listPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_type_function_listPgResource.codec)`${resource_person_type_function_listPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_type_function_listPgResource.codec)`${resource_person_type_function_listPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_type_function_listPgResource.execute(selectArgs);
@@ -29869,7 +30814,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs64(args);
+      const extraSelectArgs = makeArgs69(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29883,18 +30828,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_compound_type_computed_fieldPgResource.isUnique && !resource_compound_type_computed_fieldPgResource.codec.attributes && typeof resource_compound_type_computed_fieldPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_compound_type_computed_fieldPgResource.codec)`${resource_compound_type_computed_fieldPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_compound_type_computed_fieldPgResource.codec)`${resource_compound_type_computed_fieldPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_compound_type_computed_fieldPgResource.execute(selectArgs);
@@ -30038,7 +30993,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs66(args);
+      const extraSelectArgs = makeArgs71(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -30052,18 +31007,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_post_computed_interval_arrayPgResource.isUnique && !resource_post_computed_interval_arrayPgResource.codec.attributes && typeof resource_post_computed_interval_arrayPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_post_computed_interval_arrayPgResource.codec)`${resource_post_computed_interval_arrayPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_post_computed_interval_arrayPgResource.codec)`${resource_post_computed_interval_arrayPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_post_computed_interval_arrayPgResource.execute(selectArgs);
@@ -30072,7 +31037,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs67(args);
+      const extraSelectArgs = makeArgs72(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -30086,221 +31051,33 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_post_computed_text_arrayPgResource.isUnique && !resource_post_computed_text_arrayPgResource.codec.attributes && typeof resource_post_computed_text_arrayPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_post_computed_text_arrayPgResource.codec)`${resource_post_computed_text_arrayPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_post_computed_text_arrayPgResource.codec)`${resource_post_computed_text_arrayPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_post_computed_text_arrayPgResource.execute(selectArgs);
     },
     computedWithOptionalArg: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs68(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_computed_with_optional_argPgResource.isUnique && !resource_post_computed_with_optional_argPgResource.codec.attributes && typeof resource_post_computed_with_optional_argPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_computed_with_optional_argPgResource.codec)`${resource_post_computed_with_optional_argPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_computed_with_optional_argPgResource.execute(selectArgs);
-      },
-      args: {
-        i: undefined
-      }
-    },
-    computedWithRequiredArg: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs69(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_computed_with_required_argPgResource.isUnique && !resource_post_computed_with_required_argPgResource.codec.attributes && typeof resource_post_computed_with_required_argPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_computed_with_required_argPgResource.codec)`${resource_post_computed_with_required_argPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_computed_with_required_argPgResource.execute(selectArgs);
-      },
-      args: {
-        i: undefined
-      }
-    },
-    headlineTrimmed: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs70(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_headline_trimmedPgResource.isUnique && !resource_post_headline_trimmedPgResource.codec.attributes && typeof resource_post_headline_trimmedPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_headline_trimmedPgResource.codec)`${resource_post_headline_trimmedPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_headline_trimmedPgResource.execute(selectArgs);
-      },
-      args: {
-        length: undefined,
-        omission: undefined
-      }
-    },
-    headlineTrimmedNoDefaults: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs71(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_headline_trimmed_no_defaultsPgResource.isUnique && !resource_post_headline_trimmed_no_defaultsPgResource.codec.attributes && typeof resource_post_headline_trimmed_no_defaultsPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_headline_trimmed_no_defaultsPgResource.codec)`${resource_post_headline_trimmed_no_defaultsPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_headline_trimmed_no_defaultsPgResource.execute(selectArgs);
-      },
-      args: {
-        length: undefined,
-        omission: undefined
-      }
-    },
-    headlineTrimmedStrict: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs72(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_headline_trimmed_strictPgResource.isUnique && !resource_post_headline_trimmed_strictPgResource.codec.attributes && typeof resource_post_headline_trimmed_strictPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_headline_trimmed_strictPgResource.codec)`${resource_post_headline_trimmed_strictPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_headline_trimmed_strictPgResource.execute(selectArgs);
-      },
-      args: {
-        length: undefined,
-        omission: undefined
-      }
-    },
-    computedCompoundTypeArray: {
       plan($in, args, _info) {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -30317,20 +31094,278 @@ export const plans = {
         const selectArgs = [{
           step: $row.record()
         }, ...extraSelectArgs];
-        if (resource_post_computed_compound_type_arrayPgResource.isUnique && !resource_post_computed_compound_type_arrayPgResource.codec.attributes && typeof resource_post_computed_compound_type_arrayPgResource.from === "function") {
+        if (resource_post_computed_with_optional_argPgResource.isUnique && !resource_post_computed_with_optional_argPgResource.codec.attributes && typeof resource_post_computed_with_optional_argPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_post_computed_compound_type_arrayPgResource.codec)`${resource_post_computed_compound_type_arrayPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_post_computed_with_optional_argPgResource.codec)`${resource_post_computed_with_optional_argPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_computed_with_optional_argPgResource.execute(selectArgs);
+      },
+      args: {
+        i: undefined
+      }
+    },
+    computedWithRequiredArg: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs74(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_computed_with_required_argPgResource.isUnique && !resource_post_computed_with_required_argPgResource.codec.attributes && typeof resource_post_computed_with_required_argPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_computed_with_required_argPgResource.codec)`${resource_post_computed_with_required_argPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_computed_with_required_argPgResource.execute(selectArgs);
+      },
+      args: {
+        i: undefined
+      }
+    },
+    headlineTrimmed: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs75(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_headline_trimmedPgResource.isUnique && !resource_post_headline_trimmedPgResource.codec.attributes && typeof resource_post_headline_trimmedPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_headline_trimmedPgResource.codec)`${resource_post_headline_trimmedPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_headline_trimmedPgResource.execute(selectArgs);
+      },
+      args: {
+        length: undefined,
+        omission: undefined
+      }
+    },
+    headlineTrimmedNoDefaults: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs76(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_headline_trimmed_no_defaultsPgResource.isUnique && !resource_post_headline_trimmed_no_defaultsPgResource.codec.attributes && typeof resource_post_headline_trimmed_no_defaultsPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_headline_trimmed_no_defaultsPgResource.codec)`${resource_post_headline_trimmed_no_defaultsPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_headline_trimmed_no_defaultsPgResource.execute(selectArgs);
+      },
+      args: {
+        length: undefined,
+        omission: undefined
+      }
+    },
+    headlineTrimmedStrict: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs77(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_headline_trimmed_strictPgResource.isUnique && !resource_post_headline_trimmed_strictPgResource.codec.attributes && typeof resource_post_headline_trimmed_strictPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_headline_trimmed_strictPgResource.codec)`${resource_post_headline_trimmed_strictPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_headline_trimmed_strictPgResource.execute(selectArgs);
+      },
+      args: {
+        length: undefined,
+        omission: undefined
+      }
+    },
+    computedCompoundTypeArray: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs78(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_computed_compound_type_arrayPgResource.isUnique && !resource_post_computed_compound_type_arrayPgResource.codec.attributes && typeof resource_post_computed_compound_type_arrayPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_computed_compound_type_arrayPgResource.codec)`${resource_post_computed_compound_type_arrayPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_post_computed_compound_type_arrayPgResource.execute(selectArgs);
@@ -38672,7 +39707,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs74(args);
+      const extraSelectArgs = makeArgs79(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -38686,18 +39721,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_edge_case_computedPgResource.isUnique && !resource_edge_case_computedPgResource.codec.attributes && typeof resource_edge_case_computedPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_edge_case_computedPgResource.codec)`${resource_edge_case_computedPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_edge_case_computedPgResource.codec)`${resource_edge_case_computedPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_edge_case_computedPgResource.execute(selectArgs);
@@ -39373,7 +40418,7 @@ export const plans = {
     __assertStep: __ValueStep,
     mutationOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs75(args, ["input"]);
+        const selectArgs = makeArgs80(args, ["input"]);
         const $result = resource_mutation_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39390,7 +40435,7 @@ export const plans = {
     },
     mutationOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs76(args, ["input"]);
+        const selectArgs = makeArgs81(args, ["input"]);
         const $result = resource_mutation_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39407,7 +40452,7 @@ export const plans = {
     },
     mutationOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs77(args, ["input"]);
+        const selectArgs = makeArgs82(args, ["input"]);
         const $result = resource_mutation_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39424,7 +40469,7 @@ export const plans = {
     },
     noArgsMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs78(args, ["input"]);
+        const selectArgs = makeArgs83(args, ["input"]);
         const $result = resource_no_args_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39441,7 +40486,7 @@ export const plans = {
     },
     returnVoidMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs79(args, ["input"]);
+        const selectArgs = makeArgs84(args, ["input"]);
         const $result = resource_return_void_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39458,7 +40503,7 @@ export const plans = {
     },
     mutationIntervalSet: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs80(args, ["input"]);
+        const selectArgs = makeArgs85(args, ["input"]);
         const $result = resource_mutation_interval_setPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39475,7 +40520,7 @@ export const plans = {
     },
     mutationInOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs81(args, ["input"]);
+        const selectArgs = makeArgs86(args, ["input"]);
         const $result = resource_mutation_in_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39492,7 +40537,7 @@ export const plans = {
     },
     mutationReturnsTableOneCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs82(args, ["input"]);
+        const selectArgs = makeArgs87(args, ["input"]);
         const $result = resource_mutation_returns_table_one_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39509,7 +40554,7 @@ export const plans = {
     },
     jsonIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs83(args, ["input"]);
+        const selectArgs = makeArgs88(args, ["input"]);
         const $result = resource_json_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39526,7 +40571,7 @@ export const plans = {
     },
     jsonbIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs84(args, ["input"]);
+        const selectArgs = makeArgs89(args, ["input"]);
         const $result = resource_jsonb_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39543,7 +40588,7 @@ export const plans = {
     },
     jsonbIdentityMutationPlpgsql: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs85(args, ["input"]);
+        const selectArgs = makeArgs90(args, ["input"]);
         const $result = resource_jsonb_identity_mutation_plpgsqlPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39560,7 +40605,7 @@ export const plans = {
     },
     jsonbIdentityMutationPlpgsqlWithDefault: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs86(args, ["input"]);
+        const selectArgs = makeArgs91(args, ["input"]);
         const $result = resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39577,7 +40622,7 @@ export const plans = {
     },
     add1Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs87(args, ["input"]);
+        const selectArgs = makeArgs92(args, ["input"]);
         const $result = resource_add_1_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39594,7 +40639,7 @@ export const plans = {
     },
     add2Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs88(args, ["input"]);
+        const selectArgs = makeArgs93(args, ["input"]);
         const $result = resource_add_2_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39611,7 +40656,7 @@ export const plans = {
     },
     add3Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs89(args, ["input"]);
+        const selectArgs = makeArgs94(args, ["input"]);
         const $result = resource_add_3_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39628,7 +40673,7 @@ export const plans = {
     },
     add4Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs90(args, ["input"]);
+        const selectArgs = makeArgs95(args, ["input"]);
         const $result = resource_add_4_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39645,7 +40690,7 @@ export const plans = {
     },
     add4MutationError: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs91(args, ["input"]);
+        const selectArgs = makeArgs96(args, ["input"]);
         const $result = resource_add_4_mutation_errorPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39662,7 +40707,7 @@ export const plans = {
     },
     mult1: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs92(args, ["input"]);
+        const selectArgs = makeArgs97(args, ["input"]);
         const $result = resource_mult_1PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39679,7 +40724,7 @@ export const plans = {
     },
     mult2: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs93(args, ["input"]);
+        const selectArgs = makeArgs98(args, ["input"]);
         const $result = resource_mult_2PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39696,7 +40741,7 @@ export const plans = {
     },
     mult3: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs94(args, ["input"]);
+        const selectArgs = makeArgs99(args, ["input"]);
         const $result = resource_mult_3PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39713,7 +40758,7 @@ export const plans = {
     },
     mult4: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs95(args, ["input"]);
+        const selectArgs = makeArgs100(args, ["input"]);
         const $result = resource_mult_4PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39730,7 +40775,7 @@ export const plans = {
     },
     mutationInInout: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs96(args, ["input"]);
+        const selectArgs = makeArgs101(args, ["input"]);
         const $result = resource_mutation_in_inoutPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39747,7 +40792,7 @@ export const plans = {
     },
     mutationOutOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs97(args, ["input"]);
+        const selectArgs = makeArgs102(args, ["input"]);
         const $result = resource_mutation_out_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39764,7 +40809,7 @@ export const plans = {
     },
     mutationOutOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs98(args, ["input"]);
+        const selectArgs = makeArgs103(args, ["input"]);
         const $result = resource_mutation_out_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39781,7 +40826,7 @@ export const plans = {
     },
     mutationOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs99(args, ["input"]);
+        const selectArgs = makeArgs104(args, ["input"]);
         const $result = resource_mutation_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39798,7 +40843,7 @@ export const plans = {
     },
     intSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs100(args, ["input"]);
+        const selectArgs = makeArgs105(args, ["input"]);
         const $result = resource_int_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39815,7 +40860,7 @@ export const plans = {
     },
     mutationOutUnnamedOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs101(args, ["input"]);
+        const selectArgs = makeArgs106(args, ["input"]);
         const $result = resource_mutation_out_unnamed_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39832,7 +40877,7 @@ export const plans = {
     },
     mutationReturnsTableMultiCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs102(args, ["input"]);
+        const selectArgs = makeArgs107(args, ["input"]);
         const $result = resource_mutation_returns_table_multi_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39849,7 +40894,7 @@ export const plans = {
     },
     guidFn: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs103(args, ["input"]);
+        const selectArgs = makeArgs108(args, ["input"]);
         const $result = resource_guid_fnPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39866,7 +40911,7 @@ export const plans = {
     },
     mutationIntervalArray: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs104(args, ["input"]);
+        const selectArgs = makeArgs109(args, ["input"]);
         const $result = resource_mutation_interval_arrayPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39883,7 +40928,7 @@ export const plans = {
     },
     mutationTextArray: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs105(args, ["input"]);
+        const selectArgs = makeArgs110(args, ["input"]);
         const $result = resource_mutation_text_arrayPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39900,7 +40945,7 @@ export const plans = {
     },
     listBdeMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs106(args, ["input"]);
+        const selectArgs = makeArgs111(args, ["input"]);
         const $result = resource_list_bde_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39917,7 +40962,7 @@ export const plans = {
     },
     authenticateFail: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs107(args, ["input"]);
+        const selectArgs = makeArgs112(args, ["input"]);
         const $result = resource_authenticate_failPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39934,7 +40979,7 @@ export const plans = {
     },
     authenticate: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs108(args, ["input"]);
+        const selectArgs = makeArgs113(args, ["input"]);
         const $result = resource_authenticatePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39951,7 +40996,7 @@ export const plans = {
     },
     leftArmIdentity: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs109(args, ["input"]);
+        const selectArgs = makeArgs114(args, ["input"]);
         const $result = resource_left_arm_identityPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39968,7 +41013,7 @@ export const plans = {
     },
     issue756Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs110(args, ["input"]);
+        const selectArgs = makeArgs115(args, ["input"]);
         const $result = resource_issue756_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39985,7 +41030,7 @@ export const plans = {
     },
     issue756SetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs111(args, ["input"]);
+        const selectArgs = makeArgs116(args, ["input"]);
         const $result = resource_issue756_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40002,7 +41047,7 @@ export const plans = {
     },
     authenticateMany: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs112(args, ["input"]);
+        const selectArgs = makeArgs117(args, ["input"]);
         const $result = resource_authenticate_manyPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40019,7 +41064,7 @@ export const plans = {
     },
     authenticatePayload: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs113(args, ["input"]);
+        const selectArgs = makeArgs118(args, ["input"]);
         const $result = resource_authenticate_payloadPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40036,7 +41081,7 @@ export const plans = {
     },
     typesMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs114(args, ["input"]);
+        const selectArgs = makeArgs119(args, ["input"]);
         const $result = resource_types_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40053,7 +41098,7 @@ export const plans = {
     },
     mutationOutOutCompoundType: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs115(args, ["input"]);
+        const selectArgs = makeArgs120(args, ["input"]);
         const $result = resource_mutation_out_out_compound_typePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40070,7 +41115,7 @@ export const plans = {
     },
     compoundTypeMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs116(args, ["input"]);
+        const selectArgs = makeArgs121(args, ["input"]);
         const $result = resource_compound_type_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40087,7 +41132,7 @@ export const plans = {
     },
     compoundTypeSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs117(args, ["input"]);
+        const selectArgs = makeArgs122(args, ["input"]);
         const $result = resource_compound_type_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40104,7 +41149,7 @@ export const plans = {
     },
     createPost: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs118(args, ["input"]);
+        const selectArgs = makeArgs123(args, ["input"]);
         const $result = resource_create_postPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40121,7 +41166,7 @@ export const plans = {
     },
     tableMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs119(args, ["input"]);
+        const selectArgs = makeArgs124(args, ["input"]);
         const $result = resource_table_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40138,7 +41183,7 @@ export const plans = {
     },
     postWithSuffix: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs120(args, ["input"]);
+        const selectArgs = makeArgs125(args, ["input"]);
         const $result = resource_post_with_suffixPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40155,7 +41200,7 @@ export const plans = {
     },
     mutationCompoundTypeArray: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs121(args, ["input"]);
+        const selectArgs = makeArgs126(args, ["input"]);
         const $result = resource_mutation_compound_type_arrayPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40172,7 +41217,7 @@ export const plans = {
     },
     compoundTypeArrayMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs122(args, ["input"]);
+        const selectArgs = makeArgs127(args, ["input"]);
         const $result = resource_compound_type_array_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40189,7 +41234,7 @@ export const plans = {
     },
     postMany: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs123(args, ["input"]);
+        const selectArgs = makeArgs128(args, ["input"]);
         const $result = resource_post_manyPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40206,7 +41251,7 @@ export const plans = {
     },
     mutationOutComplex: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs124(args, ["input"]);
+        const selectArgs = makeArgs129(args, ["input"]);
         const $result = resource_mutation_out_complexPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40223,7 +41268,7 @@ export const plans = {
     },
     mutationOutComplexSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs125(args, ["input"]);
+        const selectArgs = makeArgs130(args, ["input"]);
         const $result = resource_mutation_out_complex_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40240,7 +41285,7 @@ export const plans = {
     },
     mutationOutTable: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs126(args, ["input"]);
+        const selectArgs = makeArgs131(args, ["input"]);
         const $result = resource_mutation_out_tablePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40257,7 +41302,7 @@ export const plans = {
     },
     mutationOutTableSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs127(args, ["input"]);
+        const selectArgs = makeArgs132(args, ["input"]);
         const $result = resource_mutation_out_table_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40274,7 +41319,7 @@ export const plans = {
     },
     tableSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs128(args, ["input"]);
+        const selectArgs = makeArgs133(args, ["input"]);
         const $result = resource_table_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40291,7 +41336,7 @@ export const plans = {
     },
     typeFunctionConnectionMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs129(args, ["input"]);
+        const selectArgs = makeArgs134(args, ["input"]);
         const $result = resource_type_function_connection_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40308,7 +41353,7 @@ export const plans = {
     },
     typeFunctionMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs130(args, ["input"]);
+        const selectArgs = makeArgs135(args, ["input"]);
         const $result = resource_type_function_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40325,7 +41370,7 @@ export const plans = {
     },
     typeFunctionListMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs131(args, ["input"]);
+        const selectArgs = makeArgs136(args, ["input"]);
         const $result = resource_type_function_list_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.graphql
@@ -5897,6 +5897,11 @@ type Person implements Node {
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, arg2: Int, b: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
 
   """This `Person`'s `PersonSecret`."""
   personSecretByPersonId: PersonSecret @deprecated(reason: "This is deprecated (comment on table c.person_secret).")

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.export.mjs
@@ -3495,6 +3495,11 @@ const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_compu
 const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
 const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
 const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const person_optional_missing_middle_1FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_1");
+const person_optional_missing_middle_2FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_2");
+const person_optional_missing_middle_3FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_3");
+const person_optional_missing_middle_4FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_4");
+const person_optional_missing_middle_5FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_5");
 const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
 const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
 const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
@@ -7409,6 +7414,216 @@ const registry = makeRegistry({
           serviceName: "main",
           schemaName: "c",
           name: "person_computed_first_arg_inout_out"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_1: {
+      executor,
+      name: "person_optional_missing_middle_1",
+      identifier: "main.c.person_optional_missing_middle_1(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_1"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_2: {
+      executor,
+      name: "person_optional_missing_middle_2",
+      identifier: "main.c.person_optional_missing_middle_2(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_2"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_3: {
+      executor,
+      name: "person_optional_missing_middle_3",
+      identifier: "main.c.person_optional_missing_middle_3(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_3"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_4: {
+      executor,
+      name: "person_optional_missing_middle_4",
+      identifier: "main.c.person_optional_missing_middle_4(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_4"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_5: {
+      executor,
+      name: "person_optional_missing_middle_5",
+      identifier: "main.c.person_optional_missing_middle_5(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_5FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_5"
         },
         tags: {}
       },
@@ -11896,22 +12111,28 @@ const makeArgs56 = (args, path = []) => {
 };
 const resource_person_computed_first_arg_inout_outPgResource = registry.pgResources["person_computed_first_arg_inout_out"];
 const argDetailsSimple57 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
+  graphqlArgName: "arg0",
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
   graphqlArgName: "b",
   postgresArgName: "b",
-  pgCodec: TYPES.text,
-  required: true,
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
   fetcher: null
 }];
 const makeArgs57 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11922,7 +12143,7 @@ const makeArgs57 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 1 - 1) {
         skipped = true;
         continue;
       } else {
@@ -11952,12 +12173,30 @@ const makeArgs57 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
-const argDetailsSimple58 = [];
+const resource_person_optional_missing_middle_1PgResource = registry.pgResources["person_optional_missing_middle_1"];
+const argDetailsSimple58 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs58 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11998,12 +12237,30 @@ const makeArgs58 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
-const argDetailsSimple59 = [];
+const resource_person_optional_missing_middle_2PgResource = registry.pgResources["person_optional_missing_middle_2"];
+const argDetailsSimple59 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs59 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12014,7 +12271,7 @@ const makeArgs59 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 2 - 1) {
         skipped = true;
         continue;
       } else {
@@ -12044,12 +12301,30 @@ const makeArgs59 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
-const argDetailsSimple60 = [];
+const resource_person_optional_missing_middle_3PgResource = registry.pgResources["person_optional_missing_middle_3"];
+const argDetailsSimple60 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs60 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12060,7 +12335,7 @@ const makeArgs60 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -12090,46 +12365,30 @@ const makeArgs60 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_friendsPgResource = registry.pgResources["person_friends"];
-const getSelectPlanFromParentAndArgs15 = ($in, args, _info) => {
-  if (!hasRecord($in)) {
-    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-  }
-  const extraSelectArgs = makeArgs60(args);
-  /**
-   * An optimisation - if all our dependencies are
-   * compatible with the expression's class plan then we
-   * can inline ourselves into that, otherwise we must
-   * issue the query separately.
-   */
-  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-  const selectArgs = [{
-    step: $row.record()
-  }, ...extraSelectArgs];
-  if (resource_person_friendsPgResource.isUnique && !resource_person_friendsPgResource.codec.attributes && typeof resource_person_friendsPgResource.from === "function") {
-    // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
-      if (i === 0) {
-        return $row.getClassStep().alias;
-      } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
-      } else {
-        return $row.placeholder(arg.step);
-      }
-    });
-    return pgClassExpression($row, resource_person_friendsPgResource.codec)`${resource_person_friendsPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
-  }
-  // PERF: or here, if scalar add select to `$row`?
-  return resource_person_friendsPgResource.execute(selectArgs);
-};
-const argDetailsSimple61 = [];
+const resource_person_optional_missing_middle_4PgResource = registry.pgResources["person_optional_missing_middle_4"];
+const argDetailsSimple61 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs61 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12140,7 +12399,7 @@ const makeArgs61 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -12170,52 +12429,24 @@ const makeArgs61 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
-const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
-  if (!hasRecord($in)) {
-    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-  }
-  const extraSelectArgs = makeArgs61(args);
-  /**
-   * An optimisation - if all our dependencies are
-   * compatible with the expression's class plan then we
-   * can inline ourselves into that, otherwise we must
-   * issue the query separately.
-   */
-  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-  const selectArgs = [{
-    step: $row.record()
-  }, ...extraSelectArgs];
-  if (resource_person_type_function_connectionPgResource.isUnique && !resource_person_type_function_connectionPgResource.codec.attributes && typeof resource_person_type_function_connectionPgResource.from === "function") {
-    // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
-      if (i === 0) {
-        return $row.getClassStep().alias;
-      } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
-      } else {
-        return $row.placeholder(arg.step);
-      }
-    });
-    return pgClassExpression($row, resource_person_type_function_connectionPgResource.codec)`${resource_person_type_function_connectionPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
-  }
-  // PERF: or here, if scalar add select to `$row`?
-  return resource_person_type_function_connectionPgResource.execute(selectArgs);
-};
+const resource_person_optional_missing_middle_5PgResource = registry.pgResources["person_optional_missing_middle_5"];
 const argDetailsSimple62 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs62 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12256,7 +12487,7 @@ const makeArgs62 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
+const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
 const argDetailsSimple63 = [];
 const makeArgs63 = (args, path = []) => {
   const selectArgs = [];
@@ -12302,9 +12533,7 @@ const makeArgs63 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
-const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
-const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
+const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
 const argDetailsSimple64 = [];
 const makeArgs64 = (args, path = []) => {
   const selectArgs = [];
@@ -12350,16 +12579,7 @@ const makeArgs64 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
-function UUIDSerialize(value) {
-  return "" + value;
-}
-const coerce = string => {
-  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
-    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
-  }
-  return string;
-};
+const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -12405,8 +12625,8 @@ const makeArgs65 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_interval_setPgResource = registry.pgResources["post_computed_interval_set"];
-const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
+const resource_person_friendsPgResource = registry.pgResources["person_friends"];
+const getSelectPlanFromParentAndArgs15 = ($in, args, _info) => {
   if (!hasRecord($in)) {
     throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
   }
@@ -12422,23 +12642,33 @@ const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
   const selectArgs = [{
     step: $row.record()
   }, ...extraSelectArgs];
-  if (resource_post_computed_interval_setPgResource.isUnique && !resource_post_computed_interval_setPgResource.codec.attributes && typeof resource_post_computed_interval_setPgResource.from === "function") {
+  if (resource_person_friendsPgResource.isUnique && !resource_person_friendsPgResource.codec.attributes && typeof resource_person_friendsPgResource.from === "function") {
     // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
       if (i === 0) {
-        return $row.getClassStep().alias;
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
       } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
       } else {
-        return $row.placeholder(arg.step);
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
       }
     });
-    return pgClassExpression($row, resource_post_computed_interval_setPgResource.codec)`${resource_post_computed_interval_setPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
+    return pgClassExpression($row, resource_person_friendsPgResource.codec)`${resource_person_friendsPgResource.from(...newSelectArgs)}`;
   }
   // PERF: or here, if scalar add select to `$row`?
-  return resource_post_computed_interval_setPgResource.execute(selectArgs);
+  return resource_person_friendsPgResource.execute(selectArgs);
 };
 const argDetailsSimple66 = [];
 const makeArgs66 = (args, path = []) => {
@@ -12485,12 +12715,62 @@ const makeArgs66 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_interval_arrayPgResource = registry.pgResources["post_computed_interval_array"];
-const argDetailsSimple67 = [];
+const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
+const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
+  if (!hasRecord($in)) {
+    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+  }
+  const extraSelectArgs = makeArgs66(args);
+  /**
+   * An optimisation - if all our dependencies are
+   * compatible with the expression's class plan then we
+   * can inline ourselves into that, otherwise we must
+   * issue the query separately.
+   */
+  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+  const selectArgs = [{
+    step: $row.record()
+  }, ...extraSelectArgs];
+  if (resource_person_type_function_connectionPgResource.isUnique && !resource_person_type_function_connectionPgResource.codec.attributes && typeof resource_person_type_function_connectionPgResource.from === "function") {
+    // This is a scalar computed attribute, let's inline the expression
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
+      if (i === 0) {
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
+      } else if ("pgCodec" in arg && arg.pgCodec) {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
+      } else {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
+      }
+    });
+    return pgClassExpression($row, resource_person_type_function_connectionPgResource.codec)`${resource_person_type_function_connectionPgResource.from(...newSelectArgs)}`;
+  }
+  // PERF: or here, if scalar add select to `$row`?
+  return resource_person_type_function_connectionPgResource.execute(selectArgs);
+};
+const argDetailsSimple67 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs67 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12531,18 +12811,12 @@ const makeArgs67 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_text_arrayPgResource = registry.pgResources["post_computed_text_array"];
-const argDetailsSimple68 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: false,
-  fetcher: null
-}];
+const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
+const argDetailsSimple68 = [];
 const makeArgs68 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12583,18 +12857,14 @@ const makeArgs68 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_with_optional_argPgResource = registry.pgResources["post_computed_with_optional_arg"];
-const argDetailsSimple69 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
+const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
+const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
+const argDetailsSimple69 = [];
 const makeArgs69 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12635,24 +12905,21 @@ const makeArgs69 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_with_required_argPgResource = registry.pgResources["post_computed_with_required_arg"];
-const argDetailsSimple70 = [{
-  graphqlArgName: "length",
-  postgresArgName: "length",
-  pgCodec: TYPES.int,
-  required: false,
-  fetcher: null
-}, {
-  graphqlArgName: "omission",
-  postgresArgName: "omission",
-  pgCodec: TYPES.text,
-  required: false,
-  fetcher: null
-}];
+const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
+function UUIDSerialize(value) {
+  return "" + value;
+}
+const coerce = string => {
+  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
+    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
+  }
+  return string;
+};
+const argDetailsSimple70 = [];
 const makeArgs70 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12693,24 +12960,56 @@ const makeArgs70 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmedPgResource = registry.pgResources["post_headline_trimmed"];
-const argDetailsSimple71 = [{
-  graphqlArgName: "length",
-  postgresArgName: "length",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "omission",
-  postgresArgName: "omission",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_post_computed_interval_setPgResource = registry.pgResources["post_computed_interval_set"];
+const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
+  if (!hasRecord($in)) {
+    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+  }
+  const extraSelectArgs = makeArgs70(args);
+  /**
+   * An optimisation - if all our dependencies are
+   * compatible with the expression's class plan then we
+   * can inline ourselves into that, otherwise we must
+   * issue the query separately.
+   */
+  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+  const selectArgs = [{
+    step: $row.record()
+  }, ...extraSelectArgs];
+  if (resource_post_computed_interval_setPgResource.isUnique && !resource_post_computed_interval_setPgResource.codec.attributes && typeof resource_post_computed_interval_setPgResource.from === "function") {
+    // This is a scalar computed attribute, let's inline the expression
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
+      if (i === 0) {
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
+      } else if ("pgCodec" in arg && arg.pgCodec) {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
+      } else {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
+      }
+    });
+    return pgClassExpression($row, resource_post_computed_interval_setPgResource.codec)`${resource_post_computed_interval_setPgResource.from(...newSelectArgs)}`;
+  }
+  // PERF: or here, if scalar add select to `$row`?
+  return resource_post_computed_interval_setPgResource.execute(selectArgs);
+};
+const argDetailsSimple71 = [];
 const makeArgs71 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12751,24 +13050,12 @@ const makeArgs71 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmed_no_defaultsPgResource = registry.pgResources["post_headline_trimmed_no_defaults"];
-const argDetailsSimple72 = [{
-  graphqlArgName: "length",
-  postgresArgName: "length",
-  pgCodec: TYPES.int,
-  required: false,
-  fetcher: null
-}, {
-  graphqlArgName: "omission",
-  postgresArgName: "omission",
-  pgCodec: TYPES.text,
-  required: false,
-  fetcher: null
-}];
+const resource_post_computed_interval_arrayPgResource = registry.pgResources["post_computed_interval_array"];
+const argDetailsSimple72 = [];
 const makeArgs72 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12809,12 +13096,12 @@ const makeArgs72 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmed_strictPgResource = registry.pgResources["post_headline_trimmed_strict"];
+const resource_post_computed_text_arrayPgResource = registry.pgResources["post_computed_text_array"];
 const argDetailsSimple73 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
-  required: true,
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: false,
   fetcher: null
 }];
 const makeArgs73 = (args, path = []) => {
@@ -12828,6 +13115,284 @@ const makeArgs73 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple73[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_computed_with_optional_argPgResource = registry.pgResources["post_computed_with_optional_arg"];
+const argDetailsSimple74 = [{
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs74 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple74[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_computed_with_required_argPgResource = registry.pgResources["post_computed_with_required_arg"];
+const argDetailsSimple75 = [{
+  graphqlArgName: "length",
+  postgresArgName: "length",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "omission",
+  postgresArgName: "omission",
+  pgCodec: TYPES.text,
+  required: false,
+  fetcher: null
+}];
+const makeArgs75 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple75[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_headline_trimmedPgResource = registry.pgResources["post_headline_trimmed"];
+const argDetailsSimple76 = [{
+  graphqlArgName: "length",
+  postgresArgName: "length",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "omission",
+  postgresArgName: "omission",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
+const makeArgs76 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple76[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_headline_trimmed_no_defaultsPgResource = registry.pgResources["post_headline_trimmed_no_defaults"];
+const argDetailsSimple77 = [{
+  graphqlArgName: "length",
+  postgresArgName: "length",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "omission",
+  postgresArgName: "omission",
+  pgCodec: TYPES.text,
+  required: false,
+  fetcher: null
+}];
+const makeArgs77 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple77[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_headline_trimmed_strictPgResource = registry.pgResources["post_headline_trimmed_strict"];
+const argDetailsSimple78 = [{
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
+  required: true,
+  fetcher: null
+}];
+const makeArgs78 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple78[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -12918,236 +13483,6 @@ const parseValueLiteral = (ast, variables) => {
       return undefined;
   }
 };
-const argDetailsSimple74 = [];
-const makeArgs74 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple74[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
-const argDetailsSimple75 = [];
-const makeArgs75 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple75[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
-const argDetailsSimple76 = [];
-const makeArgs76 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple76[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
-const argDetailsSimple77 = [];
-const makeArgs77 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple77[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
-const argDetailsSimple78 = [];
-const makeArgs78 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple78[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
 const argDetailsSimple79 = [];
 const makeArgs79 = (args, path = []) => {
   const selectArgs = [];
@@ -13193,7 +13528,7 @@ const makeArgs79 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
+const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
 const argDetailsSimple80 = [];
 const makeArgs80 = (args, path = []) => {
   const selectArgs = [];
@@ -13239,18 +13574,12 @@ const makeArgs80 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
-const argDetailsSimple81 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
+const argDetailsSimple81 = [];
 const makeArgs81 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13291,18 +13620,12 @@ const makeArgs81 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
-const argDetailsSimple82 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
+const argDetailsSimple82 = [];
 const makeArgs82 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13343,18 +13666,12 @@ const makeArgs82 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
-const argDetailsSimple83 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
+const argDetailsSimple83 = [];
 const makeArgs83 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13395,18 +13712,12 @@ const makeArgs83 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
-const argDetailsSimple84 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
+const argDetailsSimple84 = [];
 const makeArgs84 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13447,18 +13758,12 @@ const makeArgs84 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
-const argDetailsSimple85 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
+const argDetailsSimple85 = [];
 const makeArgs85 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13499,12 +13804,12 @@ const makeArgs85 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
+const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
 const argDetailsSimple86 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: false,
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
   fetcher: null
 }];
 const makeArgs86 = (args, path = []) => {
@@ -13551,16 +13856,10 @@ const makeArgs86 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
+const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
 const argDetailsSimple87 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: null,
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "arg1",
-  postgresArgName: null,
+  graphqlArgName: "i",
+  postgresArgName: "i",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -13568,7 +13867,7 @@ const argDetailsSimple87 = [{
 const makeArgs87 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13579,7 +13878,7 @@ const makeArgs87 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 2 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13609,24 +13908,18 @@ const makeArgs87 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
+const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
 const argDetailsSimple88 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.json,
   required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.int,
-  required: false,
   fetcher: null
 }];
 const makeArgs88 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13667,24 +13960,18 @@ const makeArgs88 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
+const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
 const argDetailsSimple89 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "arg1",
-  postgresArgName: "",
-  pgCodec: TYPES.int,
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.jsonb,
   required: true,
   fetcher: null
 }];
 const makeArgs89 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13695,7 +13982,7 @@ const makeArgs89 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 2 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13725,24 +14012,18 @@ const makeArgs89 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
+const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
 const argDetailsSimple90 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: "",
-  pgCodec: TYPES.int,
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
   required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.int,
-  required: false,
   fetcher: null
 }];
 const makeArgs90 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13753,7 +14034,7 @@ const makeArgs90 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 1 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13783,24 +14064,18 @@ const makeArgs90 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
+const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
 const argDetailsSimple91 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: "",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.int,
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
   required: false,
   fetcher: null
 }];
 const makeArgs91 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13811,7 +14086,7 @@ const makeArgs91 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 1 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13841,7 +14116,7 @@ const makeArgs91 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
+const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
 const argDetailsSimple92 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -13899,18 +14174,18 @@ const makeArgs92 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_1PgResource = registry.pgResources["mult_1"];
+const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
 const argDetailsSimple93 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: null,
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "arg1",
-  postgresArgName: null,
+  graphqlArgName: "b",
+  postgresArgName: "b",
   pgCodec: TYPES.int,
-  required: true,
+  required: false,
   fetcher: null
 }];
 const makeArgs93 = (args, path = []) => {
@@ -13927,7 +14202,7 @@ const makeArgs93 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 2 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13957,16 +14232,16 @@ const makeArgs93 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_2PgResource = registry.pgResources["mult_2"];
+const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
 const argDetailsSimple94 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: null,
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
   graphqlArgName: "arg1",
-  postgresArgName: null,
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -14015,18 +14290,18 @@ const makeArgs94 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_3PgResource = registry.pgResources["mult_3"];
+const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
 const argDetailsSimple95 = [{
   graphqlArgName: "arg0",
-  postgresArgName: null,
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "arg1",
-  postgresArgName: null,
+  graphqlArgName: "b",
+  postgresArgName: "b",
   pgCodec: TYPES.int,
-  required: true,
+  required: false,
   fetcher: null
 }];
 const makeArgs95 = (args, path = []) => {
@@ -14040,6 +14315,296 @@ const makeArgs95 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple95[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 1 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
+const argDetailsSimple96 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
+const makeArgs96 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple96[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 1 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
+const argDetailsSimple97 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs97 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple97[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 2 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mult_1PgResource = registry.pgResources["mult_1"];
+const argDetailsSimple98 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs98 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple98[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 2 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mult_2PgResource = registry.pgResources["mult_2"];
+const argDetailsSimple99 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs99 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple99[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 2 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mult_3PgResource = registry.pgResources["mult_3"];
+const argDetailsSimple100 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs100 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple100[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -14074,7 +14639,7 @@ const makeArgs95 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_4PgResource = registry.pgResources["mult_4"];
-const argDetailsSimple96 = [{
+const argDetailsSimple101 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
   pgCodec: TYPES.int,
@@ -14087,258 +14652,10 @@ const argDetailsSimple96 = [{
   required: true,
   fetcher: null
 }];
-const makeArgs96 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 2; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple96[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
-const argDetailsSimple97 = [];
-const makeArgs97 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple97[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
-const argDetailsSimple98 = [];
-const makeArgs98 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple98[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
-const argDetailsSimple99 = [];
-const makeArgs99 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple99[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
-const argDetailsSimple100 = [{
-  graphqlArgName: "x",
-  postgresArgName: "x",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "y",
-  postgresArgName: "y",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "z",
-  postgresArgName: "z",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
-const makeArgs100 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 3; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple100[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
-const argDetailsSimple101 = [];
 const makeArgs101 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14379,18 +14696,12 @@ const makeArgs101 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
-const argDetailsSimple102 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
+const argDetailsSimple102 = [];
 const makeArgs102 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14431,18 +14742,12 @@ const makeArgs102 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
-const argDetailsSimple103 = [{
-  graphqlArgName: "g",
-  postgresArgName: "g",
-  pgCodec: guidCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
+const argDetailsSimple103 = [];
 const makeArgs103 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14483,7 +14788,7 @@ const makeArgs103 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_guid_fnPgResource = registry.pgResources["guid_fn"];
+const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
 const argDetailsSimple104 = [];
 const makeArgs104 = (args, path = []) => {
   const selectArgs = [];
@@ -14529,12 +14834,30 @@ const makeArgs104 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
-const argDetailsSimple105 = [];
+const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
+const argDetailsSimple105 = [{
+  graphqlArgName: "x",
+  postgresArgName: "x",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "y",
+  postgresArgName: "y",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "z",
+  postgresArgName: "z",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs105 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14575,30 +14898,12 @@ const makeArgs105 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
-const argDetailsSimple106 = [{
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: textArrayCodec,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "d",
-  postgresArgName: "d",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "e",
-  postgresArgName: "e",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
+const argDetailsSimple106 = [];
 const makeArgs106 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14639,12 +14944,18 @@ const makeArgs106 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_list_bde_mutationPgResource = registry.pgResources["list_bde_mutation"];
-const argDetailsSimple107 = [];
+const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
+const argDetailsSimple107 = [{
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs107 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14685,30 +14996,18 @@ const makeArgs107 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_failPgResource = registry.pgResources["authenticate_fail"];
+const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
 const argDetailsSimple108 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.numeric,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.bigint,
+  graphqlArgName: "g",
+  postgresArgName: "g",
+  pgCodec: guidCodec,
   required: true,
   fetcher: null
 }];
 const makeArgs108 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14749,18 +15048,12 @@ const makeArgs108 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticatePgResource = registry.pgResources["authenticate"];
-const argDetailsSimple109 = [{
-  graphqlArgName: "leftArm",
-  postgresArgName: "left_arm",
-  pgCodec: leftArmCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_guid_fnPgResource = registry.pgResources["guid_fn"];
+const argDetailsSimple109 = [];
 const makeArgs109 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14801,7 +15094,7 @@ const makeArgs109 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
+const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
 const argDetailsSimple110 = [];
 const makeArgs110 = (args, path = []) => {
   const selectArgs = [];
@@ -14847,12 +15140,30 @@ const makeArgs110 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
-const argDetailsSimple111 = [];
+const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
+const argDetailsSimple111 = [{
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: textArrayCodec,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "d",
+  postgresArgName: "d",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "e",
+  postgresArgName: "e",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
 const makeArgs111 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14893,30 +15204,12 @@ const makeArgs111 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
-const argDetailsSimple112 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.numeric,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.bigint,
-  required: true,
-  fetcher: null
-}];
+const resource_list_bde_mutationPgResource = registry.pgResources["list_bde_mutation"];
+const argDetailsSimple112 = [];
 const makeArgs112 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14957,7 +15250,7 @@ const makeArgs112 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_manyPgResource = registry.pgResources["authenticate_many"];
+const resource_authenticate_failPgResource = registry.pgResources["authenticate_fail"];
 const argDetailsSimple113 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -15021,48 +15314,18 @@ const makeArgs113 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_payloadPgResource = registry.pgResources["authenticate_payload"];
+const resource_authenticatePgResource = registry.pgResources["authenticate"];
 const argDetailsSimple114 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.bigint,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.boolean,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.varchar,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "d",
-  postgresArgName: "d",
-  pgCodec: int4ArrayCodec,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "e",
-  postgresArgName: "e",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "f",
-  postgresArgName: "f",
-  pgCodec: floatrangeCodec,
+  graphqlArgName: "leftArm",
+  postgresArgName: "left_arm",
+  pgCodec: leftArmCodec,
   required: true,
   fetcher: null
 }];
 const makeArgs114 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 6; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15103,18 +15366,12 @@ const makeArgs114 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
-const argDetailsSimple115 = [{
-  graphqlArgName: "i1",
-  postgresArgName: "i1",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
+const argDetailsSimple115 = [];
 const makeArgs115 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15155,18 +15412,12 @@ const makeArgs115 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
-const argDetailsSimple116 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
+const argDetailsSimple116 = [];
 const makeArgs116 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15207,18 +15458,30 @@ const makeArgs116 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_mutationPgResource = registry.pgResources["compound_type_mutation"];
+const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
 const argDetailsSimple117 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.numeric,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.bigint,
   required: true,
   fetcher: null
 }];
 const makeArgs117 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15259,18 +15522,30 @@ const makeArgs117 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
+const resource_authenticate_manyPgResource = registry.pgResources["authenticate_many"];
 const argDetailsSimple118 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.numeric,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.bigint,
   required: true,
   fetcher: null
 }];
 const makeArgs118 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15311,24 +15586,48 @@ const makeArgs118 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
+const resource_authenticate_payloadPgResource = registry.pgResources["authenticate_payload"];
 const argDetailsSimple119 = [{
-  graphqlArgName: "post",
-  postgresArgName: "post",
-  pgCodec: postCodec,
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.bigint,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "suffix",
-  postgresArgName: "suffix",
-  pgCodec: TYPES.text,
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.boolean,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.varchar,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "d",
+  postgresArgName: "d",
+  pgCodec: int4ArrayCodec,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "e",
+  postgresArgName: "e",
+  pgCodec: TYPES.json,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "f",
+  postgresArgName: "f",
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
 const makeArgs119 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 6; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15369,11 +15668,11 @@ const makeArgs119 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_with_suffixPgResource = registry.pgResources["post_with_suffix"];
+const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
 const argDetailsSimple120 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
+  graphqlArgName: "i1",
+  postgresArgName: "i1",
+  pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }];
@@ -15421,7 +15720,7 @@ const makeArgs120 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
+const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
 const argDetailsSimple121 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -15473,11 +15772,11 @@ const makeArgs121 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_array_mutationPgResource = registry.pgResources["compound_type_array_mutation"];
+const resource_compound_type_mutationPgResource = registry.pgResources["compound_type_mutation"];
 const argDetailsSimple122 = [{
-  graphqlArgName: "posts",
-  postgresArgName: "posts",
-  pgCodec: postArrayCodec,
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -15525,24 +15824,18 @@ const makeArgs122 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_manyPgResource = registry.pgResources["post_many"];
+const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
 const argDetailsSimple123 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
+  graphqlArgName: "id",
+  postgresArgName: "id",
   pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs123 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15583,16 +15876,16 @@ const makeArgs123 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
+const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
 const argDetailsSimple124 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
+  graphqlArgName: "post",
+  postgresArgName: "post",
+  pgCodec: postCodec,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
+  graphqlArgName: "suffix",
+  postgresArgName: "suffix",
   pgCodec: TYPES.text,
   required: true,
   fetcher: null
@@ -15641,12 +15934,18 @@ const makeArgs124 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
-const argDetailsSimple125 = [];
+const resource_post_with_suffixPgResource = registry.pgResources["post_with_suffix"];
+const argDetailsSimple125 = [{
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs125 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15687,12 +15986,18 @@ const makeArgs125 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
-const argDetailsSimple126 = [];
+const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
+const argDetailsSimple126 = [{
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs126 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15733,12 +16038,18 @@ const makeArgs126 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
-const argDetailsSimple127 = [];
+const resource_compound_type_array_mutationPgResource = registry.pgResources["compound_type_array_mutation"];
+const argDetailsSimple127 = [{
+  graphqlArgName: "posts",
+  postgresArgName: "posts",
+  pgCodec: postArrayCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs127 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15779,12 +16090,24 @@ const makeArgs127 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
-const argDetailsSimple128 = [];
+const resource_post_manyPgResource = registry.pgResources["post_many"];
+const argDetailsSimple128 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
 const makeArgs128 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15825,18 +16148,24 @@ const makeArgs128 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_type_function_connection_mutationPgResource = registry.pgResources["type_function_connection_mutation"];
+const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
 const argDetailsSimple129 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs129 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15877,7 +16206,7 @@ const makeArgs129 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_type_function_mutationPgResource = registry.pgResources["type_function_mutation"];
+const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
 const argDetailsSimple130 = [];
 const makeArgs130 = (args, path = []) => {
   const selectArgs = [];
@@ -15890,6 +16219,242 @@ const makeArgs130 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple130[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
+const argDetailsSimple131 = [];
+const makeArgs131 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple131[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
+const argDetailsSimple132 = [];
+const makeArgs132 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple132[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
+const argDetailsSimple133 = [];
+const makeArgs133 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple133[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_type_function_connection_mutationPgResource = registry.pgResources["type_function_connection_mutation"];
+const argDetailsSimple134 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs134 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple134[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_type_function_mutationPgResource = registry.pgResources["type_function_mutation"];
+const argDetailsSimple135 = [];
+const makeArgs135 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple135[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -17486,6 +18051,11 @@ type Person implements Node {
   computedInoutOut(ino: String): PersonComputedInoutOutRecord
   exists(email: Email): Boolean @deprecated(reason: "This is deprecated (comment on function c.person_exists).")
   computedFirstArgInoutOut: PersonComputedFirstArgInoutOutRecord
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, b: Int, arg2: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
   computedComplex(a: Int, b: String): PersonComputedComplexRecord
 
   """The first post by the person."""
@@ -28964,18 +29534,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_outPgResource.isUnique && !resource_person_computed_outPgResource.codec.attributes && typeof resource_person_computed_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_outPgResource.codec)`${resource_person_computed_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_outPgResource.codec)`${resource_person_computed_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_outPgResource.execute(selectArgs);
@@ -28998,18 +29578,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_first_namePgResource.isUnique && !resource_person_first_namePgResource.codec.attributes && typeof resource_person_first_namePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_first_namePgResource.codec)`${resource_person_first_namePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_first_namePgResource.codec)`${resource_person_first_namePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_first_namePgResource.execute(selectArgs);
@@ -29032,18 +29622,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_out_outPgResource.isUnique && !resource_person_computed_out_outPgResource.codec.attributes && typeof resource_person_computed_out_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_out_outPgResource.codec)`${resource_person_computed_out_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_out_outPgResource.codec)`${resource_person_computed_out_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_out_outPgResource.execute(selectArgs);
@@ -29067,18 +29667,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_computed_inoutPgResource.isUnique && !resource_person_computed_inoutPgResource.codec.attributes && typeof resource_person_computed_inoutPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_inoutPgResource.codec)`${resource_person_computed_inoutPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_computed_inoutPgResource.codec)`${resource_person_computed_inoutPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_inoutPgResource.execute(selectArgs);
@@ -29106,18 +29716,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_computed_inout_outPgResource.isUnique && !resource_person_computed_inout_outPgResource.codec.attributes && typeof resource_person_computed_inout_outPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_inout_outPgResource.codec)`${resource_person_computed_inout_outPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_computed_inout_outPgResource.codec)`${resource_person_computed_inout_outPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_inout_outPgResource.execute(selectArgs);
@@ -29145,18 +29765,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_existsPgResource.isUnique && !resource_person_existsPgResource.codec.attributes && typeof resource_person_existsPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_existsPgResource.codec)`${resource_person_existsPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_existsPgResource.codec)`${resource_person_existsPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_existsPgResource.execute(selectArgs);
@@ -29183,23 +29813,33 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_first_arg_inout_outPgResource.isUnique && !resource_person_computed_first_arg_inout_outPgResource.codec.attributes && typeof resource_person_computed_first_arg_inout_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_first_arg_inout_outPgResource.codec)`${resource_person_computed_first_arg_inout_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_first_arg_inout_outPgResource.codec)`${resource_person_computed_first_arg_inout_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_first_arg_inout_outPgResource.execute(selectArgs);
     },
-    computedComplex: {
+    optionalMissingMiddle1: {
       plan($in, args, _info) {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -29216,20 +29856,285 @@ export const plans = {
         const selectArgs = [{
           step: $row.record()
         }, ...extraSelectArgs];
-        if (resource_person_computed_complexPgResource.isUnique && !resource_person_computed_complexPgResource.codec.attributes && typeof resource_person_computed_complexPgResource.from === "function") {
+        if (resource_person_optional_missing_middle_1PgResource.isUnique && !resource_person_optional_missing_middle_1PgResource.codec.attributes && typeof resource_person_optional_missing_middle_1PgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_complexPgResource.codec)`${resource_person_computed_complexPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_optional_missing_middle_1PgResource.codec)`${resource_person_optional_missing_middle_1PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_1PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle2: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs58(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_2PgResource.isUnique && !resource_person_optional_missing_middle_2PgResource.codec.attributes && typeof resource_person_optional_missing_middle_2PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_2PgResource.codec)`${resource_person_optional_missing_middle_2PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_2PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        b: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle3: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs59(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_3PgResource.isUnique && !resource_person_optional_missing_middle_3PgResource.codec.attributes && typeof resource_person_optional_missing_middle_3PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_3PgResource.codec)`${resource_person_optional_missing_middle_3PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_3PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle4: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs60(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_4PgResource.isUnique && !resource_person_optional_missing_middle_4PgResource.codec.attributes && typeof resource_person_optional_missing_middle_4PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_4PgResource.codec)`${resource_person_optional_missing_middle_4PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_4PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        arg2: undefined
+      }
+    },
+    optionalMissingMiddle5: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs61(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_5PgResource.isUnique && !resource_person_optional_missing_middle_5PgResource.codec.attributes && typeof resource_person_optional_missing_middle_5PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_5PgResource.codec)`${resource_person_optional_missing_middle_5PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_5PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        arg2: undefined
+      }
+    },
+    computedComplex: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs62(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_computed_complexPgResource.isUnique && !resource_person_computed_complexPgResource.codec.attributes && typeof resource_person_computed_complexPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_computed_complexPgResource.codec)`${resource_person_computed_complexPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_complexPgResource.execute(selectArgs);
@@ -29243,7 +30148,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs58(args);
+      const extraSelectArgs = makeArgs63(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29257,18 +30162,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_first_postPgResource.isUnique && !resource_person_first_postPgResource.codec.attributes && typeof resource_person_first_postPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_first_postPgResource.codec)`${resource_person_first_postPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_first_postPgResource.codec)`${resource_person_first_postPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_first_postPgResource.execute(selectArgs);
@@ -29277,7 +30192,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs59(args);
+      const extraSelectArgs = makeArgs64(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29291,18 +30206,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_first_arg_inoutPgResource.isUnique && !resource_person_computed_first_arg_inoutPgResource.codec.attributes && typeof resource_person_computed_first_arg_inoutPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_first_arg_inoutPgResource.codec)`${resource_person_computed_first_arg_inoutPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_first_arg_inoutPgResource.codec)`${resource_person_computed_first_arg_inoutPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_first_arg_inoutPgResource.execute(selectArgs);
@@ -29407,7 +30332,7 @@ export const plans = {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
         }
-        const extraSelectArgs = makeArgs62(args);
+        const extraSelectArgs = makeArgs67(args);
         /**
          * An optimisation - if all our dependencies are
          * compatible with the expression's class plan then we
@@ -29421,18 +30346,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_type_functionPgResource.isUnique && !resource_person_type_functionPgResource.codec.attributes && typeof resource_person_type_functionPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_type_functionPgResource.codec)`${resource_person_type_functionPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_type_functionPgResource.codec)`${resource_person_type_functionPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_type_functionPgResource.execute(selectArgs);
@@ -29445,7 +30380,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs63(args);
+      const extraSelectArgs = makeArgs68(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29459,18 +30394,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_type_function_listPgResource.isUnique && !resource_person_type_function_listPgResource.codec.attributes && typeof resource_person_type_function_listPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_type_function_listPgResource.codec)`${resource_person_type_function_listPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_type_function_listPgResource.codec)`${resource_person_type_function_listPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_type_function_listPgResource.execute(selectArgs);
@@ -29817,7 +30762,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs64(args);
+      const extraSelectArgs = makeArgs69(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29831,18 +30776,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_compound_type_computed_fieldPgResource.isUnique && !resource_compound_type_computed_fieldPgResource.codec.attributes && typeof resource_compound_type_computed_fieldPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_compound_type_computed_fieldPgResource.codec)`${resource_compound_type_computed_fieldPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_compound_type_computed_fieldPgResource.codec)`${resource_compound_type_computed_fieldPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_compound_type_computed_fieldPgResource.execute(selectArgs);
@@ -29986,7 +30941,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs66(args);
+      const extraSelectArgs = makeArgs71(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -30000,18 +30955,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_post_computed_interval_arrayPgResource.isUnique && !resource_post_computed_interval_arrayPgResource.codec.attributes && typeof resource_post_computed_interval_arrayPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_post_computed_interval_arrayPgResource.codec)`${resource_post_computed_interval_arrayPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_post_computed_interval_arrayPgResource.codec)`${resource_post_computed_interval_arrayPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_post_computed_interval_arrayPgResource.execute(selectArgs);
@@ -30020,7 +30985,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs67(args);
+      const extraSelectArgs = makeArgs72(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -30034,221 +30999,33 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_post_computed_text_arrayPgResource.isUnique && !resource_post_computed_text_arrayPgResource.codec.attributes && typeof resource_post_computed_text_arrayPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_post_computed_text_arrayPgResource.codec)`${resource_post_computed_text_arrayPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_post_computed_text_arrayPgResource.codec)`${resource_post_computed_text_arrayPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_post_computed_text_arrayPgResource.execute(selectArgs);
     },
     computedWithOptionalArg: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs68(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_computed_with_optional_argPgResource.isUnique && !resource_post_computed_with_optional_argPgResource.codec.attributes && typeof resource_post_computed_with_optional_argPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_computed_with_optional_argPgResource.codec)`${resource_post_computed_with_optional_argPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_computed_with_optional_argPgResource.execute(selectArgs);
-      },
-      args: {
-        i: undefined
-      }
-    },
-    computedWithRequiredArg: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs69(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_computed_with_required_argPgResource.isUnique && !resource_post_computed_with_required_argPgResource.codec.attributes && typeof resource_post_computed_with_required_argPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_computed_with_required_argPgResource.codec)`${resource_post_computed_with_required_argPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_computed_with_required_argPgResource.execute(selectArgs);
-      },
-      args: {
-        i: undefined
-      }
-    },
-    headlineTrimmed: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs70(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_headline_trimmedPgResource.isUnique && !resource_post_headline_trimmedPgResource.codec.attributes && typeof resource_post_headline_trimmedPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_headline_trimmedPgResource.codec)`${resource_post_headline_trimmedPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_headline_trimmedPgResource.execute(selectArgs);
-      },
-      args: {
-        length: undefined,
-        omission: undefined
-      }
-    },
-    headlineTrimmedNoDefaults: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs71(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_headline_trimmed_no_defaultsPgResource.isUnique && !resource_post_headline_trimmed_no_defaultsPgResource.codec.attributes && typeof resource_post_headline_trimmed_no_defaultsPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_headline_trimmed_no_defaultsPgResource.codec)`${resource_post_headline_trimmed_no_defaultsPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_headline_trimmed_no_defaultsPgResource.execute(selectArgs);
-      },
-      args: {
-        length: undefined,
-        omission: undefined
-      }
-    },
-    headlineTrimmedStrict: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs72(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_headline_trimmed_strictPgResource.isUnique && !resource_post_headline_trimmed_strictPgResource.codec.attributes && typeof resource_post_headline_trimmed_strictPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_headline_trimmed_strictPgResource.codec)`${resource_post_headline_trimmed_strictPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_headline_trimmed_strictPgResource.execute(selectArgs);
-      },
-      args: {
-        length: undefined,
-        omission: undefined
-      }
-    },
-    computedCompoundTypeArray: {
       plan($in, args, _info) {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -30265,20 +31042,278 @@ export const plans = {
         const selectArgs = [{
           step: $row.record()
         }, ...extraSelectArgs];
-        if (resource_post_computed_compound_type_arrayPgResource.isUnique && !resource_post_computed_compound_type_arrayPgResource.codec.attributes && typeof resource_post_computed_compound_type_arrayPgResource.from === "function") {
+        if (resource_post_computed_with_optional_argPgResource.isUnique && !resource_post_computed_with_optional_argPgResource.codec.attributes && typeof resource_post_computed_with_optional_argPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_post_computed_compound_type_arrayPgResource.codec)`${resource_post_computed_compound_type_arrayPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_post_computed_with_optional_argPgResource.codec)`${resource_post_computed_with_optional_argPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_computed_with_optional_argPgResource.execute(selectArgs);
+      },
+      args: {
+        i: undefined
+      }
+    },
+    computedWithRequiredArg: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs74(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_computed_with_required_argPgResource.isUnique && !resource_post_computed_with_required_argPgResource.codec.attributes && typeof resource_post_computed_with_required_argPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_computed_with_required_argPgResource.codec)`${resource_post_computed_with_required_argPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_computed_with_required_argPgResource.execute(selectArgs);
+      },
+      args: {
+        i: undefined
+      }
+    },
+    headlineTrimmed: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs75(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_headline_trimmedPgResource.isUnique && !resource_post_headline_trimmedPgResource.codec.attributes && typeof resource_post_headline_trimmedPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_headline_trimmedPgResource.codec)`${resource_post_headline_trimmedPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_headline_trimmedPgResource.execute(selectArgs);
+      },
+      args: {
+        length: undefined,
+        omission: undefined
+      }
+    },
+    headlineTrimmedNoDefaults: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs76(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_headline_trimmed_no_defaultsPgResource.isUnique && !resource_post_headline_trimmed_no_defaultsPgResource.codec.attributes && typeof resource_post_headline_trimmed_no_defaultsPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_headline_trimmed_no_defaultsPgResource.codec)`${resource_post_headline_trimmed_no_defaultsPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_headline_trimmed_no_defaultsPgResource.execute(selectArgs);
+      },
+      args: {
+        length: undefined,
+        omission: undefined
+      }
+    },
+    headlineTrimmedStrict: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs77(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_headline_trimmed_strictPgResource.isUnique && !resource_post_headline_trimmed_strictPgResource.codec.attributes && typeof resource_post_headline_trimmed_strictPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_headline_trimmed_strictPgResource.codec)`${resource_post_headline_trimmed_strictPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_headline_trimmed_strictPgResource.execute(selectArgs);
+      },
+      args: {
+        length: undefined,
+        omission: undefined
+      }
+    },
+    computedCompoundTypeArray: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs78(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_computed_compound_type_arrayPgResource.isUnique && !resource_post_computed_compound_type_arrayPgResource.codec.attributes && typeof resource_post_computed_compound_type_arrayPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_computed_compound_type_arrayPgResource.codec)`${resource_post_computed_compound_type_arrayPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_post_computed_compound_type_arrayPgResource.execute(selectArgs);
@@ -38620,7 +39655,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs74(args);
+      const extraSelectArgs = makeArgs79(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -38634,18 +39669,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_edge_case_computedPgResource.isUnique && !resource_edge_case_computedPgResource.codec.attributes && typeof resource_edge_case_computedPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_edge_case_computedPgResource.codec)`${resource_edge_case_computedPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_edge_case_computedPgResource.codec)`${resource_edge_case_computedPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_edge_case_computedPgResource.execute(selectArgs);
@@ -39321,7 +40366,7 @@ export const plans = {
     __assertStep: __ValueStep,
     mutationOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs75(args, ["input"]);
+        const selectArgs = makeArgs80(args, ["input"]);
         const $result = resource_mutation_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39338,7 +40383,7 @@ export const plans = {
     },
     mutationOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs76(args, ["input"]);
+        const selectArgs = makeArgs81(args, ["input"]);
         const $result = resource_mutation_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39355,7 +40400,7 @@ export const plans = {
     },
     mutationOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs77(args, ["input"]);
+        const selectArgs = makeArgs82(args, ["input"]);
         const $result = resource_mutation_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39372,7 +40417,7 @@ export const plans = {
     },
     noArgsMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs78(args, ["input"]);
+        const selectArgs = makeArgs83(args, ["input"]);
         const $result = resource_no_args_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39389,7 +40434,7 @@ export const plans = {
     },
     returnVoidMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs79(args, ["input"]);
+        const selectArgs = makeArgs84(args, ["input"]);
         const $result = resource_return_void_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39406,7 +40451,7 @@ export const plans = {
     },
     mutationIntervalSet: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs80(args, ["input"]);
+        const selectArgs = makeArgs85(args, ["input"]);
         const $result = resource_mutation_interval_setPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39423,7 +40468,7 @@ export const plans = {
     },
     mutationInOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs81(args, ["input"]);
+        const selectArgs = makeArgs86(args, ["input"]);
         const $result = resource_mutation_in_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39440,7 +40485,7 @@ export const plans = {
     },
     mutationReturnsTableOneCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs82(args, ["input"]);
+        const selectArgs = makeArgs87(args, ["input"]);
         const $result = resource_mutation_returns_table_one_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39457,7 +40502,7 @@ export const plans = {
     },
     jsonIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs83(args, ["input"]);
+        const selectArgs = makeArgs88(args, ["input"]);
         const $result = resource_json_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39474,7 +40519,7 @@ export const plans = {
     },
     jsonbIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs84(args, ["input"]);
+        const selectArgs = makeArgs89(args, ["input"]);
         const $result = resource_jsonb_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39491,7 +40536,7 @@ export const plans = {
     },
     jsonbIdentityMutationPlpgsql: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs85(args, ["input"]);
+        const selectArgs = makeArgs90(args, ["input"]);
         const $result = resource_jsonb_identity_mutation_plpgsqlPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39508,7 +40553,7 @@ export const plans = {
     },
     jsonbIdentityMutationPlpgsqlWithDefault: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs86(args, ["input"]);
+        const selectArgs = makeArgs91(args, ["input"]);
         const $result = resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39525,7 +40570,7 @@ export const plans = {
     },
     add1Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs87(args, ["input"]);
+        const selectArgs = makeArgs92(args, ["input"]);
         const $result = resource_add_1_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39542,7 +40587,7 @@ export const plans = {
     },
     add2Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs88(args, ["input"]);
+        const selectArgs = makeArgs93(args, ["input"]);
         const $result = resource_add_2_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39559,7 +40604,7 @@ export const plans = {
     },
     add3Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs89(args, ["input"]);
+        const selectArgs = makeArgs94(args, ["input"]);
         const $result = resource_add_3_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39576,7 +40621,7 @@ export const plans = {
     },
     add4Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs90(args, ["input"]);
+        const selectArgs = makeArgs95(args, ["input"]);
         const $result = resource_add_4_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39593,7 +40638,7 @@ export const plans = {
     },
     add4MutationError: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs91(args, ["input"]);
+        const selectArgs = makeArgs96(args, ["input"]);
         const $result = resource_add_4_mutation_errorPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39610,7 +40655,7 @@ export const plans = {
     },
     mult1: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs92(args, ["input"]);
+        const selectArgs = makeArgs97(args, ["input"]);
         const $result = resource_mult_1PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39627,7 +40672,7 @@ export const plans = {
     },
     mult2: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs93(args, ["input"]);
+        const selectArgs = makeArgs98(args, ["input"]);
         const $result = resource_mult_2PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39644,7 +40689,7 @@ export const plans = {
     },
     mult3: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs94(args, ["input"]);
+        const selectArgs = makeArgs99(args, ["input"]);
         const $result = resource_mult_3PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39661,7 +40706,7 @@ export const plans = {
     },
     mult4: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs95(args, ["input"]);
+        const selectArgs = makeArgs100(args, ["input"]);
         const $result = resource_mult_4PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39678,7 +40723,7 @@ export const plans = {
     },
     mutationInInout: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs96(args, ["input"]);
+        const selectArgs = makeArgs101(args, ["input"]);
         const $result = resource_mutation_in_inoutPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39695,7 +40740,7 @@ export const plans = {
     },
     mutationOutOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs97(args, ["input"]);
+        const selectArgs = makeArgs102(args, ["input"]);
         const $result = resource_mutation_out_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39712,7 +40757,7 @@ export const plans = {
     },
     mutationOutOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs98(args, ["input"]);
+        const selectArgs = makeArgs103(args, ["input"]);
         const $result = resource_mutation_out_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39729,7 +40774,7 @@ export const plans = {
     },
     mutationOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs99(args, ["input"]);
+        const selectArgs = makeArgs104(args, ["input"]);
         const $result = resource_mutation_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39746,7 +40791,7 @@ export const plans = {
     },
     intSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs100(args, ["input"]);
+        const selectArgs = makeArgs105(args, ["input"]);
         const $result = resource_int_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39763,7 +40808,7 @@ export const plans = {
     },
     mutationOutUnnamedOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs101(args, ["input"]);
+        const selectArgs = makeArgs106(args, ["input"]);
         const $result = resource_mutation_out_unnamed_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39780,7 +40825,7 @@ export const plans = {
     },
     mutationReturnsTableMultiCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs102(args, ["input"]);
+        const selectArgs = makeArgs107(args, ["input"]);
         const $result = resource_mutation_returns_table_multi_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39797,7 +40842,7 @@ export const plans = {
     },
     guidFn: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs103(args, ["input"]);
+        const selectArgs = makeArgs108(args, ["input"]);
         const $result = resource_guid_fnPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39814,7 +40859,7 @@ export const plans = {
     },
     mutationIntervalArray: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs104(args, ["input"]);
+        const selectArgs = makeArgs109(args, ["input"]);
         const $result = resource_mutation_interval_arrayPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39831,7 +40876,7 @@ export const plans = {
     },
     mutationTextArray: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs105(args, ["input"]);
+        const selectArgs = makeArgs110(args, ["input"]);
         const $result = resource_mutation_text_arrayPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39848,7 +40893,7 @@ export const plans = {
     },
     listBdeMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs106(args, ["input"]);
+        const selectArgs = makeArgs111(args, ["input"]);
         const $result = resource_list_bde_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39865,7 +40910,7 @@ export const plans = {
     },
     authenticateFail: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs107(args, ["input"]);
+        const selectArgs = makeArgs112(args, ["input"]);
         const $result = resource_authenticate_failPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39882,7 +40927,7 @@ export const plans = {
     },
     authenticate: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs108(args, ["input"]);
+        const selectArgs = makeArgs113(args, ["input"]);
         const $result = resource_authenticatePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39899,7 +40944,7 @@ export const plans = {
     },
     leftArmIdentity: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs109(args, ["input"]);
+        const selectArgs = makeArgs114(args, ["input"]);
         const $result = resource_left_arm_identityPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39916,7 +40961,7 @@ export const plans = {
     },
     issue756Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs110(args, ["input"]);
+        const selectArgs = makeArgs115(args, ["input"]);
         const $result = resource_issue756_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39933,7 +40978,7 @@ export const plans = {
     },
     issue756SetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs111(args, ["input"]);
+        const selectArgs = makeArgs116(args, ["input"]);
         const $result = resource_issue756_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39950,7 +40995,7 @@ export const plans = {
     },
     authenticateMany: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs112(args, ["input"]);
+        const selectArgs = makeArgs117(args, ["input"]);
         const $result = resource_authenticate_manyPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39967,7 +41012,7 @@ export const plans = {
     },
     authenticatePayload: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs113(args, ["input"]);
+        const selectArgs = makeArgs118(args, ["input"]);
         const $result = resource_authenticate_payloadPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39984,7 +41029,7 @@ export const plans = {
     },
     typesMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs114(args, ["input"]);
+        const selectArgs = makeArgs119(args, ["input"]);
         const $result = resource_types_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40001,7 +41046,7 @@ export const plans = {
     },
     mutationOutOutCompoundType: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs115(args, ["input"]);
+        const selectArgs = makeArgs120(args, ["input"]);
         const $result = resource_mutation_out_out_compound_typePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40018,7 +41063,7 @@ export const plans = {
     },
     compoundTypeMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs116(args, ["input"]);
+        const selectArgs = makeArgs121(args, ["input"]);
         const $result = resource_compound_type_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40035,7 +41080,7 @@ export const plans = {
     },
     compoundTypeSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs117(args, ["input"]);
+        const selectArgs = makeArgs122(args, ["input"]);
         const $result = resource_compound_type_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40052,7 +41097,7 @@ export const plans = {
     },
     tableMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs118(args, ["input"]);
+        const selectArgs = makeArgs123(args, ["input"]);
         const $result = resource_table_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40069,7 +41114,7 @@ export const plans = {
     },
     postWithSuffix: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs119(args, ["input"]);
+        const selectArgs = makeArgs124(args, ["input"]);
         const $result = resource_post_with_suffixPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40086,7 +41131,7 @@ export const plans = {
     },
     mutationCompoundTypeArray: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs120(args, ["input"]);
+        const selectArgs = makeArgs125(args, ["input"]);
         const $result = resource_mutation_compound_type_arrayPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40103,7 +41148,7 @@ export const plans = {
     },
     compoundTypeArrayMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs121(args, ["input"]);
+        const selectArgs = makeArgs126(args, ["input"]);
         const $result = resource_compound_type_array_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40120,7 +41165,7 @@ export const plans = {
     },
     postMany: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs122(args, ["input"]);
+        const selectArgs = makeArgs127(args, ["input"]);
         const $result = resource_post_manyPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40137,7 +41182,7 @@ export const plans = {
     },
     mutationOutComplex: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs123(args, ["input"]);
+        const selectArgs = makeArgs128(args, ["input"]);
         const $result = resource_mutation_out_complexPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40154,7 +41199,7 @@ export const plans = {
     },
     mutationOutComplexSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs124(args, ["input"]);
+        const selectArgs = makeArgs129(args, ["input"]);
         const $result = resource_mutation_out_complex_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40171,7 +41216,7 @@ export const plans = {
     },
     mutationOutTable: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs125(args, ["input"]);
+        const selectArgs = makeArgs130(args, ["input"]);
         const $result = resource_mutation_out_tablePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40188,7 +41233,7 @@ export const plans = {
     },
     mutationOutTableSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs126(args, ["input"]);
+        const selectArgs = makeArgs131(args, ["input"]);
         const $result = resource_mutation_out_table_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40205,7 +41250,7 @@ export const plans = {
     },
     tableSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs127(args, ["input"]);
+        const selectArgs = makeArgs132(args, ["input"]);
         const $result = resource_table_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40222,7 +41267,7 @@ export const plans = {
     },
     typeFunctionConnectionMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs128(args, ["input"]);
+        const selectArgs = makeArgs133(args, ["input"]);
         const $result = resource_type_function_connection_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40239,7 +41284,7 @@ export const plans = {
     },
     typeFunctionMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs129(args, ["input"]);
+        const selectArgs = makeArgs134(args, ["input"]);
         const $result = resource_type_function_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40256,7 +41301,7 @@ export const plans = {
     },
     typeFunctionListMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs130(args, ["input"]);
+        const selectArgs = makeArgs135(args, ["input"]);
         const $result = resource_type_function_list_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.graphql
@@ -5903,6 +5903,11 @@ type Person implements Node {
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, arg2: Int, b: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
 
   """This `Person`'s `PersonSecret`."""
   personSecretByPersonId: PersonSecret @deprecated(reason: "This is deprecated (comment on table c.person_secret).")

--- a/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.export.mjs
@@ -3608,6 +3608,11 @@ const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_compu
 const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
 const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
 const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const person_optional_missing_middle_1FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_1");
+const person_optional_missing_middle_2FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_2");
+const person_optional_missing_middle_3FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_3");
+const person_optional_missing_middle_4FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_4");
+const person_optional_missing_middle_5FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_5");
 const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
 const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
 const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
@@ -7509,6 +7514,216 @@ const registry = makeRegistry({
           serviceName: "main",
           schemaName: "c",
           name: "person_computed_first_arg_inout_out"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_1: {
+      executor,
+      name: "person_optional_missing_middle_1",
+      identifier: "main.c.person_optional_missing_middle_1(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_1"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_2: {
+      executor,
+      name: "person_optional_missing_middle_2",
+      identifier: "main.c.person_optional_missing_middle_2(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_2"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_3: {
+      executor,
+      name: "person_optional_missing_middle_3",
+      identifier: "main.c.person_optional_missing_middle_3(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_3"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_4: {
+      executor,
+      name: "person_optional_missing_middle_4",
+      identifier: "main.c.person_optional_missing_middle_4(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_4"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_5: {
+      executor,
+      name: "person_optional_missing_middle_5",
+      identifier: "main.c.person_optional_missing_middle_5(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_5FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_5"
         },
         tags: {}
       },
@@ -11999,22 +12214,28 @@ const makeArgs56 = (args, path = []) => {
 };
 const resource_person_computed_first_arg_inout_outPgResource = registry.pgResources["person_computed_first_arg_inout_out"];
 const argDetailsSimple57 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
+  graphqlArgName: "arg0",
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
   graphqlArgName: "b",
   postgresArgName: "b",
-  pgCodec: TYPES.text,
-  required: true,
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
   fetcher: null
 }];
 const makeArgs57 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12025,7 +12246,7 @@ const makeArgs57 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 1 - 1) {
         skipped = true;
         continue;
       } else {
@@ -12055,12 +12276,30 @@ const makeArgs57 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
-const argDetailsSimple58 = [];
+const resource_person_optional_missing_middle_1PgResource = registry.pgResources["person_optional_missing_middle_1"];
+const argDetailsSimple58 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs58 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12101,12 +12340,30 @@ const makeArgs58 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
-const argDetailsSimple59 = [];
+const resource_person_optional_missing_middle_2PgResource = registry.pgResources["person_optional_missing_middle_2"];
+const argDetailsSimple59 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs59 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12117,7 +12374,7 @@ const makeArgs59 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 2 - 1) {
         skipped = true;
         continue;
       } else {
@@ -12147,12 +12404,30 @@ const makeArgs59 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
-const argDetailsSimple60 = [];
+const resource_person_optional_missing_middle_3PgResource = registry.pgResources["person_optional_missing_middle_3"];
+const argDetailsSimple60 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs60 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12163,7 +12438,7 @@ const makeArgs60 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -12193,46 +12468,30 @@ const makeArgs60 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_friendsPgResource = registry.pgResources["person_friends"];
-const getSelectPlanFromParentAndArgs15 = ($in, args, _info) => {
-  if (!hasRecord($in)) {
-    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-  }
-  const extraSelectArgs = makeArgs60(args);
-  /**
-   * An optimisation - if all our dependencies are
-   * compatible with the expression's class plan then we
-   * can inline ourselves into that, otherwise we must
-   * issue the query separately.
-   */
-  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-  const selectArgs = [{
-    step: $row.record()
-  }, ...extraSelectArgs];
-  if (resource_person_friendsPgResource.isUnique && !resource_person_friendsPgResource.codec.attributes && typeof resource_person_friendsPgResource.from === "function") {
-    // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
-      if (i === 0) {
-        return $row.getClassStep().alias;
-      } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
-      } else {
-        return $row.placeholder(arg.step);
-      }
-    });
-    return pgClassExpression($row, resource_person_friendsPgResource.codec)`${resource_person_friendsPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
-  }
-  // PERF: or here, if scalar add select to `$row`?
-  return resource_person_friendsPgResource.execute(selectArgs);
-};
-const argDetailsSimple61 = [];
+const resource_person_optional_missing_middle_4PgResource = registry.pgResources["person_optional_missing_middle_4"];
+const argDetailsSimple61 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs61 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12243,7 +12502,7 @@ const makeArgs61 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -12273,52 +12532,24 @@ const makeArgs61 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
-const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
-  if (!hasRecord($in)) {
-    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-  }
-  const extraSelectArgs = makeArgs61(args);
-  /**
-   * An optimisation - if all our dependencies are
-   * compatible with the expression's class plan then we
-   * can inline ourselves into that, otherwise we must
-   * issue the query separately.
-   */
-  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-  const selectArgs = [{
-    step: $row.record()
-  }, ...extraSelectArgs];
-  if (resource_person_type_function_connectionPgResource.isUnique && !resource_person_type_function_connectionPgResource.codec.attributes && typeof resource_person_type_function_connectionPgResource.from === "function") {
-    // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
-      if (i === 0) {
-        return $row.getClassStep().alias;
-      } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
-      } else {
-        return $row.placeholder(arg.step);
-      }
-    });
-    return pgClassExpression($row, resource_person_type_function_connectionPgResource.codec)`${resource_person_type_function_connectionPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
-  }
-  // PERF: or here, if scalar add select to `$row`?
-  return resource_person_type_function_connectionPgResource.execute(selectArgs);
-};
+const resource_person_optional_missing_middle_5PgResource = registry.pgResources["person_optional_missing_middle_5"];
 const argDetailsSimple62 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs62 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12359,7 +12590,7 @@ const makeArgs62 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
+const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
 const argDetailsSimple63 = [];
 const makeArgs63 = (args, path = []) => {
   const selectArgs = [];
@@ -12405,9 +12636,7 @@ const makeArgs63 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
-const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
-const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
+const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
 const argDetailsSimple64 = [];
 const makeArgs64 = (args, path = []) => {
   const selectArgs = [];
@@ -12453,16 +12682,7 @@ const makeArgs64 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
-function UUIDSerialize(value) {
-  return "" + value;
-}
-const coerce = string => {
-  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
-    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
-  }
-  return string;
-};
+const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -12508,8 +12728,8 @@ const makeArgs65 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_interval_setPgResource = registry.pgResources["post_computed_interval_set"];
-const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
+const resource_person_friendsPgResource = registry.pgResources["person_friends"];
+const getSelectPlanFromParentAndArgs15 = ($in, args, _info) => {
   if (!hasRecord($in)) {
     throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
   }
@@ -12525,23 +12745,33 @@ const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
   const selectArgs = [{
     step: $row.record()
   }, ...extraSelectArgs];
-  if (resource_post_computed_interval_setPgResource.isUnique && !resource_post_computed_interval_setPgResource.codec.attributes && typeof resource_post_computed_interval_setPgResource.from === "function") {
+  if (resource_person_friendsPgResource.isUnique && !resource_person_friendsPgResource.codec.attributes && typeof resource_person_friendsPgResource.from === "function") {
     // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
       if (i === 0) {
-        return $row.getClassStep().alias;
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
       } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
       } else {
-        return $row.placeholder(arg.step);
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
       }
     });
-    return pgClassExpression($row, resource_post_computed_interval_setPgResource.codec)`${resource_post_computed_interval_setPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
+    return pgClassExpression($row, resource_person_friendsPgResource.codec)`${resource_person_friendsPgResource.from(...newSelectArgs)}`;
   }
   // PERF: or here, if scalar add select to `$row`?
-  return resource_post_computed_interval_setPgResource.execute(selectArgs);
+  return resource_person_friendsPgResource.execute(selectArgs);
 };
 const argDetailsSimple66 = [];
 const makeArgs66 = (args, path = []) => {
@@ -12588,12 +12818,62 @@ const makeArgs66 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_interval_arrayPgResource = registry.pgResources["post_computed_interval_array"];
-const argDetailsSimple67 = [];
+const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
+const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
+  if (!hasRecord($in)) {
+    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+  }
+  const extraSelectArgs = makeArgs66(args);
+  /**
+   * An optimisation - if all our dependencies are
+   * compatible with the expression's class plan then we
+   * can inline ourselves into that, otherwise we must
+   * issue the query separately.
+   */
+  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+  const selectArgs = [{
+    step: $row.record()
+  }, ...extraSelectArgs];
+  if (resource_person_type_function_connectionPgResource.isUnique && !resource_person_type_function_connectionPgResource.codec.attributes && typeof resource_person_type_function_connectionPgResource.from === "function") {
+    // This is a scalar computed attribute, let's inline the expression
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
+      if (i === 0) {
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
+      } else if ("pgCodec" in arg && arg.pgCodec) {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
+      } else {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
+      }
+    });
+    return pgClassExpression($row, resource_person_type_function_connectionPgResource.codec)`${resource_person_type_function_connectionPgResource.from(...newSelectArgs)}`;
+  }
+  // PERF: or here, if scalar add select to `$row`?
+  return resource_person_type_function_connectionPgResource.execute(selectArgs);
+};
+const argDetailsSimple67 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs67 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12634,18 +12914,12 @@ const makeArgs67 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_text_arrayPgResource = registry.pgResources["post_computed_text_array"];
-const argDetailsSimple68 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: false,
-  fetcher: null
-}];
+const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
+const argDetailsSimple68 = [];
 const makeArgs68 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12686,18 +12960,14 @@ const makeArgs68 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_with_optional_argPgResource = registry.pgResources["post_computed_with_optional_arg"];
-const argDetailsSimple69 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
+const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
+const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
+const argDetailsSimple69 = [];
 const makeArgs69 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12738,24 +13008,21 @@ const makeArgs69 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_with_required_argPgResource = registry.pgResources["post_computed_with_required_arg"];
-const argDetailsSimple70 = [{
-  graphqlArgName: "length",
-  postgresArgName: "length",
-  pgCodec: TYPES.int,
-  required: false,
-  fetcher: null
-}, {
-  graphqlArgName: "omission",
-  postgresArgName: "omission",
-  pgCodec: TYPES.text,
-  required: false,
-  fetcher: null
-}];
+const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
+function UUIDSerialize(value) {
+  return "" + value;
+}
+const coerce = string => {
+  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
+    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
+  }
+  return string;
+};
+const argDetailsSimple70 = [];
 const makeArgs70 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12796,24 +13063,56 @@ const makeArgs70 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmedPgResource = registry.pgResources["post_headline_trimmed"];
-const argDetailsSimple71 = [{
-  graphqlArgName: "length",
-  postgresArgName: "length",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "omission",
-  postgresArgName: "omission",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_post_computed_interval_setPgResource = registry.pgResources["post_computed_interval_set"];
+const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
+  if (!hasRecord($in)) {
+    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+  }
+  const extraSelectArgs = makeArgs70(args);
+  /**
+   * An optimisation - if all our dependencies are
+   * compatible with the expression's class plan then we
+   * can inline ourselves into that, otherwise we must
+   * issue the query separately.
+   */
+  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+  const selectArgs = [{
+    step: $row.record()
+  }, ...extraSelectArgs];
+  if (resource_post_computed_interval_setPgResource.isUnique && !resource_post_computed_interval_setPgResource.codec.attributes && typeof resource_post_computed_interval_setPgResource.from === "function") {
+    // This is a scalar computed attribute, let's inline the expression
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
+      if (i === 0) {
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
+      } else if ("pgCodec" in arg && arg.pgCodec) {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
+      } else {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
+      }
+    });
+    return pgClassExpression($row, resource_post_computed_interval_setPgResource.codec)`${resource_post_computed_interval_setPgResource.from(...newSelectArgs)}`;
+  }
+  // PERF: or here, if scalar add select to `$row`?
+  return resource_post_computed_interval_setPgResource.execute(selectArgs);
+};
+const argDetailsSimple71 = [];
 const makeArgs71 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12854,24 +13153,12 @@ const makeArgs71 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmed_no_defaultsPgResource = registry.pgResources["post_headline_trimmed_no_defaults"];
-const argDetailsSimple72 = [{
-  graphqlArgName: "length",
-  postgresArgName: "length",
-  pgCodec: TYPES.int,
-  required: false,
-  fetcher: null
-}, {
-  graphqlArgName: "omission",
-  postgresArgName: "omission",
-  pgCodec: TYPES.text,
-  required: false,
-  fetcher: null
-}];
+const resource_post_computed_interval_arrayPgResource = registry.pgResources["post_computed_interval_array"];
+const argDetailsSimple72 = [];
 const makeArgs72 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12912,12 +13199,12 @@ const makeArgs72 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmed_strictPgResource = registry.pgResources["post_headline_trimmed_strict"];
+const resource_post_computed_text_arrayPgResource = registry.pgResources["post_computed_text_array"];
 const argDetailsSimple73 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
-  required: true,
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: false,
   fetcher: null
 }];
 const makeArgs73 = (args, path = []) => {
@@ -12931,6 +13218,284 @@ const makeArgs73 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple73[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_computed_with_optional_argPgResource = registry.pgResources["post_computed_with_optional_arg"];
+const argDetailsSimple74 = [{
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs74 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple74[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_computed_with_required_argPgResource = registry.pgResources["post_computed_with_required_arg"];
+const argDetailsSimple75 = [{
+  graphqlArgName: "length",
+  postgresArgName: "length",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "omission",
+  postgresArgName: "omission",
+  pgCodec: TYPES.text,
+  required: false,
+  fetcher: null
+}];
+const makeArgs75 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple75[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_headline_trimmedPgResource = registry.pgResources["post_headline_trimmed"];
+const argDetailsSimple76 = [{
+  graphqlArgName: "length",
+  postgresArgName: "length",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "omission",
+  postgresArgName: "omission",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
+const makeArgs76 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple76[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_headline_trimmed_no_defaultsPgResource = registry.pgResources["post_headline_trimmed_no_defaults"];
+const argDetailsSimple77 = [{
+  graphqlArgName: "length",
+  postgresArgName: "length",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "omission",
+  postgresArgName: "omission",
+  pgCodec: TYPES.text,
+  required: false,
+  fetcher: null
+}];
+const makeArgs77 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple77[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_headline_trimmed_strictPgResource = registry.pgResources["post_headline_trimmed_strict"];
+const argDetailsSimple78 = [{
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
+  required: true,
+  fetcher: null
+}];
+const makeArgs78 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple78[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -13021,236 +13586,6 @@ const parseValueLiteral = (ast, variables) => {
       return undefined;
   }
 };
-const argDetailsSimple74 = [];
-const makeArgs74 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple74[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
-const argDetailsSimple75 = [];
-const makeArgs75 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple75[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
-const argDetailsSimple76 = [];
-const makeArgs76 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple76[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
-const argDetailsSimple77 = [];
-const makeArgs77 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple77[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
-const argDetailsSimple78 = [];
-const makeArgs78 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple78[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
 const argDetailsSimple79 = [];
 const makeArgs79 = (args, path = []) => {
   const selectArgs = [];
@@ -13296,7 +13631,7 @@ const makeArgs79 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
+const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
 const argDetailsSimple80 = [];
 const makeArgs80 = (args, path = []) => {
   const selectArgs = [];
@@ -13342,18 +13677,12 @@ const makeArgs80 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
-const argDetailsSimple81 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
+const argDetailsSimple81 = [];
 const makeArgs81 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13394,18 +13723,12 @@ const makeArgs81 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
-const argDetailsSimple82 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
+const argDetailsSimple82 = [];
 const makeArgs82 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13446,18 +13769,12 @@ const makeArgs82 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
-const argDetailsSimple83 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
+const argDetailsSimple83 = [];
 const makeArgs83 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13498,18 +13815,12 @@ const makeArgs83 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
-const argDetailsSimple84 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
+const argDetailsSimple84 = [];
 const makeArgs84 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13550,18 +13861,12 @@ const makeArgs84 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
-const argDetailsSimple85 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
+const argDetailsSimple85 = [];
 const makeArgs85 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13602,12 +13907,12 @@ const makeArgs85 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
+const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
 const argDetailsSimple86 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: false,
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
   fetcher: null
 }];
 const makeArgs86 = (args, path = []) => {
@@ -13654,16 +13959,10 @@ const makeArgs86 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
+const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
 const argDetailsSimple87 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: null,
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "arg1",
-  postgresArgName: null,
+  graphqlArgName: "i",
+  postgresArgName: "i",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -13671,7 +13970,7 @@ const argDetailsSimple87 = [{
 const makeArgs87 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13682,7 +13981,7 @@ const makeArgs87 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 2 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13712,24 +14011,18 @@ const makeArgs87 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
+const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
 const argDetailsSimple88 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.json,
   required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.int,
-  required: false,
   fetcher: null
 }];
 const makeArgs88 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13770,24 +14063,18 @@ const makeArgs88 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
+const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
 const argDetailsSimple89 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "arg1",
-  postgresArgName: "",
-  pgCodec: TYPES.int,
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.jsonb,
   required: true,
   fetcher: null
 }];
 const makeArgs89 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13798,7 +14085,7 @@ const makeArgs89 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 2 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13828,24 +14115,18 @@ const makeArgs89 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
+const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
 const argDetailsSimple90 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: "",
-  pgCodec: TYPES.int,
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
   required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.int,
-  required: false,
   fetcher: null
 }];
 const makeArgs90 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13856,7 +14137,7 @@ const makeArgs90 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 1 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13886,24 +14167,18 @@ const makeArgs90 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
+const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
 const argDetailsSimple91 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: "",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.int,
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
   required: false,
   fetcher: null
 }];
 const makeArgs91 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13914,7 +14189,7 @@ const makeArgs91 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 1 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13944,7 +14219,7 @@ const makeArgs91 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
+const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
 const argDetailsSimple92 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -14002,18 +14277,18 @@ const makeArgs92 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_1PgResource = registry.pgResources["mult_1"];
+const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
 const argDetailsSimple93 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: null,
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "arg1",
-  postgresArgName: null,
+  graphqlArgName: "b",
+  postgresArgName: "b",
   pgCodec: TYPES.int,
-  required: true,
+  required: false,
   fetcher: null
 }];
 const makeArgs93 = (args, path = []) => {
@@ -14030,7 +14305,7 @@ const makeArgs93 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 2 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -14060,16 +14335,16 @@ const makeArgs93 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_2PgResource = registry.pgResources["mult_2"];
+const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
 const argDetailsSimple94 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: null,
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
   graphqlArgName: "arg1",
-  postgresArgName: null,
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -14118,18 +14393,18 @@ const makeArgs94 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_3PgResource = registry.pgResources["mult_3"];
+const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
 const argDetailsSimple95 = [{
   graphqlArgName: "arg0",
-  postgresArgName: null,
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "arg1",
-  postgresArgName: null,
+  graphqlArgName: "b",
+  postgresArgName: "b",
   pgCodec: TYPES.int,
-  required: true,
+  required: false,
   fetcher: null
 }];
 const makeArgs95 = (args, path = []) => {
@@ -14143,6 +14418,296 @@ const makeArgs95 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple95[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 1 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
+const argDetailsSimple96 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
+const makeArgs96 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple96[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 1 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
+const argDetailsSimple97 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs97 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple97[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 2 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mult_1PgResource = registry.pgResources["mult_1"];
+const argDetailsSimple98 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs98 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple98[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 2 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mult_2PgResource = registry.pgResources["mult_2"];
+const argDetailsSimple99 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs99 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple99[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 2 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mult_3PgResource = registry.pgResources["mult_3"];
+const argDetailsSimple100 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs100 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple100[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -14177,7 +14742,7 @@ const makeArgs95 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_4PgResource = registry.pgResources["mult_4"];
-const argDetailsSimple96 = [{
+const argDetailsSimple101 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
   pgCodec: TYPES.int,
@@ -14190,258 +14755,10 @@ const argDetailsSimple96 = [{
   required: true,
   fetcher: null
 }];
-const makeArgs96 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 2; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple96[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
-const argDetailsSimple97 = [];
-const makeArgs97 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple97[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
-const argDetailsSimple98 = [];
-const makeArgs98 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple98[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
-const argDetailsSimple99 = [];
-const makeArgs99 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple99[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
-const argDetailsSimple100 = [{
-  graphqlArgName: "x",
-  postgresArgName: "x",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "y",
-  postgresArgName: "y",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "z",
-  postgresArgName: "z",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
-const makeArgs100 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 3; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple100[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
-const argDetailsSimple101 = [];
 const makeArgs101 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14482,18 +14799,12 @@ const makeArgs101 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
-const argDetailsSimple102 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
+const argDetailsSimple102 = [];
 const makeArgs102 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14534,18 +14845,12 @@ const makeArgs102 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
-const argDetailsSimple103 = [{
-  graphqlArgName: "g",
-  postgresArgName: "g",
-  pgCodec: guidCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
+const argDetailsSimple103 = [];
 const makeArgs103 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14586,7 +14891,7 @@ const makeArgs103 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_guid_fnPgResource = registry.pgResources["guid_fn"];
+const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
 const argDetailsSimple104 = [];
 const makeArgs104 = (args, path = []) => {
   const selectArgs = [];
@@ -14632,12 +14937,30 @@ const makeArgs104 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
-const argDetailsSimple105 = [];
+const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
+const argDetailsSimple105 = [{
+  graphqlArgName: "x",
+  postgresArgName: "x",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "y",
+  postgresArgName: "y",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "z",
+  postgresArgName: "z",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs105 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14678,30 +15001,12 @@ const makeArgs105 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
-const argDetailsSimple106 = [{
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: textArrayCodec,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "d",
-  postgresArgName: "d",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "e",
-  postgresArgName: "e",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
+const argDetailsSimple106 = [];
 const makeArgs106 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14742,12 +15047,18 @@ const makeArgs106 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_list_bde_mutationPgResource = registry.pgResources["list_bde_mutation"];
-const argDetailsSimple107 = [];
+const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
+const argDetailsSimple107 = [{
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs107 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14788,30 +15099,18 @@ const makeArgs107 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_failPgResource = registry.pgResources["authenticate_fail"];
+const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
 const argDetailsSimple108 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.numeric,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.bigint,
+  graphqlArgName: "g",
+  postgresArgName: "g",
+  pgCodec: guidCodec,
   required: true,
   fetcher: null
 }];
 const makeArgs108 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14852,18 +15151,12 @@ const makeArgs108 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticatePgResource = registry.pgResources["authenticate"];
-const argDetailsSimple109 = [{
-  graphqlArgName: "leftArm",
-  postgresArgName: "left_arm",
-  pgCodec: leftArmCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_guid_fnPgResource = registry.pgResources["guid_fn"];
+const argDetailsSimple109 = [];
 const makeArgs109 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14904,7 +15197,7 @@ const makeArgs109 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
+const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
 const argDetailsSimple110 = [];
 const makeArgs110 = (args, path = []) => {
   const selectArgs = [];
@@ -14950,12 +15243,30 @@ const makeArgs110 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
-const argDetailsSimple111 = [];
+const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
+const argDetailsSimple111 = [{
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: textArrayCodec,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "d",
+  postgresArgName: "d",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "e",
+  postgresArgName: "e",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
 const makeArgs111 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14996,30 +15307,12 @@ const makeArgs111 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
-const argDetailsSimple112 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.numeric,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.bigint,
-  required: true,
-  fetcher: null
-}];
+const resource_list_bde_mutationPgResource = registry.pgResources["list_bde_mutation"];
+const argDetailsSimple112 = [];
 const makeArgs112 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15060,7 +15353,7 @@ const makeArgs112 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_manyPgResource = registry.pgResources["authenticate_many"];
+const resource_authenticate_failPgResource = registry.pgResources["authenticate_fail"];
 const argDetailsSimple113 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -15124,48 +15417,18 @@ const makeArgs113 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_payloadPgResource = registry.pgResources["authenticate_payload"];
+const resource_authenticatePgResource = registry.pgResources["authenticate"];
 const argDetailsSimple114 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.bigint,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.boolean,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.varchar,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "d",
-  postgresArgName: "d",
-  pgCodec: int4ArrayCodec,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "e",
-  postgresArgName: "e",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "f",
-  postgresArgName: "f",
-  pgCodec: floatrangeCodec,
+  graphqlArgName: "leftArm",
+  postgresArgName: "left_arm",
+  pgCodec: leftArmCodec,
   required: true,
   fetcher: null
 }];
 const makeArgs114 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 6; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15206,18 +15469,12 @@ const makeArgs114 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
-const argDetailsSimple115 = [{
-  graphqlArgName: "i1",
-  postgresArgName: "i1",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
+const argDetailsSimple115 = [];
 const makeArgs115 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15258,18 +15515,12 @@ const makeArgs115 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
-const argDetailsSimple116 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
+const argDetailsSimple116 = [];
 const makeArgs116 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15310,18 +15561,30 @@ const makeArgs116 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_mutationPgResource = registry.pgResources["compound_type_mutation"];
+const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
 const argDetailsSimple117 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.numeric,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.bigint,
   required: true,
   fetcher: null
 }];
 const makeArgs117 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15362,18 +15625,30 @@ const makeArgs117 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
+const resource_authenticate_manyPgResource = registry.pgResources["authenticate_many"];
 const argDetailsSimple118 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.numeric,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.bigint,
   required: true,
   fetcher: null
 }];
 const makeArgs118 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15414,24 +15689,48 @@ const makeArgs118 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
+const resource_authenticate_payloadPgResource = registry.pgResources["authenticate_payload"];
 const argDetailsSimple119 = [{
-  graphqlArgName: "post",
-  postgresArgName: "post",
-  pgCodec: postCodec,
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.bigint,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "suffix",
-  postgresArgName: "suffix",
-  pgCodec: TYPES.text,
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.boolean,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.varchar,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "d",
+  postgresArgName: "d",
+  pgCodec: int4ArrayCodec,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "e",
+  postgresArgName: "e",
+  pgCodec: TYPES.json,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "f",
+  postgresArgName: "f",
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
 const makeArgs119 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 6; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15472,11 +15771,11 @@ const makeArgs119 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_with_suffixPgResource = registry.pgResources["post_with_suffix"];
+const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
 const argDetailsSimple120 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
+  graphqlArgName: "i1",
+  postgresArgName: "i1",
+  pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }];
@@ -15524,7 +15823,7 @@ const makeArgs120 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
+const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
 const argDetailsSimple121 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -15576,11 +15875,11 @@ const makeArgs121 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_array_mutationPgResource = registry.pgResources["compound_type_array_mutation"];
+const resource_compound_type_mutationPgResource = registry.pgResources["compound_type_mutation"];
 const argDetailsSimple122 = [{
-  graphqlArgName: "posts",
-  postgresArgName: "posts",
-  pgCodec: postArrayCodec,
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -15628,24 +15927,18 @@ const makeArgs122 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_manyPgResource = registry.pgResources["post_many"];
+const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
 const argDetailsSimple123 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
+  graphqlArgName: "id",
+  postgresArgName: "id",
   pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs123 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15686,16 +15979,16 @@ const makeArgs123 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
+const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
 const argDetailsSimple124 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
+  graphqlArgName: "post",
+  postgresArgName: "post",
+  pgCodec: postCodec,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
+  graphqlArgName: "suffix",
+  postgresArgName: "suffix",
   pgCodec: TYPES.text,
   required: true,
   fetcher: null
@@ -15744,12 +16037,18 @@ const makeArgs124 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
-const argDetailsSimple125 = [];
+const resource_post_with_suffixPgResource = registry.pgResources["post_with_suffix"];
+const argDetailsSimple125 = [{
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs125 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15790,12 +16089,18 @@ const makeArgs125 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
-const argDetailsSimple126 = [];
+const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
+const argDetailsSimple126 = [{
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs126 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15836,12 +16141,18 @@ const makeArgs126 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
-const argDetailsSimple127 = [];
+const resource_compound_type_array_mutationPgResource = registry.pgResources["compound_type_array_mutation"];
+const argDetailsSimple127 = [{
+  graphqlArgName: "posts",
+  postgresArgName: "posts",
+  pgCodec: postArrayCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs127 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15882,12 +16193,24 @@ const makeArgs127 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
-const argDetailsSimple128 = [];
+const resource_post_manyPgResource = registry.pgResources["post_many"];
+const argDetailsSimple128 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
 const makeArgs128 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15928,18 +16251,24 @@ const makeArgs128 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_type_function_connection_mutationPgResource = registry.pgResources["type_function_connection_mutation"];
+const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
 const argDetailsSimple129 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs129 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15980,7 +16309,7 @@ const makeArgs129 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_type_function_mutationPgResource = registry.pgResources["type_function_mutation"];
+const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
 const argDetailsSimple130 = [];
 const makeArgs130 = (args, path = []) => {
   const selectArgs = [];
@@ -15993,6 +16322,242 @@ const makeArgs130 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple130[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
+const argDetailsSimple131 = [];
+const makeArgs131 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple131[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
+const argDetailsSimple132 = [];
+const makeArgs132 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple132[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
+const argDetailsSimple133 = [];
+const makeArgs133 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple133[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_type_function_connection_mutationPgResource = registry.pgResources["type_function_connection_mutation"];
+const argDetailsSimple134 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs134 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple134[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_type_function_mutationPgResource = registry.pgResources["type_function_mutation"];
+const argDetailsSimple135 = [];
+const makeArgs135 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple135[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -17535,6 +18100,11 @@ type Person implements Node {
   computedInoutOut(ino: String): PersonComputedInoutOutRecord
   exists(email: Email): Boolean @deprecated(reason: "This is deprecated (comment on function c.person_exists).")
   computedFirstArgInoutOut: PersonComputedFirstArgInoutOutRecord
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, b: Int, arg2: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
   computedComplex(a: Int, b: String): PersonComputedComplexRecord
 
   """The first post by the person."""
@@ -28392,18 +28962,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_outPgResource.isUnique && !resource_person_computed_outPgResource.codec.attributes && typeof resource_person_computed_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_outPgResource.codec)`${resource_person_computed_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_outPgResource.codec)`${resource_person_computed_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_outPgResource.execute(selectArgs);
@@ -28426,18 +29006,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_first_namePgResource.isUnique && !resource_person_first_namePgResource.codec.attributes && typeof resource_person_first_namePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_first_namePgResource.codec)`${resource_person_first_namePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_first_namePgResource.codec)`${resource_person_first_namePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_first_namePgResource.execute(selectArgs);
@@ -28460,18 +29050,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_out_outPgResource.isUnique && !resource_person_computed_out_outPgResource.codec.attributes && typeof resource_person_computed_out_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_out_outPgResource.codec)`${resource_person_computed_out_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_out_outPgResource.codec)`${resource_person_computed_out_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_out_outPgResource.execute(selectArgs);
@@ -28495,18 +29095,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_computed_inoutPgResource.isUnique && !resource_person_computed_inoutPgResource.codec.attributes && typeof resource_person_computed_inoutPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_inoutPgResource.codec)`${resource_person_computed_inoutPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_computed_inoutPgResource.codec)`${resource_person_computed_inoutPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_inoutPgResource.execute(selectArgs);
@@ -28534,18 +29144,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_computed_inout_outPgResource.isUnique && !resource_person_computed_inout_outPgResource.codec.attributes && typeof resource_person_computed_inout_outPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_inout_outPgResource.codec)`${resource_person_computed_inout_outPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_computed_inout_outPgResource.codec)`${resource_person_computed_inout_outPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_inout_outPgResource.execute(selectArgs);
@@ -28573,18 +29193,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_existsPgResource.isUnique && !resource_person_existsPgResource.codec.attributes && typeof resource_person_existsPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_existsPgResource.codec)`${resource_person_existsPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_existsPgResource.codec)`${resource_person_existsPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_existsPgResource.execute(selectArgs);
@@ -28611,23 +29241,33 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_first_arg_inout_outPgResource.isUnique && !resource_person_computed_first_arg_inout_outPgResource.codec.attributes && typeof resource_person_computed_first_arg_inout_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_first_arg_inout_outPgResource.codec)`${resource_person_computed_first_arg_inout_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_first_arg_inout_outPgResource.codec)`${resource_person_computed_first_arg_inout_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_first_arg_inout_outPgResource.execute(selectArgs);
     },
-    computedComplex: {
+    optionalMissingMiddle1: {
       plan($in, args, _info) {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -28644,20 +29284,285 @@ export const plans = {
         const selectArgs = [{
           step: $row.record()
         }, ...extraSelectArgs];
-        if (resource_person_computed_complexPgResource.isUnique && !resource_person_computed_complexPgResource.codec.attributes && typeof resource_person_computed_complexPgResource.from === "function") {
+        if (resource_person_optional_missing_middle_1PgResource.isUnique && !resource_person_optional_missing_middle_1PgResource.codec.attributes && typeof resource_person_optional_missing_middle_1PgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_complexPgResource.codec)`${resource_person_computed_complexPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_optional_missing_middle_1PgResource.codec)`${resource_person_optional_missing_middle_1PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_1PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle2: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs58(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_2PgResource.isUnique && !resource_person_optional_missing_middle_2PgResource.codec.attributes && typeof resource_person_optional_missing_middle_2PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_2PgResource.codec)`${resource_person_optional_missing_middle_2PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_2PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        b: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle3: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs59(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_3PgResource.isUnique && !resource_person_optional_missing_middle_3PgResource.codec.attributes && typeof resource_person_optional_missing_middle_3PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_3PgResource.codec)`${resource_person_optional_missing_middle_3PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_3PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle4: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs60(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_4PgResource.isUnique && !resource_person_optional_missing_middle_4PgResource.codec.attributes && typeof resource_person_optional_missing_middle_4PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_4PgResource.codec)`${resource_person_optional_missing_middle_4PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_4PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        arg2: undefined
+      }
+    },
+    optionalMissingMiddle5: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs61(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_5PgResource.isUnique && !resource_person_optional_missing_middle_5PgResource.codec.attributes && typeof resource_person_optional_missing_middle_5PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_5PgResource.codec)`${resource_person_optional_missing_middle_5PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_5PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        arg2: undefined
+      }
+    },
+    computedComplex: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs62(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_computed_complexPgResource.isUnique && !resource_person_computed_complexPgResource.codec.attributes && typeof resource_person_computed_complexPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_computed_complexPgResource.codec)`${resource_person_computed_complexPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_complexPgResource.execute(selectArgs);
@@ -28671,7 +29576,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs58(args);
+      const extraSelectArgs = makeArgs63(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -28685,18 +29590,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_first_postPgResource.isUnique && !resource_person_first_postPgResource.codec.attributes && typeof resource_person_first_postPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_first_postPgResource.codec)`${resource_person_first_postPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_first_postPgResource.codec)`${resource_person_first_postPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_first_postPgResource.execute(selectArgs);
@@ -28705,7 +29620,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs59(args);
+      const extraSelectArgs = makeArgs64(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -28719,18 +29634,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_first_arg_inoutPgResource.isUnique && !resource_person_computed_first_arg_inoutPgResource.codec.attributes && typeof resource_person_computed_first_arg_inoutPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_first_arg_inoutPgResource.codec)`${resource_person_computed_first_arg_inoutPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_first_arg_inoutPgResource.codec)`${resource_person_computed_first_arg_inoutPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_first_arg_inoutPgResource.execute(selectArgs);
@@ -28835,7 +29760,7 @@ export const plans = {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
         }
-        const extraSelectArgs = makeArgs62(args);
+        const extraSelectArgs = makeArgs67(args);
         /**
          * An optimisation - if all our dependencies are
          * compatible with the expression's class plan then we
@@ -28849,18 +29774,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_type_functionPgResource.isUnique && !resource_person_type_functionPgResource.codec.attributes && typeof resource_person_type_functionPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_type_functionPgResource.codec)`${resource_person_type_functionPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_type_functionPgResource.codec)`${resource_person_type_functionPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_type_functionPgResource.execute(selectArgs);
@@ -28873,7 +29808,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs63(args);
+      const extraSelectArgs = makeArgs68(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -28887,18 +29822,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_type_function_listPgResource.isUnique && !resource_person_type_function_listPgResource.codec.attributes && typeof resource_person_type_function_listPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_type_function_listPgResource.codec)`${resource_person_type_function_listPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_type_function_listPgResource.codec)`${resource_person_type_function_listPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_type_function_listPgResource.execute(selectArgs);
@@ -29133,7 +30078,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs64(args);
+      const extraSelectArgs = makeArgs69(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29147,18 +30092,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_compound_type_computed_fieldPgResource.isUnique && !resource_compound_type_computed_fieldPgResource.codec.attributes && typeof resource_compound_type_computed_fieldPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_compound_type_computed_fieldPgResource.codec)`${resource_compound_type_computed_fieldPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_compound_type_computed_fieldPgResource.codec)`${resource_compound_type_computed_fieldPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_compound_type_computed_fieldPgResource.execute(selectArgs);
@@ -29302,7 +30257,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs66(args);
+      const extraSelectArgs = makeArgs71(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29316,18 +30271,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_post_computed_interval_arrayPgResource.isUnique && !resource_post_computed_interval_arrayPgResource.codec.attributes && typeof resource_post_computed_interval_arrayPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_post_computed_interval_arrayPgResource.codec)`${resource_post_computed_interval_arrayPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_post_computed_interval_arrayPgResource.codec)`${resource_post_computed_interval_arrayPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_post_computed_interval_arrayPgResource.execute(selectArgs);
@@ -29336,7 +30301,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs67(args);
+      const extraSelectArgs = makeArgs72(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29350,221 +30315,33 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_post_computed_text_arrayPgResource.isUnique && !resource_post_computed_text_arrayPgResource.codec.attributes && typeof resource_post_computed_text_arrayPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_post_computed_text_arrayPgResource.codec)`${resource_post_computed_text_arrayPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_post_computed_text_arrayPgResource.codec)`${resource_post_computed_text_arrayPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_post_computed_text_arrayPgResource.execute(selectArgs);
     },
     computedWithOptionalArg: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs68(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_computed_with_optional_argPgResource.isUnique && !resource_post_computed_with_optional_argPgResource.codec.attributes && typeof resource_post_computed_with_optional_argPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_computed_with_optional_argPgResource.codec)`${resource_post_computed_with_optional_argPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_computed_with_optional_argPgResource.execute(selectArgs);
-      },
-      args: {
-        i: undefined
-      }
-    },
-    computedWithRequiredArg: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs69(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_computed_with_required_argPgResource.isUnique && !resource_post_computed_with_required_argPgResource.codec.attributes && typeof resource_post_computed_with_required_argPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_computed_with_required_argPgResource.codec)`${resource_post_computed_with_required_argPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_computed_with_required_argPgResource.execute(selectArgs);
-      },
-      args: {
-        i: undefined
-      }
-    },
-    headlineTrimmed: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs70(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_headline_trimmedPgResource.isUnique && !resource_post_headline_trimmedPgResource.codec.attributes && typeof resource_post_headline_trimmedPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_headline_trimmedPgResource.codec)`${resource_post_headline_trimmedPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_headline_trimmedPgResource.execute(selectArgs);
-      },
-      args: {
-        length: undefined,
-        omission: undefined
-      }
-    },
-    headlineTrimmedNoDefaults: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs71(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_headline_trimmed_no_defaultsPgResource.isUnique && !resource_post_headline_trimmed_no_defaultsPgResource.codec.attributes && typeof resource_post_headline_trimmed_no_defaultsPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_headline_trimmed_no_defaultsPgResource.codec)`${resource_post_headline_trimmed_no_defaultsPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_headline_trimmed_no_defaultsPgResource.execute(selectArgs);
-      },
-      args: {
-        length: undefined,
-        omission: undefined
-      }
-    },
-    headlineTrimmedStrict: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs72(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_headline_trimmed_strictPgResource.isUnique && !resource_post_headline_trimmed_strictPgResource.codec.attributes && typeof resource_post_headline_trimmed_strictPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_headline_trimmed_strictPgResource.codec)`${resource_post_headline_trimmed_strictPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_headline_trimmed_strictPgResource.execute(selectArgs);
-      },
-      args: {
-        length: undefined,
-        omission: undefined
-      }
-    },
-    computedCompoundTypeArray: {
       plan($in, args, _info) {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -29581,20 +30358,278 @@ export const plans = {
         const selectArgs = [{
           step: $row.record()
         }, ...extraSelectArgs];
-        if (resource_post_computed_compound_type_arrayPgResource.isUnique && !resource_post_computed_compound_type_arrayPgResource.codec.attributes && typeof resource_post_computed_compound_type_arrayPgResource.from === "function") {
+        if (resource_post_computed_with_optional_argPgResource.isUnique && !resource_post_computed_with_optional_argPgResource.codec.attributes && typeof resource_post_computed_with_optional_argPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_post_computed_compound_type_arrayPgResource.codec)`${resource_post_computed_compound_type_arrayPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_post_computed_with_optional_argPgResource.codec)`${resource_post_computed_with_optional_argPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_computed_with_optional_argPgResource.execute(selectArgs);
+      },
+      args: {
+        i: undefined
+      }
+    },
+    computedWithRequiredArg: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs74(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_computed_with_required_argPgResource.isUnique && !resource_post_computed_with_required_argPgResource.codec.attributes && typeof resource_post_computed_with_required_argPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_computed_with_required_argPgResource.codec)`${resource_post_computed_with_required_argPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_computed_with_required_argPgResource.execute(selectArgs);
+      },
+      args: {
+        i: undefined
+      }
+    },
+    headlineTrimmed: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs75(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_headline_trimmedPgResource.isUnique && !resource_post_headline_trimmedPgResource.codec.attributes && typeof resource_post_headline_trimmedPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_headline_trimmedPgResource.codec)`${resource_post_headline_trimmedPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_headline_trimmedPgResource.execute(selectArgs);
+      },
+      args: {
+        length: undefined,
+        omission: undefined
+      }
+    },
+    headlineTrimmedNoDefaults: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs76(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_headline_trimmed_no_defaultsPgResource.isUnique && !resource_post_headline_trimmed_no_defaultsPgResource.codec.attributes && typeof resource_post_headline_trimmed_no_defaultsPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_headline_trimmed_no_defaultsPgResource.codec)`${resource_post_headline_trimmed_no_defaultsPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_headline_trimmed_no_defaultsPgResource.execute(selectArgs);
+      },
+      args: {
+        length: undefined,
+        omission: undefined
+      }
+    },
+    headlineTrimmedStrict: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs77(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_headline_trimmed_strictPgResource.isUnique && !resource_post_headline_trimmed_strictPgResource.codec.attributes && typeof resource_post_headline_trimmed_strictPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_headline_trimmed_strictPgResource.codec)`${resource_post_headline_trimmed_strictPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_headline_trimmed_strictPgResource.execute(selectArgs);
+      },
+      args: {
+        length: undefined,
+        omission: undefined
+      }
+    },
+    computedCompoundTypeArray: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs78(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_computed_compound_type_arrayPgResource.isUnique && !resource_post_computed_compound_type_arrayPgResource.codec.attributes && typeof resource_post_computed_compound_type_arrayPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_computed_compound_type_arrayPgResource.codec)`${resource_post_computed_compound_type_arrayPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_post_computed_compound_type_arrayPgResource.execute(selectArgs);
@@ -33326,7 +34361,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs74(args);
+      const extraSelectArgs = makeArgs79(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -33340,18 +34375,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_edge_case_computedPgResource.isUnique && !resource_edge_case_computedPgResource.codec.attributes && typeof resource_edge_case_computedPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_edge_case_computedPgResource.codec)`${resource_edge_case_computedPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_edge_case_computedPgResource.codec)`${resource_edge_case_computedPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_edge_case_computedPgResource.execute(selectArgs);
@@ -33683,7 +34728,7 @@ export const plans = {
     __assertStep: __ValueStep,
     mutationOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs75(args, ["input"]);
+        const selectArgs = makeArgs80(args, ["input"]);
         const $result = resource_mutation_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -33700,7 +34745,7 @@ export const plans = {
     },
     mutationOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs76(args, ["input"]);
+        const selectArgs = makeArgs81(args, ["input"]);
         const $result = resource_mutation_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -33717,7 +34762,7 @@ export const plans = {
     },
     mutationOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs77(args, ["input"]);
+        const selectArgs = makeArgs82(args, ["input"]);
         const $result = resource_mutation_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -33734,7 +34779,7 @@ export const plans = {
     },
     noArgsMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs78(args, ["input"]);
+        const selectArgs = makeArgs83(args, ["input"]);
         const $result = resource_no_args_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -33751,7 +34796,7 @@ export const plans = {
     },
     returnVoidMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs79(args, ["input"]);
+        const selectArgs = makeArgs84(args, ["input"]);
         const $result = resource_return_void_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -33768,7 +34813,7 @@ export const plans = {
     },
     mutationIntervalSet: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs80(args, ["input"]);
+        const selectArgs = makeArgs85(args, ["input"]);
         const $result = resource_mutation_interval_setPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -33785,7 +34830,7 @@ export const plans = {
     },
     mutationInOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs81(args, ["input"]);
+        const selectArgs = makeArgs86(args, ["input"]);
         const $result = resource_mutation_in_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -33802,7 +34847,7 @@ export const plans = {
     },
     mutationReturnsTableOneCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs82(args, ["input"]);
+        const selectArgs = makeArgs87(args, ["input"]);
         const $result = resource_mutation_returns_table_one_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -33819,7 +34864,7 @@ export const plans = {
     },
     jsonIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs83(args, ["input"]);
+        const selectArgs = makeArgs88(args, ["input"]);
         const $result = resource_json_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -33836,7 +34881,7 @@ export const plans = {
     },
     jsonbIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs84(args, ["input"]);
+        const selectArgs = makeArgs89(args, ["input"]);
         const $result = resource_jsonb_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -33853,7 +34898,7 @@ export const plans = {
     },
     jsonbIdentityMutationPlpgsql: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs85(args, ["input"]);
+        const selectArgs = makeArgs90(args, ["input"]);
         const $result = resource_jsonb_identity_mutation_plpgsqlPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -33870,7 +34915,7 @@ export const plans = {
     },
     jsonbIdentityMutationPlpgsqlWithDefault: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs86(args, ["input"]);
+        const selectArgs = makeArgs91(args, ["input"]);
         const $result = resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -33887,7 +34932,7 @@ export const plans = {
     },
     add1Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs87(args, ["input"]);
+        const selectArgs = makeArgs92(args, ["input"]);
         const $result = resource_add_1_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -33904,7 +34949,7 @@ export const plans = {
     },
     add2Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs88(args, ["input"]);
+        const selectArgs = makeArgs93(args, ["input"]);
         const $result = resource_add_2_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -33921,7 +34966,7 @@ export const plans = {
     },
     add3Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs89(args, ["input"]);
+        const selectArgs = makeArgs94(args, ["input"]);
         const $result = resource_add_3_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -33938,7 +34983,7 @@ export const plans = {
     },
     add4Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs90(args, ["input"]);
+        const selectArgs = makeArgs95(args, ["input"]);
         const $result = resource_add_4_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -33955,7 +35000,7 @@ export const plans = {
     },
     add4MutationError: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs91(args, ["input"]);
+        const selectArgs = makeArgs96(args, ["input"]);
         const $result = resource_add_4_mutation_errorPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -33972,7 +35017,7 @@ export const plans = {
     },
     mult1: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs92(args, ["input"]);
+        const selectArgs = makeArgs97(args, ["input"]);
         const $result = resource_mult_1PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -33989,7 +35034,7 @@ export const plans = {
     },
     mult2: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs93(args, ["input"]);
+        const selectArgs = makeArgs98(args, ["input"]);
         const $result = resource_mult_2PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34006,7 +35051,7 @@ export const plans = {
     },
     mult3: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs94(args, ["input"]);
+        const selectArgs = makeArgs99(args, ["input"]);
         const $result = resource_mult_3PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34023,7 +35068,7 @@ export const plans = {
     },
     mult4: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs95(args, ["input"]);
+        const selectArgs = makeArgs100(args, ["input"]);
         const $result = resource_mult_4PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34040,7 +35085,7 @@ export const plans = {
     },
     mutationInInout: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs96(args, ["input"]);
+        const selectArgs = makeArgs101(args, ["input"]);
         const $result = resource_mutation_in_inoutPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34057,7 +35102,7 @@ export const plans = {
     },
     mutationOutOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs97(args, ["input"]);
+        const selectArgs = makeArgs102(args, ["input"]);
         const $result = resource_mutation_out_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34074,7 +35119,7 @@ export const plans = {
     },
     mutationOutOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs98(args, ["input"]);
+        const selectArgs = makeArgs103(args, ["input"]);
         const $result = resource_mutation_out_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34091,7 +35136,7 @@ export const plans = {
     },
     mutationOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs99(args, ["input"]);
+        const selectArgs = makeArgs104(args, ["input"]);
         const $result = resource_mutation_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34108,7 +35153,7 @@ export const plans = {
     },
     intSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs100(args, ["input"]);
+        const selectArgs = makeArgs105(args, ["input"]);
         const $result = resource_int_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34125,7 +35170,7 @@ export const plans = {
     },
     mutationOutUnnamedOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs101(args, ["input"]);
+        const selectArgs = makeArgs106(args, ["input"]);
         const $result = resource_mutation_out_unnamed_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34142,7 +35187,7 @@ export const plans = {
     },
     mutationReturnsTableMultiCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs102(args, ["input"]);
+        const selectArgs = makeArgs107(args, ["input"]);
         const $result = resource_mutation_returns_table_multi_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34159,7 +35204,7 @@ export const plans = {
     },
     guidFn: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs103(args, ["input"]);
+        const selectArgs = makeArgs108(args, ["input"]);
         const $result = resource_guid_fnPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34176,7 +35221,7 @@ export const plans = {
     },
     mutationIntervalArray: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs104(args, ["input"]);
+        const selectArgs = makeArgs109(args, ["input"]);
         const $result = resource_mutation_interval_arrayPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34193,7 +35238,7 @@ export const plans = {
     },
     mutationTextArray: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs105(args, ["input"]);
+        const selectArgs = makeArgs110(args, ["input"]);
         const $result = resource_mutation_text_arrayPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34210,7 +35255,7 @@ export const plans = {
     },
     listBdeMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs106(args, ["input"]);
+        const selectArgs = makeArgs111(args, ["input"]);
         const $result = resource_list_bde_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34227,7 +35272,7 @@ export const plans = {
     },
     authenticateFail: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs107(args, ["input"]);
+        const selectArgs = makeArgs112(args, ["input"]);
         const $result = resource_authenticate_failPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34244,7 +35289,7 @@ export const plans = {
     },
     authenticate: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs108(args, ["input"]);
+        const selectArgs = makeArgs113(args, ["input"]);
         const $result = resource_authenticatePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34261,7 +35306,7 @@ export const plans = {
     },
     leftArmIdentity: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs109(args, ["input"]);
+        const selectArgs = makeArgs114(args, ["input"]);
         const $result = resource_left_arm_identityPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34278,7 +35323,7 @@ export const plans = {
     },
     issue756Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs110(args, ["input"]);
+        const selectArgs = makeArgs115(args, ["input"]);
         const $result = resource_issue756_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34295,7 +35340,7 @@ export const plans = {
     },
     issue756SetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs111(args, ["input"]);
+        const selectArgs = makeArgs116(args, ["input"]);
         const $result = resource_issue756_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34312,7 +35357,7 @@ export const plans = {
     },
     authenticateMany: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs112(args, ["input"]);
+        const selectArgs = makeArgs117(args, ["input"]);
         const $result = resource_authenticate_manyPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34329,7 +35374,7 @@ export const plans = {
     },
     authenticatePayload: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs113(args, ["input"]);
+        const selectArgs = makeArgs118(args, ["input"]);
         const $result = resource_authenticate_payloadPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34346,7 +35391,7 @@ export const plans = {
     },
     typesMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs114(args, ["input"]);
+        const selectArgs = makeArgs119(args, ["input"]);
         const $result = resource_types_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34363,7 +35408,7 @@ export const plans = {
     },
     mutationOutOutCompoundType: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs115(args, ["input"]);
+        const selectArgs = makeArgs120(args, ["input"]);
         const $result = resource_mutation_out_out_compound_typePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34380,7 +35425,7 @@ export const plans = {
     },
     compoundTypeMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs116(args, ["input"]);
+        const selectArgs = makeArgs121(args, ["input"]);
         const $result = resource_compound_type_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34397,7 +35442,7 @@ export const plans = {
     },
     compoundTypeSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs117(args, ["input"]);
+        const selectArgs = makeArgs122(args, ["input"]);
         const $result = resource_compound_type_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34414,7 +35459,7 @@ export const plans = {
     },
     tableMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs118(args, ["input"]);
+        const selectArgs = makeArgs123(args, ["input"]);
         const $result = resource_table_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34431,7 +35476,7 @@ export const plans = {
     },
     postWithSuffix: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs119(args, ["input"]);
+        const selectArgs = makeArgs124(args, ["input"]);
         const $result = resource_post_with_suffixPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34448,7 +35493,7 @@ export const plans = {
     },
     mutationCompoundTypeArray: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs120(args, ["input"]);
+        const selectArgs = makeArgs125(args, ["input"]);
         const $result = resource_mutation_compound_type_arrayPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34465,7 +35510,7 @@ export const plans = {
     },
     compoundTypeArrayMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs121(args, ["input"]);
+        const selectArgs = makeArgs126(args, ["input"]);
         const $result = resource_compound_type_array_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34482,7 +35527,7 @@ export const plans = {
     },
     postMany: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs122(args, ["input"]);
+        const selectArgs = makeArgs127(args, ["input"]);
         const $result = resource_post_manyPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34499,7 +35544,7 @@ export const plans = {
     },
     mutationOutComplex: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs123(args, ["input"]);
+        const selectArgs = makeArgs128(args, ["input"]);
         const $result = resource_mutation_out_complexPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34516,7 +35561,7 @@ export const plans = {
     },
     mutationOutComplexSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs124(args, ["input"]);
+        const selectArgs = makeArgs129(args, ["input"]);
         const $result = resource_mutation_out_complex_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34533,7 +35578,7 @@ export const plans = {
     },
     mutationOutTable: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs125(args, ["input"]);
+        const selectArgs = makeArgs130(args, ["input"]);
         const $result = resource_mutation_out_tablePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34550,7 +35595,7 @@ export const plans = {
     },
     mutationOutTableSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs126(args, ["input"]);
+        const selectArgs = makeArgs131(args, ["input"]);
         const $result = resource_mutation_out_table_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34567,7 +35612,7 @@ export const plans = {
     },
     tableSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs127(args, ["input"]);
+        const selectArgs = makeArgs132(args, ["input"]);
         const $result = resource_table_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34584,7 +35629,7 @@ export const plans = {
     },
     typeFunctionConnectionMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs128(args, ["input"]);
+        const selectArgs = makeArgs133(args, ["input"]);
         const $result = resource_type_function_connection_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34601,7 +35646,7 @@ export const plans = {
     },
     typeFunctionMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs129(args, ["input"]);
+        const selectArgs = makeArgs134(args, ["input"]);
         const $result = resource_type_function_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -34618,7 +35663,7 @@ export const plans = {
     },
     typeFunctionListMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs130(args, ["input"]);
+        const selectArgs = makeArgs135(args, ["input"]);
         const $result = resource_type_function_list_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result

--- a/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.graphql
@@ -5692,6 +5692,11 @@ type Person implements Node {
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, arg2: Int, b: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
 
   """This `Person`'s `PersonSecret`."""
   personSecretByPersonId: PersonSecret @deprecated(reason: "This is deprecated (comment on table c.person_secret).")

--- a/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.export.mjs
@@ -3494,6 +3494,11 @@ const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_compu
 const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
 const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
 const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const person_optional_missing_middle_1FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_1");
+const person_optional_missing_middle_2FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_2");
+const person_optional_missing_middle_3FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_3");
+const person_optional_missing_middle_4FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_4");
+const person_optional_missing_middle_5FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_5");
 const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
 const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
 const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
@@ -7383,6 +7388,216 @@ const registry = makeRegistry({
           serviceName: "main",
           schemaName: "c",
           name: "person_computed_first_arg_inout_out"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_1: {
+      executor,
+      name: "person_optional_missing_middle_1",
+      identifier: "main.c.person_optional_missing_middle_1(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_1"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_2: {
+      executor,
+      name: "person_optional_missing_middle_2",
+      identifier: "main.c.person_optional_missing_middle_2(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_2"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_3: {
+      executor,
+      name: "person_optional_missing_middle_3",
+      identifier: "main.c.person_optional_missing_middle_3(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_3"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_4: {
+      executor,
+      name: "person_optional_missing_middle_4",
+      identifier: "main.c.person_optional_missing_middle_4(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_4"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_5: {
+      executor,
+      name: "person_optional_missing_middle_5",
+      identifier: "main.c.person_optional_missing_middle_5(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_5FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_5"
         },
         tags: {}
       },
@@ -11870,22 +12085,28 @@ const makeArgs56 = (args, path = []) => {
 };
 const resource_person_computed_first_arg_inout_outPgResource = registry.pgResources["person_computed_first_arg_inout_out"];
 const argDetailsSimple57 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
+  graphqlArgName: "arg0",
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
   graphqlArgName: "b",
   postgresArgName: "b",
-  pgCodec: TYPES.text,
-  required: true,
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
   fetcher: null
 }];
 const makeArgs57 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11896,7 +12117,7 @@ const makeArgs57 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 1 - 1) {
         skipped = true;
         continue;
       } else {
@@ -11926,12 +12147,30 @@ const makeArgs57 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
-const argDetailsSimple58 = [];
+const resource_person_optional_missing_middle_1PgResource = registry.pgResources["person_optional_missing_middle_1"];
+const argDetailsSimple58 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs58 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11972,12 +12211,30 @@ const makeArgs58 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
-const argDetailsSimple59 = [];
+const resource_person_optional_missing_middle_2PgResource = registry.pgResources["person_optional_missing_middle_2"];
+const argDetailsSimple59 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs59 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11988,7 +12245,7 @@ const makeArgs59 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 2 - 1) {
         skipped = true;
         continue;
       } else {
@@ -12018,12 +12275,30 @@ const makeArgs59 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
-const argDetailsSimple60 = [];
+const resource_person_optional_missing_middle_3PgResource = registry.pgResources["person_optional_missing_middle_3"];
+const argDetailsSimple60 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs60 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12034,7 +12309,7 @@ const makeArgs60 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -12064,46 +12339,30 @@ const makeArgs60 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_friendsPgResource = registry.pgResources["person_friends"];
-const getSelectPlanFromParentAndArgs15 = ($in, args, _info) => {
-  if (!hasRecord($in)) {
-    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-  }
-  const extraSelectArgs = makeArgs60(args);
-  /**
-   * An optimisation - if all our dependencies are
-   * compatible with the expression's class plan then we
-   * can inline ourselves into that, otherwise we must
-   * issue the query separately.
-   */
-  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-  const selectArgs = [{
-    step: $row.record()
-  }, ...extraSelectArgs];
-  if (resource_person_friendsPgResource.isUnique && !resource_person_friendsPgResource.codec.attributes && typeof resource_person_friendsPgResource.from === "function") {
-    // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
-      if (i === 0) {
-        return $row.getClassStep().alias;
-      } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
-      } else {
-        return $row.placeholder(arg.step);
-      }
-    });
-    return pgClassExpression($row, resource_person_friendsPgResource.codec)`${resource_person_friendsPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
-  }
-  // PERF: or here, if scalar add select to `$row`?
-  return resource_person_friendsPgResource.execute(selectArgs);
-};
-const argDetailsSimple61 = [];
+const resource_person_optional_missing_middle_4PgResource = registry.pgResources["person_optional_missing_middle_4"];
+const argDetailsSimple61 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs61 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12114,7 +12373,7 @@ const makeArgs61 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -12144,52 +12403,24 @@ const makeArgs61 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
-const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
-  if (!hasRecord($in)) {
-    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-  }
-  const extraSelectArgs = makeArgs61(args);
-  /**
-   * An optimisation - if all our dependencies are
-   * compatible with the expression's class plan then we
-   * can inline ourselves into that, otherwise we must
-   * issue the query separately.
-   */
-  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-  const selectArgs = [{
-    step: $row.record()
-  }, ...extraSelectArgs];
-  if (resource_person_type_function_connectionPgResource.isUnique && !resource_person_type_function_connectionPgResource.codec.attributes && typeof resource_person_type_function_connectionPgResource.from === "function") {
-    // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
-      if (i === 0) {
-        return $row.getClassStep().alias;
-      } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
-      } else {
-        return $row.placeholder(arg.step);
-      }
-    });
-    return pgClassExpression($row, resource_person_type_function_connectionPgResource.codec)`${resource_person_type_function_connectionPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
-  }
-  // PERF: or here, if scalar add select to `$row`?
-  return resource_person_type_function_connectionPgResource.execute(selectArgs);
-};
+const resource_person_optional_missing_middle_5PgResource = registry.pgResources["person_optional_missing_middle_5"];
 const argDetailsSimple62 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs62 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12230,7 +12461,7 @@ const makeArgs62 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
+const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
 const argDetailsSimple63 = [];
 const makeArgs63 = (args, path = []) => {
   const selectArgs = [];
@@ -12276,9 +12507,7 @@ const makeArgs63 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
-const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
-const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
+const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
 const argDetailsSimple64 = [];
 const makeArgs64 = (args, path = []) => {
   const selectArgs = [];
@@ -12324,16 +12553,7 @@ const makeArgs64 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
-function UUIDSerialize(value) {
-  return "" + value;
-}
-const coerce = string => {
-  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
-    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
-  }
-  return string;
-};
+const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -12379,8 +12599,8 @@ const makeArgs65 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_interval_setPgResource = registry.pgResources["post_computed_interval_set"];
-const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
+const resource_person_friendsPgResource = registry.pgResources["person_friends"];
+const getSelectPlanFromParentAndArgs15 = ($in, args, _info) => {
   if (!hasRecord($in)) {
     throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
   }
@@ -12396,23 +12616,33 @@ const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
   const selectArgs = [{
     step: $row.record()
   }, ...extraSelectArgs];
-  if (resource_post_computed_interval_setPgResource.isUnique && !resource_post_computed_interval_setPgResource.codec.attributes && typeof resource_post_computed_interval_setPgResource.from === "function") {
+  if (resource_person_friendsPgResource.isUnique && !resource_person_friendsPgResource.codec.attributes && typeof resource_person_friendsPgResource.from === "function") {
     // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
       if (i === 0) {
-        return $row.getClassStep().alias;
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
       } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
       } else {
-        return $row.placeholder(arg.step);
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
       }
     });
-    return pgClassExpression($row, resource_post_computed_interval_setPgResource.codec)`${resource_post_computed_interval_setPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
+    return pgClassExpression($row, resource_person_friendsPgResource.codec)`${resource_person_friendsPgResource.from(...newSelectArgs)}`;
   }
   // PERF: or here, if scalar add select to `$row`?
-  return resource_post_computed_interval_setPgResource.execute(selectArgs);
+  return resource_person_friendsPgResource.execute(selectArgs);
 };
 const argDetailsSimple66 = [];
 const makeArgs66 = (args, path = []) => {
@@ -12459,12 +12689,62 @@ const makeArgs66 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_interval_arrayPgResource = registry.pgResources["post_computed_interval_array"];
-const argDetailsSimple67 = [];
+const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
+const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
+  if (!hasRecord($in)) {
+    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+  }
+  const extraSelectArgs = makeArgs66(args);
+  /**
+   * An optimisation - if all our dependencies are
+   * compatible with the expression's class plan then we
+   * can inline ourselves into that, otherwise we must
+   * issue the query separately.
+   */
+  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+  const selectArgs = [{
+    step: $row.record()
+  }, ...extraSelectArgs];
+  if (resource_person_type_function_connectionPgResource.isUnique && !resource_person_type_function_connectionPgResource.codec.attributes && typeof resource_person_type_function_connectionPgResource.from === "function") {
+    // This is a scalar computed attribute, let's inline the expression
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
+      if (i === 0) {
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
+      } else if ("pgCodec" in arg && arg.pgCodec) {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
+      } else {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
+      }
+    });
+    return pgClassExpression($row, resource_person_type_function_connectionPgResource.codec)`${resource_person_type_function_connectionPgResource.from(...newSelectArgs)}`;
+  }
+  // PERF: or here, if scalar add select to `$row`?
+  return resource_person_type_function_connectionPgResource.execute(selectArgs);
+};
+const argDetailsSimple67 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs67 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12505,18 +12785,12 @@ const makeArgs67 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_text_arrayPgResource = registry.pgResources["post_computed_text_array"];
-const argDetailsSimple68 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: false,
-  fetcher: null
-}];
+const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
+const argDetailsSimple68 = [];
 const makeArgs68 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12557,18 +12831,14 @@ const makeArgs68 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_with_optional_argPgResource = registry.pgResources["post_computed_with_optional_arg"];
-const argDetailsSimple69 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
+const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
+const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
+const argDetailsSimple69 = [];
 const makeArgs69 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12609,24 +12879,21 @@ const makeArgs69 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_with_required_argPgResource = registry.pgResources["post_computed_with_required_arg"];
-const argDetailsSimple70 = [{
-  graphqlArgName: "length",
-  postgresArgName: "length",
-  pgCodec: TYPES.int,
-  required: false,
-  fetcher: null
-}, {
-  graphqlArgName: "omission",
-  postgresArgName: "omission",
-  pgCodec: TYPES.text,
-  required: false,
-  fetcher: null
-}];
+const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
+function UUIDSerialize(value) {
+  return "" + value;
+}
+const coerce = string => {
+  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
+    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
+  }
+  return string;
+};
+const argDetailsSimple70 = [];
 const makeArgs70 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12667,24 +12934,56 @@ const makeArgs70 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmedPgResource = registry.pgResources["post_headline_trimmed"];
-const argDetailsSimple71 = [{
-  graphqlArgName: "length",
-  postgresArgName: "length",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "omission",
-  postgresArgName: "omission",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_post_computed_interval_setPgResource = registry.pgResources["post_computed_interval_set"];
+const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
+  if (!hasRecord($in)) {
+    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+  }
+  const extraSelectArgs = makeArgs70(args);
+  /**
+   * An optimisation - if all our dependencies are
+   * compatible with the expression's class plan then we
+   * can inline ourselves into that, otherwise we must
+   * issue the query separately.
+   */
+  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+  const selectArgs = [{
+    step: $row.record()
+  }, ...extraSelectArgs];
+  if (resource_post_computed_interval_setPgResource.isUnique && !resource_post_computed_interval_setPgResource.codec.attributes && typeof resource_post_computed_interval_setPgResource.from === "function") {
+    // This is a scalar computed attribute, let's inline the expression
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
+      if (i === 0) {
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
+      } else if ("pgCodec" in arg && arg.pgCodec) {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
+      } else {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
+      }
+    });
+    return pgClassExpression($row, resource_post_computed_interval_setPgResource.codec)`${resource_post_computed_interval_setPgResource.from(...newSelectArgs)}`;
+  }
+  // PERF: or here, if scalar add select to `$row`?
+  return resource_post_computed_interval_setPgResource.execute(selectArgs);
+};
+const argDetailsSimple71 = [];
 const makeArgs71 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12725,24 +13024,12 @@ const makeArgs71 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmed_no_defaultsPgResource = registry.pgResources["post_headline_trimmed_no_defaults"];
-const argDetailsSimple72 = [{
-  graphqlArgName: "length",
-  postgresArgName: "length",
-  pgCodec: TYPES.int,
-  required: false,
-  fetcher: null
-}, {
-  graphqlArgName: "omission",
-  postgresArgName: "omission",
-  pgCodec: TYPES.text,
-  required: false,
-  fetcher: null
-}];
+const resource_post_computed_interval_arrayPgResource = registry.pgResources["post_computed_interval_array"];
+const argDetailsSimple72 = [];
 const makeArgs72 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12783,12 +13070,12 @@ const makeArgs72 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmed_strictPgResource = registry.pgResources["post_headline_trimmed_strict"];
+const resource_post_computed_text_arrayPgResource = registry.pgResources["post_computed_text_array"];
 const argDetailsSimple73 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
-  required: true,
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: false,
   fetcher: null
 }];
 const makeArgs73 = (args, path = []) => {
@@ -12802,6 +13089,284 @@ const makeArgs73 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple73[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_computed_with_optional_argPgResource = registry.pgResources["post_computed_with_optional_arg"];
+const argDetailsSimple74 = [{
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs74 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple74[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_computed_with_required_argPgResource = registry.pgResources["post_computed_with_required_arg"];
+const argDetailsSimple75 = [{
+  graphqlArgName: "length",
+  postgresArgName: "length",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "omission",
+  postgresArgName: "omission",
+  pgCodec: TYPES.text,
+  required: false,
+  fetcher: null
+}];
+const makeArgs75 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple75[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_headline_trimmedPgResource = registry.pgResources["post_headline_trimmed"];
+const argDetailsSimple76 = [{
+  graphqlArgName: "length",
+  postgresArgName: "length",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "omission",
+  postgresArgName: "omission",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
+const makeArgs76 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple76[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_headline_trimmed_no_defaultsPgResource = registry.pgResources["post_headline_trimmed_no_defaults"];
+const argDetailsSimple77 = [{
+  graphqlArgName: "length",
+  postgresArgName: "length",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "omission",
+  postgresArgName: "omission",
+  pgCodec: TYPES.text,
+  required: false,
+  fetcher: null
+}];
+const makeArgs77 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple77[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_headline_trimmed_strictPgResource = registry.pgResources["post_headline_trimmed_strict"];
+const argDetailsSimple78 = [{
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
+  required: true,
+  fetcher: null
+}];
+const makeArgs78 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple78[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -12892,236 +13457,6 @@ const parseValueLiteral = (ast, variables) => {
       return undefined;
   }
 };
-const argDetailsSimple74 = [];
-const makeArgs74 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple74[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
-const argDetailsSimple75 = [];
-const makeArgs75 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple75[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
-const argDetailsSimple76 = [];
-const makeArgs76 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple76[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
-const argDetailsSimple77 = [];
-const makeArgs77 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple77[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
-const argDetailsSimple78 = [];
-const makeArgs78 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple78[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
 const argDetailsSimple79 = [];
 const makeArgs79 = (args, path = []) => {
   const selectArgs = [];
@@ -13167,7 +13502,7 @@ const makeArgs79 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
+const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
 const argDetailsSimple80 = [];
 const makeArgs80 = (args, path = []) => {
   const selectArgs = [];
@@ -13213,18 +13548,12 @@ const makeArgs80 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
-const argDetailsSimple81 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
+const argDetailsSimple81 = [];
 const makeArgs81 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13265,18 +13594,12 @@ const makeArgs81 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
-const argDetailsSimple82 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
+const argDetailsSimple82 = [];
 const makeArgs82 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13317,18 +13640,12 @@ const makeArgs82 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
-const argDetailsSimple83 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
+const argDetailsSimple83 = [];
 const makeArgs83 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13369,18 +13686,12 @@ const makeArgs83 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
-const argDetailsSimple84 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
+const argDetailsSimple84 = [];
 const makeArgs84 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13421,18 +13732,12 @@ const makeArgs84 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
-const argDetailsSimple85 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
+const argDetailsSimple85 = [];
 const makeArgs85 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13473,12 +13778,12 @@ const makeArgs85 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
+const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
 const argDetailsSimple86 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: false,
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
   fetcher: null
 }];
 const makeArgs86 = (args, path = []) => {
@@ -13525,16 +13830,10 @@ const makeArgs86 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
+const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
 const argDetailsSimple87 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: null,
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "arg1",
-  postgresArgName: null,
+  graphqlArgName: "i",
+  postgresArgName: "i",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -13542,7 +13841,7 @@ const argDetailsSimple87 = [{
 const makeArgs87 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13553,7 +13852,7 @@ const makeArgs87 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 2 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13583,24 +13882,18 @@ const makeArgs87 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
+const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
 const argDetailsSimple88 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.json,
   required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.int,
-  required: false,
   fetcher: null
 }];
 const makeArgs88 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13641,24 +13934,18 @@ const makeArgs88 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
+const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
 const argDetailsSimple89 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "arg1",
-  postgresArgName: "",
-  pgCodec: TYPES.int,
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.jsonb,
   required: true,
   fetcher: null
 }];
 const makeArgs89 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13669,7 +13956,7 @@ const makeArgs89 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 2 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13699,24 +13986,18 @@ const makeArgs89 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
+const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
 const argDetailsSimple90 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: "",
-  pgCodec: TYPES.int,
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
   required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.int,
-  required: false,
   fetcher: null
 }];
 const makeArgs90 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13727,7 +14008,7 @@ const makeArgs90 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 1 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13757,24 +14038,18 @@ const makeArgs90 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
+const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
 const argDetailsSimple91 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: "",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.int,
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
   required: false,
   fetcher: null
 }];
 const makeArgs91 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13785,7 +14060,7 @@ const makeArgs91 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 1 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13815,7 +14090,7 @@ const makeArgs91 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
+const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
 const argDetailsSimple92 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -13873,18 +14148,18 @@ const makeArgs92 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_1PgResource = registry.pgResources["mult_1"];
+const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
 const argDetailsSimple93 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: null,
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "arg1",
-  postgresArgName: null,
+  graphqlArgName: "b",
+  postgresArgName: "b",
   pgCodec: TYPES.int,
-  required: true,
+  required: false,
   fetcher: null
 }];
 const makeArgs93 = (args, path = []) => {
@@ -13901,7 +14176,7 @@ const makeArgs93 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 2 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13931,16 +14206,16 @@ const makeArgs93 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_2PgResource = registry.pgResources["mult_2"];
+const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
 const argDetailsSimple94 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: null,
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
   graphqlArgName: "arg1",
-  postgresArgName: null,
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -13989,18 +14264,18 @@ const makeArgs94 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_3PgResource = registry.pgResources["mult_3"];
+const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
 const argDetailsSimple95 = [{
   graphqlArgName: "arg0",
-  postgresArgName: null,
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "arg1",
-  postgresArgName: null,
+  graphqlArgName: "b",
+  postgresArgName: "b",
   pgCodec: TYPES.int,
-  required: true,
+  required: false,
   fetcher: null
 }];
 const makeArgs95 = (args, path = []) => {
@@ -14014,6 +14289,296 @@ const makeArgs95 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple95[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 1 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
+const argDetailsSimple96 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
+const makeArgs96 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple96[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 1 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
+const argDetailsSimple97 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs97 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple97[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 2 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mult_1PgResource = registry.pgResources["mult_1"];
+const argDetailsSimple98 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs98 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple98[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 2 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mult_2PgResource = registry.pgResources["mult_2"];
+const argDetailsSimple99 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs99 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple99[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 2 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mult_3PgResource = registry.pgResources["mult_3"];
+const argDetailsSimple100 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs100 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple100[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -14048,7 +14613,7 @@ const makeArgs95 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_4PgResource = registry.pgResources["mult_4"];
-const argDetailsSimple96 = [{
+const argDetailsSimple101 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
   pgCodec: TYPES.int,
@@ -14061,258 +14626,10 @@ const argDetailsSimple96 = [{
   required: true,
   fetcher: null
 }];
-const makeArgs96 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 2; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple96[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
-const argDetailsSimple97 = [];
-const makeArgs97 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple97[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
-const argDetailsSimple98 = [];
-const makeArgs98 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple98[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
-const argDetailsSimple99 = [];
-const makeArgs99 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple99[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
-const argDetailsSimple100 = [{
-  graphqlArgName: "x",
-  postgresArgName: "x",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "y",
-  postgresArgName: "y",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "z",
-  postgresArgName: "z",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
-const makeArgs100 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 3; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple100[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
-const argDetailsSimple101 = [];
 const makeArgs101 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14353,18 +14670,12 @@ const makeArgs101 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
-const argDetailsSimple102 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
+const argDetailsSimple102 = [];
 const makeArgs102 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14405,18 +14716,12 @@ const makeArgs102 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
-const argDetailsSimple103 = [{
-  graphqlArgName: "g",
-  postgresArgName: "g",
-  pgCodec: guidCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
+const argDetailsSimple103 = [];
 const makeArgs103 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14457,7 +14762,7 @@ const makeArgs103 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_guid_fnPgResource = registry.pgResources["guid_fn"];
+const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
 const argDetailsSimple104 = [];
 const makeArgs104 = (args, path = []) => {
   const selectArgs = [];
@@ -14503,12 +14808,30 @@ const makeArgs104 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
-const argDetailsSimple105 = [];
+const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
+const argDetailsSimple105 = [{
+  graphqlArgName: "x",
+  postgresArgName: "x",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "y",
+  postgresArgName: "y",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "z",
+  postgresArgName: "z",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs105 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14549,30 +14872,12 @@ const makeArgs105 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
-const argDetailsSimple106 = [{
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: textArrayCodec,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "d",
-  postgresArgName: "d",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "e",
-  postgresArgName: "e",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
+const argDetailsSimple106 = [];
 const makeArgs106 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14613,12 +14918,18 @@ const makeArgs106 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_list_bde_mutationPgResource = registry.pgResources["list_bde_mutation"];
-const argDetailsSimple107 = [];
+const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
+const argDetailsSimple107 = [{
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs107 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14659,30 +14970,18 @@ const makeArgs107 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_failPgResource = registry.pgResources["authenticate_fail"];
+const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
 const argDetailsSimple108 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.numeric,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.bigint,
+  graphqlArgName: "g",
+  postgresArgName: "g",
+  pgCodec: guidCodec,
   required: true,
   fetcher: null
 }];
 const makeArgs108 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14723,18 +15022,12 @@ const makeArgs108 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticatePgResource = registry.pgResources["authenticate"];
-const argDetailsSimple109 = [{
-  graphqlArgName: "leftArm",
-  postgresArgName: "left_arm",
-  pgCodec: leftArmCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_guid_fnPgResource = registry.pgResources["guid_fn"];
+const argDetailsSimple109 = [];
 const makeArgs109 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14775,7 +15068,7 @@ const makeArgs109 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
+const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
 const argDetailsSimple110 = [];
 const makeArgs110 = (args, path = []) => {
   const selectArgs = [];
@@ -14821,12 +15114,30 @@ const makeArgs110 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
-const argDetailsSimple111 = [];
+const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
+const argDetailsSimple111 = [{
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: textArrayCodec,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "d",
+  postgresArgName: "d",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "e",
+  postgresArgName: "e",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
 const makeArgs111 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14867,30 +15178,12 @@ const makeArgs111 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
-const argDetailsSimple112 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.numeric,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.bigint,
-  required: true,
-  fetcher: null
-}];
+const resource_list_bde_mutationPgResource = registry.pgResources["list_bde_mutation"];
+const argDetailsSimple112 = [];
 const makeArgs112 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14931,7 +15224,7 @@ const makeArgs112 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_manyPgResource = registry.pgResources["authenticate_many"];
+const resource_authenticate_failPgResource = registry.pgResources["authenticate_fail"];
 const argDetailsSimple113 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -14995,48 +15288,18 @@ const makeArgs113 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_payloadPgResource = registry.pgResources["authenticate_payload"];
+const resource_authenticatePgResource = registry.pgResources["authenticate"];
 const argDetailsSimple114 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.bigint,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.boolean,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.varchar,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "d",
-  postgresArgName: "d",
-  pgCodec: int4ArrayCodec,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "e",
-  postgresArgName: "e",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "f",
-  postgresArgName: "f",
-  pgCodec: floatrangeCodec,
+  graphqlArgName: "leftArm",
+  postgresArgName: "left_arm",
+  pgCodec: leftArmCodec,
   required: true,
   fetcher: null
 }];
 const makeArgs114 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 6; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15077,18 +15340,12 @@ const makeArgs114 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
-const argDetailsSimple115 = [{
-  graphqlArgName: "i1",
-  postgresArgName: "i1",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
+const argDetailsSimple115 = [];
 const makeArgs115 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15129,18 +15386,12 @@ const makeArgs115 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
-const argDetailsSimple116 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
+const argDetailsSimple116 = [];
 const makeArgs116 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15181,18 +15432,30 @@ const makeArgs116 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_mutationPgResource = registry.pgResources["compound_type_mutation"];
+const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
 const argDetailsSimple117 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.numeric,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.bigint,
   required: true,
   fetcher: null
 }];
 const makeArgs117 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15233,18 +15496,30 @@ const makeArgs117 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
+const resource_authenticate_manyPgResource = registry.pgResources["authenticate_many"];
 const argDetailsSimple118 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.numeric,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.bigint,
   required: true,
   fetcher: null
 }];
 const makeArgs118 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15285,24 +15560,48 @@ const makeArgs118 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
+const resource_authenticate_payloadPgResource = registry.pgResources["authenticate_payload"];
 const argDetailsSimple119 = [{
-  graphqlArgName: "post",
-  postgresArgName: "post",
-  pgCodec: postCodec,
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.bigint,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "suffix",
-  postgresArgName: "suffix",
-  pgCodec: TYPES.text,
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.boolean,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.varchar,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "d",
+  postgresArgName: "d",
+  pgCodec: int4ArrayCodec,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "e",
+  postgresArgName: "e",
+  pgCodec: TYPES.json,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "f",
+  postgresArgName: "f",
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
 const makeArgs119 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 6; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15343,11 +15642,11 @@ const makeArgs119 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_with_suffixPgResource = registry.pgResources["post_with_suffix"];
+const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
 const argDetailsSimple120 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
+  graphqlArgName: "i1",
+  postgresArgName: "i1",
+  pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }];
@@ -15395,7 +15694,7 @@ const makeArgs120 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
+const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
 const argDetailsSimple121 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -15447,11 +15746,11 @@ const makeArgs121 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_array_mutationPgResource = registry.pgResources["compound_type_array_mutation"];
+const resource_compound_type_mutationPgResource = registry.pgResources["compound_type_mutation"];
 const argDetailsSimple122 = [{
-  graphqlArgName: "posts",
-  postgresArgName: "posts",
-  pgCodec: postArrayCodec,
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -15499,24 +15798,18 @@ const makeArgs122 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_manyPgResource = registry.pgResources["post_many"];
+const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
 const argDetailsSimple123 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
+  graphqlArgName: "id",
+  postgresArgName: "id",
   pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs123 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15557,16 +15850,16 @@ const makeArgs123 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
+const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
 const argDetailsSimple124 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
+  graphqlArgName: "post",
+  postgresArgName: "post",
+  pgCodec: postCodec,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
+  graphqlArgName: "suffix",
+  postgresArgName: "suffix",
   pgCodec: TYPES.text,
   required: true,
   fetcher: null
@@ -15615,12 +15908,18 @@ const makeArgs124 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
-const argDetailsSimple125 = [];
+const resource_post_with_suffixPgResource = registry.pgResources["post_with_suffix"];
+const argDetailsSimple125 = [{
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs125 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15661,12 +15960,18 @@ const makeArgs125 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
-const argDetailsSimple126 = [];
+const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
+const argDetailsSimple126 = [{
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs126 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15707,12 +16012,18 @@ const makeArgs126 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
-const argDetailsSimple127 = [];
+const resource_compound_type_array_mutationPgResource = registry.pgResources["compound_type_array_mutation"];
+const argDetailsSimple127 = [{
+  graphqlArgName: "posts",
+  postgresArgName: "posts",
+  pgCodec: postArrayCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs127 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15753,12 +16064,24 @@ const makeArgs127 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
-const argDetailsSimple128 = [];
+const resource_post_manyPgResource = registry.pgResources["post_many"];
+const argDetailsSimple128 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
 const makeArgs128 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15799,18 +16122,24 @@ const makeArgs128 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_type_function_connection_mutationPgResource = registry.pgResources["type_function_connection_mutation"];
+const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
 const argDetailsSimple129 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs129 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15851,7 +16180,7 @@ const makeArgs129 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_type_function_mutationPgResource = registry.pgResources["type_function_mutation"];
+const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
 const argDetailsSimple130 = [];
 const makeArgs130 = (args, path = []) => {
   const selectArgs = [];
@@ -15864,6 +16193,242 @@ const makeArgs130 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple130[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
+const argDetailsSimple131 = [];
+const makeArgs131 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple131[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
+const argDetailsSimple132 = [];
+const makeArgs132 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple132[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
+const argDetailsSimple133 = [];
+const makeArgs133 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple133[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_type_function_connection_mutationPgResource = registry.pgResources["type_function_connection_mutation"];
+const argDetailsSimple134 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs134 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple134[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_type_function_mutationPgResource = registry.pgResources["type_function_mutation"];
+const argDetailsSimple135 = [];
+const makeArgs135 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple135[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -17465,6 +18030,11 @@ type Person implements N {
   computedInoutOut(ino: String): PersonComputedInoutOutRecord
   exists(email: Email): Boolean @deprecated(reason: "This is deprecated (comment on function c.person_exists).")
   computedFirstArgInoutOut: PersonComputedFirstArgInoutOutRecord
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, b: Int, arg2: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
   computedComplex(a: Int, b: String): PersonComputedComplexRecord
 
   """The first post by the person."""
@@ -28943,18 +29513,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_outPgResource.isUnique && !resource_person_computed_outPgResource.codec.attributes && typeof resource_person_computed_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_outPgResource.codec)`${resource_person_computed_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_outPgResource.codec)`${resource_person_computed_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_outPgResource.execute(selectArgs);
@@ -28977,18 +29557,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_first_namePgResource.isUnique && !resource_person_first_namePgResource.codec.attributes && typeof resource_person_first_namePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_first_namePgResource.codec)`${resource_person_first_namePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_first_namePgResource.codec)`${resource_person_first_namePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_first_namePgResource.execute(selectArgs);
@@ -29011,18 +29601,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_out_outPgResource.isUnique && !resource_person_computed_out_outPgResource.codec.attributes && typeof resource_person_computed_out_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_out_outPgResource.codec)`${resource_person_computed_out_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_out_outPgResource.codec)`${resource_person_computed_out_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_out_outPgResource.execute(selectArgs);
@@ -29046,18 +29646,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_computed_inoutPgResource.isUnique && !resource_person_computed_inoutPgResource.codec.attributes && typeof resource_person_computed_inoutPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_inoutPgResource.codec)`${resource_person_computed_inoutPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_computed_inoutPgResource.codec)`${resource_person_computed_inoutPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_inoutPgResource.execute(selectArgs);
@@ -29085,18 +29695,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_computed_inout_outPgResource.isUnique && !resource_person_computed_inout_outPgResource.codec.attributes && typeof resource_person_computed_inout_outPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_inout_outPgResource.codec)`${resource_person_computed_inout_outPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_computed_inout_outPgResource.codec)`${resource_person_computed_inout_outPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_inout_outPgResource.execute(selectArgs);
@@ -29124,18 +29744,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_existsPgResource.isUnique && !resource_person_existsPgResource.codec.attributes && typeof resource_person_existsPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_existsPgResource.codec)`${resource_person_existsPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_existsPgResource.codec)`${resource_person_existsPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_existsPgResource.execute(selectArgs);
@@ -29162,23 +29792,33 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_first_arg_inout_outPgResource.isUnique && !resource_person_computed_first_arg_inout_outPgResource.codec.attributes && typeof resource_person_computed_first_arg_inout_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_first_arg_inout_outPgResource.codec)`${resource_person_computed_first_arg_inout_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_first_arg_inout_outPgResource.codec)`${resource_person_computed_first_arg_inout_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_first_arg_inout_outPgResource.execute(selectArgs);
     },
-    computedComplex: {
+    optionalMissingMiddle1: {
       plan($in, args, _info) {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -29195,20 +29835,285 @@ export const plans = {
         const selectArgs = [{
           step: $row.record()
         }, ...extraSelectArgs];
-        if (resource_person_computed_complexPgResource.isUnique && !resource_person_computed_complexPgResource.codec.attributes && typeof resource_person_computed_complexPgResource.from === "function") {
+        if (resource_person_optional_missing_middle_1PgResource.isUnique && !resource_person_optional_missing_middle_1PgResource.codec.attributes && typeof resource_person_optional_missing_middle_1PgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_complexPgResource.codec)`${resource_person_computed_complexPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_optional_missing_middle_1PgResource.codec)`${resource_person_optional_missing_middle_1PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_1PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle2: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs58(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_2PgResource.isUnique && !resource_person_optional_missing_middle_2PgResource.codec.attributes && typeof resource_person_optional_missing_middle_2PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_2PgResource.codec)`${resource_person_optional_missing_middle_2PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_2PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        b: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle3: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs59(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_3PgResource.isUnique && !resource_person_optional_missing_middle_3PgResource.codec.attributes && typeof resource_person_optional_missing_middle_3PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_3PgResource.codec)`${resource_person_optional_missing_middle_3PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_3PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle4: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs60(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_4PgResource.isUnique && !resource_person_optional_missing_middle_4PgResource.codec.attributes && typeof resource_person_optional_missing_middle_4PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_4PgResource.codec)`${resource_person_optional_missing_middle_4PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_4PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        arg2: undefined
+      }
+    },
+    optionalMissingMiddle5: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs61(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_5PgResource.isUnique && !resource_person_optional_missing_middle_5PgResource.codec.attributes && typeof resource_person_optional_missing_middle_5PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_5PgResource.codec)`${resource_person_optional_missing_middle_5PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_5PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        arg2: undefined
+      }
+    },
+    computedComplex: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs62(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_computed_complexPgResource.isUnique && !resource_person_computed_complexPgResource.codec.attributes && typeof resource_person_computed_complexPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_computed_complexPgResource.codec)`${resource_person_computed_complexPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_complexPgResource.execute(selectArgs);
@@ -29222,7 +30127,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs58(args);
+      const extraSelectArgs = makeArgs63(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29236,18 +30141,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_first_postPgResource.isUnique && !resource_person_first_postPgResource.codec.attributes && typeof resource_person_first_postPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_first_postPgResource.codec)`${resource_person_first_postPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_first_postPgResource.codec)`${resource_person_first_postPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_first_postPgResource.execute(selectArgs);
@@ -29256,7 +30171,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs59(args);
+      const extraSelectArgs = makeArgs64(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29270,18 +30185,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_first_arg_inoutPgResource.isUnique && !resource_person_computed_first_arg_inoutPgResource.codec.attributes && typeof resource_person_computed_first_arg_inoutPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_first_arg_inoutPgResource.codec)`${resource_person_computed_first_arg_inoutPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_first_arg_inoutPgResource.codec)`${resource_person_computed_first_arg_inoutPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_first_arg_inoutPgResource.execute(selectArgs);
@@ -29386,7 +30311,7 @@ export const plans = {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
         }
-        const extraSelectArgs = makeArgs62(args);
+        const extraSelectArgs = makeArgs67(args);
         /**
          * An optimisation - if all our dependencies are
          * compatible with the expression's class plan then we
@@ -29400,18 +30325,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_type_functionPgResource.isUnique && !resource_person_type_functionPgResource.codec.attributes && typeof resource_person_type_functionPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_type_functionPgResource.codec)`${resource_person_type_functionPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_type_functionPgResource.codec)`${resource_person_type_functionPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_type_functionPgResource.execute(selectArgs);
@@ -29424,7 +30359,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs63(args);
+      const extraSelectArgs = makeArgs68(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29438,18 +30373,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_type_function_listPgResource.isUnique && !resource_person_type_function_listPgResource.codec.attributes && typeof resource_person_type_function_listPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_type_function_listPgResource.codec)`${resource_person_type_function_listPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_type_function_listPgResource.codec)`${resource_person_type_function_listPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_type_function_listPgResource.execute(selectArgs);
@@ -29796,7 +30741,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs64(args);
+      const extraSelectArgs = makeArgs69(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29810,18 +30755,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_compound_type_computed_fieldPgResource.isUnique && !resource_compound_type_computed_fieldPgResource.codec.attributes && typeof resource_compound_type_computed_fieldPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_compound_type_computed_fieldPgResource.codec)`${resource_compound_type_computed_fieldPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_compound_type_computed_fieldPgResource.codec)`${resource_compound_type_computed_fieldPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_compound_type_computed_fieldPgResource.execute(selectArgs);
@@ -29965,7 +30920,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs66(args);
+      const extraSelectArgs = makeArgs71(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29979,18 +30934,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_post_computed_interval_arrayPgResource.isUnique && !resource_post_computed_interval_arrayPgResource.codec.attributes && typeof resource_post_computed_interval_arrayPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_post_computed_interval_arrayPgResource.codec)`${resource_post_computed_interval_arrayPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_post_computed_interval_arrayPgResource.codec)`${resource_post_computed_interval_arrayPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_post_computed_interval_arrayPgResource.execute(selectArgs);
@@ -29999,7 +30964,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs67(args);
+      const extraSelectArgs = makeArgs72(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -30013,221 +30978,33 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_post_computed_text_arrayPgResource.isUnique && !resource_post_computed_text_arrayPgResource.codec.attributes && typeof resource_post_computed_text_arrayPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_post_computed_text_arrayPgResource.codec)`${resource_post_computed_text_arrayPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_post_computed_text_arrayPgResource.codec)`${resource_post_computed_text_arrayPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_post_computed_text_arrayPgResource.execute(selectArgs);
     },
     computedWithOptionalArg: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs68(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_computed_with_optional_argPgResource.isUnique && !resource_post_computed_with_optional_argPgResource.codec.attributes && typeof resource_post_computed_with_optional_argPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_computed_with_optional_argPgResource.codec)`${resource_post_computed_with_optional_argPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_computed_with_optional_argPgResource.execute(selectArgs);
-      },
-      args: {
-        i: undefined
-      }
-    },
-    computedWithRequiredArg: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs69(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_computed_with_required_argPgResource.isUnique && !resource_post_computed_with_required_argPgResource.codec.attributes && typeof resource_post_computed_with_required_argPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_computed_with_required_argPgResource.codec)`${resource_post_computed_with_required_argPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_computed_with_required_argPgResource.execute(selectArgs);
-      },
-      args: {
-        i: undefined
-      }
-    },
-    headlineTrimmed: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs70(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_headline_trimmedPgResource.isUnique && !resource_post_headline_trimmedPgResource.codec.attributes && typeof resource_post_headline_trimmedPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_headline_trimmedPgResource.codec)`${resource_post_headline_trimmedPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_headline_trimmedPgResource.execute(selectArgs);
-      },
-      args: {
-        length: undefined,
-        omission: undefined
-      }
-    },
-    headlineTrimmedNoDefaults: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs71(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_headline_trimmed_no_defaultsPgResource.isUnique && !resource_post_headline_trimmed_no_defaultsPgResource.codec.attributes && typeof resource_post_headline_trimmed_no_defaultsPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_headline_trimmed_no_defaultsPgResource.codec)`${resource_post_headline_trimmed_no_defaultsPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_headline_trimmed_no_defaultsPgResource.execute(selectArgs);
-      },
-      args: {
-        length: undefined,
-        omission: undefined
-      }
-    },
-    headlineTrimmedStrict: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs72(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_headline_trimmed_strictPgResource.isUnique && !resource_post_headline_trimmed_strictPgResource.codec.attributes && typeof resource_post_headline_trimmed_strictPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_headline_trimmed_strictPgResource.codec)`${resource_post_headline_trimmed_strictPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_headline_trimmed_strictPgResource.execute(selectArgs);
-      },
-      args: {
-        length: undefined,
-        omission: undefined
-      }
-    },
-    computedCompoundTypeArray: {
       plan($in, args, _info) {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -30244,20 +31021,278 @@ export const plans = {
         const selectArgs = [{
           step: $row.record()
         }, ...extraSelectArgs];
-        if (resource_post_computed_compound_type_arrayPgResource.isUnique && !resource_post_computed_compound_type_arrayPgResource.codec.attributes && typeof resource_post_computed_compound_type_arrayPgResource.from === "function") {
+        if (resource_post_computed_with_optional_argPgResource.isUnique && !resource_post_computed_with_optional_argPgResource.codec.attributes && typeof resource_post_computed_with_optional_argPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_post_computed_compound_type_arrayPgResource.codec)`${resource_post_computed_compound_type_arrayPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_post_computed_with_optional_argPgResource.codec)`${resource_post_computed_with_optional_argPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_computed_with_optional_argPgResource.execute(selectArgs);
+      },
+      args: {
+        i: undefined
+      }
+    },
+    computedWithRequiredArg: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs74(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_computed_with_required_argPgResource.isUnique && !resource_post_computed_with_required_argPgResource.codec.attributes && typeof resource_post_computed_with_required_argPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_computed_with_required_argPgResource.codec)`${resource_post_computed_with_required_argPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_computed_with_required_argPgResource.execute(selectArgs);
+      },
+      args: {
+        i: undefined
+      }
+    },
+    headlineTrimmed: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs75(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_headline_trimmedPgResource.isUnique && !resource_post_headline_trimmedPgResource.codec.attributes && typeof resource_post_headline_trimmedPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_headline_trimmedPgResource.codec)`${resource_post_headline_trimmedPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_headline_trimmedPgResource.execute(selectArgs);
+      },
+      args: {
+        length: undefined,
+        omission: undefined
+      }
+    },
+    headlineTrimmedNoDefaults: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs76(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_headline_trimmed_no_defaultsPgResource.isUnique && !resource_post_headline_trimmed_no_defaultsPgResource.codec.attributes && typeof resource_post_headline_trimmed_no_defaultsPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_headline_trimmed_no_defaultsPgResource.codec)`${resource_post_headline_trimmed_no_defaultsPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_headline_trimmed_no_defaultsPgResource.execute(selectArgs);
+      },
+      args: {
+        length: undefined,
+        omission: undefined
+      }
+    },
+    headlineTrimmedStrict: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs77(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_headline_trimmed_strictPgResource.isUnique && !resource_post_headline_trimmed_strictPgResource.codec.attributes && typeof resource_post_headline_trimmed_strictPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_headline_trimmed_strictPgResource.codec)`${resource_post_headline_trimmed_strictPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_headline_trimmed_strictPgResource.execute(selectArgs);
+      },
+      args: {
+        length: undefined,
+        omission: undefined
+      }
+    },
+    computedCompoundTypeArray: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs78(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_computed_compound_type_arrayPgResource.isUnique && !resource_post_computed_compound_type_arrayPgResource.codec.attributes && typeof resource_post_computed_compound_type_arrayPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_computed_compound_type_arrayPgResource.codec)`${resource_post_computed_compound_type_arrayPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_post_computed_compound_type_arrayPgResource.execute(selectArgs);
@@ -38599,7 +39634,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs74(args);
+      const extraSelectArgs = makeArgs79(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -38613,18 +39648,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_edge_case_computedPgResource.isUnique && !resource_edge_case_computedPgResource.codec.attributes && typeof resource_edge_case_computedPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_edge_case_computedPgResource.codec)`${resource_edge_case_computedPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_edge_case_computedPgResource.codec)`${resource_edge_case_computedPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_edge_case_computedPgResource.execute(selectArgs);
@@ -39300,7 +40345,7 @@ export const plans = {
     __assertStep: __ValueStep,
     mutationOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs75(args, ["input"]);
+        const selectArgs = makeArgs80(args, ["input"]);
         const $result = resource_mutation_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39317,7 +40362,7 @@ export const plans = {
     },
     mutationOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs76(args, ["input"]);
+        const selectArgs = makeArgs81(args, ["input"]);
         const $result = resource_mutation_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39334,7 +40379,7 @@ export const plans = {
     },
     mutationOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs77(args, ["input"]);
+        const selectArgs = makeArgs82(args, ["input"]);
         const $result = resource_mutation_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39351,7 +40396,7 @@ export const plans = {
     },
     noArgsMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs78(args, ["input"]);
+        const selectArgs = makeArgs83(args, ["input"]);
         const $result = resource_no_args_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39368,7 +40413,7 @@ export const plans = {
     },
     returnVoidMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs79(args, ["input"]);
+        const selectArgs = makeArgs84(args, ["input"]);
         const $result = resource_return_void_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39385,7 +40430,7 @@ export const plans = {
     },
     mutationIntervalSet: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs80(args, ["input"]);
+        const selectArgs = makeArgs85(args, ["input"]);
         const $result = resource_mutation_interval_setPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39402,7 +40447,7 @@ export const plans = {
     },
     mutationInOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs81(args, ["input"]);
+        const selectArgs = makeArgs86(args, ["input"]);
         const $result = resource_mutation_in_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39419,7 +40464,7 @@ export const plans = {
     },
     mutationReturnsTableOneCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs82(args, ["input"]);
+        const selectArgs = makeArgs87(args, ["input"]);
         const $result = resource_mutation_returns_table_one_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39436,7 +40481,7 @@ export const plans = {
     },
     jsonIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs83(args, ["input"]);
+        const selectArgs = makeArgs88(args, ["input"]);
         const $result = resource_json_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39453,7 +40498,7 @@ export const plans = {
     },
     jsonbIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs84(args, ["input"]);
+        const selectArgs = makeArgs89(args, ["input"]);
         const $result = resource_jsonb_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39470,7 +40515,7 @@ export const plans = {
     },
     jsonbIdentityMutationPlpgsql: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs85(args, ["input"]);
+        const selectArgs = makeArgs90(args, ["input"]);
         const $result = resource_jsonb_identity_mutation_plpgsqlPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39487,7 +40532,7 @@ export const plans = {
     },
     jsonbIdentityMutationPlpgsqlWithDefault: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs86(args, ["input"]);
+        const selectArgs = makeArgs91(args, ["input"]);
         const $result = resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39504,7 +40549,7 @@ export const plans = {
     },
     add1Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs87(args, ["input"]);
+        const selectArgs = makeArgs92(args, ["input"]);
         const $result = resource_add_1_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39521,7 +40566,7 @@ export const plans = {
     },
     add2Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs88(args, ["input"]);
+        const selectArgs = makeArgs93(args, ["input"]);
         const $result = resource_add_2_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39538,7 +40583,7 @@ export const plans = {
     },
     add3Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs89(args, ["input"]);
+        const selectArgs = makeArgs94(args, ["input"]);
         const $result = resource_add_3_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39555,7 +40600,7 @@ export const plans = {
     },
     add4Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs90(args, ["input"]);
+        const selectArgs = makeArgs95(args, ["input"]);
         const $result = resource_add_4_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39572,7 +40617,7 @@ export const plans = {
     },
     add4MutationError: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs91(args, ["input"]);
+        const selectArgs = makeArgs96(args, ["input"]);
         const $result = resource_add_4_mutation_errorPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39589,7 +40634,7 @@ export const plans = {
     },
     mult1: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs92(args, ["input"]);
+        const selectArgs = makeArgs97(args, ["input"]);
         const $result = resource_mult_1PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39606,7 +40651,7 @@ export const plans = {
     },
     mult2: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs93(args, ["input"]);
+        const selectArgs = makeArgs98(args, ["input"]);
         const $result = resource_mult_2PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39623,7 +40668,7 @@ export const plans = {
     },
     mult3: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs94(args, ["input"]);
+        const selectArgs = makeArgs99(args, ["input"]);
         const $result = resource_mult_3PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39640,7 +40685,7 @@ export const plans = {
     },
     mult4: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs95(args, ["input"]);
+        const selectArgs = makeArgs100(args, ["input"]);
         const $result = resource_mult_4PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39657,7 +40702,7 @@ export const plans = {
     },
     mutationInInout: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs96(args, ["input"]);
+        const selectArgs = makeArgs101(args, ["input"]);
         const $result = resource_mutation_in_inoutPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39674,7 +40719,7 @@ export const plans = {
     },
     mutationOutOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs97(args, ["input"]);
+        const selectArgs = makeArgs102(args, ["input"]);
         const $result = resource_mutation_out_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39691,7 +40736,7 @@ export const plans = {
     },
     mutationOutOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs98(args, ["input"]);
+        const selectArgs = makeArgs103(args, ["input"]);
         const $result = resource_mutation_out_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39708,7 +40753,7 @@ export const plans = {
     },
     mutationOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs99(args, ["input"]);
+        const selectArgs = makeArgs104(args, ["input"]);
         const $result = resource_mutation_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39725,7 +40770,7 @@ export const plans = {
     },
     intSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs100(args, ["input"]);
+        const selectArgs = makeArgs105(args, ["input"]);
         const $result = resource_int_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39742,7 +40787,7 @@ export const plans = {
     },
     mutationOutUnnamedOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs101(args, ["input"]);
+        const selectArgs = makeArgs106(args, ["input"]);
         const $result = resource_mutation_out_unnamed_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39759,7 +40804,7 @@ export const plans = {
     },
     mutationReturnsTableMultiCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs102(args, ["input"]);
+        const selectArgs = makeArgs107(args, ["input"]);
         const $result = resource_mutation_returns_table_multi_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39776,7 +40821,7 @@ export const plans = {
     },
     guidFn: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs103(args, ["input"]);
+        const selectArgs = makeArgs108(args, ["input"]);
         const $result = resource_guid_fnPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39793,7 +40838,7 @@ export const plans = {
     },
     mutationIntervalArray: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs104(args, ["input"]);
+        const selectArgs = makeArgs109(args, ["input"]);
         const $result = resource_mutation_interval_arrayPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39810,7 +40855,7 @@ export const plans = {
     },
     mutationTextArray: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs105(args, ["input"]);
+        const selectArgs = makeArgs110(args, ["input"]);
         const $result = resource_mutation_text_arrayPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39827,7 +40872,7 @@ export const plans = {
     },
     listBdeMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs106(args, ["input"]);
+        const selectArgs = makeArgs111(args, ["input"]);
         const $result = resource_list_bde_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39844,7 +40889,7 @@ export const plans = {
     },
     authenticateFail: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs107(args, ["input"]);
+        const selectArgs = makeArgs112(args, ["input"]);
         const $result = resource_authenticate_failPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39861,7 +40906,7 @@ export const plans = {
     },
     authenticate: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs108(args, ["input"]);
+        const selectArgs = makeArgs113(args, ["input"]);
         const $result = resource_authenticatePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39878,7 +40923,7 @@ export const plans = {
     },
     leftArmIdentity: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs109(args, ["input"]);
+        const selectArgs = makeArgs114(args, ["input"]);
         const $result = resource_left_arm_identityPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39895,7 +40940,7 @@ export const plans = {
     },
     issue756Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs110(args, ["input"]);
+        const selectArgs = makeArgs115(args, ["input"]);
         const $result = resource_issue756_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39912,7 +40957,7 @@ export const plans = {
     },
     issue756SetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs111(args, ["input"]);
+        const selectArgs = makeArgs116(args, ["input"]);
         const $result = resource_issue756_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39929,7 +40974,7 @@ export const plans = {
     },
     authenticateMany: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs112(args, ["input"]);
+        const selectArgs = makeArgs117(args, ["input"]);
         const $result = resource_authenticate_manyPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39946,7 +40991,7 @@ export const plans = {
     },
     authenticatePayload: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs113(args, ["input"]);
+        const selectArgs = makeArgs118(args, ["input"]);
         const $result = resource_authenticate_payloadPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39963,7 +41008,7 @@ export const plans = {
     },
     typesMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs114(args, ["input"]);
+        const selectArgs = makeArgs119(args, ["input"]);
         const $result = resource_types_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39980,7 +41025,7 @@ export const plans = {
     },
     mutationOutOutCompoundType: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs115(args, ["input"]);
+        const selectArgs = makeArgs120(args, ["input"]);
         const $result = resource_mutation_out_out_compound_typePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39997,7 +41042,7 @@ export const plans = {
     },
     compoundTypeMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs116(args, ["input"]);
+        const selectArgs = makeArgs121(args, ["input"]);
         const $result = resource_compound_type_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40014,7 +41059,7 @@ export const plans = {
     },
     compoundTypeSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs117(args, ["input"]);
+        const selectArgs = makeArgs122(args, ["input"]);
         const $result = resource_compound_type_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40031,7 +41076,7 @@ export const plans = {
     },
     tableMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs118(args, ["input"]);
+        const selectArgs = makeArgs123(args, ["input"]);
         const $result = resource_table_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40048,7 +41093,7 @@ export const plans = {
     },
     postWithSuffix: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs119(args, ["input"]);
+        const selectArgs = makeArgs124(args, ["input"]);
         const $result = resource_post_with_suffixPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40065,7 +41110,7 @@ export const plans = {
     },
     mutationCompoundTypeArray: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs120(args, ["input"]);
+        const selectArgs = makeArgs125(args, ["input"]);
         const $result = resource_mutation_compound_type_arrayPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40082,7 +41127,7 @@ export const plans = {
     },
     compoundTypeArrayMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs121(args, ["input"]);
+        const selectArgs = makeArgs126(args, ["input"]);
         const $result = resource_compound_type_array_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40099,7 +41144,7 @@ export const plans = {
     },
     postMany: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs122(args, ["input"]);
+        const selectArgs = makeArgs127(args, ["input"]);
         const $result = resource_post_manyPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40116,7 +41161,7 @@ export const plans = {
     },
     mutationOutComplex: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs123(args, ["input"]);
+        const selectArgs = makeArgs128(args, ["input"]);
         const $result = resource_mutation_out_complexPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40133,7 +41178,7 @@ export const plans = {
     },
     mutationOutComplexSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs124(args, ["input"]);
+        const selectArgs = makeArgs129(args, ["input"]);
         const $result = resource_mutation_out_complex_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40150,7 +41195,7 @@ export const plans = {
     },
     mutationOutTable: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs125(args, ["input"]);
+        const selectArgs = makeArgs130(args, ["input"]);
         const $result = resource_mutation_out_tablePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40167,7 +41212,7 @@ export const plans = {
     },
     mutationOutTableSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs126(args, ["input"]);
+        const selectArgs = makeArgs131(args, ["input"]);
         const $result = resource_mutation_out_table_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40184,7 +41229,7 @@ export const plans = {
     },
     tableSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs127(args, ["input"]);
+        const selectArgs = makeArgs132(args, ["input"]);
         const $result = resource_table_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40201,7 +41246,7 @@ export const plans = {
     },
     typeFunctionConnectionMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs128(args, ["input"]);
+        const selectArgs = makeArgs133(args, ["input"]);
         const $result = resource_type_function_connection_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40218,7 +41263,7 @@ export const plans = {
     },
     typeFunctionMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs129(args, ["input"]);
+        const selectArgs = makeArgs134(args, ["input"]);
         const $result = resource_type_function_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40235,7 +41280,7 @@ export const plans = {
     },
     typeFunctionListMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs130(args, ["input"]);
+        const selectArgs = makeArgs135(args, ["input"]);
         const $result = resource_type_function_list_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result

--- a/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.graphql
@@ -5920,6 +5920,11 @@ type Person implements N {
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, arg2: Int, b: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
 
   """This `Person`'s `PersonSecret`."""
   personSecretByPersonId: PersonSecret @deprecated(reason: "This is deprecated (comment on table c.person_secret).")

--- a/postgraphile/postgraphile/__tests__/schema/v4/js-reserved.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/js-reserved.1.export.mjs
@@ -9136,18 +9136,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_null_yieldPgResource.isUnique && !resource_null_yieldPgResource.codec.attributes && typeof resource_null_yieldPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_null_yieldPgResource.codec)`${resource_null_yieldPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_null_yieldPgResource.codec)`${resource_null_yieldPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_null_yieldPgResource.execute(selectArgs);

--- a/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.export.mjs
@@ -2502,6 +2502,11 @@ const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_compu
 const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
 const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
 const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const person_optional_missing_middle_1FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_1");
+const person_optional_missing_middle_2FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_2");
+const person_optional_missing_middle_3FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_3");
+const person_optional_missing_middle_4FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_4");
+const person_optional_missing_middle_5FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_5");
 const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
 const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
 const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
@@ -4292,6 +4297,216 @@ const registry = makeRegistry({
           serviceName: "main",
           schemaName: "c",
           name: "person_computed_first_arg_inout_out"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_1: {
+      executor,
+      name: "person_optional_missing_middle_1",
+      identifier: "main.c.person_optional_missing_middle_1(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_1"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_2: {
+      executor,
+      name: "person_optional_missing_middle_2",
+      identifier: "main.c.person_optional_missing_middle_2(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_2"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_3: {
+      executor,
+      name: "person_optional_missing_middle_3",
+      identifier: "main.c.person_optional_missing_middle_3(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_3"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_4: {
+      executor,
+      name: "person_optional_missing_middle_4",
+      identifier: "main.c.person_optional_missing_middle_4(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_4"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_5: {
+      executor,
+      name: "person_optional_missing_middle_5",
+      identifier: "main.c.person_optional_missing_middle_5(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_5FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_5"
         },
         tags: {}
       },
@@ -7093,22 +7308,28 @@ const makeArgs37 = (args, path = []) => {
 };
 const resource_person_computed_first_arg_inout_outPgResource = registry.pgResources["person_computed_first_arg_inout_out"];
 const argDetailsSimple38 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
+  graphqlArgName: "arg0",
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
   graphqlArgName: "b",
   postgresArgName: "b",
-  pgCodec: TYPES.text,
-  required: true,
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
   fetcher: null
 }];
 const makeArgs38 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7119,7 +7340,7 @@ const makeArgs38 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 1 - 1) {
         skipped = true;
         continue;
       } else {
@@ -7149,12 +7370,30 @@ const makeArgs38 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
-const argDetailsSimple39 = [];
+const resource_person_optional_missing_middle_1PgResource = registry.pgResources["person_optional_missing_middle_1"];
+const argDetailsSimple39 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs39 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7195,12 +7434,30 @@ const makeArgs39 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
-const argDetailsSimple40 = [];
+const resource_person_optional_missing_middle_2PgResource = registry.pgResources["person_optional_missing_middle_2"];
+const argDetailsSimple40 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs40 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7211,7 +7468,7 @@ const makeArgs40 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 2 - 1) {
         skipped = true;
         continue;
       } else {
@@ -7241,12 +7498,30 @@ const makeArgs40 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
-const argDetailsSimple41 = [];
+const resource_person_optional_missing_middle_3PgResource = registry.pgResources["person_optional_missing_middle_3"];
+const argDetailsSimple41 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs41 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7257,7 +7532,7 @@ const makeArgs41 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -7287,46 +7562,30 @@ const makeArgs41 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_friendsPgResource = registry.pgResources["person_friends"];
-const getSelectPlanFromParentAndArgs12 = ($in, args, _info) => {
-  if (!hasRecord($in)) {
-    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-  }
-  const extraSelectArgs = makeArgs41(args);
-  /**
-   * An optimisation - if all our dependencies are
-   * compatible with the expression's class plan then we
-   * can inline ourselves into that, otherwise we must
-   * issue the query separately.
-   */
-  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-  const selectArgs = [{
-    step: $row.record()
-  }, ...extraSelectArgs];
-  if (resource_person_friendsPgResource.isUnique && !resource_person_friendsPgResource.codec.attributes && typeof resource_person_friendsPgResource.from === "function") {
-    // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
-      if (i === 0) {
-        return $row.getClassStep().alias;
-      } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
-      } else {
-        return $row.placeholder(arg.step);
-      }
-    });
-    return pgClassExpression($row, resource_person_friendsPgResource.codec)`${resource_person_friendsPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
-  }
-  // PERF: or here, if scalar add select to `$row`?
-  return resource_person_friendsPgResource.execute(selectArgs);
-};
-const argDetailsSimple42 = [];
+const resource_person_optional_missing_middle_4PgResource = registry.pgResources["person_optional_missing_middle_4"];
+const argDetailsSimple42 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs42 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7337,7 +7596,7 @@ const makeArgs42 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -7367,52 +7626,24 @@ const makeArgs42 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
-const getSelectPlanFromParentAndArgs13 = ($in, args, _info) => {
-  if (!hasRecord($in)) {
-    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-  }
-  const extraSelectArgs = makeArgs42(args);
-  /**
-   * An optimisation - if all our dependencies are
-   * compatible with the expression's class plan then we
-   * can inline ourselves into that, otherwise we must
-   * issue the query separately.
-   */
-  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-  const selectArgs = [{
-    step: $row.record()
-  }, ...extraSelectArgs];
-  if (resource_person_type_function_connectionPgResource.isUnique && !resource_person_type_function_connectionPgResource.codec.attributes && typeof resource_person_type_function_connectionPgResource.from === "function") {
-    // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
-      if (i === 0) {
-        return $row.getClassStep().alias;
-      } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
-      } else {
-        return $row.placeholder(arg.step);
-      }
-    });
-    return pgClassExpression($row, resource_person_type_function_connectionPgResource.codec)`${resource_person_type_function_connectionPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
-  }
-  // PERF: or here, if scalar add select to `$row`?
-  return resource_person_type_function_connectionPgResource.execute(selectArgs);
-};
+const resource_person_optional_missing_middle_5PgResource = registry.pgResources["person_optional_missing_middle_5"];
 const argDetailsSimple43 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs43 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7453,7 +7684,7 @@ const makeArgs43 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
+const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
 const argDetailsSimple44 = [];
 const makeArgs44 = (args, path = []) => {
   const selectArgs = [];
@@ -7499,9 +7730,7 @@ const makeArgs44 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
-const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
-const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
+const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
 const argDetailsSimple45 = [];
 const makeArgs45 = (args, path = []) => {
   const selectArgs = [];
@@ -7514,6 +7743,332 @@ const makeArgs45 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple45[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
+const argDetailsSimple46 = [];
+const makeArgs46 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple46[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_person_friendsPgResource = registry.pgResources["person_friends"];
+const getSelectPlanFromParentAndArgs12 = ($in, args, _info) => {
+  if (!hasRecord($in)) {
+    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+  }
+  const extraSelectArgs = makeArgs46(args);
+  /**
+   * An optimisation - if all our dependencies are
+   * compatible with the expression's class plan then we
+   * can inline ourselves into that, otherwise we must
+   * issue the query separately.
+   */
+  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+  const selectArgs = [{
+    step: $row.record()
+  }, ...extraSelectArgs];
+  if (resource_person_friendsPgResource.isUnique && !resource_person_friendsPgResource.codec.attributes && typeof resource_person_friendsPgResource.from === "function") {
+    // This is a scalar computed attribute, let's inline the expression
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
+      if (i === 0) {
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
+      } else if ("pgCodec" in arg && arg.pgCodec) {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
+      } else {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
+      }
+    });
+    return pgClassExpression($row, resource_person_friendsPgResource.codec)`${resource_person_friendsPgResource.from(...newSelectArgs)}`;
+  }
+  // PERF: or here, if scalar add select to `$row`?
+  return resource_person_friendsPgResource.execute(selectArgs);
+};
+const argDetailsSimple47 = [];
+const makeArgs47 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple47[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
+const getSelectPlanFromParentAndArgs13 = ($in, args, _info) => {
+  if (!hasRecord($in)) {
+    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+  }
+  const extraSelectArgs = makeArgs47(args);
+  /**
+   * An optimisation - if all our dependencies are
+   * compatible with the expression's class plan then we
+   * can inline ourselves into that, otherwise we must
+   * issue the query separately.
+   */
+  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+  const selectArgs = [{
+    step: $row.record()
+  }, ...extraSelectArgs];
+  if (resource_person_type_function_connectionPgResource.isUnique && !resource_person_type_function_connectionPgResource.codec.attributes && typeof resource_person_type_function_connectionPgResource.from === "function") {
+    // This is a scalar computed attribute, let's inline the expression
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
+      if (i === 0) {
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
+      } else if ("pgCodec" in arg && arg.pgCodec) {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
+      } else {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
+      }
+    });
+    return pgClassExpression($row, resource_person_type_function_connectionPgResource.codec)`${resource_person_type_function_connectionPgResource.from(...newSelectArgs)}`;
+  }
+  // PERF: or here, if scalar add select to `$row`?
+  return resource_person_type_function_connectionPgResource.execute(selectArgs);
+};
+const argDetailsSimple48 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs48 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple48[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
+const argDetailsSimple49 = [];
+const makeArgs49 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple49[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
+const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
+const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
+const argDetailsSimple50 = [];
+const makeArgs50 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple50[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -7614,247 +8169,11 @@ const parseValueLiteral = (ast, variables) => {
   }
 };
 const resource_frmcdc_postPgResource = registry.pgResources["frmcdc_post"];
-const argDetailsSimple46 = [];
-const makeArgs46 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple46[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
-const argDetailsSimple47 = [];
-const makeArgs47 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple47[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
-const argDetailsSimple48 = [];
-const makeArgs48 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple48[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
-const argDetailsSimple49 = [];
-const makeArgs49 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple49[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
-const argDetailsSimple50 = [];
-const makeArgs50 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple50[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
-const argDetailsSimple51 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const argDetailsSimple51 = [];
 const makeArgs51 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7895,18 +8214,12 @@ const makeArgs51 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
-const argDetailsSimple52 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
+const argDetailsSimple52 = [];
 const makeArgs52 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7947,18 +8260,12 @@ const makeArgs52 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
-const argDetailsSimple53 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
+const argDetailsSimple53 = [];
 const makeArgs53 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7999,18 +8306,12 @@ const makeArgs53 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
-const argDetailsSimple54 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
+const argDetailsSimple54 = [];
 const makeArgs54 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8051,18 +8352,12 @@ const makeArgs54 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
-const argDetailsSimple55 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
+const argDetailsSimple55 = [];
 const makeArgs55 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8103,12 +8398,12 @@ const makeArgs55 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
+const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
 const argDetailsSimple56 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: false,
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
   fetcher: null
 }];
 const makeArgs56 = (args, path = []) => {
@@ -8155,16 +8450,10 @@ const makeArgs56 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
+const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
 const argDetailsSimple57 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "ino",
-  postgresArgName: "ino",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -8172,7 +8461,7 @@ const argDetailsSimple57 = [{
 const makeArgs57 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8213,12 +8502,18 @@ const makeArgs57 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
-const argDetailsSimple58 = [];
+const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
+const argDetailsSimple58 = [{
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.json,
+  required: true,
+  fetcher: null
+}];
 const makeArgs58 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8259,12 +8554,18 @@ const makeArgs58 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
-const argDetailsSimple59 = [];
+const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
+const argDetailsSimple59 = [{
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.jsonb,
+  required: true,
+  fetcher: null
+}];
 const makeArgs59 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8305,12 +8606,18 @@ const makeArgs59 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
-const argDetailsSimple60 = [];
+const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
+const argDetailsSimple60 = [{
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
+  required: true,
+  fetcher: null
+}];
 const makeArgs60 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8351,30 +8658,18 @@ const makeArgs60 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
+const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
 const argDetailsSimple61 = [{
-  graphqlArgName: "x",
-  postgresArgName: "x",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "y",
-  postgresArgName: "y",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "z",
-  postgresArgName: "z",
-  pgCodec: TYPES.int,
-  required: true,
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
+  required: false,
   fetcher: null
 }];
 const makeArgs61 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8415,12 +8710,24 @@ const makeArgs61 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
-const argDetailsSimple62 = [];
+const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
+const argDetailsSimple62 = [{
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "ino",
+  postgresArgName: "ino",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs62 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8461,18 +8768,12 @@ const makeArgs62 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
-const argDetailsSimple63 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
+const argDetailsSimple63 = [];
 const makeArgs63 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8513,18 +8814,12 @@ const makeArgs63 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
-const argDetailsSimple64 = [{
-  graphqlArgName: "leftArm",
-  postgresArgName: "left_arm",
-  pgCodec: leftArmCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
+const argDetailsSimple64 = [];
 const makeArgs64 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8565,7 +8860,7 @@ const makeArgs64 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
+const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -8611,12 +8906,30 @@ const makeArgs65 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
-const argDetailsSimple66 = [];
+const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
+const argDetailsSimple66 = [{
+  graphqlArgName: "x",
+  postgresArgName: "x",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "y",
+  postgresArgName: "y",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "z",
+  postgresArgName: "z",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs66 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8657,48 +8970,12 @@ const makeArgs66 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
-const argDetailsSimple67 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.bigint,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.boolean,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.varchar,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "d",
-  postgresArgName: "d",
-  pgCodec: int4ArrayCodec,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "e",
-  postgresArgName: "e",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "f",
-  postgresArgName: "f",
-  pgCodec: floatrangeCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
+const argDetailsSimple67 = [];
 const makeArgs67 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 6; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8739,10 +9016,10 @@ const makeArgs67 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
+const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
 const argDetailsSimple68 = [{
-  graphqlArgName: "i1",
-  postgresArgName: "i1",
+  graphqlArgName: "i",
+  postgresArgName: "i",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -8791,11 +9068,11 @@ const makeArgs68 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
+const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
 const argDetailsSimple69 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
-  pgCodec: TYPES.int,
+  graphqlArgName: "leftArm",
+  postgresArgName: "left_arm",
+  pgCodec: leftArmCodec,
   required: true,
   fetcher: null
 }];
@@ -8843,24 +9120,12 @@ const makeArgs69 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
-const argDetailsSimple70 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
+const argDetailsSimple70 = [];
 const makeArgs70 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8901,24 +9166,12 @@ const makeArgs70 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
-const argDetailsSimple71 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
+const argDetailsSimple71 = [];
 const makeArgs71 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8959,12 +9212,48 @@ const makeArgs71 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
-const argDetailsSimple72 = [];
+const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
+const argDetailsSimple72 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.bigint,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.boolean,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.varchar,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "d",
+  postgresArgName: "d",
+  pgCodec: int4ArrayCodec,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "e",
+  postgresArgName: "e",
+  pgCodec: TYPES.json,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "f",
+  postgresArgName: "f",
+  pgCodec: floatrangeCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs72 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 6; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -9005,12 +9294,18 @@ const makeArgs72 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
-const argDetailsSimple73 = [];
+const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
+const argDetailsSimple73 = [{
+  graphqlArgName: "i1",
+  postgresArgName: "i1",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs73 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -9051,9 +9346,177 @@ const makeArgs73 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
-const argDetailsSimple74 = [];
+const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
+const argDetailsSimple74 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs74 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple74[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
+const argDetailsSimple75 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
+const makeArgs75 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple75[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
+const argDetailsSimple76 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
+const makeArgs76 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple76[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
+const argDetailsSimple77 = [];
+const makeArgs77 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
   for (let i = 0; i < 0; i++) {
@@ -9063,7 +9526,99 @@ const makeArgs74 = (args, path = []) => {
       pgCodec,
       required,
       fetcher
-    } = argDetailsSimple74[i];
+    } = argDetailsSimple77[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
+const argDetailsSimple78 = [];
+const makeArgs78 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple78[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
+const argDetailsSimple79 = [];
+const makeArgs79 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple79[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -9756,6 +10311,11 @@ type Person implements Node {
   computedInoutOut(ino: String): PersonComputedInoutOutRecord
   exists(email: Email): Boolean @deprecated(reason: "This is deprecated (comment on function c.person_exists).")
   computedFirstArgInoutOut: PersonComputedFirstArgInoutOutRecord
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, b: Int, arg2: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
   computedComplex(a: Int, b: String): PersonComputedComplexRecord
 
   """The first post by the person."""
@@ -13307,18 +13867,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_outPgResource.isUnique && !resource_person_computed_outPgResource.codec.attributes && typeof resource_person_computed_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_outPgResource.codec)`${resource_person_computed_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_outPgResource.codec)`${resource_person_computed_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_outPgResource.execute(selectArgs);
@@ -13341,18 +13911,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_first_namePgResource.isUnique && !resource_person_first_namePgResource.codec.attributes && typeof resource_person_first_namePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_first_namePgResource.codec)`${resource_person_first_namePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_first_namePgResource.codec)`${resource_person_first_namePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_first_namePgResource.execute(selectArgs);
@@ -13375,18 +13955,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_out_outPgResource.isUnique && !resource_person_computed_out_outPgResource.codec.attributes && typeof resource_person_computed_out_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_out_outPgResource.codec)`${resource_person_computed_out_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_out_outPgResource.codec)`${resource_person_computed_out_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_out_outPgResource.execute(selectArgs);
@@ -13410,18 +14000,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_computed_inoutPgResource.isUnique && !resource_person_computed_inoutPgResource.codec.attributes && typeof resource_person_computed_inoutPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_inoutPgResource.codec)`${resource_person_computed_inoutPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_computed_inoutPgResource.codec)`${resource_person_computed_inoutPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_inoutPgResource.execute(selectArgs);
@@ -13449,18 +14049,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_computed_inout_outPgResource.isUnique && !resource_person_computed_inout_outPgResource.codec.attributes && typeof resource_person_computed_inout_outPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_inout_outPgResource.codec)`${resource_person_computed_inout_outPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_computed_inout_outPgResource.codec)`${resource_person_computed_inout_outPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_inout_outPgResource.execute(selectArgs);
@@ -13488,18 +14098,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_existsPgResource.isUnique && !resource_person_existsPgResource.codec.attributes && typeof resource_person_existsPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_existsPgResource.codec)`${resource_person_existsPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_existsPgResource.codec)`${resource_person_existsPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_existsPgResource.execute(selectArgs);
@@ -13526,23 +14146,33 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_first_arg_inout_outPgResource.isUnique && !resource_person_computed_first_arg_inout_outPgResource.codec.attributes && typeof resource_person_computed_first_arg_inout_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_first_arg_inout_outPgResource.codec)`${resource_person_computed_first_arg_inout_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_first_arg_inout_outPgResource.codec)`${resource_person_computed_first_arg_inout_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_first_arg_inout_outPgResource.execute(selectArgs);
     },
-    computedComplex: {
+    optionalMissingMiddle1: {
       plan($in, args, _info) {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -13559,20 +14189,285 @@ export const plans = {
         const selectArgs = [{
           step: $row.record()
         }, ...extraSelectArgs];
-        if (resource_person_computed_complexPgResource.isUnique && !resource_person_computed_complexPgResource.codec.attributes && typeof resource_person_computed_complexPgResource.from === "function") {
+        if (resource_person_optional_missing_middle_1PgResource.isUnique && !resource_person_optional_missing_middle_1PgResource.codec.attributes && typeof resource_person_optional_missing_middle_1PgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_complexPgResource.codec)`${resource_person_computed_complexPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_optional_missing_middle_1PgResource.codec)`${resource_person_optional_missing_middle_1PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_1PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle2: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs39(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_2PgResource.isUnique && !resource_person_optional_missing_middle_2PgResource.codec.attributes && typeof resource_person_optional_missing_middle_2PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_2PgResource.codec)`${resource_person_optional_missing_middle_2PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_2PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        b: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle3: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs40(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_3PgResource.isUnique && !resource_person_optional_missing_middle_3PgResource.codec.attributes && typeof resource_person_optional_missing_middle_3PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_3PgResource.codec)`${resource_person_optional_missing_middle_3PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_3PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle4: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs41(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_4PgResource.isUnique && !resource_person_optional_missing_middle_4PgResource.codec.attributes && typeof resource_person_optional_missing_middle_4PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_4PgResource.codec)`${resource_person_optional_missing_middle_4PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_4PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        arg2: undefined
+      }
+    },
+    optionalMissingMiddle5: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs42(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_5PgResource.isUnique && !resource_person_optional_missing_middle_5PgResource.codec.attributes && typeof resource_person_optional_missing_middle_5PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_5PgResource.codec)`${resource_person_optional_missing_middle_5PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_5PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        arg2: undefined
+      }
+    },
+    computedComplex: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs43(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_computed_complexPgResource.isUnique && !resource_person_computed_complexPgResource.codec.attributes && typeof resource_person_computed_complexPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_computed_complexPgResource.codec)`${resource_person_computed_complexPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_complexPgResource.execute(selectArgs);
@@ -13586,7 +14481,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs39(args);
+      const extraSelectArgs = makeArgs44(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -13600,18 +14495,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_first_postPgResource.isUnique && !resource_person_first_postPgResource.codec.attributes && typeof resource_person_first_postPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_first_postPgResource.codec)`${resource_person_first_postPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_first_postPgResource.codec)`${resource_person_first_postPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_first_postPgResource.execute(selectArgs);
@@ -13620,7 +14525,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs40(args);
+      const extraSelectArgs = makeArgs45(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -13634,18 +14539,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_first_arg_inoutPgResource.isUnique && !resource_person_computed_first_arg_inoutPgResource.codec.attributes && typeof resource_person_computed_first_arg_inoutPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_first_arg_inoutPgResource.codec)`${resource_person_computed_first_arg_inoutPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_first_arg_inoutPgResource.codec)`${resource_person_computed_first_arg_inoutPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_first_arg_inoutPgResource.execute(selectArgs);
@@ -13750,7 +14665,7 @@ export const plans = {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
         }
-        const extraSelectArgs = makeArgs43(args);
+        const extraSelectArgs = makeArgs48(args);
         /**
          * An optimisation - if all our dependencies are
          * compatible with the expression's class plan then we
@@ -13764,18 +14679,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_type_functionPgResource.isUnique && !resource_person_type_functionPgResource.codec.attributes && typeof resource_person_type_functionPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_type_functionPgResource.codec)`${resource_person_type_functionPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_type_functionPgResource.codec)`${resource_person_type_functionPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_type_functionPgResource.execute(selectArgs);
@@ -13788,7 +14713,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs44(args);
+      const extraSelectArgs = makeArgs49(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -13802,18 +14727,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_type_function_listPgResource.isUnique && !resource_person_type_function_listPgResource.codec.attributes && typeof resource_person_type_function_listPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_type_function_listPgResource.codec)`${resource_person_type_function_listPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_type_function_listPgResource.codec)`${resource_person_type_function_listPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_type_function_listPgResource.execute(selectArgs);
@@ -14048,7 +14983,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs45(args);
+      const extraSelectArgs = makeArgs50(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -14062,18 +14997,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_compound_type_computed_fieldPgResource.isUnique && !resource_compound_type_computed_fieldPgResource.codec.attributes && typeof resource_compound_type_computed_fieldPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_compound_type_computed_fieldPgResource.codec)`${resource_compound_type_computed_fieldPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_compound_type_computed_fieldPgResource.codec)`${resource_compound_type_computed_fieldPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_compound_type_computed_fieldPgResource.execute(selectArgs);
@@ -16808,7 +17753,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs46(args);
+      const extraSelectArgs = makeArgs51(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -16822,18 +17767,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_edge_case_computedPgResource.isUnique && !resource_edge_case_computedPgResource.codec.attributes && typeof resource_edge_case_computedPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_edge_case_computedPgResource.codec)`${resource_edge_case_computedPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_edge_case_computedPgResource.codec)`${resource_edge_case_computedPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_edge_case_computedPgResource.execute(selectArgs);
@@ -17509,7 +18464,7 @@ export const plans = {
     __assertStep: __ValueStep,
     mutationOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs47(args, ["input"]);
+        const selectArgs = makeArgs52(args, ["input"]);
         const $result = resource_mutation_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17526,7 +18481,7 @@ export const plans = {
     },
     mutationOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs48(args, ["input"]);
+        const selectArgs = makeArgs53(args, ["input"]);
         const $result = resource_mutation_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17543,7 +18498,7 @@ export const plans = {
     },
     mutationOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs49(args, ["input"]);
+        const selectArgs = makeArgs54(args, ["input"]);
         const $result = resource_mutation_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17560,7 +18515,7 @@ export const plans = {
     },
     noArgsMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs50(args, ["input"]);
+        const selectArgs = makeArgs55(args, ["input"]);
         const $result = resource_no_args_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17577,7 +18532,7 @@ export const plans = {
     },
     mutationInOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs51(args, ["input"]);
+        const selectArgs = makeArgs56(args, ["input"]);
         const $result = resource_mutation_in_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17594,7 +18549,7 @@ export const plans = {
     },
     mutationReturnsTableOneCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs52(args, ["input"]);
+        const selectArgs = makeArgs57(args, ["input"]);
         const $result = resource_mutation_returns_table_one_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17611,7 +18566,7 @@ export const plans = {
     },
     jsonIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs53(args, ["input"]);
+        const selectArgs = makeArgs58(args, ["input"]);
         const $result = resource_json_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17628,7 +18583,7 @@ export const plans = {
     },
     jsonbIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs54(args, ["input"]);
+        const selectArgs = makeArgs59(args, ["input"]);
         const $result = resource_jsonb_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17645,7 +18600,7 @@ export const plans = {
     },
     jsonbIdentityMutationPlpgsql: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs55(args, ["input"]);
+        const selectArgs = makeArgs60(args, ["input"]);
         const $result = resource_jsonb_identity_mutation_plpgsqlPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17662,7 +18617,7 @@ export const plans = {
     },
     jsonbIdentityMutationPlpgsqlWithDefault: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs56(args, ["input"]);
+        const selectArgs = makeArgs61(args, ["input"]);
         const $result = resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17679,7 +18634,7 @@ export const plans = {
     },
     mutationInInout: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs57(args, ["input"]);
+        const selectArgs = makeArgs62(args, ["input"]);
         const $result = resource_mutation_in_inoutPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17696,7 +18651,7 @@ export const plans = {
     },
     mutationOutOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs58(args, ["input"]);
+        const selectArgs = makeArgs63(args, ["input"]);
         const $result = resource_mutation_out_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17713,7 +18668,7 @@ export const plans = {
     },
     mutationOutOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs59(args, ["input"]);
+        const selectArgs = makeArgs64(args, ["input"]);
         const $result = resource_mutation_out_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17730,7 +18685,7 @@ export const plans = {
     },
     mutationOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs60(args, ["input"]);
+        const selectArgs = makeArgs65(args, ["input"]);
         const $result = resource_mutation_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17747,7 +18702,7 @@ export const plans = {
     },
     intSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs61(args, ["input"]);
+        const selectArgs = makeArgs66(args, ["input"]);
         const $result = resource_int_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17764,7 +18719,7 @@ export const plans = {
     },
     mutationOutUnnamedOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs62(args, ["input"]);
+        const selectArgs = makeArgs67(args, ["input"]);
         const $result = resource_mutation_out_unnamed_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17781,7 +18736,7 @@ export const plans = {
     },
     mutationReturnsTableMultiCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs63(args, ["input"]);
+        const selectArgs = makeArgs68(args, ["input"]);
         const $result = resource_mutation_returns_table_multi_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17798,7 +18753,7 @@ export const plans = {
     },
     leftArmIdentity: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs64(args, ["input"]);
+        const selectArgs = makeArgs69(args, ["input"]);
         const $result = resource_left_arm_identityPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17815,7 +18770,7 @@ export const plans = {
     },
     issue756Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs65(args, ["input"]);
+        const selectArgs = makeArgs70(args, ["input"]);
         const $result = resource_issue756_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17832,7 +18787,7 @@ export const plans = {
     },
     issue756SetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs66(args, ["input"]);
+        const selectArgs = makeArgs71(args, ["input"]);
         const $result = resource_issue756_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17849,7 +18804,7 @@ export const plans = {
     },
     typesMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs67(args, ["input"]);
+        const selectArgs = makeArgs72(args, ["input"]);
         const $result = resource_types_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17866,7 +18821,7 @@ export const plans = {
     },
     mutationOutOutCompoundType: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs68(args, ["input"]);
+        const selectArgs = makeArgs73(args, ["input"]);
         const $result = resource_mutation_out_out_compound_typePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17883,7 +18838,7 @@ export const plans = {
     },
     tableMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs69(args, ["input"]);
+        const selectArgs = makeArgs74(args, ["input"]);
         const $result = resource_table_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17900,7 +18855,7 @@ export const plans = {
     },
     mutationOutComplex: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs70(args, ["input"]);
+        const selectArgs = makeArgs75(args, ["input"]);
         const $result = resource_mutation_out_complexPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17917,7 +18872,7 @@ export const plans = {
     },
     mutationOutComplexSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs71(args, ["input"]);
+        const selectArgs = makeArgs76(args, ["input"]);
         const $result = resource_mutation_out_complex_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17934,7 +18889,7 @@ export const plans = {
     },
     mutationOutTable: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs72(args, ["input"]);
+        const selectArgs = makeArgs77(args, ["input"]);
         const $result = resource_mutation_out_tablePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17951,7 +18906,7 @@ export const plans = {
     },
     mutationOutTableSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs73(args, ["input"]);
+        const selectArgs = makeArgs78(args, ["input"]);
         const $result = resource_mutation_out_table_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17968,7 +18923,7 @@ export const plans = {
     },
     tableSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs74(args, ["input"]);
+        const selectArgs = makeArgs79(args, ["input"]);
         const $result = resource_table_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result

--- a/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.graphql
@@ -1918,6 +1918,11 @@ type Person implements Node {
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, arg2: Int, b: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
 
   """This `Person`'s `PersonSecret`."""
   personSecretByPersonId: PersonSecret @deprecated(reason: "This is deprecated (comment on table c.person_secret).")

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.1.export.mjs
@@ -5079,18 +5079,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_full_namePgResource.isUnique && !resource_person_full_namePgResource.codec.attributes && typeof resource_person_full_namePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_full_namePgResource.codec)`${resource_person_full_namePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_full_namePgResource.codec)`${resource_person_full_namePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_full_namePgResource.execute(selectArgs);

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.1.export.mjs
@@ -5081,18 +5081,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_full_namePgResource.isUnique && !resource_person_full_namePgResource.codec.attributes && typeof resource_person_full_namePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_full_namePgResource.codec)`${resource_person_full_namePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_full_namePgResource.codec)`${resource_person_full_namePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_full_namePgResource.execute(selectArgs);

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.loads-title.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.loads-title.1.export.mjs
@@ -5076,18 +5076,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_full_namePgResource.isUnique && !resource_person_full_namePgResource.codec.attributes && typeof resource_person_full_namePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_full_namePgResource.codec)`${resource_person_full_namePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_full_namePgResource.codec)`${resource_person_full_namePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_full_namePgResource.execute(selectArgs);

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.shows-title-asterisk.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.shows-title-asterisk.1.export.mjs
@@ -4949,18 +4949,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_full_namePgResource.isUnique && !resource_person_full_namePgResource.codec.attributes && typeof resource_person_full_namePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_full_namePgResource.codec)`${resource_person_full_namePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_full_namePgResource.codec)`${resource_person_full_namePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_full_namePgResource.execute(selectArgs);

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.title-order.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.title-order.1.export.mjs
@@ -5046,18 +5046,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_full_namePgResource.isUnique && !resource_person_full_namePgResource.codec.attributes && typeof resource_person_full_namePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_full_namePgResource.codec)`${resource_person_full_namePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_full_namePgResource.codec)`${resource_person_full_namePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_full_namePgResource.execute(selectArgs);

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.update-title.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitcolumns.update-title.1.export.mjs
@@ -5081,18 +5081,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_full_namePgResource.isUnique && !resource_person_full_namePgResource.codec.attributes && typeof resource_person_full_namePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_full_namePgResource.codec)`${resource_person_full_namePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_full_namePgResource.codec)`${resource_person_full_namePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_full_namePgResource.execute(selectArgs);

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.1.export.mjs
@@ -4885,18 +4885,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_full_namePgResource.isUnique && !resource_person_full_namePgResource.codec.attributes && typeof resource_person_full_namePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_full_namePgResource.codec)`${resource_person_full_namePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_full_namePgResource.codec)`${resource_person_full_namePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_full_namePgResource.execute(selectArgs);

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.constraints.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.constraints.1.export.mjs
@@ -4351,18 +4351,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_full_namePgResource.isUnique && !resource_person_full_namePgResource.codec.attributes && typeof resource_person_full_namePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_full_namePgResource.codec)`${resource_person_full_namePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_full_namePgResource.codec)`${resource_person_full_namePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_full_namePgResource.execute(selectArgs);

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-asterisk.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-asterisk.1.export.mjs
@@ -3545,18 +3545,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_full_namePgResource.isUnique && !resource_person_full_namePgResource.codec.attributes && typeof resource_person_full_namePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_full_namePgResource.codec)`${resource_person_full_namePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_full_namePgResource.codec)`${resource_person_full_namePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_full_namePgResource.execute(selectArgs);

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-create.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-create.1.export.mjs
@@ -5036,18 +5036,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_full_namePgResource.isUnique && !resource_person_full_namePgResource.codec.attributes && typeof resource_person_full_namePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_full_namePgResource.codec)`${resource_person_full_namePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_full_namePgResource.codec)`${resource_person_full_namePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_full_namePgResource.execute(selectArgs);

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-delete.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-delete.1.export.mjs
@@ -5017,18 +5017,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_full_namePgResource.isUnique && !resource_person_full_namePgResource.codec.attributes && typeof resource_person_full_namePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_full_namePgResource.codec)`${resource_person_full_namePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_full_namePgResource.codec)`${resource_person_full_namePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_full_namePgResource.execute(selectArgs);

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-loads.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-loads.1.export.mjs
@@ -4676,18 +4676,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_full_namePgResource.isUnique && !resource_person_full_namePgResource.codec.attributes && typeof resource_person_full_namePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_full_namePgResource.codec)`${resource_person_full_namePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_full_namePgResource.codec)`${resource_person_full_namePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_full_namePgResource.execute(selectArgs);

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-update.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.films-update.1.export.mjs
@@ -5002,18 +5002,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_full_namePgResource.isUnique && !resource_person_full_namePgResource.codec.attributes && typeof resource_person_full_namePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_full_namePgResource.codec)`${resource_person_full_namePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_full_namePgResource.codec)`${resource_person_full_namePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_full_namePgResource.execute(selectArgs);

--- a/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.shows-order.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/omit-rename.omitstuff.shows-order.1.export.mjs
@@ -4890,18 +4890,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_full_namePgResource.isUnique && !resource_person_full_namePgResource.codec.attributes && typeof resource_person_full_namePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_full_namePgResource.codec)`${resource_person_full_namePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_full_namePgResource.codec)`${resource_person_full_namePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_full_namePgResource.execute(selectArgs);

--- a/postgraphile/postgraphile/__tests__/schema/v4/polymorphic-auto-add-types.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/polymorphic-auto-add-types.1.export.mjs
@@ -9951,18 +9951,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_single_table_items_meaning_of_lifePgResource.isUnique && !resource_single_table_items_meaning_of_lifePgResource.codec.attributes && typeof resource_single_table_items_meaning_of_lifePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_single_table_items_meaning_of_lifePgResource.execute(selectArgs);
@@ -13094,18 +13104,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_single_table_items_meaning_of_lifePgResource.isUnique && !resource_single_table_items_meaning_of_lifePgResource.codec.attributes && typeof resource_single_table_items_meaning_of_lifePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_single_table_items_meaning_of_lifePgResource.execute(selectArgs);
@@ -13538,18 +13558,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_single_table_items_meaning_of_lifePgResource.isUnique && !resource_single_table_items_meaning_of_lifePgResource.codec.attributes && typeof resource_single_table_items_meaning_of_lifePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_single_table_items_meaning_of_lifePgResource.execute(selectArgs);
@@ -13906,18 +13936,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_single_table_items_meaning_of_lifePgResource.isUnique && !resource_single_table_items_meaning_of_lifePgResource.codec.attributes && typeof resource_single_table_items_meaning_of_lifePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_single_table_items_meaning_of_lifePgResource.execute(selectArgs);
@@ -14276,18 +14316,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_single_table_items_meaning_of_lifePgResource.isUnique && !resource_single_table_items_meaning_of_lifePgResource.codec.attributes && typeof resource_single_table_items_meaning_of_lifePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_single_table_items_meaning_of_lifePgResource.execute(selectArgs);

--- a/postgraphile/postgraphile/__tests__/schema/v4/polymorphic.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/polymorphic.1.export.mjs
@@ -14325,18 +14325,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_single_table_items_meaning_of_lifePgResource.isUnique && !resource_single_table_items_meaning_of_lifePgResource.codec.attributes && typeof resource_single_table_items_meaning_of_lifePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_single_table_items_meaning_of_lifePgResource.execute(selectArgs);
@@ -19006,18 +19016,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_single_table_items_meaning_of_lifePgResource.isUnique && !resource_single_table_items_meaning_of_lifePgResource.codec.attributes && typeof resource_single_table_items_meaning_of_lifePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_single_table_items_meaning_of_lifePgResource.execute(selectArgs);
@@ -19458,18 +19478,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_single_table_items_meaning_of_lifePgResource.isUnique && !resource_single_table_items_meaning_of_lifePgResource.codec.attributes && typeof resource_single_table_items_meaning_of_lifePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_single_table_items_meaning_of_lifePgResource.execute(selectArgs);
@@ -19830,18 +19860,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_single_table_items_meaning_of_lifePgResource.isUnique && !resource_single_table_items_meaning_of_lifePgResource.codec.attributes && typeof resource_single_table_items_meaning_of_lifePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_single_table_items_meaning_of_lifePgResource.execute(selectArgs);
@@ -20204,18 +20244,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_single_table_items_meaning_of_lifePgResource.isUnique && !resource_single_table_items_meaning_of_lifePgResource.codec.attributes && typeof resource_single_table_items_meaning_of_lifePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_single_table_items_meaning_of_lifePgResource.execute(selectArgs);

--- a/postgraphile/postgraphile/__tests__/schema/v4/rbac.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/rbac.1.export.mjs
@@ -3776,6 +3776,11 @@ const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_compu
 const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
 const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
 const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const person_optional_missing_middle_1FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_1");
+const person_optional_missing_middle_2FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_2");
+const person_optional_missing_middle_3FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_3");
+const person_optional_missing_middle_4FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_4");
+const person_optional_missing_middle_5FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_5");
 const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
 const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
 const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
@@ -7923,6 +7928,221 @@ const registry = makeRegistry({
           serviceName: "main",
           schemaName: "c",
           name: "person_computed_first_arg_inout_out"
+        },
+        tags: {},
+        canExecute: false
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_1: {
+      executor,
+      name: "person_optional_missing_middle_1",
+      identifier: "main.c.person_optional_missing_middle_1(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_1"
+        },
+        tags: {},
+        canExecute: false
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_2: {
+      executor,
+      name: "person_optional_missing_middle_2",
+      identifier: "main.c.person_optional_missing_middle_2(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_2"
+        },
+        tags: {},
+        canExecute: false
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_3: {
+      executor,
+      name: "person_optional_missing_middle_3",
+      identifier: "main.c.person_optional_missing_middle_3(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_3"
+        },
+        tags: {},
+        canExecute: false
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_4: {
+      executor,
+      name: "person_optional_missing_middle_4",
+      identifier: "main.c.person_optional_missing_middle_4(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_4"
+        },
+        tags: {},
+        canExecute: false
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_5: {
+      executor,
+      name: "person_optional_missing_middle_5",
+      identifier: "main.c.person_optional_missing_middle_5(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_5FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_5"
         },
         tags: {},
         canExecute: false

--- a/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.export.mjs
@@ -3494,6 +3494,11 @@ const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_compu
 const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
 const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
 const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const person_optional_missing_middle_1FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_1");
+const person_optional_missing_middle_2FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_2");
+const person_optional_missing_middle_3FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_3");
+const person_optional_missing_middle_4FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_4");
+const person_optional_missing_middle_5FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_5");
 const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
 const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
 const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
@@ -7383,6 +7388,216 @@ const registry = makeRegistry({
           serviceName: "main",
           schemaName: "c",
           name: "person_computed_first_arg_inout_out"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_1: {
+      executor,
+      name: "person_optional_missing_middle_1",
+      identifier: "main.c.person_optional_missing_middle_1(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_1"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_2: {
+      executor,
+      name: "person_optional_missing_middle_2",
+      identifier: "main.c.person_optional_missing_middle_2(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_2"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_3: {
+      executor,
+      name: "person_optional_missing_middle_3",
+      identifier: "main.c.person_optional_missing_middle_3(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_3"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_4: {
+      executor,
+      name: "person_optional_missing_middle_4",
+      identifier: "main.c.person_optional_missing_middle_4(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_4"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_5: {
+      executor,
+      name: "person_optional_missing_middle_5",
+      identifier: "main.c.person_optional_missing_middle_5(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_5FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_5"
         },
         tags: {}
       },
@@ -11870,22 +12085,28 @@ const makeArgs56 = (args, path = []) => {
 };
 const resource_person_computed_first_arg_inout_outPgResource = registry.pgResources["person_computed_first_arg_inout_out"];
 const argDetailsSimple57 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
+  graphqlArgName: "arg0",
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
   graphqlArgName: "b",
   postgresArgName: "b",
-  pgCodec: TYPES.text,
-  required: true,
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
   fetcher: null
 }];
 const makeArgs57 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11896,7 +12117,7 @@ const makeArgs57 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 1 - 1) {
         skipped = true;
         continue;
       } else {
@@ -11926,12 +12147,30 @@ const makeArgs57 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
-const argDetailsSimple58 = [];
+const resource_person_optional_missing_middle_1PgResource = registry.pgResources["person_optional_missing_middle_1"];
+const argDetailsSimple58 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs58 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11972,12 +12211,30 @@ const makeArgs58 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
-const argDetailsSimple59 = [];
+const resource_person_optional_missing_middle_2PgResource = registry.pgResources["person_optional_missing_middle_2"];
+const argDetailsSimple59 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs59 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11988,7 +12245,7 @@ const makeArgs59 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 2 - 1) {
         skipped = true;
         continue;
       } else {
@@ -12018,12 +12275,30 @@ const makeArgs59 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
-const argDetailsSimple60 = [];
+const resource_person_optional_missing_middle_3PgResource = registry.pgResources["person_optional_missing_middle_3"];
+const argDetailsSimple60 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs60 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12034,7 +12309,7 @@ const makeArgs60 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -12064,46 +12339,30 @@ const makeArgs60 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_friendsPgResource = registry.pgResources["person_friends"];
-const getSelectPlanFromParentAndArgs15 = ($in, args, _info) => {
-  if (!hasRecord($in)) {
-    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-  }
-  const extraSelectArgs = makeArgs60(args);
-  /**
-   * An optimisation - if all our dependencies are
-   * compatible with the expression's class plan then we
-   * can inline ourselves into that, otherwise we must
-   * issue the query separately.
-   */
-  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-  const selectArgs = [{
-    step: $row.record()
-  }, ...extraSelectArgs];
-  if (resource_person_friendsPgResource.isUnique && !resource_person_friendsPgResource.codec.attributes && typeof resource_person_friendsPgResource.from === "function") {
-    // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
-      if (i === 0) {
-        return $row.getClassStep().alias;
-      } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
-      } else {
-        return $row.placeholder(arg.step);
-      }
-    });
-    return pgClassExpression($row, resource_person_friendsPgResource.codec)`${resource_person_friendsPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
-  }
-  // PERF: or here, if scalar add select to `$row`?
-  return resource_person_friendsPgResource.execute(selectArgs);
-};
-const argDetailsSimple61 = [];
+const resource_person_optional_missing_middle_4PgResource = registry.pgResources["person_optional_missing_middle_4"];
+const argDetailsSimple61 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs61 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12114,7 +12373,7 @@ const makeArgs61 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -12144,52 +12403,24 @@ const makeArgs61 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
-const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
-  if (!hasRecord($in)) {
-    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-  }
-  const extraSelectArgs = makeArgs61(args);
-  /**
-   * An optimisation - if all our dependencies are
-   * compatible with the expression's class plan then we
-   * can inline ourselves into that, otherwise we must
-   * issue the query separately.
-   */
-  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-  const selectArgs = [{
-    step: $row.record()
-  }, ...extraSelectArgs];
-  if (resource_person_type_function_connectionPgResource.isUnique && !resource_person_type_function_connectionPgResource.codec.attributes && typeof resource_person_type_function_connectionPgResource.from === "function") {
-    // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
-      if (i === 0) {
-        return $row.getClassStep().alias;
-      } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
-      } else {
-        return $row.placeholder(arg.step);
-      }
-    });
-    return pgClassExpression($row, resource_person_type_function_connectionPgResource.codec)`${resource_person_type_function_connectionPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
-  }
-  // PERF: or here, if scalar add select to `$row`?
-  return resource_person_type_function_connectionPgResource.execute(selectArgs);
-};
+const resource_person_optional_missing_middle_5PgResource = registry.pgResources["person_optional_missing_middle_5"];
 const argDetailsSimple62 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs62 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12230,7 +12461,7 @@ const makeArgs62 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
+const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
 const argDetailsSimple63 = [];
 const makeArgs63 = (args, path = []) => {
   const selectArgs = [];
@@ -12276,9 +12507,7 @@ const makeArgs63 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
-const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
-const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
+const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
 const argDetailsSimple64 = [];
 const makeArgs64 = (args, path = []) => {
   const selectArgs = [];
@@ -12324,16 +12553,7 @@ const makeArgs64 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
-function UUIDSerialize(value) {
-  return "" + value;
-}
-const coerce = string => {
-  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
-    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
-  }
-  return string;
-};
+const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -12379,8 +12599,8 @@ const makeArgs65 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_interval_setPgResource = registry.pgResources["post_computed_interval_set"];
-const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
+const resource_person_friendsPgResource = registry.pgResources["person_friends"];
+const getSelectPlanFromParentAndArgs15 = ($in, args, _info) => {
   if (!hasRecord($in)) {
     throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
   }
@@ -12396,23 +12616,33 @@ const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
   const selectArgs = [{
     step: $row.record()
   }, ...extraSelectArgs];
-  if (resource_post_computed_interval_setPgResource.isUnique && !resource_post_computed_interval_setPgResource.codec.attributes && typeof resource_post_computed_interval_setPgResource.from === "function") {
+  if (resource_person_friendsPgResource.isUnique && !resource_person_friendsPgResource.codec.attributes && typeof resource_person_friendsPgResource.from === "function") {
     // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
       if (i === 0) {
-        return $row.getClassStep().alias;
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
       } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
       } else {
-        return $row.placeholder(arg.step);
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
       }
     });
-    return pgClassExpression($row, resource_post_computed_interval_setPgResource.codec)`${resource_post_computed_interval_setPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
+    return pgClassExpression($row, resource_person_friendsPgResource.codec)`${resource_person_friendsPgResource.from(...newSelectArgs)}`;
   }
   // PERF: or here, if scalar add select to `$row`?
-  return resource_post_computed_interval_setPgResource.execute(selectArgs);
+  return resource_person_friendsPgResource.execute(selectArgs);
 };
 const argDetailsSimple66 = [];
 const makeArgs66 = (args, path = []) => {
@@ -12459,12 +12689,62 @@ const makeArgs66 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_interval_arrayPgResource = registry.pgResources["post_computed_interval_array"];
-const argDetailsSimple67 = [];
+const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
+const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
+  if (!hasRecord($in)) {
+    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+  }
+  const extraSelectArgs = makeArgs66(args);
+  /**
+   * An optimisation - if all our dependencies are
+   * compatible with the expression's class plan then we
+   * can inline ourselves into that, otherwise we must
+   * issue the query separately.
+   */
+  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+  const selectArgs = [{
+    step: $row.record()
+  }, ...extraSelectArgs];
+  if (resource_person_type_function_connectionPgResource.isUnique && !resource_person_type_function_connectionPgResource.codec.attributes && typeof resource_person_type_function_connectionPgResource.from === "function") {
+    // This is a scalar computed attribute, let's inline the expression
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
+      if (i === 0) {
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
+      } else if ("pgCodec" in arg && arg.pgCodec) {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
+      } else {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
+      }
+    });
+    return pgClassExpression($row, resource_person_type_function_connectionPgResource.codec)`${resource_person_type_function_connectionPgResource.from(...newSelectArgs)}`;
+  }
+  // PERF: or here, if scalar add select to `$row`?
+  return resource_person_type_function_connectionPgResource.execute(selectArgs);
+};
+const argDetailsSimple67 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs67 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12505,18 +12785,12 @@ const makeArgs67 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_text_arrayPgResource = registry.pgResources["post_computed_text_array"];
-const argDetailsSimple68 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: false,
-  fetcher: null
-}];
+const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
+const argDetailsSimple68 = [];
 const makeArgs68 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12557,18 +12831,14 @@ const makeArgs68 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_with_optional_argPgResource = registry.pgResources["post_computed_with_optional_arg"];
-const argDetailsSimple69 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
+const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
+const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
+const argDetailsSimple69 = [];
 const makeArgs69 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12609,24 +12879,21 @@ const makeArgs69 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_with_required_argPgResource = registry.pgResources["post_computed_with_required_arg"];
-const argDetailsSimple70 = [{
-  graphqlArgName: "length",
-  postgresArgName: "length",
-  pgCodec: TYPES.int,
-  required: false,
-  fetcher: null
-}, {
-  graphqlArgName: "omission",
-  postgresArgName: "omission",
-  pgCodec: TYPES.text,
-  required: false,
-  fetcher: null
-}];
+const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
+function UUIDSerialize(value) {
+  return "" + value;
+}
+const coerce = string => {
+  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
+    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
+  }
+  return string;
+};
+const argDetailsSimple70 = [];
 const makeArgs70 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12667,24 +12934,56 @@ const makeArgs70 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmedPgResource = registry.pgResources["post_headline_trimmed"];
-const argDetailsSimple71 = [{
-  graphqlArgName: "length",
-  postgresArgName: "length",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "omission",
-  postgresArgName: "omission",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_post_computed_interval_setPgResource = registry.pgResources["post_computed_interval_set"];
+const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
+  if (!hasRecord($in)) {
+    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+  }
+  const extraSelectArgs = makeArgs70(args);
+  /**
+   * An optimisation - if all our dependencies are
+   * compatible with the expression's class plan then we
+   * can inline ourselves into that, otherwise we must
+   * issue the query separately.
+   */
+  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+  const selectArgs = [{
+    step: $row.record()
+  }, ...extraSelectArgs];
+  if (resource_post_computed_interval_setPgResource.isUnique && !resource_post_computed_interval_setPgResource.codec.attributes && typeof resource_post_computed_interval_setPgResource.from === "function") {
+    // This is a scalar computed attribute, let's inline the expression
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
+      if (i === 0) {
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
+      } else if ("pgCodec" in arg && arg.pgCodec) {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
+      } else {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
+      }
+    });
+    return pgClassExpression($row, resource_post_computed_interval_setPgResource.codec)`${resource_post_computed_interval_setPgResource.from(...newSelectArgs)}`;
+  }
+  // PERF: or here, if scalar add select to `$row`?
+  return resource_post_computed_interval_setPgResource.execute(selectArgs);
+};
+const argDetailsSimple71 = [];
 const makeArgs71 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12725,24 +13024,12 @@ const makeArgs71 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmed_no_defaultsPgResource = registry.pgResources["post_headline_trimmed_no_defaults"];
-const argDetailsSimple72 = [{
-  graphqlArgName: "length",
-  postgresArgName: "length",
-  pgCodec: TYPES.int,
-  required: false,
-  fetcher: null
-}, {
-  graphqlArgName: "omission",
-  postgresArgName: "omission",
-  pgCodec: TYPES.text,
-  required: false,
-  fetcher: null
-}];
+const resource_post_computed_interval_arrayPgResource = registry.pgResources["post_computed_interval_array"];
+const argDetailsSimple72 = [];
 const makeArgs72 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12783,12 +13070,12 @@ const makeArgs72 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmed_strictPgResource = registry.pgResources["post_headline_trimmed_strict"];
+const resource_post_computed_text_arrayPgResource = registry.pgResources["post_computed_text_array"];
 const argDetailsSimple73 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
-  required: true,
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: false,
   fetcher: null
 }];
 const makeArgs73 = (args, path = []) => {
@@ -12802,6 +13089,284 @@ const makeArgs73 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple73[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_computed_with_optional_argPgResource = registry.pgResources["post_computed_with_optional_arg"];
+const argDetailsSimple74 = [{
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs74 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple74[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_computed_with_required_argPgResource = registry.pgResources["post_computed_with_required_arg"];
+const argDetailsSimple75 = [{
+  graphqlArgName: "length",
+  postgresArgName: "length",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "omission",
+  postgresArgName: "omission",
+  pgCodec: TYPES.text,
+  required: false,
+  fetcher: null
+}];
+const makeArgs75 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple75[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_headline_trimmedPgResource = registry.pgResources["post_headline_trimmed"];
+const argDetailsSimple76 = [{
+  graphqlArgName: "length",
+  postgresArgName: "length",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "omission",
+  postgresArgName: "omission",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
+const makeArgs76 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple76[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_headline_trimmed_no_defaultsPgResource = registry.pgResources["post_headline_trimmed_no_defaults"];
+const argDetailsSimple77 = [{
+  graphqlArgName: "length",
+  postgresArgName: "length",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "omission",
+  postgresArgName: "omission",
+  pgCodec: TYPES.text,
+  required: false,
+  fetcher: null
+}];
+const makeArgs77 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple77[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_headline_trimmed_strictPgResource = registry.pgResources["post_headline_trimmed_strict"];
+const argDetailsSimple78 = [{
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
+  required: true,
+  fetcher: null
+}];
+const makeArgs78 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple78[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -12892,236 +13457,6 @@ const parseValueLiteral = (ast, variables) => {
       return undefined;
   }
 };
-const argDetailsSimple74 = [];
-const makeArgs74 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple74[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
-const argDetailsSimple75 = [];
-const makeArgs75 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple75[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
-const argDetailsSimple76 = [];
-const makeArgs76 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple76[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
-const argDetailsSimple77 = [];
-const makeArgs77 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple77[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
-const argDetailsSimple78 = [];
-const makeArgs78 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple78[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
 const argDetailsSimple79 = [];
 const makeArgs79 = (args, path = []) => {
   const selectArgs = [];
@@ -13167,7 +13502,7 @@ const makeArgs79 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
+const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
 const argDetailsSimple80 = [];
 const makeArgs80 = (args, path = []) => {
   const selectArgs = [];
@@ -13213,18 +13548,12 @@ const makeArgs80 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
-const argDetailsSimple81 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
+const argDetailsSimple81 = [];
 const makeArgs81 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13265,18 +13594,12 @@ const makeArgs81 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
-const argDetailsSimple82 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
+const argDetailsSimple82 = [];
 const makeArgs82 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13317,18 +13640,12 @@ const makeArgs82 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
-const argDetailsSimple83 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
+const argDetailsSimple83 = [];
 const makeArgs83 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13369,18 +13686,12 @@ const makeArgs83 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
-const argDetailsSimple84 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
+const argDetailsSimple84 = [];
 const makeArgs84 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13421,18 +13732,12 @@ const makeArgs84 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
-const argDetailsSimple85 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
+const argDetailsSimple85 = [];
 const makeArgs85 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13473,12 +13778,12 @@ const makeArgs85 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
+const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
 const argDetailsSimple86 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: false,
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
   fetcher: null
 }];
 const makeArgs86 = (args, path = []) => {
@@ -13525,16 +13830,10 @@ const makeArgs86 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
+const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
 const argDetailsSimple87 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: null,
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "arg1",
-  postgresArgName: null,
+  graphqlArgName: "i",
+  postgresArgName: "i",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -13542,7 +13841,7 @@ const argDetailsSimple87 = [{
 const makeArgs87 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13553,7 +13852,7 @@ const makeArgs87 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 2 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13583,24 +13882,18 @@ const makeArgs87 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
+const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
 const argDetailsSimple88 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.json,
   required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.int,
-  required: false,
   fetcher: null
 }];
 const makeArgs88 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13641,24 +13934,18 @@ const makeArgs88 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
+const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
 const argDetailsSimple89 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "arg1",
-  postgresArgName: "",
-  pgCodec: TYPES.int,
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.jsonb,
   required: true,
   fetcher: null
 }];
 const makeArgs89 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13669,7 +13956,7 @@ const makeArgs89 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 2 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13699,24 +13986,18 @@ const makeArgs89 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
+const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
 const argDetailsSimple90 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: "",
-  pgCodec: TYPES.int,
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
   required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.int,
-  required: false,
   fetcher: null
 }];
 const makeArgs90 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13727,7 +14008,7 @@ const makeArgs90 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 1 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13757,24 +14038,18 @@ const makeArgs90 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
+const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
 const argDetailsSimple91 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: "",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.int,
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
   required: false,
   fetcher: null
 }];
 const makeArgs91 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13785,7 +14060,7 @@ const makeArgs91 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 1 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13815,7 +14090,7 @@ const makeArgs91 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
+const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
 const argDetailsSimple92 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -13873,18 +14148,18 @@ const makeArgs92 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_1PgResource = registry.pgResources["mult_1"];
+const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
 const argDetailsSimple93 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: null,
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "arg1",
-  postgresArgName: null,
+  graphqlArgName: "b",
+  postgresArgName: "b",
   pgCodec: TYPES.int,
-  required: true,
+  required: false,
   fetcher: null
 }];
 const makeArgs93 = (args, path = []) => {
@@ -13901,7 +14176,7 @@ const makeArgs93 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 2 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13931,16 +14206,16 @@ const makeArgs93 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_2PgResource = registry.pgResources["mult_2"];
+const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
 const argDetailsSimple94 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: null,
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
   graphqlArgName: "arg1",
-  postgresArgName: null,
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -13989,18 +14264,18 @@ const makeArgs94 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_3PgResource = registry.pgResources["mult_3"];
+const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
 const argDetailsSimple95 = [{
   graphqlArgName: "arg0",
-  postgresArgName: null,
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "arg1",
-  postgresArgName: null,
+  graphqlArgName: "b",
+  postgresArgName: "b",
   pgCodec: TYPES.int,
-  required: true,
+  required: false,
   fetcher: null
 }];
 const makeArgs95 = (args, path = []) => {
@@ -14014,6 +14289,296 @@ const makeArgs95 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple95[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 1 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
+const argDetailsSimple96 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
+const makeArgs96 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple96[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 1 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
+const argDetailsSimple97 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs97 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple97[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 2 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mult_1PgResource = registry.pgResources["mult_1"];
+const argDetailsSimple98 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs98 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple98[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 2 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mult_2PgResource = registry.pgResources["mult_2"];
+const argDetailsSimple99 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs99 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple99[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 2 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mult_3PgResource = registry.pgResources["mult_3"];
+const argDetailsSimple100 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs100 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple100[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -14048,7 +14613,7 @@ const makeArgs95 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_4PgResource = registry.pgResources["mult_4"];
-const argDetailsSimple96 = [{
+const argDetailsSimple101 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
   pgCodec: TYPES.int,
@@ -14061,258 +14626,10 @@ const argDetailsSimple96 = [{
   required: true,
   fetcher: null
 }];
-const makeArgs96 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 2; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple96[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
-const argDetailsSimple97 = [];
-const makeArgs97 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple97[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
-const argDetailsSimple98 = [];
-const makeArgs98 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple98[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
-const argDetailsSimple99 = [];
-const makeArgs99 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple99[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
-const argDetailsSimple100 = [{
-  graphqlArgName: "x",
-  postgresArgName: "x",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "y",
-  postgresArgName: "y",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "z",
-  postgresArgName: "z",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
-const makeArgs100 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 3; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple100[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
-const argDetailsSimple101 = [];
 const makeArgs101 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14353,18 +14670,12 @@ const makeArgs101 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
-const argDetailsSimple102 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
+const argDetailsSimple102 = [];
 const makeArgs102 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14405,18 +14716,12 @@ const makeArgs102 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
-const argDetailsSimple103 = [{
-  graphqlArgName: "g",
-  postgresArgName: "g",
-  pgCodec: guidCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
+const argDetailsSimple103 = [];
 const makeArgs103 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14457,7 +14762,7 @@ const makeArgs103 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_guid_fnPgResource = registry.pgResources["guid_fn"];
+const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
 const argDetailsSimple104 = [];
 const makeArgs104 = (args, path = []) => {
   const selectArgs = [];
@@ -14503,12 +14808,30 @@ const makeArgs104 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
-const argDetailsSimple105 = [];
+const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
+const argDetailsSimple105 = [{
+  graphqlArgName: "x",
+  postgresArgName: "x",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "y",
+  postgresArgName: "y",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "z",
+  postgresArgName: "z",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs105 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14549,30 +14872,12 @@ const makeArgs105 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
-const argDetailsSimple106 = [{
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: textArrayCodec,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "d",
-  postgresArgName: "d",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "e",
-  postgresArgName: "e",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
+const argDetailsSimple106 = [];
 const makeArgs106 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14613,12 +14918,18 @@ const makeArgs106 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_list_bde_mutationPgResource = registry.pgResources["list_bde_mutation"];
-const argDetailsSimple107 = [];
+const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
+const argDetailsSimple107 = [{
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs107 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14659,30 +14970,18 @@ const makeArgs107 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_failPgResource = registry.pgResources["authenticate_fail"];
+const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
 const argDetailsSimple108 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.numeric,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.bigint,
+  graphqlArgName: "g",
+  postgresArgName: "g",
+  pgCodec: guidCodec,
   required: true,
   fetcher: null
 }];
 const makeArgs108 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14723,18 +15022,12 @@ const makeArgs108 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticatePgResource = registry.pgResources["authenticate"];
-const argDetailsSimple109 = [{
-  graphqlArgName: "leftArm",
-  postgresArgName: "left_arm",
-  pgCodec: leftArmCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_guid_fnPgResource = registry.pgResources["guid_fn"];
+const argDetailsSimple109 = [];
 const makeArgs109 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14775,7 +15068,7 @@ const makeArgs109 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
+const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
 const argDetailsSimple110 = [];
 const makeArgs110 = (args, path = []) => {
   const selectArgs = [];
@@ -14821,12 +15114,30 @@ const makeArgs110 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
-const argDetailsSimple111 = [];
+const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
+const argDetailsSimple111 = [{
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: textArrayCodec,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "d",
+  postgresArgName: "d",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "e",
+  postgresArgName: "e",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
 const makeArgs111 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14867,30 +15178,12 @@ const makeArgs111 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
-const argDetailsSimple112 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.numeric,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.bigint,
-  required: true,
-  fetcher: null
-}];
+const resource_list_bde_mutationPgResource = registry.pgResources["list_bde_mutation"];
+const argDetailsSimple112 = [];
 const makeArgs112 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14931,7 +15224,7 @@ const makeArgs112 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_manyPgResource = registry.pgResources["authenticate_many"];
+const resource_authenticate_failPgResource = registry.pgResources["authenticate_fail"];
 const argDetailsSimple113 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -14995,48 +15288,18 @@ const makeArgs113 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_payloadPgResource = registry.pgResources["authenticate_payload"];
+const resource_authenticatePgResource = registry.pgResources["authenticate"];
 const argDetailsSimple114 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.bigint,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.boolean,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.varchar,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "d",
-  postgresArgName: "d",
-  pgCodec: int4ArrayCodec,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "e",
-  postgresArgName: "e",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "f",
-  postgresArgName: "f",
-  pgCodec: floatrangeCodec,
+  graphqlArgName: "leftArm",
+  postgresArgName: "left_arm",
+  pgCodec: leftArmCodec,
   required: true,
   fetcher: null
 }];
 const makeArgs114 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 6; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15077,18 +15340,12 @@ const makeArgs114 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
-const argDetailsSimple115 = [{
-  graphqlArgName: "i1",
-  postgresArgName: "i1",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
+const argDetailsSimple115 = [];
 const makeArgs115 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15129,18 +15386,12 @@ const makeArgs115 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
-const argDetailsSimple116 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
+const argDetailsSimple116 = [];
 const makeArgs116 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15181,18 +15432,30 @@ const makeArgs116 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_mutationPgResource = registry.pgResources["compound_type_mutation"];
+const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
 const argDetailsSimple117 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.numeric,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.bigint,
   required: true,
   fetcher: null
 }];
 const makeArgs117 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15233,18 +15496,30 @@ const makeArgs117 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
+const resource_authenticate_manyPgResource = registry.pgResources["authenticate_many"];
 const argDetailsSimple118 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.numeric,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.bigint,
   required: true,
   fetcher: null
 }];
 const makeArgs118 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15285,24 +15560,48 @@ const makeArgs118 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
+const resource_authenticate_payloadPgResource = registry.pgResources["authenticate_payload"];
 const argDetailsSimple119 = [{
-  graphqlArgName: "post",
-  postgresArgName: "post",
-  pgCodec: postCodec,
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.bigint,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "suffix",
-  postgresArgName: "suffix",
-  pgCodec: TYPES.text,
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.boolean,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.varchar,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "d",
+  postgresArgName: "d",
+  pgCodec: int4ArrayCodec,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "e",
+  postgresArgName: "e",
+  pgCodec: TYPES.json,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "f",
+  postgresArgName: "f",
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
 const makeArgs119 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 6; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15343,11 +15642,11 @@ const makeArgs119 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_with_suffixPgResource = registry.pgResources["post_with_suffix"];
+const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
 const argDetailsSimple120 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
+  graphqlArgName: "i1",
+  postgresArgName: "i1",
+  pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }];
@@ -15395,7 +15694,7 @@ const makeArgs120 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
+const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
 const argDetailsSimple121 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -15447,11 +15746,11 @@ const makeArgs121 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_array_mutationPgResource = registry.pgResources["compound_type_array_mutation"];
+const resource_compound_type_mutationPgResource = registry.pgResources["compound_type_mutation"];
 const argDetailsSimple122 = [{
-  graphqlArgName: "posts",
-  postgresArgName: "posts",
-  pgCodec: postArrayCodec,
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -15499,24 +15798,18 @@ const makeArgs122 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_manyPgResource = registry.pgResources["post_many"];
+const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
 const argDetailsSimple123 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
+  graphqlArgName: "id",
+  postgresArgName: "id",
   pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs123 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15557,16 +15850,16 @@ const makeArgs123 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
+const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
 const argDetailsSimple124 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
+  graphqlArgName: "post",
+  postgresArgName: "post",
+  pgCodec: postCodec,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
+  graphqlArgName: "suffix",
+  postgresArgName: "suffix",
   pgCodec: TYPES.text,
   required: true,
   fetcher: null
@@ -15615,12 +15908,18 @@ const makeArgs124 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
-const argDetailsSimple125 = [];
+const resource_post_with_suffixPgResource = registry.pgResources["post_with_suffix"];
+const argDetailsSimple125 = [{
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs125 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15661,12 +15960,18 @@ const makeArgs125 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
-const argDetailsSimple126 = [];
+const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
+const argDetailsSimple126 = [{
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs126 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15707,12 +16012,18 @@ const makeArgs126 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
-const argDetailsSimple127 = [];
+const resource_compound_type_array_mutationPgResource = registry.pgResources["compound_type_array_mutation"];
+const argDetailsSimple127 = [{
+  graphqlArgName: "posts",
+  postgresArgName: "posts",
+  pgCodec: postArrayCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs127 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15753,12 +16064,24 @@ const makeArgs127 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
-const argDetailsSimple128 = [];
+const resource_post_manyPgResource = registry.pgResources["post_many"];
+const argDetailsSimple128 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
 const makeArgs128 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15799,18 +16122,24 @@ const makeArgs128 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_type_function_connection_mutationPgResource = registry.pgResources["type_function_connection_mutation"];
+const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
 const argDetailsSimple129 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs129 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15851,7 +16180,7 @@ const makeArgs129 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_type_function_mutationPgResource = registry.pgResources["type_function_mutation"];
+const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
 const argDetailsSimple130 = [];
 const makeArgs130 = (args, path = []) => {
   const selectArgs = [];
@@ -15864,6 +16193,242 @@ const makeArgs130 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple130[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
+const argDetailsSimple131 = [];
+const makeArgs131 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple131[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
+const argDetailsSimple132 = [];
+const makeArgs132 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple132[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
+const argDetailsSimple133 = [];
+const makeArgs133 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple133[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_type_function_connection_mutationPgResource = registry.pgResources["type_function_connection_mutation"];
+const argDetailsSimple134 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs134 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple134[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_type_function_mutationPgResource = registry.pgResources["type_function_mutation"];
+const argDetailsSimple135 = [];
+const makeArgs135 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple135[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -17460,6 +18025,11 @@ type Person implements Node {
   computedInoutOut(ino: String): PersonComputedInoutOutRecord
   exists(email: Email): Boolean @deprecated(reason: "This is deprecated (comment on function c.person_exists).")
   computedFirstArgInoutOut: PersonComputedFirstArgInoutOutRecord
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, b: Int, arg2: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
   computedComplex(a: Int, b: String): PersonComputedComplexRecord
 
   """The first post by the person."""
@@ -28938,18 +29508,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_outPgResource.isUnique && !resource_person_computed_outPgResource.codec.attributes && typeof resource_person_computed_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_outPgResource.codec)`${resource_person_computed_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_outPgResource.codec)`${resource_person_computed_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_outPgResource.execute(selectArgs);
@@ -28972,18 +29552,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_first_namePgResource.isUnique && !resource_person_first_namePgResource.codec.attributes && typeof resource_person_first_namePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_first_namePgResource.codec)`${resource_person_first_namePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_first_namePgResource.codec)`${resource_person_first_namePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_first_namePgResource.execute(selectArgs);
@@ -29006,18 +29596,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_out_outPgResource.isUnique && !resource_person_computed_out_outPgResource.codec.attributes && typeof resource_person_computed_out_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_out_outPgResource.codec)`${resource_person_computed_out_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_out_outPgResource.codec)`${resource_person_computed_out_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_out_outPgResource.execute(selectArgs);
@@ -29041,18 +29641,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_computed_inoutPgResource.isUnique && !resource_person_computed_inoutPgResource.codec.attributes && typeof resource_person_computed_inoutPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_inoutPgResource.codec)`${resource_person_computed_inoutPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_computed_inoutPgResource.codec)`${resource_person_computed_inoutPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_inoutPgResource.execute(selectArgs);
@@ -29080,18 +29690,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_computed_inout_outPgResource.isUnique && !resource_person_computed_inout_outPgResource.codec.attributes && typeof resource_person_computed_inout_outPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_inout_outPgResource.codec)`${resource_person_computed_inout_outPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_computed_inout_outPgResource.codec)`${resource_person_computed_inout_outPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_inout_outPgResource.execute(selectArgs);
@@ -29119,18 +29739,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_existsPgResource.isUnique && !resource_person_existsPgResource.codec.attributes && typeof resource_person_existsPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_existsPgResource.codec)`${resource_person_existsPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_existsPgResource.codec)`${resource_person_existsPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_existsPgResource.execute(selectArgs);
@@ -29157,23 +29787,33 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_first_arg_inout_outPgResource.isUnique && !resource_person_computed_first_arg_inout_outPgResource.codec.attributes && typeof resource_person_computed_first_arg_inout_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_first_arg_inout_outPgResource.codec)`${resource_person_computed_first_arg_inout_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_first_arg_inout_outPgResource.codec)`${resource_person_computed_first_arg_inout_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_first_arg_inout_outPgResource.execute(selectArgs);
     },
-    computedComplex: {
+    optionalMissingMiddle1: {
       plan($in, args, _info) {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -29190,20 +29830,285 @@ export const plans = {
         const selectArgs = [{
           step: $row.record()
         }, ...extraSelectArgs];
-        if (resource_person_computed_complexPgResource.isUnique && !resource_person_computed_complexPgResource.codec.attributes && typeof resource_person_computed_complexPgResource.from === "function") {
+        if (resource_person_optional_missing_middle_1PgResource.isUnique && !resource_person_optional_missing_middle_1PgResource.codec.attributes && typeof resource_person_optional_missing_middle_1PgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_complexPgResource.codec)`${resource_person_computed_complexPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_optional_missing_middle_1PgResource.codec)`${resource_person_optional_missing_middle_1PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_1PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle2: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs58(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_2PgResource.isUnique && !resource_person_optional_missing_middle_2PgResource.codec.attributes && typeof resource_person_optional_missing_middle_2PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_2PgResource.codec)`${resource_person_optional_missing_middle_2PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_2PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        b: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle3: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs59(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_3PgResource.isUnique && !resource_person_optional_missing_middle_3PgResource.codec.attributes && typeof resource_person_optional_missing_middle_3PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_3PgResource.codec)`${resource_person_optional_missing_middle_3PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_3PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle4: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs60(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_4PgResource.isUnique && !resource_person_optional_missing_middle_4PgResource.codec.attributes && typeof resource_person_optional_missing_middle_4PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_4PgResource.codec)`${resource_person_optional_missing_middle_4PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_4PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        arg2: undefined
+      }
+    },
+    optionalMissingMiddle5: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs61(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_5PgResource.isUnique && !resource_person_optional_missing_middle_5PgResource.codec.attributes && typeof resource_person_optional_missing_middle_5PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_5PgResource.codec)`${resource_person_optional_missing_middle_5PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_5PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        arg2: undefined
+      }
+    },
+    computedComplex: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs62(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_computed_complexPgResource.isUnique && !resource_person_computed_complexPgResource.codec.attributes && typeof resource_person_computed_complexPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_computed_complexPgResource.codec)`${resource_person_computed_complexPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_complexPgResource.execute(selectArgs);
@@ -29217,7 +30122,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs58(args);
+      const extraSelectArgs = makeArgs63(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29231,18 +30136,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_first_postPgResource.isUnique && !resource_person_first_postPgResource.codec.attributes && typeof resource_person_first_postPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_first_postPgResource.codec)`${resource_person_first_postPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_first_postPgResource.codec)`${resource_person_first_postPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_first_postPgResource.execute(selectArgs);
@@ -29251,7 +30166,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs59(args);
+      const extraSelectArgs = makeArgs64(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29265,18 +30180,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_first_arg_inoutPgResource.isUnique && !resource_person_computed_first_arg_inoutPgResource.codec.attributes && typeof resource_person_computed_first_arg_inoutPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_first_arg_inoutPgResource.codec)`${resource_person_computed_first_arg_inoutPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_first_arg_inoutPgResource.codec)`${resource_person_computed_first_arg_inoutPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_first_arg_inoutPgResource.execute(selectArgs);
@@ -29381,7 +30306,7 @@ export const plans = {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
         }
-        const extraSelectArgs = makeArgs62(args);
+        const extraSelectArgs = makeArgs67(args);
         /**
          * An optimisation - if all our dependencies are
          * compatible with the expression's class plan then we
@@ -29395,18 +30320,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_type_functionPgResource.isUnique && !resource_person_type_functionPgResource.codec.attributes && typeof resource_person_type_functionPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_type_functionPgResource.codec)`${resource_person_type_functionPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_type_functionPgResource.codec)`${resource_person_type_functionPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_type_functionPgResource.execute(selectArgs);
@@ -29419,7 +30354,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs63(args);
+      const extraSelectArgs = makeArgs68(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29433,18 +30368,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_type_function_listPgResource.isUnique && !resource_person_type_function_listPgResource.codec.attributes && typeof resource_person_type_function_listPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_type_function_listPgResource.codec)`${resource_person_type_function_listPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_type_function_listPgResource.codec)`${resource_person_type_function_listPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_type_function_listPgResource.execute(selectArgs);
@@ -29791,7 +30736,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs64(args);
+      const extraSelectArgs = makeArgs69(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29805,18 +30750,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_compound_type_computed_fieldPgResource.isUnique && !resource_compound_type_computed_fieldPgResource.codec.attributes && typeof resource_compound_type_computed_fieldPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_compound_type_computed_fieldPgResource.codec)`${resource_compound_type_computed_fieldPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_compound_type_computed_fieldPgResource.codec)`${resource_compound_type_computed_fieldPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_compound_type_computed_fieldPgResource.execute(selectArgs);
@@ -29960,7 +30915,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs66(args);
+      const extraSelectArgs = makeArgs71(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29974,18 +30929,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_post_computed_interval_arrayPgResource.isUnique && !resource_post_computed_interval_arrayPgResource.codec.attributes && typeof resource_post_computed_interval_arrayPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_post_computed_interval_arrayPgResource.codec)`${resource_post_computed_interval_arrayPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_post_computed_interval_arrayPgResource.codec)`${resource_post_computed_interval_arrayPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_post_computed_interval_arrayPgResource.execute(selectArgs);
@@ -29994,7 +30959,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs67(args);
+      const extraSelectArgs = makeArgs72(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -30008,221 +30973,33 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_post_computed_text_arrayPgResource.isUnique && !resource_post_computed_text_arrayPgResource.codec.attributes && typeof resource_post_computed_text_arrayPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_post_computed_text_arrayPgResource.codec)`${resource_post_computed_text_arrayPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_post_computed_text_arrayPgResource.codec)`${resource_post_computed_text_arrayPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_post_computed_text_arrayPgResource.execute(selectArgs);
     },
     computedWithOptionalArg: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs68(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_computed_with_optional_argPgResource.isUnique && !resource_post_computed_with_optional_argPgResource.codec.attributes && typeof resource_post_computed_with_optional_argPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_computed_with_optional_argPgResource.codec)`${resource_post_computed_with_optional_argPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_computed_with_optional_argPgResource.execute(selectArgs);
-      },
-      args: {
-        i: undefined
-      }
-    },
-    computedWithRequiredArg: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs69(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_computed_with_required_argPgResource.isUnique && !resource_post_computed_with_required_argPgResource.codec.attributes && typeof resource_post_computed_with_required_argPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_computed_with_required_argPgResource.codec)`${resource_post_computed_with_required_argPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_computed_with_required_argPgResource.execute(selectArgs);
-      },
-      args: {
-        i: undefined
-      }
-    },
-    headlineTrimmed: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs70(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_headline_trimmedPgResource.isUnique && !resource_post_headline_trimmedPgResource.codec.attributes && typeof resource_post_headline_trimmedPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_headline_trimmedPgResource.codec)`${resource_post_headline_trimmedPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_headline_trimmedPgResource.execute(selectArgs);
-      },
-      args: {
-        length: undefined,
-        omission: undefined
-      }
-    },
-    headlineTrimmedNoDefaults: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs71(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_headline_trimmed_no_defaultsPgResource.isUnique && !resource_post_headline_trimmed_no_defaultsPgResource.codec.attributes && typeof resource_post_headline_trimmed_no_defaultsPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_headline_trimmed_no_defaultsPgResource.codec)`${resource_post_headline_trimmed_no_defaultsPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_headline_trimmed_no_defaultsPgResource.execute(selectArgs);
-      },
-      args: {
-        length: undefined,
-        omission: undefined
-      }
-    },
-    headlineTrimmedStrict: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs72(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_headline_trimmed_strictPgResource.isUnique && !resource_post_headline_trimmed_strictPgResource.codec.attributes && typeof resource_post_headline_trimmed_strictPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_headline_trimmed_strictPgResource.codec)`${resource_post_headline_trimmed_strictPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_headline_trimmed_strictPgResource.execute(selectArgs);
-      },
-      args: {
-        length: undefined,
-        omission: undefined
-      }
-    },
-    computedCompoundTypeArray: {
       plan($in, args, _info) {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -30239,20 +31016,278 @@ export const plans = {
         const selectArgs = [{
           step: $row.record()
         }, ...extraSelectArgs];
-        if (resource_post_computed_compound_type_arrayPgResource.isUnique && !resource_post_computed_compound_type_arrayPgResource.codec.attributes && typeof resource_post_computed_compound_type_arrayPgResource.from === "function") {
+        if (resource_post_computed_with_optional_argPgResource.isUnique && !resource_post_computed_with_optional_argPgResource.codec.attributes && typeof resource_post_computed_with_optional_argPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_post_computed_compound_type_arrayPgResource.codec)`${resource_post_computed_compound_type_arrayPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_post_computed_with_optional_argPgResource.codec)`${resource_post_computed_with_optional_argPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_computed_with_optional_argPgResource.execute(selectArgs);
+      },
+      args: {
+        i: undefined
+      }
+    },
+    computedWithRequiredArg: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs74(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_computed_with_required_argPgResource.isUnique && !resource_post_computed_with_required_argPgResource.codec.attributes && typeof resource_post_computed_with_required_argPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_computed_with_required_argPgResource.codec)`${resource_post_computed_with_required_argPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_computed_with_required_argPgResource.execute(selectArgs);
+      },
+      args: {
+        i: undefined
+      }
+    },
+    headlineTrimmed: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs75(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_headline_trimmedPgResource.isUnique && !resource_post_headline_trimmedPgResource.codec.attributes && typeof resource_post_headline_trimmedPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_headline_trimmedPgResource.codec)`${resource_post_headline_trimmedPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_headline_trimmedPgResource.execute(selectArgs);
+      },
+      args: {
+        length: undefined,
+        omission: undefined
+      }
+    },
+    headlineTrimmedNoDefaults: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs76(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_headline_trimmed_no_defaultsPgResource.isUnique && !resource_post_headline_trimmed_no_defaultsPgResource.codec.attributes && typeof resource_post_headline_trimmed_no_defaultsPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_headline_trimmed_no_defaultsPgResource.codec)`${resource_post_headline_trimmed_no_defaultsPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_headline_trimmed_no_defaultsPgResource.execute(selectArgs);
+      },
+      args: {
+        length: undefined,
+        omission: undefined
+      }
+    },
+    headlineTrimmedStrict: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs77(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_headline_trimmed_strictPgResource.isUnique && !resource_post_headline_trimmed_strictPgResource.codec.attributes && typeof resource_post_headline_trimmed_strictPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_headline_trimmed_strictPgResource.codec)`${resource_post_headline_trimmed_strictPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_headline_trimmed_strictPgResource.execute(selectArgs);
+      },
+      args: {
+        length: undefined,
+        omission: undefined
+      }
+    },
+    computedCompoundTypeArray: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs78(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_computed_compound_type_arrayPgResource.isUnique && !resource_post_computed_compound_type_arrayPgResource.codec.attributes && typeof resource_post_computed_compound_type_arrayPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_computed_compound_type_arrayPgResource.codec)`${resource_post_computed_compound_type_arrayPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_post_computed_compound_type_arrayPgResource.execute(selectArgs);
@@ -38594,7 +39629,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs74(args);
+      const extraSelectArgs = makeArgs79(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -38608,18 +39643,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_edge_case_computedPgResource.isUnique && !resource_edge_case_computedPgResource.codec.attributes && typeof resource_edge_case_computedPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_edge_case_computedPgResource.codec)`${resource_edge_case_computedPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_edge_case_computedPgResource.codec)`${resource_edge_case_computedPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_edge_case_computedPgResource.execute(selectArgs);
@@ -39295,7 +40340,7 @@ export const plans = {
     __assertStep: __ValueStep,
     mutationOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs75(args, ["input"]);
+        const selectArgs = makeArgs80(args, ["input"]);
         const $result = resource_mutation_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39312,7 +40357,7 @@ export const plans = {
     },
     mutationOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs76(args, ["input"]);
+        const selectArgs = makeArgs81(args, ["input"]);
         const $result = resource_mutation_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39329,7 +40374,7 @@ export const plans = {
     },
     mutationOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs77(args, ["input"]);
+        const selectArgs = makeArgs82(args, ["input"]);
         const $result = resource_mutation_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39346,7 +40391,7 @@ export const plans = {
     },
     noArgsMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs78(args, ["input"]);
+        const selectArgs = makeArgs83(args, ["input"]);
         const $result = resource_no_args_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39363,7 +40408,7 @@ export const plans = {
     },
     returnVoidMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs79(args, ["input"]);
+        const selectArgs = makeArgs84(args, ["input"]);
         const $result = resource_return_void_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39380,7 +40425,7 @@ export const plans = {
     },
     mutationIntervalSet: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs80(args, ["input"]);
+        const selectArgs = makeArgs85(args, ["input"]);
         const $result = resource_mutation_interval_setPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39397,7 +40442,7 @@ export const plans = {
     },
     mutationInOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs81(args, ["input"]);
+        const selectArgs = makeArgs86(args, ["input"]);
         const $result = resource_mutation_in_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39414,7 +40459,7 @@ export const plans = {
     },
     mutationReturnsTableOneCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs82(args, ["input"]);
+        const selectArgs = makeArgs87(args, ["input"]);
         const $result = resource_mutation_returns_table_one_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39431,7 +40476,7 @@ export const plans = {
     },
     jsonIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs83(args, ["input"]);
+        const selectArgs = makeArgs88(args, ["input"]);
         const $result = resource_json_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39448,7 +40493,7 @@ export const plans = {
     },
     jsonbIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs84(args, ["input"]);
+        const selectArgs = makeArgs89(args, ["input"]);
         const $result = resource_jsonb_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39465,7 +40510,7 @@ export const plans = {
     },
     jsonbIdentityMutationPlpgsql: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs85(args, ["input"]);
+        const selectArgs = makeArgs90(args, ["input"]);
         const $result = resource_jsonb_identity_mutation_plpgsqlPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39482,7 +40527,7 @@ export const plans = {
     },
     jsonbIdentityMutationPlpgsqlWithDefault: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs86(args, ["input"]);
+        const selectArgs = makeArgs91(args, ["input"]);
         const $result = resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39499,7 +40544,7 @@ export const plans = {
     },
     add1Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs87(args, ["input"]);
+        const selectArgs = makeArgs92(args, ["input"]);
         const $result = resource_add_1_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39516,7 +40561,7 @@ export const plans = {
     },
     add2Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs88(args, ["input"]);
+        const selectArgs = makeArgs93(args, ["input"]);
         const $result = resource_add_2_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39533,7 +40578,7 @@ export const plans = {
     },
     add3Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs89(args, ["input"]);
+        const selectArgs = makeArgs94(args, ["input"]);
         const $result = resource_add_3_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39550,7 +40595,7 @@ export const plans = {
     },
     add4Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs90(args, ["input"]);
+        const selectArgs = makeArgs95(args, ["input"]);
         const $result = resource_add_4_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39567,7 +40612,7 @@ export const plans = {
     },
     add4MutationError: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs91(args, ["input"]);
+        const selectArgs = makeArgs96(args, ["input"]);
         const $result = resource_add_4_mutation_errorPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39584,7 +40629,7 @@ export const plans = {
     },
     mult1: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs92(args, ["input"]);
+        const selectArgs = makeArgs97(args, ["input"]);
         const $result = resource_mult_1PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39601,7 +40646,7 @@ export const plans = {
     },
     mult2: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs93(args, ["input"]);
+        const selectArgs = makeArgs98(args, ["input"]);
         const $result = resource_mult_2PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39618,7 +40663,7 @@ export const plans = {
     },
     mult3: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs94(args, ["input"]);
+        const selectArgs = makeArgs99(args, ["input"]);
         const $result = resource_mult_3PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39635,7 +40680,7 @@ export const plans = {
     },
     mult4: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs95(args, ["input"]);
+        const selectArgs = makeArgs100(args, ["input"]);
         const $result = resource_mult_4PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39652,7 +40697,7 @@ export const plans = {
     },
     mutationInInout: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs96(args, ["input"]);
+        const selectArgs = makeArgs101(args, ["input"]);
         const $result = resource_mutation_in_inoutPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39669,7 +40714,7 @@ export const plans = {
     },
     mutationOutOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs97(args, ["input"]);
+        const selectArgs = makeArgs102(args, ["input"]);
         const $result = resource_mutation_out_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39686,7 +40731,7 @@ export const plans = {
     },
     mutationOutOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs98(args, ["input"]);
+        const selectArgs = makeArgs103(args, ["input"]);
         const $result = resource_mutation_out_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39703,7 +40748,7 @@ export const plans = {
     },
     mutationOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs99(args, ["input"]);
+        const selectArgs = makeArgs104(args, ["input"]);
         const $result = resource_mutation_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39720,7 +40765,7 @@ export const plans = {
     },
     intSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs100(args, ["input"]);
+        const selectArgs = makeArgs105(args, ["input"]);
         const $result = resource_int_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39737,7 +40782,7 @@ export const plans = {
     },
     mutationOutUnnamedOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs101(args, ["input"]);
+        const selectArgs = makeArgs106(args, ["input"]);
         const $result = resource_mutation_out_unnamed_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39754,7 +40799,7 @@ export const plans = {
     },
     mutationReturnsTableMultiCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs102(args, ["input"]);
+        const selectArgs = makeArgs107(args, ["input"]);
         const $result = resource_mutation_returns_table_multi_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39771,7 +40816,7 @@ export const plans = {
     },
     guidFn: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs103(args, ["input"]);
+        const selectArgs = makeArgs108(args, ["input"]);
         const $result = resource_guid_fnPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39788,7 +40833,7 @@ export const plans = {
     },
     mutationIntervalArray: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs104(args, ["input"]);
+        const selectArgs = makeArgs109(args, ["input"]);
         const $result = resource_mutation_interval_arrayPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39805,7 +40850,7 @@ export const plans = {
     },
     mutationTextArray: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs105(args, ["input"]);
+        const selectArgs = makeArgs110(args, ["input"]);
         const $result = resource_mutation_text_arrayPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39822,7 +40867,7 @@ export const plans = {
     },
     listBdeMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs106(args, ["input"]);
+        const selectArgs = makeArgs111(args, ["input"]);
         const $result = resource_list_bde_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39839,7 +40884,7 @@ export const plans = {
     },
     authenticateFail: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs107(args, ["input"]);
+        const selectArgs = makeArgs112(args, ["input"]);
         const $result = resource_authenticate_failPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39856,7 +40901,7 @@ export const plans = {
     },
     authenticate: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs108(args, ["input"]);
+        const selectArgs = makeArgs113(args, ["input"]);
         const $result = resource_authenticatePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39873,7 +40918,7 @@ export const plans = {
     },
     leftArmIdentity: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs109(args, ["input"]);
+        const selectArgs = makeArgs114(args, ["input"]);
         const $result = resource_left_arm_identityPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39890,7 +40935,7 @@ export const plans = {
     },
     issue756Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs110(args, ["input"]);
+        const selectArgs = makeArgs115(args, ["input"]);
         const $result = resource_issue756_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39907,7 +40952,7 @@ export const plans = {
     },
     issue756SetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs111(args, ["input"]);
+        const selectArgs = makeArgs116(args, ["input"]);
         const $result = resource_issue756_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39924,7 +40969,7 @@ export const plans = {
     },
     authenticateMany: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs112(args, ["input"]);
+        const selectArgs = makeArgs117(args, ["input"]);
         const $result = resource_authenticate_manyPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39941,7 +40986,7 @@ export const plans = {
     },
     authenticatePayload: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs113(args, ["input"]);
+        const selectArgs = makeArgs118(args, ["input"]);
         const $result = resource_authenticate_payloadPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39958,7 +41003,7 @@ export const plans = {
     },
     typesMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs114(args, ["input"]);
+        const selectArgs = makeArgs119(args, ["input"]);
         const $result = resource_types_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39975,7 +41020,7 @@ export const plans = {
     },
     mutationOutOutCompoundType: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs115(args, ["input"]);
+        const selectArgs = makeArgs120(args, ["input"]);
         const $result = resource_mutation_out_out_compound_typePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39992,7 +41037,7 @@ export const plans = {
     },
     compoundTypeMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs116(args, ["input"]);
+        const selectArgs = makeArgs121(args, ["input"]);
         const $result = resource_compound_type_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40009,7 +41054,7 @@ export const plans = {
     },
     compoundTypeSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs117(args, ["input"]);
+        const selectArgs = makeArgs122(args, ["input"]);
         const $result = resource_compound_type_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40026,7 +41071,7 @@ export const plans = {
     },
     tableMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs118(args, ["input"]);
+        const selectArgs = makeArgs123(args, ["input"]);
         const $result = resource_table_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40043,7 +41088,7 @@ export const plans = {
     },
     postWithSuffix: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs119(args, ["input"]);
+        const selectArgs = makeArgs124(args, ["input"]);
         const $result = resource_post_with_suffixPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40060,7 +41105,7 @@ export const plans = {
     },
     mutationCompoundTypeArray: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs120(args, ["input"]);
+        const selectArgs = makeArgs125(args, ["input"]);
         const $result = resource_mutation_compound_type_arrayPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40077,7 +41122,7 @@ export const plans = {
     },
     compoundTypeArrayMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs121(args, ["input"]);
+        const selectArgs = makeArgs126(args, ["input"]);
         const $result = resource_compound_type_array_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40094,7 +41139,7 @@ export const plans = {
     },
     postMany: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs122(args, ["input"]);
+        const selectArgs = makeArgs127(args, ["input"]);
         const $result = resource_post_manyPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40111,7 +41156,7 @@ export const plans = {
     },
     mutationOutComplex: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs123(args, ["input"]);
+        const selectArgs = makeArgs128(args, ["input"]);
         const $result = resource_mutation_out_complexPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40128,7 +41173,7 @@ export const plans = {
     },
     mutationOutComplexSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs124(args, ["input"]);
+        const selectArgs = makeArgs129(args, ["input"]);
         const $result = resource_mutation_out_complex_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40145,7 +41190,7 @@ export const plans = {
     },
     mutationOutTable: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs125(args, ["input"]);
+        const selectArgs = makeArgs130(args, ["input"]);
         const $result = resource_mutation_out_tablePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40162,7 +41207,7 @@ export const plans = {
     },
     mutationOutTableSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs126(args, ["input"]);
+        const selectArgs = makeArgs131(args, ["input"]);
         const $result = resource_mutation_out_table_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40179,7 +41224,7 @@ export const plans = {
     },
     tableSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs127(args, ["input"]);
+        const selectArgs = makeArgs132(args, ["input"]);
         const $result = resource_table_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40196,7 +41241,7 @@ export const plans = {
     },
     typeFunctionConnectionMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs128(args, ["input"]);
+        const selectArgs = makeArgs133(args, ["input"]);
         const $result = resource_type_function_connection_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40213,7 +41258,7 @@ export const plans = {
     },
     typeFunctionMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs129(args, ["input"]);
+        const selectArgs = makeArgs134(args, ["input"]);
         const $result = resource_type_function_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40230,7 +41275,7 @@ export const plans = {
     },
     typeFunctionListMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs130(args, ["input"]);
+        const selectArgs = makeArgs135(args, ["input"]);
         const $result = resource_type_function_list_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result

--- a/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.graphql
@@ -5903,6 +5903,11 @@ type Person implements Node {
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, arg2: Int, b: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
 
   """This `Person`'s `PersonSecret`."""
   personSecretByPersonId: PersonSecret @deprecated(reason: "This is deprecated (comment on table c.person_secret).")

--- a/postgraphile/postgraphile/__tests__/schema/v4/relay.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/relay.1.export.mjs
@@ -4064,18 +4064,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_full_namePgResource.isUnique && !resource_person_full_namePgResource.codec.attributes && typeof resource_person_full_namePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_full_namePgResource.codec)`${resource_person_full_namePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_full_namePgResource.codec)`${resource_person_full_namePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_full_namePgResource.execute(selectArgs);

--- a/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.export.mjs
@@ -2502,6 +2502,11 @@ const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_compu
 const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
 const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
 const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const person_optional_missing_middle_1FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_1");
+const person_optional_missing_middle_2FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_2");
+const person_optional_missing_middle_3FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_3");
+const person_optional_missing_middle_4FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_4");
+const person_optional_missing_middle_5FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_5");
 const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
 const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
 const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
@@ -4292,6 +4297,216 @@ const registry = makeRegistry({
           serviceName: "main",
           schemaName: "c",
           name: "person_computed_first_arg_inout_out"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_1: {
+      executor,
+      name: "person_optional_missing_middle_1",
+      identifier: "main.c.person_optional_missing_middle_1(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_1"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_2: {
+      executor,
+      name: "person_optional_missing_middle_2",
+      identifier: "main.c.person_optional_missing_middle_2(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_2"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_3: {
+      executor,
+      name: "person_optional_missing_middle_3",
+      identifier: "main.c.person_optional_missing_middle_3(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_3"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_4: {
+      executor,
+      name: "person_optional_missing_middle_4",
+      identifier: "main.c.person_optional_missing_middle_4(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_4"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_5: {
+      executor,
+      name: "person_optional_missing_middle_5",
+      identifier: "main.c.person_optional_missing_middle_5(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_5FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_5"
         },
         tags: {}
       },
@@ -7093,22 +7308,28 @@ const makeArgs37 = (args, path = []) => {
 };
 const resource_person_computed_first_arg_inout_outPgResource = registry.pgResources["person_computed_first_arg_inout_out"];
 const argDetailsSimple38 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
+  graphqlArgName: "arg0",
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
   graphqlArgName: "b",
   postgresArgName: "b",
-  pgCodec: TYPES.text,
-  required: true,
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
   fetcher: null
 }];
 const makeArgs38 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7119,7 +7340,7 @@ const makeArgs38 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 1 - 1) {
         skipped = true;
         continue;
       } else {
@@ -7149,12 +7370,30 @@ const makeArgs38 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
-const argDetailsSimple39 = [];
+const resource_person_optional_missing_middle_1PgResource = registry.pgResources["person_optional_missing_middle_1"];
+const argDetailsSimple39 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs39 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7195,12 +7434,30 @@ const makeArgs39 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
-const argDetailsSimple40 = [];
+const resource_person_optional_missing_middle_2PgResource = registry.pgResources["person_optional_missing_middle_2"];
+const argDetailsSimple40 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs40 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7211,7 +7468,7 @@ const makeArgs40 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 2 - 1) {
         skipped = true;
         continue;
       } else {
@@ -7241,12 +7498,30 @@ const makeArgs40 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
-const argDetailsSimple41 = [];
+const resource_person_optional_missing_middle_3PgResource = registry.pgResources["person_optional_missing_middle_3"];
+const argDetailsSimple41 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs41 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7257,7 +7532,7 @@ const makeArgs41 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -7287,46 +7562,30 @@ const makeArgs41 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_friendsPgResource = registry.pgResources["person_friends"];
-const getSelectPlanFromParentAndArgs12 = ($in, args, _info) => {
-  if (!hasRecord($in)) {
-    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-  }
-  const extraSelectArgs = makeArgs41(args);
-  /**
-   * An optimisation - if all our dependencies are
-   * compatible with the expression's class plan then we
-   * can inline ourselves into that, otherwise we must
-   * issue the query separately.
-   */
-  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-  const selectArgs = [{
-    step: $row.record()
-  }, ...extraSelectArgs];
-  if (resource_person_friendsPgResource.isUnique && !resource_person_friendsPgResource.codec.attributes && typeof resource_person_friendsPgResource.from === "function") {
-    // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
-      if (i === 0) {
-        return $row.getClassStep().alias;
-      } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
-      } else {
-        return $row.placeholder(arg.step);
-      }
-    });
-    return pgClassExpression($row, resource_person_friendsPgResource.codec)`${resource_person_friendsPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
-  }
-  // PERF: or here, if scalar add select to `$row`?
-  return resource_person_friendsPgResource.execute(selectArgs);
-};
-const argDetailsSimple42 = [];
+const resource_person_optional_missing_middle_4PgResource = registry.pgResources["person_optional_missing_middle_4"];
+const argDetailsSimple42 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs42 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7337,7 +7596,7 @@ const makeArgs42 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -7367,52 +7626,24 @@ const makeArgs42 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
-const getSelectPlanFromParentAndArgs13 = ($in, args, _info) => {
-  if (!hasRecord($in)) {
-    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-  }
-  const extraSelectArgs = makeArgs42(args);
-  /**
-   * An optimisation - if all our dependencies are
-   * compatible with the expression's class plan then we
-   * can inline ourselves into that, otherwise we must
-   * issue the query separately.
-   */
-  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-  const selectArgs = [{
-    step: $row.record()
-  }, ...extraSelectArgs];
-  if (resource_person_type_function_connectionPgResource.isUnique && !resource_person_type_function_connectionPgResource.codec.attributes && typeof resource_person_type_function_connectionPgResource.from === "function") {
-    // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
-      if (i === 0) {
-        return $row.getClassStep().alias;
-      } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
-      } else {
-        return $row.placeholder(arg.step);
-      }
-    });
-    return pgClassExpression($row, resource_person_type_function_connectionPgResource.codec)`${resource_person_type_function_connectionPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
-  }
-  // PERF: or here, if scalar add select to `$row`?
-  return resource_person_type_function_connectionPgResource.execute(selectArgs);
-};
+const resource_person_optional_missing_middle_5PgResource = registry.pgResources["person_optional_missing_middle_5"];
 const argDetailsSimple43 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs43 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7453,7 +7684,7 @@ const makeArgs43 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
+const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
 const argDetailsSimple44 = [];
 const makeArgs44 = (args, path = []) => {
   const selectArgs = [];
@@ -7499,9 +7730,7 @@ const makeArgs44 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
-const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
-const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
+const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
 const argDetailsSimple45 = [];
 const makeArgs45 = (args, path = []) => {
   const selectArgs = [];
@@ -7514,6 +7743,332 @@ const makeArgs45 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple45[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
+const argDetailsSimple46 = [];
+const makeArgs46 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple46[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_person_friendsPgResource = registry.pgResources["person_friends"];
+const getSelectPlanFromParentAndArgs12 = ($in, args, _info) => {
+  if (!hasRecord($in)) {
+    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+  }
+  const extraSelectArgs = makeArgs46(args);
+  /**
+   * An optimisation - if all our dependencies are
+   * compatible with the expression's class plan then we
+   * can inline ourselves into that, otherwise we must
+   * issue the query separately.
+   */
+  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+  const selectArgs = [{
+    step: $row.record()
+  }, ...extraSelectArgs];
+  if (resource_person_friendsPgResource.isUnique && !resource_person_friendsPgResource.codec.attributes && typeof resource_person_friendsPgResource.from === "function") {
+    // This is a scalar computed attribute, let's inline the expression
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
+      if (i === 0) {
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
+      } else if ("pgCodec" in arg && arg.pgCodec) {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
+      } else {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
+      }
+    });
+    return pgClassExpression($row, resource_person_friendsPgResource.codec)`${resource_person_friendsPgResource.from(...newSelectArgs)}`;
+  }
+  // PERF: or here, if scalar add select to `$row`?
+  return resource_person_friendsPgResource.execute(selectArgs);
+};
+const argDetailsSimple47 = [];
+const makeArgs47 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple47[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
+const getSelectPlanFromParentAndArgs13 = ($in, args, _info) => {
+  if (!hasRecord($in)) {
+    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+  }
+  const extraSelectArgs = makeArgs47(args);
+  /**
+   * An optimisation - if all our dependencies are
+   * compatible with the expression's class plan then we
+   * can inline ourselves into that, otherwise we must
+   * issue the query separately.
+   */
+  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+  const selectArgs = [{
+    step: $row.record()
+  }, ...extraSelectArgs];
+  if (resource_person_type_function_connectionPgResource.isUnique && !resource_person_type_function_connectionPgResource.codec.attributes && typeof resource_person_type_function_connectionPgResource.from === "function") {
+    // This is a scalar computed attribute, let's inline the expression
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
+      if (i === 0) {
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
+      } else if ("pgCodec" in arg && arg.pgCodec) {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
+      } else {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
+      }
+    });
+    return pgClassExpression($row, resource_person_type_function_connectionPgResource.codec)`${resource_person_type_function_connectionPgResource.from(...newSelectArgs)}`;
+  }
+  // PERF: or here, if scalar add select to `$row`?
+  return resource_person_type_function_connectionPgResource.execute(selectArgs);
+};
+const argDetailsSimple48 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs48 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple48[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
+const argDetailsSimple49 = [];
+const makeArgs49 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple49[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
+const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
+const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
+const argDetailsSimple50 = [];
+const makeArgs50 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple50[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -7614,247 +8169,11 @@ const parseValueLiteral = (ast, variables) => {
   }
 };
 const resource_frmcdc_postPgResource = registry.pgResources["frmcdc_post"];
-const argDetailsSimple46 = [];
-const makeArgs46 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple46[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
-const argDetailsSimple47 = [];
-const makeArgs47 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple47[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
-const argDetailsSimple48 = [];
-const makeArgs48 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple48[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
-const argDetailsSimple49 = [];
-const makeArgs49 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple49[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
-const argDetailsSimple50 = [];
-const makeArgs50 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple50[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
-const argDetailsSimple51 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const argDetailsSimple51 = [];
 const makeArgs51 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7895,18 +8214,12 @@ const makeArgs51 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
-const argDetailsSimple52 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
+const argDetailsSimple52 = [];
 const makeArgs52 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7947,18 +8260,12 @@ const makeArgs52 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
-const argDetailsSimple53 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
+const argDetailsSimple53 = [];
 const makeArgs53 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7999,18 +8306,12 @@ const makeArgs53 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
-const argDetailsSimple54 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
+const argDetailsSimple54 = [];
 const makeArgs54 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8051,18 +8352,12 @@ const makeArgs54 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
-const argDetailsSimple55 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
+const argDetailsSimple55 = [];
 const makeArgs55 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8103,12 +8398,12 @@ const makeArgs55 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
+const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
 const argDetailsSimple56 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: false,
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
   fetcher: null
 }];
 const makeArgs56 = (args, path = []) => {
@@ -8155,16 +8450,10 @@ const makeArgs56 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
+const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
 const argDetailsSimple57 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "ino",
-  postgresArgName: "ino",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -8172,7 +8461,7 @@ const argDetailsSimple57 = [{
 const makeArgs57 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8213,12 +8502,18 @@ const makeArgs57 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
-const argDetailsSimple58 = [];
+const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
+const argDetailsSimple58 = [{
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.json,
+  required: true,
+  fetcher: null
+}];
 const makeArgs58 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8259,12 +8554,18 @@ const makeArgs58 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
-const argDetailsSimple59 = [];
+const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
+const argDetailsSimple59 = [{
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.jsonb,
+  required: true,
+  fetcher: null
+}];
 const makeArgs59 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8305,12 +8606,18 @@ const makeArgs59 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
-const argDetailsSimple60 = [];
+const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
+const argDetailsSimple60 = [{
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
+  required: true,
+  fetcher: null
+}];
 const makeArgs60 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8351,30 +8658,18 @@ const makeArgs60 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
+const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
 const argDetailsSimple61 = [{
-  graphqlArgName: "x",
-  postgresArgName: "x",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "y",
-  postgresArgName: "y",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "z",
-  postgresArgName: "z",
-  pgCodec: TYPES.int,
-  required: true,
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
+  required: false,
   fetcher: null
 }];
 const makeArgs61 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8415,12 +8710,24 @@ const makeArgs61 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
-const argDetailsSimple62 = [];
+const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
+const argDetailsSimple62 = [{
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "ino",
+  postgresArgName: "ino",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs62 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8461,18 +8768,12 @@ const makeArgs62 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
-const argDetailsSimple63 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
+const argDetailsSimple63 = [];
 const makeArgs63 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8513,18 +8814,12 @@ const makeArgs63 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
-const argDetailsSimple64 = [{
-  graphqlArgName: "leftArm",
-  postgresArgName: "left_arm",
-  pgCodec: leftArmCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
+const argDetailsSimple64 = [];
 const makeArgs64 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8565,7 +8860,7 @@ const makeArgs64 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
+const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -8611,12 +8906,30 @@ const makeArgs65 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
-const argDetailsSimple66 = [];
+const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
+const argDetailsSimple66 = [{
+  graphqlArgName: "x",
+  postgresArgName: "x",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "y",
+  postgresArgName: "y",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "z",
+  postgresArgName: "z",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs66 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8657,48 +8970,12 @@ const makeArgs66 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
-const argDetailsSimple67 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.bigint,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.boolean,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.varchar,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "d",
-  postgresArgName: "d",
-  pgCodec: int4ArrayCodec,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "e",
-  postgresArgName: "e",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "f",
-  postgresArgName: "f",
-  pgCodec: floatrangeCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
+const argDetailsSimple67 = [];
 const makeArgs67 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 6; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8739,10 +9016,10 @@ const makeArgs67 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
+const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
 const argDetailsSimple68 = [{
-  graphqlArgName: "i1",
-  postgresArgName: "i1",
+  graphqlArgName: "i",
+  postgresArgName: "i",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -8791,11 +9068,11 @@ const makeArgs68 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
+const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
 const argDetailsSimple69 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
-  pgCodec: TYPES.int,
+  graphqlArgName: "leftArm",
+  postgresArgName: "left_arm",
+  pgCodec: leftArmCodec,
   required: true,
   fetcher: null
 }];
@@ -8843,24 +9120,12 @@ const makeArgs69 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
-const argDetailsSimple70 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
+const argDetailsSimple70 = [];
 const makeArgs70 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8901,24 +9166,12 @@ const makeArgs70 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
-const argDetailsSimple71 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
+const argDetailsSimple71 = [];
 const makeArgs71 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8959,12 +9212,48 @@ const makeArgs71 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
-const argDetailsSimple72 = [];
+const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
+const argDetailsSimple72 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.bigint,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.boolean,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.varchar,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "d",
+  postgresArgName: "d",
+  pgCodec: int4ArrayCodec,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "e",
+  postgresArgName: "e",
+  pgCodec: TYPES.json,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "f",
+  postgresArgName: "f",
+  pgCodec: floatrangeCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs72 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 6; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -9005,12 +9294,18 @@ const makeArgs72 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
-const argDetailsSimple73 = [];
+const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
+const argDetailsSimple73 = [{
+  graphqlArgName: "i1",
+  postgresArgName: "i1",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs73 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -9051,9 +9346,177 @@ const makeArgs73 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
-const argDetailsSimple74 = [];
+const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
+const argDetailsSimple74 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs74 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple74[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
+const argDetailsSimple75 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
+const makeArgs75 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple75[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
+const argDetailsSimple76 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
+const makeArgs76 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple76[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
+const argDetailsSimple77 = [];
+const makeArgs77 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
   for (let i = 0; i < 0; i++) {
@@ -9063,7 +9526,99 @@ const makeArgs74 = (args, path = []) => {
       pgCodec,
       required,
       fetcher
-    } = argDetailsSimple74[i];
+    } = argDetailsSimple77[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
+const argDetailsSimple78 = [];
+const makeArgs78 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple78[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
+const argDetailsSimple79 = [];
+const makeArgs79 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple79[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -9812,6 +10367,11 @@ type Person implements Node {
   computedInoutOut(ino: String): PersonComputedInoutOutRecord
   exists(email: Email): Boolean @deprecated(reason: "This is deprecated (comment on function c.person_exists).")
   computedFirstArgInoutOut: PersonComputedFirstArgInoutOutRecord
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, b: Int, arg2: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
   computedComplex(a: Int, b: String): PersonComputedComplexRecord
 
   """The first post by the person."""
@@ -14933,18 +15493,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_outPgResource.isUnique && !resource_person_computed_outPgResource.codec.attributes && typeof resource_person_computed_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_outPgResource.codec)`${resource_person_computed_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_outPgResource.codec)`${resource_person_computed_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_outPgResource.execute(selectArgs);
@@ -14967,18 +15537,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_first_namePgResource.isUnique && !resource_person_first_namePgResource.codec.attributes && typeof resource_person_first_namePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_first_namePgResource.codec)`${resource_person_first_namePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_first_namePgResource.codec)`${resource_person_first_namePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_first_namePgResource.execute(selectArgs);
@@ -15001,18 +15581,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_out_outPgResource.isUnique && !resource_person_computed_out_outPgResource.codec.attributes && typeof resource_person_computed_out_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_out_outPgResource.codec)`${resource_person_computed_out_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_out_outPgResource.codec)`${resource_person_computed_out_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_out_outPgResource.execute(selectArgs);
@@ -15036,18 +15626,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_computed_inoutPgResource.isUnique && !resource_person_computed_inoutPgResource.codec.attributes && typeof resource_person_computed_inoutPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_inoutPgResource.codec)`${resource_person_computed_inoutPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_computed_inoutPgResource.codec)`${resource_person_computed_inoutPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_inoutPgResource.execute(selectArgs);
@@ -15075,18 +15675,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_computed_inout_outPgResource.isUnique && !resource_person_computed_inout_outPgResource.codec.attributes && typeof resource_person_computed_inout_outPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_inout_outPgResource.codec)`${resource_person_computed_inout_outPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_computed_inout_outPgResource.codec)`${resource_person_computed_inout_outPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_inout_outPgResource.execute(selectArgs);
@@ -15114,18 +15724,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_existsPgResource.isUnique && !resource_person_existsPgResource.codec.attributes && typeof resource_person_existsPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_existsPgResource.codec)`${resource_person_existsPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_existsPgResource.codec)`${resource_person_existsPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_existsPgResource.execute(selectArgs);
@@ -15152,23 +15772,33 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_first_arg_inout_outPgResource.isUnique && !resource_person_computed_first_arg_inout_outPgResource.codec.attributes && typeof resource_person_computed_first_arg_inout_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_first_arg_inout_outPgResource.codec)`${resource_person_computed_first_arg_inout_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_first_arg_inout_outPgResource.codec)`${resource_person_computed_first_arg_inout_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_first_arg_inout_outPgResource.execute(selectArgs);
     },
-    computedComplex: {
+    optionalMissingMiddle1: {
       plan($in, args, _info) {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -15185,20 +15815,285 @@ export const plans = {
         const selectArgs = [{
           step: $row.record()
         }, ...extraSelectArgs];
-        if (resource_person_computed_complexPgResource.isUnique && !resource_person_computed_complexPgResource.codec.attributes && typeof resource_person_computed_complexPgResource.from === "function") {
+        if (resource_person_optional_missing_middle_1PgResource.isUnique && !resource_person_optional_missing_middle_1PgResource.codec.attributes && typeof resource_person_optional_missing_middle_1PgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_complexPgResource.codec)`${resource_person_computed_complexPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_optional_missing_middle_1PgResource.codec)`${resource_person_optional_missing_middle_1PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_1PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle2: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs39(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_2PgResource.isUnique && !resource_person_optional_missing_middle_2PgResource.codec.attributes && typeof resource_person_optional_missing_middle_2PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_2PgResource.codec)`${resource_person_optional_missing_middle_2PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_2PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        b: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle3: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs40(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_3PgResource.isUnique && !resource_person_optional_missing_middle_3PgResource.codec.attributes && typeof resource_person_optional_missing_middle_3PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_3PgResource.codec)`${resource_person_optional_missing_middle_3PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_3PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle4: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs41(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_4PgResource.isUnique && !resource_person_optional_missing_middle_4PgResource.codec.attributes && typeof resource_person_optional_missing_middle_4PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_4PgResource.codec)`${resource_person_optional_missing_middle_4PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_4PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        arg2: undefined
+      }
+    },
+    optionalMissingMiddle5: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs42(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_5PgResource.isUnique && !resource_person_optional_missing_middle_5PgResource.codec.attributes && typeof resource_person_optional_missing_middle_5PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_5PgResource.codec)`${resource_person_optional_missing_middle_5PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_5PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        arg2: undefined
+      }
+    },
+    computedComplex: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs43(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_computed_complexPgResource.isUnique && !resource_person_computed_complexPgResource.codec.attributes && typeof resource_person_computed_complexPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_computed_complexPgResource.codec)`${resource_person_computed_complexPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_complexPgResource.execute(selectArgs);
@@ -15212,7 +16107,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs39(args);
+      const extraSelectArgs = makeArgs44(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -15226,18 +16121,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_first_postPgResource.isUnique && !resource_person_first_postPgResource.codec.attributes && typeof resource_person_first_postPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_first_postPgResource.codec)`${resource_person_first_postPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_first_postPgResource.codec)`${resource_person_first_postPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_first_postPgResource.execute(selectArgs);
@@ -15246,7 +16151,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs40(args);
+      const extraSelectArgs = makeArgs45(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -15260,18 +16165,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_first_arg_inoutPgResource.isUnique && !resource_person_computed_first_arg_inoutPgResource.codec.attributes && typeof resource_person_computed_first_arg_inoutPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_first_arg_inoutPgResource.codec)`${resource_person_computed_first_arg_inoutPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_first_arg_inoutPgResource.codec)`${resource_person_computed_first_arg_inoutPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_first_arg_inoutPgResource.execute(selectArgs);
@@ -15376,7 +16291,7 @@ export const plans = {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
         }
-        const extraSelectArgs = makeArgs43(args);
+        const extraSelectArgs = makeArgs48(args);
         /**
          * An optimisation - if all our dependencies are
          * compatible with the expression's class plan then we
@@ -15390,18 +16305,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_type_functionPgResource.isUnique && !resource_person_type_functionPgResource.codec.attributes && typeof resource_person_type_functionPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_type_functionPgResource.codec)`${resource_person_type_functionPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_type_functionPgResource.codec)`${resource_person_type_functionPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_type_functionPgResource.execute(selectArgs);
@@ -15414,7 +16339,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs44(args);
+      const extraSelectArgs = makeArgs49(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -15428,18 +16353,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_type_function_listPgResource.isUnique && !resource_person_type_function_listPgResource.codec.attributes && typeof resource_person_type_function_listPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_type_function_listPgResource.codec)`${resource_person_type_function_listPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_type_function_listPgResource.codec)`${resource_person_type_function_listPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_type_function_listPgResource.execute(selectArgs);
@@ -15674,7 +16609,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs45(args);
+      const extraSelectArgs = makeArgs50(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -15688,18 +16623,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_compound_type_computed_fieldPgResource.isUnique && !resource_compound_type_computed_fieldPgResource.codec.attributes && typeof resource_compound_type_computed_fieldPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_compound_type_computed_fieldPgResource.codec)`${resource_compound_type_computed_fieldPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_compound_type_computed_fieldPgResource.codec)`${resource_compound_type_computed_fieldPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_compound_type_computed_fieldPgResource.execute(selectArgs);
@@ -18434,7 +19379,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs46(args);
+      const extraSelectArgs = makeArgs51(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -18448,18 +19393,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_edge_case_computedPgResource.isUnique && !resource_edge_case_computedPgResource.codec.attributes && typeof resource_edge_case_computedPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_edge_case_computedPgResource.codec)`${resource_edge_case_computedPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_edge_case_computedPgResource.codec)`${resource_edge_case_computedPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_edge_case_computedPgResource.execute(selectArgs);
@@ -19135,7 +20090,7 @@ export const plans = {
     __assertStep: __ValueStep,
     mutationOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs47(args, ["input"]);
+        const selectArgs = makeArgs52(args, ["input"]);
         const $result = resource_mutation_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19152,7 +20107,7 @@ export const plans = {
     },
     mutationOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs48(args, ["input"]);
+        const selectArgs = makeArgs53(args, ["input"]);
         const $result = resource_mutation_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19169,7 +20124,7 @@ export const plans = {
     },
     mutationOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs49(args, ["input"]);
+        const selectArgs = makeArgs54(args, ["input"]);
         const $result = resource_mutation_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19186,7 +20141,7 @@ export const plans = {
     },
     noArgsMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs50(args, ["input"]);
+        const selectArgs = makeArgs55(args, ["input"]);
         const $result = resource_no_args_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19203,7 +20158,7 @@ export const plans = {
     },
     mutationInOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs51(args, ["input"]);
+        const selectArgs = makeArgs56(args, ["input"]);
         const $result = resource_mutation_in_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19220,7 +20175,7 @@ export const plans = {
     },
     mutationReturnsTableOneCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs52(args, ["input"]);
+        const selectArgs = makeArgs57(args, ["input"]);
         const $result = resource_mutation_returns_table_one_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19237,7 +20192,7 @@ export const plans = {
     },
     jsonIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs53(args, ["input"]);
+        const selectArgs = makeArgs58(args, ["input"]);
         const $result = resource_json_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19254,7 +20209,7 @@ export const plans = {
     },
     jsonbIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs54(args, ["input"]);
+        const selectArgs = makeArgs59(args, ["input"]);
         const $result = resource_jsonb_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19271,7 +20226,7 @@ export const plans = {
     },
     jsonbIdentityMutationPlpgsql: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs55(args, ["input"]);
+        const selectArgs = makeArgs60(args, ["input"]);
         const $result = resource_jsonb_identity_mutation_plpgsqlPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19288,7 +20243,7 @@ export const plans = {
     },
     jsonbIdentityMutationPlpgsqlWithDefault: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs56(args, ["input"]);
+        const selectArgs = makeArgs61(args, ["input"]);
         const $result = resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19305,7 +20260,7 @@ export const plans = {
     },
     mutationInInout: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs57(args, ["input"]);
+        const selectArgs = makeArgs62(args, ["input"]);
         const $result = resource_mutation_in_inoutPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19322,7 +20277,7 @@ export const plans = {
     },
     mutationOutOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs58(args, ["input"]);
+        const selectArgs = makeArgs63(args, ["input"]);
         const $result = resource_mutation_out_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19339,7 +20294,7 @@ export const plans = {
     },
     mutationOutOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs59(args, ["input"]);
+        const selectArgs = makeArgs64(args, ["input"]);
         const $result = resource_mutation_out_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19356,7 +20311,7 @@ export const plans = {
     },
     mutationOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs60(args, ["input"]);
+        const selectArgs = makeArgs65(args, ["input"]);
         const $result = resource_mutation_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19373,7 +20328,7 @@ export const plans = {
     },
     intSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs61(args, ["input"]);
+        const selectArgs = makeArgs66(args, ["input"]);
         const $result = resource_int_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19390,7 +20345,7 @@ export const plans = {
     },
     mutationOutUnnamedOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs62(args, ["input"]);
+        const selectArgs = makeArgs67(args, ["input"]);
         const $result = resource_mutation_out_unnamed_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19407,7 +20362,7 @@ export const plans = {
     },
     mutationReturnsTableMultiCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs63(args, ["input"]);
+        const selectArgs = makeArgs68(args, ["input"]);
         const $result = resource_mutation_returns_table_multi_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19424,7 +20379,7 @@ export const plans = {
     },
     leftArmIdentity: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs64(args, ["input"]);
+        const selectArgs = makeArgs69(args, ["input"]);
         const $result = resource_left_arm_identityPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19441,7 +20396,7 @@ export const plans = {
     },
     issue756Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs65(args, ["input"]);
+        const selectArgs = makeArgs70(args, ["input"]);
         const $result = resource_issue756_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19458,7 +20413,7 @@ export const plans = {
     },
     issue756SetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs66(args, ["input"]);
+        const selectArgs = makeArgs71(args, ["input"]);
         const $result = resource_issue756_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19475,7 +20430,7 @@ export const plans = {
     },
     typesMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs67(args, ["input"]);
+        const selectArgs = makeArgs72(args, ["input"]);
         const $result = resource_types_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19492,7 +20447,7 @@ export const plans = {
     },
     mutationOutOutCompoundType: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs68(args, ["input"]);
+        const selectArgs = makeArgs73(args, ["input"]);
         const $result = resource_mutation_out_out_compound_typePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19509,7 +20464,7 @@ export const plans = {
     },
     tableMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs69(args, ["input"]);
+        const selectArgs = makeArgs74(args, ["input"]);
         const $result = resource_table_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19526,7 +20481,7 @@ export const plans = {
     },
     mutationOutComplex: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs70(args, ["input"]);
+        const selectArgs = makeArgs75(args, ["input"]);
         const $result = resource_mutation_out_complexPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19543,7 +20498,7 @@ export const plans = {
     },
     mutationOutComplexSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs71(args, ["input"]);
+        const selectArgs = makeArgs76(args, ["input"]);
         const $result = resource_mutation_out_complex_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19560,7 +20515,7 @@ export const plans = {
     },
     mutationOutTable: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs72(args, ["input"]);
+        const selectArgs = makeArgs77(args, ["input"]);
         const $result = resource_mutation_out_tablePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19577,7 +20532,7 @@ export const plans = {
     },
     mutationOutTableSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs73(args, ["input"]);
+        const selectArgs = makeArgs78(args, ["input"]);
         const $result = resource_mutation_out_table_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -19594,7 +20549,7 @@ export const plans = {
     },
     tableSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs74(args, ["input"]);
+        const selectArgs = makeArgs79(args, ["input"]);
         const $result = resource_table_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result

--- a/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.graphql
@@ -2980,6 +2980,11 @@ type Person implements Node {
 
   """The person’s name"""
   name: String!
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, arg2: Int, b: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
 
   """This `Person`'s `PersonSecret`."""
   personSecretByPersonId: PersonSecret @deprecated(reason: "This is deprecated (comment on table c.person_secret).")

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.export.mjs
@@ -2502,6 +2502,11 @@ const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_compu
 const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
 const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
 const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const person_optional_missing_middle_1FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_1");
+const person_optional_missing_middle_2FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_2");
+const person_optional_missing_middle_3FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_3");
+const person_optional_missing_middle_4FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_4");
+const person_optional_missing_middle_5FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_5");
 const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
 const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
 const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
@@ -4292,6 +4297,216 @@ const registry = makeRegistry({
           serviceName: "main",
           schemaName: "c",
           name: "person_computed_first_arg_inout_out"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_1: {
+      executor,
+      name: "person_optional_missing_middle_1",
+      identifier: "main.c.person_optional_missing_middle_1(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_1"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_2: {
+      executor,
+      name: "person_optional_missing_middle_2",
+      identifier: "main.c.person_optional_missing_middle_2(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_2"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_3: {
+      executor,
+      name: "person_optional_missing_middle_3",
+      identifier: "main.c.person_optional_missing_middle_3(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_3"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_4: {
+      executor,
+      name: "person_optional_missing_middle_4",
+      identifier: "main.c.person_optional_missing_middle_4(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_4"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_5: {
+      executor,
+      name: "person_optional_missing_middle_5",
+      identifier: "main.c.person_optional_missing_middle_5(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_5FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_5"
         },
         tags: {}
       },
@@ -7093,22 +7308,28 @@ const makeArgs37 = (args, path = []) => {
 };
 const resource_person_computed_first_arg_inout_outPgResource = registry.pgResources["person_computed_first_arg_inout_out"];
 const argDetailsSimple38 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
+  graphqlArgName: "arg0",
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
   graphqlArgName: "b",
   postgresArgName: "b",
-  pgCodec: TYPES.text,
-  required: true,
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
   fetcher: null
 }];
 const makeArgs38 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7119,7 +7340,7 @@ const makeArgs38 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 1 - 1) {
         skipped = true;
         continue;
       } else {
@@ -7149,12 +7370,30 @@ const makeArgs38 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
-const argDetailsSimple39 = [];
+const resource_person_optional_missing_middle_1PgResource = registry.pgResources["person_optional_missing_middle_1"];
+const argDetailsSimple39 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs39 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7195,12 +7434,30 @@ const makeArgs39 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
-const argDetailsSimple40 = [];
+const resource_person_optional_missing_middle_2PgResource = registry.pgResources["person_optional_missing_middle_2"];
+const argDetailsSimple40 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs40 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7211,7 +7468,7 @@ const makeArgs40 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 2 - 1) {
         skipped = true;
         continue;
       } else {
@@ -7241,12 +7498,30 @@ const makeArgs40 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
-const argDetailsSimple41 = [];
+const resource_person_optional_missing_middle_3PgResource = registry.pgResources["person_optional_missing_middle_3"];
+const argDetailsSimple41 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs41 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7257,7 +7532,7 @@ const makeArgs41 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -7287,46 +7562,30 @@ const makeArgs41 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_friendsPgResource = registry.pgResources["person_friends"];
-const getSelectPlanFromParentAndArgs12 = ($in, args, _info) => {
-  if (!hasRecord($in)) {
-    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-  }
-  const extraSelectArgs = makeArgs41(args);
-  /**
-   * An optimisation - if all our dependencies are
-   * compatible with the expression's class plan then we
-   * can inline ourselves into that, otherwise we must
-   * issue the query separately.
-   */
-  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-  const selectArgs = [{
-    step: $row.record()
-  }, ...extraSelectArgs];
-  if (resource_person_friendsPgResource.isUnique && !resource_person_friendsPgResource.codec.attributes && typeof resource_person_friendsPgResource.from === "function") {
-    // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
-      if (i === 0) {
-        return $row.getClassStep().alias;
-      } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
-      } else {
-        return $row.placeholder(arg.step);
-      }
-    });
-    return pgClassExpression($row, resource_person_friendsPgResource.codec)`${resource_person_friendsPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
-  }
-  // PERF: or here, if scalar add select to `$row`?
-  return resource_person_friendsPgResource.execute(selectArgs);
-};
-const argDetailsSimple42 = [];
+const resource_person_optional_missing_middle_4PgResource = registry.pgResources["person_optional_missing_middle_4"];
+const argDetailsSimple42 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs42 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7337,7 +7596,7 @@ const makeArgs42 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -7367,52 +7626,24 @@ const makeArgs42 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
-const getSelectPlanFromParentAndArgs13 = ($in, args, _info) => {
-  if (!hasRecord($in)) {
-    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-  }
-  const extraSelectArgs = makeArgs42(args);
-  /**
-   * An optimisation - if all our dependencies are
-   * compatible with the expression's class plan then we
-   * can inline ourselves into that, otherwise we must
-   * issue the query separately.
-   */
-  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-  const selectArgs = [{
-    step: $row.record()
-  }, ...extraSelectArgs];
-  if (resource_person_type_function_connectionPgResource.isUnique && !resource_person_type_function_connectionPgResource.codec.attributes && typeof resource_person_type_function_connectionPgResource.from === "function") {
-    // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
-      if (i === 0) {
-        return $row.getClassStep().alias;
-      } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
-      } else {
-        return $row.placeholder(arg.step);
-      }
-    });
-    return pgClassExpression($row, resource_person_type_function_connectionPgResource.codec)`${resource_person_type_function_connectionPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
-  }
-  // PERF: or here, if scalar add select to `$row`?
-  return resource_person_type_function_connectionPgResource.execute(selectArgs);
-};
+const resource_person_optional_missing_middle_5PgResource = registry.pgResources["person_optional_missing_middle_5"];
 const argDetailsSimple43 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs43 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7453,7 +7684,7 @@ const makeArgs43 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
+const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
 const argDetailsSimple44 = [];
 const makeArgs44 = (args, path = []) => {
   const selectArgs = [];
@@ -7499,9 +7730,7 @@ const makeArgs44 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
-const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
-const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
+const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
 const argDetailsSimple45 = [];
 const makeArgs45 = (args, path = []) => {
   const selectArgs = [];
@@ -7514,6 +7743,332 @@ const makeArgs45 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple45[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
+const argDetailsSimple46 = [];
+const makeArgs46 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple46[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_person_friendsPgResource = registry.pgResources["person_friends"];
+const getSelectPlanFromParentAndArgs12 = ($in, args, _info) => {
+  if (!hasRecord($in)) {
+    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+  }
+  const extraSelectArgs = makeArgs46(args);
+  /**
+   * An optimisation - if all our dependencies are
+   * compatible with the expression's class plan then we
+   * can inline ourselves into that, otherwise we must
+   * issue the query separately.
+   */
+  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+  const selectArgs = [{
+    step: $row.record()
+  }, ...extraSelectArgs];
+  if (resource_person_friendsPgResource.isUnique && !resource_person_friendsPgResource.codec.attributes && typeof resource_person_friendsPgResource.from === "function") {
+    // This is a scalar computed attribute, let's inline the expression
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
+      if (i === 0) {
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
+      } else if ("pgCodec" in arg && arg.pgCodec) {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
+      } else {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
+      }
+    });
+    return pgClassExpression($row, resource_person_friendsPgResource.codec)`${resource_person_friendsPgResource.from(...newSelectArgs)}`;
+  }
+  // PERF: or here, if scalar add select to `$row`?
+  return resource_person_friendsPgResource.execute(selectArgs);
+};
+const argDetailsSimple47 = [];
+const makeArgs47 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple47[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
+const getSelectPlanFromParentAndArgs13 = ($in, args, _info) => {
+  if (!hasRecord($in)) {
+    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+  }
+  const extraSelectArgs = makeArgs47(args);
+  /**
+   * An optimisation - if all our dependencies are
+   * compatible with the expression's class plan then we
+   * can inline ourselves into that, otherwise we must
+   * issue the query separately.
+   */
+  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+  const selectArgs = [{
+    step: $row.record()
+  }, ...extraSelectArgs];
+  if (resource_person_type_function_connectionPgResource.isUnique && !resource_person_type_function_connectionPgResource.codec.attributes && typeof resource_person_type_function_connectionPgResource.from === "function") {
+    // This is a scalar computed attribute, let's inline the expression
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
+      if (i === 0) {
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
+      } else if ("pgCodec" in arg && arg.pgCodec) {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
+      } else {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
+      }
+    });
+    return pgClassExpression($row, resource_person_type_function_connectionPgResource.codec)`${resource_person_type_function_connectionPgResource.from(...newSelectArgs)}`;
+  }
+  // PERF: or here, if scalar add select to `$row`?
+  return resource_person_type_function_connectionPgResource.execute(selectArgs);
+};
+const argDetailsSimple48 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs48 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple48[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
+const argDetailsSimple49 = [];
+const makeArgs49 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple49[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
+const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
+const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
+const argDetailsSimple50 = [];
+const makeArgs50 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple50[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -7614,247 +8169,11 @@ const parseValueLiteral = (ast, variables) => {
   }
 };
 const resource_frmcdc_postPgResource = registry.pgResources["frmcdc_post"];
-const argDetailsSimple46 = [];
-const makeArgs46 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple46[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
-const argDetailsSimple47 = [];
-const makeArgs47 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple47[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
-const argDetailsSimple48 = [];
-const makeArgs48 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple48[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
-const argDetailsSimple49 = [];
-const makeArgs49 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple49[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
-const argDetailsSimple50 = [];
-const makeArgs50 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple50[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
-const argDetailsSimple51 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const argDetailsSimple51 = [];
 const makeArgs51 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7895,18 +8214,12 @@ const makeArgs51 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
-const argDetailsSimple52 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
+const argDetailsSimple52 = [];
 const makeArgs52 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7947,18 +8260,12 @@ const makeArgs52 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
-const argDetailsSimple53 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
+const argDetailsSimple53 = [];
 const makeArgs53 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7999,18 +8306,12 @@ const makeArgs53 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
-const argDetailsSimple54 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
+const argDetailsSimple54 = [];
 const makeArgs54 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8051,18 +8352,12 @@ const makeArgs54 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
-const argDetailsSimple55 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
+const argDetailsSimple55 = [];
 const makeArgs55 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8103,12 +8398,12 @@ const makeArgs55 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
+const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
 const argDetailsSimple56 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: false,
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
   fetcher: null
 }];
 const makeArgs56 = (args, path = []) => {
@@ -8155,16 +8450,10 @@ const makeArgs56 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
+const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
 const argDetailsSimple57 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "ino",
-  postgresArgName: "ino",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -8172,7 +8461,7 @@ const argDetailsSimple57 = [{
 const makeArgs57 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8213,12 +8502,18 @@ const makeArgs57 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
-const argDetailsSimple58 = [];
+const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
+const argDetailsSimple58 = [{
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.json,
+  required: true,
+  fetcher: null
+}];
 const makeArgs58 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8259,12 +8554,18 @@ const makeArgs58 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
-const argDetailsSimple59 = [];
+const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
+const argDetailsSimple59 = [{
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.jsonb,
+  required: true,
+  fetcher: null
+}];
 const makeArgs59 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8305,12 +8606,18 @@ const makeArgs59 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
-const argDetailsSimple60 = [];
+const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
+const argDetailsSimple60 = [{
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
+  required: true,
+  fetcher: null
+}];
 const makeArgs60 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8351,30 +8658,18 @@ const makeArgs60 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
+const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
 const argDetailsSimple61 = [{
-  graphqlArgName: "x",
-  postgresArgName: "x",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "y",
-  postgresArgName: "y",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "z",
-  postgresArgName: "z",
-  pgCodec: TYPES.int,
-  required: true,
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
+  required: false,
   fetcher: null
 }];
 const makeArgs61 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8415,12 +8710,24 @@ const makeArgs61 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
-const argDetailsSimple62 = [];
+const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
+const argDetailsSimple62 = [{
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "ino",
+  postgresArgName: "ino",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs62 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8461,18 +8768,12 @@ const makeArgs62 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
-const argDetailsSimple63 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
+const argDetailsSimple63 = [];
 const makeArgs63 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8513,18 +8814,12 @@ const makeArgs63 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
-const argDetailsSimple64 = [{
-  graphqlArgName: "leftArm",
-  postgresArgName: "left_arm",
-  pgCodec: leftArmCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
+const argDetailsSimple64 = [];
 const makeArgs64 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8565,7 +8860,7 @@ const makeArgs64 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
+const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -8611,12 +8906,30 @@ const makeArgs65 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
-const argDetailsSimple66 = [];
+const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
+const argDetailsSimple66 = [{
+  graphqlArgName: "x",
+  postgresArgName: "x",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "y",
+  postgresArgName: "y",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "z",
+  postgresArgName: "z",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs66 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8657,48 +8970,12 @@ const makeArgs66 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
-const argDetailsSimple67 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.bigint,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.boolean,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.varchar,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "d",
-  postgresArgName: "d",
-  pgCodec: int4ArrayCodec,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "e",
-  postgresArgName: "e",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "f",
-  postgresArgName: "f",
-  pgCodec: floatrangeCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
+const argDetailsSimple67 = [];
 const makeArgs67 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 6; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8739,10 +9016,10 @@ const makeArgs67 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
+const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
 const argDetailsSimple68 = [{
-  graphqlArgName: "i1",
-  postgresArgName: "i1",
+  graphqlArgName: "i",
+  postgresArgName: "i",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -8791,11 +9068,11 @@ const makeArgs68 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
+const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
 const argDetailsSimple69 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
-  pgCodec: TYPES.int,
+  graphqlArgName: "leftArm",
+  postgresArgName: "left_arm",
+  pgCodec: leftArmCodec,
   required: true,
   fetcher: null
 }];
@@ -8843,24 +9120,12 @@ const makeArgs69 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
-const argDetailsSimple70 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
+const argDetailsSimple70 = [];
 const makeArgs70 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8901,24 +9166,12 @@ const makeArgs70 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
-const argDetailsSimple71 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
+const argDetailsSimple71 = [];
 const makeArgs71 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8959,12 +9212,48 @@ const makeArgs71 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
-const argDetailsSimple72 = [];
+const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
+const argDetailsSimple72 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.bigint,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.boolean,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.varchar,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "d",
+  postgresArgName: "d",
+  pgCodec: int4ArrayCodec,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "e",
+  postgresArgName: "e",
+  pgCodec: TYPES.json,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "f",
+  postgresArgName: "f",
+  pgCodec: floatrangeCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs72 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 6; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -9005,12 +9294,18 @@ const makeArgs72 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
-const argDetailsSimple73 = [];
+const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
+const argDetailsSimple73 = [{
+  graphqlArgName: "i1",
+  postgresArgName: "i1",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs73 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -9051,9 +9346,177 @@ const makeArgs73 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
-const argDetailsSimple74 = [];
+const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
+const argDetailsSimple74 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs74 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple74[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
+const argDetailsSimple75 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
+const makeArgs75 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple75[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
+const argDetailsSimple76 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
+const makeArgs76 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple76[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
+const argDetailsSimple77 = [];
+const makeArgs77 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
   for (let i = 0; i < 0; i++) {
@@ -9063,7 +9526,99 @@ const makeArgs74 = (args, path = []) => {
       pgCodec,
       required,
       fetcher
-    } = argDetailsSimple74[i];
+    } = argDetailsSimple77[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
+const argDetailsSimple78 = [];
+const makeArgs78 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple78[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
+const argDetailsSimple79 = [];
+const makeArgs79 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple79[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -10044,6 +10599,11 @@ type Person implements Node {
   computedInoutOut(ino: String): PersonComputedInoutOutRecord
   exists(email: Email): Boolean @deprecated(reason: "This is deprecated (comment on function c.person_exists).")
   computedFirstArgInoutOut: PersonComputedFirstArgInoutOutRecord
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, b: Int, arg2: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
   computedComplex(a: Int, b: String): PersonComputedComplexRecord
 
   """The first post by the person."""
@@ -15688,18 +16248,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_outPgResource.isUnique && !resource_person_computed_outPgResource.codec.attributes && typeof resource_person_computed_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_outPgResource.codec)`${resource_person_computed_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_outPgResource.codec)`${resource_person_computed_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_outPgResource.execute(selectArgs);
@@ -15722,18 +16292,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_first_namePgResource.isUnique && !resource_person_first_namePgResource.codec.attributes && typeof resource_person_first_namePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_first_namePgResource.codec)`${resource_person_first_namePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_first_namePgResource.codec)`${resource_person_first_namePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_first_namePgResource.execute(selectArgs);
@@ -15756,18 +16336,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_out_outPgResource.isUnique && !resource_person_computed_out_outPgResource.codec.attributes && typeof resource_person_computed_out_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_out_outPgResource.codec)`${resource_person_computed_out_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_out_outPgResource.codec)`${resource_person_computed_out_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_out_outPgResource.execute(selectArgs);
@@ -15791,18 +16381,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_computed_inoutPgResource.isUnique && !resource_person_computed_inoutPgResource.codec.attributes && typeof resource_person_computed_inoutPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_inoutPgResource.codec)`${resource_person_computed_inoutPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_computed_inoutPgResource.codec)`${resource_person_computed_inoutPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_inoutPgResource.execute(selectArgs);
@@ -15830,18 +16430,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_computed_inout_outPgResource.isUnique && !resource_person_computed_inout_outPgResource.codec.attributes && typeof resource_person_computed_inout_outPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_inout_outPgResource.codec)`${resource_person_computed_inout_outPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_computed_inout_outPgResource.codec)`${resource_person_computed_inout_outPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_inout_outPgResource.execute(selectArgs);
@@ -15869,18 +16479,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_existsPgResource.isUnique && !resource_person_existsPgResource.codec.attributes && typeof resource_person_existsPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_existsPgResource.codec)`${resource_person_existsPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_existsPgResource.codec)`${resource_person_existsPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_existsPgResource.execute(selectArgs);
@@ -15907,23 +16527,33 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_first_arg_inout_outPgResource.isUnique && !resource_person_computed_first_arg_inout_outPgResource.codec.attributes && typeof resource_person_computed_first_arg_inout_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_first_arg_inout_outPgResource.codec)`${resource_person_computed_first_arg_inout_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_first_arg_inout_outPgResource.codec)`${resource_person_computed_first_arg_inout_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_first_arg_inout_outPgResource.execute(selectArgs);
     },
-    computedComplex: {
+    optionalMissingMiddle1: {
       plan($in, args, _info) {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -15940,20 +16570,285 @@ export const plans = {
         const selectArgs = [{
           step: $row.record()
         }, ...extraSelectArgs];
-        if (resource_person_computed_complexPgResource.isUnique && !resource_person_computed_complexPgResource.codec.attributes && typeof resource_person_computed_complexPgResource.from === "function") {
+        if (resource_person_optional_missing_middle_1PgResource.isUnique && !resource_person_optional_missing_middle_1PgResource.codec.attributes && typeof resource_person_optional_missing_middle_1PgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_complexPgResource.codec)`${resource_person_computed_complexPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_optional_missing_middle_1PgResource.codec)`${resource_person_optional_missing_middle_1PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_1PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle2: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs39(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_2PgResource.isUnique && !resource_person_optional_missing_middle_2PgResource.codec.attributes && typeof resource_person_optional_missing_middle_2PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_2PgResource.codec)`${resource_person_optional_missing_middle_2PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_2PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        b: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle3: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs40(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_3PgResource.isUnique && !resource_person_optional_missing_middle_3PgResource.codec.attributes && typeof resource_person_optional_missing_middle_3PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_3PgResource.codec)`${resource_person_optional_missing_middle_3PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_3PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle4: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs41(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_4PgResource.isUnique && !resource_person_optional_missing_middle_4PgResource.codec.attributes && typeof resource_person_optional_missing_middle_4PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_4PgResource.codec)`${resource_person_optional_missing_middle_4PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_4PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        arg2: undefined
+      }
+    },
+    optionalMissingMiddle5: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs42(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_5PgResource.isUnique && !resource_person_optional_missing_middle_5PgResource.codec.attributes && typeof resource_person_optional_missing_middle_5PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_5PgResource.codec)`${resource_person_optional_missing_middle_5PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_5PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        arg2: undefined
+      }
+    },
+    computedComplex: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs43(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_computed_complexPgResource.isUnique && !resource_person_computed_complexPgResource.codec.attributes && typeof resource_person_computed_complexPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_computed_complexPgResource.codec)`${resource_person_computed_complexPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_complexPgResource.execute(selectArgs);
@@ -15967,7 +16862,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs39(args);
+      const extraSelectArgs = makeArgs44(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -15981,18 +16876,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_first_postPgResource.isUnique && !resource_person_first_postPgResource.codec.attributes && typeof resource_person_first_postPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_first_postPgResource.codec)`${resource_person_first_postPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_first_postPgResource.codec)`${resource_person_first_postPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_first_postPgResource.execute(selectArgs);
@@ -16001,7 +16906,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs40(args);
+      const extraSelectArgs = makeArgs45(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -16015,18 +16920,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_first_arg_inoutPgResource.isUnique && !resource_person_computed_first_arg_inoutPgResource.codec.attributes && typeof resource_person_computed_first_arg_inoutPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_first_arg_inoutPgResource.codec)`${resource_person_computed_first_arg_inoutPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_first_arg_inoutPgResource.codec)`${resource_person_computed_first_arg_inoutPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_first_arg_inoutPgResource.execute(selectArgs);
@@ -16173,7 +17088,7 @@ export const plans = {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
         }
-        const extraSelectArgs = makeArgs43(args);
+        const extraSelectArgs = makeArgs48(args);
         /**
          * An optimisation - if all our dependencies are
          * compatible with the expression's class plan then we
@@ -16187,18 +17102,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_type_functionPgResource.isUnique && !resource_person_type_functionPgResource.codec.attributes && typeof resource_person_type_functionPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_type_functionPgResource.codec)`${resource_person_type_functionPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_type_functionPgResource.codec)`${resource_person_type_functionPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_type_functionPgResource.execute(selectArgs);
@@ -16211,7 +17136,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs44(args);
+      const extraSelectArgs = makeArgs49(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -16225,18 +17150,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_type_function_listPgResource.isUnique && !resource_person_type_function_listPgResource.codec.attributes && typeof resource_person_type_function_listPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_type_function_listPgResource.codec)`${resource_person_type_function_listPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_type_function_listPgResource.codec)`${resource_person_type_function_listPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_type_function_listPgResource.execute(selectArgs);
@@ -16541,7 +17476,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs45(args);
+      const extraSelectArgs = makeArgs50(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -16555,18 +17490,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_compound_type_computed_fieldPgResource.isUnique && !resource_compound_type_computed_fieldPgResource.codec.attributes && typeof resource_compound_type_computed_fieldPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_compound_type_computed_fieldPgResource.codec)`${resource_compound_type_computed_fieldPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_compound_type_computed_fieldPgResource.codec)`${resource_compound_type_computed_fieldPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_compound_type_computed_fieldPgResource.execute(selectArgs);
@@ -19285,7 +20230,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs46(args);
+      const extraSelectArgs = makeArgs51(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -19299,18 +20244,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_edge_case_computedPgResource.isUnique && !resource_edge_case_computedPgResource.codec.attributes && typeof resource_edge_case_computedPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_edge_case_computedPgResource.codec)`${resource_edge_case_computedPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_edge_case_computedPgResource.codec)`${resource_edge_case_computedPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_edge_case_computedPgResource.execute(selectArgs);
@@ -20002,7 +20957,7 @@ export const plans = {
     __assertStep: __ValueStep,
     mutationOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs47(args, ["input"]);
+        const selectArgs = makeArgs52(args, ["input"]);
         const $result = resource_mutation_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -20019,7 +20974,7 @@ export const plans = {
     },
     mutationOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs48(args, ["input"]);
+        const selectArgs = makeArgs53(args, ["input"]);
         const $result = resource_mutation_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -20036,7 +20991,7 @@ export const plans = {
     },
     mutationOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs49(args, ["input"]);
+        const selectArgs = makeArgs54(args, ["input"]);
         const $result = resource_mutation_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -20053,7 +21008,7 @@ export const plans = {
     },
     noArgsMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs50(args, ["input"]);
+        const selectArgs = makeArgs55(args, ["input"]);
         const $result = resource_no_args_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -20070,7 +21025,7 @@ export const plans = {
     },
     mutationInOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs51(args, ["input"]);
+        const selectArgs = makeArgs56(args, ["input"]);
         const $result = resource_mutation_in_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -20087,7 +21042,7 @@ export const plans = {
     },
     mutationReturnsTableOneCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs52(args, ["input"]);
+        const selectArgs = makeArgs57(args, ["input"]);
         const $result = resource_mutation_returns_table_one_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -20104,7 +21059,7 @@ export const plans = {
     },
     jsonIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs53(args, ["input"]);
+        const selectArgs = makeArgs58(args, ["input"]);
         const $result = resource_json_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -20121,7 +21076,7 @@ export const plans = {
     },
     jsonbIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs54(args, ["input"]);
+        const selectArgs = makeArgs59(args, ["input"]);
         const $result = resource_jsonb_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -20138,7 +21093,7 @@ export const plans = {
     },
     jsonbIdentityMutationPlpgsql: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs55(args, ["input"]);
+        const selectArgs = makeArgs60(args, ["input"]);
         const $result = resource_jsonb_identity_mutation_plpgsqlPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -20155,7 +21110,7 @@ export const plans = {
     },
     jsonbIdentityMutationPlpgsqlWithDefault: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs56(args, ["input"]);
+        const selectArgs = makeArgs61(args, ["input"]);
         const $result = resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -20172,7 +21127,7 @@ export const plans = {
     },
     mutationInInout: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs57(args, ["input"]);
+        const selectArgs = makeArgs62(args, ["input"]);
         const $result = resource_mutation_in_inoutPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -20189,7 +21144,7 @@ export const plans = {
     },
     mutationOutOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs58(args, ["input"]);
+        const selectArgs = makeArgs63(args, ["input"]);
         const $result = resource_mutation_out_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -20206,7 +21161,7 @@ export const plans = {
     },
     mutationOutOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs59(args, ["input"]);
+        const selectArgs = makeArgs64(args, ["input"]);
         const $result = resource_mutation_out_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -20223,7 +21178,7 @@ export const plans = {
     },
     mutationOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs60(args, ["input"]);
+        const selectArgs = makeArgs65(args, ["input"]);
         const $result = resource_mutation_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -20240,7 +21195,7 @@ export const plans = {
     },
     intSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs61(args, ["input"]);
+        const selectArgs = makeArgs66(args, ["input"]);
         const $result = resource_int_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -20257,7 +21212,7 @@ export const plans = {
     },
     mutationOutUnnamedOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs62(args, ["input"]);
+        const selectArgs = makeArgs67(args, ["input"]);
         const $result = resource_mutation_out_unnamed_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -20274,7 +21229,7 @@ export const plans = {
     },
     mutationReturnsTableMultiCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs63(args, ["input"]);
+        const selectArgs = makeArgs68(args, ["input"]);
         const $result = resource_mutation_returns_table_multi_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -20291,7 +21246,7 @@ export const plans = {
     },
     leftArmIdentity: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs64(args, ["input"]);
+        const selectArgs = makeArgs69(args, ["input"]);
         const $result = resource_left_arm_identityPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -20308,7 +21263,7 @@ export const plans = {
     },
     issue756Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs65(args, ["input"]);
+        const selectArgs = makeArgs70(args, ["input"]);
         const $result = resource_issue756_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -20325,7 +21280,7 @@ export const plans = {
     },
     issue756SetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs66(args, ["input"]);
+        const selectArgs = makeArgs71(args, ["input"]);
         const $result = resource_issue756_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -20342,7 +21297,7 @@ export const plans = {
     },
     typesMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs67(args, ["input"]);
+        const selectArgs = makeArgs72(args, ["input"]);
         const $result = resource_types_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -20359,7 +21314,7 @@ export const plans = {
     },
     mutationOutOutCompoundType: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs68(args, ["input"]);
+        const selectArgs = makeArgs73(args, ["input"]);
         const $result = resource_mutation_out_out_compound_typePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -20376,7 +21331,7 @@ export const plans = {
     },
     tableMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs69(args, ["input"]);
+        const selectArgs = makeArgs74(args, ["input"]);
         const $result = resource_table_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -20393,7 +21348,7 @@ export const plans = {
     },
     mutationOutComplex: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs70(args, ["input"]);
+        const selectArgs = makeArgs75(args, ["input"]);
         const $result = resource_mutation_out_complexPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -20410,7 +21365,7 @@ export const plans = {
     },
     mutationOutComplexSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs71(args, ["input"]);
+        const selectArgs = makeArgs76(args, ["input"]);
         const $result = resource_mutation_out_complex_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -20427,7 +21382,7 @@ export const plans = {
     },
     mutationOutTable: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs72(args, ["input"]);
+        const selectArgs = makeArgs77(args, ["input"]);
         const $result = resource_mutation_out_tablePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -20444,7 +21399,7 @@ export const plans = {
     },
     mutationOutTableSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs73(args, ["input"]);
+        const selectArgs = makeArgs78(args, ["input"]);
         const $result = resource_mutation_out_table_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -20461,7 +21416,7 @@ export const plans = {
     },
     tableSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs74(args, ["input"]);
+        const selectArgs = makeArgs79(args, ["input"]);
         const $result = resource_table_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.graphql
@@ -3031,6 +3031,11 @@ type Person implements Node {
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, arg2: Int, b: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
 
   """This `Person`'s `PersonSecret`."""
   personSecretByPersonId: PersonSecret @deprecated(reason: "This is deprecated (comment on table c.person_secret).")

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.omit-pets-simple.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.omit-pets-simple.1.export.mjs
@@ -1337,18 +1337,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_people_odd_petsPgResource.isUnique && !resource_people_odd_petsPgResource.codec.attributes && typeof resource_people_odd_petsPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_people_odd_petsPgResource.codec)`${resource_people_odd_petsPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_people_odd_petsPgResource.codec)`${resource_people_odd_petsPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_people_odd_petsPgResource.execute(selectArgs);

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only-people-omit.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only-people-omit.1.export.mjs
@@ -1252,18 +1252,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_people_odd_petsPgResource.isUnique && !resource_people_odd_petsPgResource.codec.attributes && typeof resource_people_odd_petsPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_people_odd_petsPgResource.codec)`${resource_people_odd_petsPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_people_odd_petsPgResource.codec)`${resource_people_odd_petsPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_people_odd_petsPgResource.execute(selectArgs);

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only.1.export.mjs
@@ -2502,6 +2502,11 @@ const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_compu
 const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
 const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
 const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const person_optional_missing_middle_1FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_1");
+const person_optional_missing_middle_2FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_2");
+const person_optional_missing_middle_3FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_3");
+const person_optional_missing_middle_4FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_4");
+const person_optional_missing_middle_5FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_5");
 const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
 const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
 const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
@@ -4292,6 +4297,216 @@ const registry = makeRegistry({
           serviceName: "main",
           schemaName: "c",
           name: "person_computed_first_arg_inout_out"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_1: {
+      executor,
+      name: "person_optional_missing_middle_1",
+      identifier: "main.c.person_optional_missing_middle_1(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_1"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_2: {
+      executor,
+      name: "person_optional_missing_middle_2",
+      identifier: "main.c.person_optional_missing_middle_2(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_2"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_3: {
+      executor,
+      name: "person_optional_missing_middle_3",
+      identifier: "main.c.person_optional_missing_middle_3(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_3"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_4: {
+      executor,
+      name: "person_optional_missing_middle_4",
+      identifier: "main.c.person_optional_missing_middle_4(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_4"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_5: {
+      executor,
+      name: "person_optional_missing_middle_5",
+      identifier: "main.c.person_optional_missing_middle_5(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_5FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_5"
         },
         tags: {}
       },
@@ -7049,22 +7264,28 @@ const makeArgs37 = (args, path = []) => {
 };
 const resource_person_computed_first_arg_inout_outPgResource = registry.pgResources["person_computed_first_arg_inout_out"];
 const argDetailsSimple38 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
+  graphqlArgName: "arg0",
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
   graphqlArgName: "b",
   postgresArgName: "b",
-  pgCodec: TYPES.text,
-  required: true,
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
   fetcher: null
 }];
 const makeArgs38 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7075,7 +7296,7 @@ const makeArgs38 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 1 - 1) {
         skipped = true;
         continue;
       } else {
@@ -7105,12 +7326,30 @@ const makeArgs38 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
-const argDetailsSimple39 = [];
+const resource_person_optional_missing_middle_1PgResource = registry.pgResources["person_optional_missing_middle_1"];
+const argDetailsSimple39 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs39 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7151,12 +7390,30 @@ const makeArgs39 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
-const argDetailsSimple40 = [];
+const resource_person_optional_missing_middle_2PgResource = registry.pgResources["person_optional_missing_middle_2"];
+const argDetailsSimple40 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs40 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7167,7 +7424,7 @@ const makeArgs40 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 2 - 1) {
         skipped = true;
         continue;
       } else {
@@ -7197,12 +7454,30 @@ const makeArgs40 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
-const argDetailsSimple41 = [];
+const resource_person_optional_missing_middle_3PgResource = registry.pgResources["person_optional_missing_middle_3"];
+const argDetailsSimple41 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs41 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7213,7 +7488,7 @@ const makeArgs41 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -7243,12 +7518,30 @@ const makeArgs41 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_friendsPgResource = registry.pgResources["person_friends"];
-const argDetailsSimple42 = [];
+const resource_person_optional_missing_middle_4PgResource = registry.pgResources["person_optional_missing_middle_4"];
+const argDetailsSimple42 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs42 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7259,7 +7552,7 @@ const makeArgs42 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -7289,18 +7582,24 @@ const makeArgs42 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
+const resource_person_optional_missing_middle_5PgResource = registry.pgResources["person_optional_missing_middle_5"];
 const argDetailsSimple43 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs43 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7341,7 +7640,7 @@ const makeArgs43 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
+const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
 const argDetailsSimple44 = [];
 const makeArgs44 = (args, path = []) => {
   const selectArgs = [];
@@ -7387,9 +7686,7 @@ const makeArgs44 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
-const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
-const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
+const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
 const argDetailsSimple45 = [];
 const makeArgs45 = (args, path = []) => {
   const selectArgs = [];
@@ -7402,6 +7699,244 @@ const makeArgs45 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple45[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
+const argDetailsSimple46 = [];
+const makeArgs46 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple46[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_person_friendsPgResource = registry.pgResources["person_friends"];
+const argDetailsSimple47 = [];
+const makeArgs47 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple47[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
+const argDetailsSimple48 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs48 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple48[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
+const argDetailsSimple49 = [];
+const makeArgs49 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple49[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
+const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
+const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
+const argDetailsSimple50 = [];
+const makeArgs50 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple50[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -7502,247 +8037,11 @@ const parseValueLiteral = (ast, variables) => {
   }
 };
 const resource_frmcdc_postPgResource = registry.pgResources["frmcdc_post"];
-const argDetailsSimple46 = [];
-const makeArgs46 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple46[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
-const argDetailsSimple47 = [];
-const makeArgs47 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple47[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
-const argDetailsSimple48 = [];
-const makeArgs48 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple48[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
-const argDetailsSimple49 = [];
-const makeArgs49 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple49[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
-const argDetailsSimple50 = [];
-const makeArgs50 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple50[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
-const argDetailsSimple51 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const argDetailsSimple51 = [];
 const makeArgs51 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7783,18 +8082,12 @@ const makeArgs51 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
-const argDetailsSimple52 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
+const argDetailsSimple52 = [];
 const makeArgs52 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7835,18 +8128,12 @@ const makeArgs52 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
-const argDetailsSimple53 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
+const argDetailsSimple53 = [];
 const makeArgs53 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7887,18 +8174,12 @@ const makeArgs53 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
-const argDetailsSimple54 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
+const argDetailsSimple54 = [];
 const makeArgs54 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7939,18 +8220,12 @@ const makeArgs54 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
-const argDetailsSimple55 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
+const argDetailsSimple55 = [];
 const makeArgs55 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -7991,12 +8266,12 @@ const makeArgs55 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
+const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
 const argDetailsSimple56 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: false,
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
   fetcher: null
 }];
 const makeArgs56 = (args, path = []) => {
@@ -8043,16 +8318,10 @@ const makeArgs56 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
+const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
 const argDetailsSimple57 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "ino",
-  postgresArgName: "ino",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -8060,7 +8329,7 @@ const argDetailsSimple57 = [{
 const makeArgs57 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8101,12 +8370,18 @@ const makeArgs57 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
-const argDetailsSimple58 = [];
+const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
+const argDetailsSimple58 = [{
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.json,
+  required: true,
+  fetcher: null
+}];
 const makeArgs58 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8147,12 +8422,18 @@ const makeArgs58 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
-const argDetailsSimple59 = [];
+const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
+const argDetailsSimple59 = [{
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.jsonb,
+  required: true,
+  fetcher: null
+}];
 const makeArgs59 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8193,12 +8474,18 @@ const makeArgs59 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
-const argDetailsSimple60 = [];
+const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
+const argDetailsSimple60 = [{
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
+  required: true,
+  fetcher: null
+}];
 const makeArgs60 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8239,30 +8526,18 @@ const makeArgs60 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
+const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
 const argDetailsSimple61 = [{
-  graphqlArgName: "x",
-  postgresArgName: "x",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "y",
-  postgresArgName: "y",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "z",
-  postgresArgName: "z",
-  pgCodec: TYPES.int,
-  required: true,
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
+  required: false,
   fetcher: null
 }];
 const makeArgs61 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8303,12 +8578,24 @@ const makeArgs61 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
-const argDetailsSimple62 = [];
+const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
+const argDetailsSimple62 = [{
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "ino",
+  postgresArgName: "ino",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs62 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8349,18 +8636,12 @@ const makeArgs62 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
-const argDetailsSimple63 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
+const argDetailsSimple63 = [];
 const makeArgs63 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8401,18 +8682,12 @@ const makeArgs63 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
-const argDetailsSimple64 = [{
-  graphqlArgName: "leftArm",
-  postgresArgName: "left_arm",
-  pgCodec: leftArmCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
+const argDetailsSimple64 = [];
 const makeArgs64 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8453,7 +8728,7 @@ const makeArgs64 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
+const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -8499,12 +8774,30 @@ const makeArgs65 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
-const argDetailsSimple66 = [];
+const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
+const argDetailsSimple66 = [{
+  graphqlArgName: "x",
+  postgresArgName: "x",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "y",
+  postgresArgName: "y",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "z",
+  postgresArgName: "z",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs66 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8545,48 +8838,12 @@ const makeArgs66 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
-const argDetailsSimple67 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.bigint,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.boolean,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.varchar,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "d",
-  postgresArgName: "d",
-  pgCodec: int4ArrayCodec,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "e",
-  postgresArgName: "e",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "f",
-  postgresArgName: "f",
-  pgCodec: floatrangeCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
+const argDetailsSimple67 = [];
 const makeArgs67 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 6; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8627,10 +8884,10 @@ const makeArgs67 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
+const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
 const argDetailsSimple68 = [{
-  graphqlArgName: "i1",
-  postgresArgName: "i1",
+  graphqlArgName: "i",
+  postgresArgName: "i",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -8679,11 +8936,11 @@ const makeArgs68 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
+const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
 const argDetailsSimple69 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
-  pgCodec: TYPES.int,
+  graphqlArgName: "leftArm",
+  postgresArgName: "left_arm",
+  pgCodec: leftArmCodec,
   required: true,
   fetcher: null
 }];
@@ -8731,24 +8988,12 @@ const makeArgs69 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
-const argDetailsSimple70 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
+const argDetailsSimple70 = [];
 const makeArgs70 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8789,24 +9034,12 @@ const makeArgs70 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
-const argDetailsSimple71 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
+const argDetailsSimple71 = [];
 const makeArgs71 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8847,12 +9080,48 @@ const makeArgs71 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
-const argDetailsSimple72 = [];
+const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
+const argDetailsSimple72 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.bigint,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.boolean,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.varchar,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "d",
+  postgresArgName: "d",
+  pgCodec: int4ArrayCodec,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "e",
+  postgresArgName: "e",
+  pgCodec: TYPES.json,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "f",
+  postgresArgName: "f",
+  pgCodec: floatrangeCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs72 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 6; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8893,12 +9162,18 @@ const makeArgs72 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
-const argDetailsSimple73 = [];
+const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
+const argDetailsSimple73 = [{
+  graphqlArgName: "i1",
+  postgresArgName: "i1",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs73 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -8939,9 +9214,177 @@ const makeArgs73 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
-const argDetailsSimple74 = [];
+const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
+const argDetailsSimple74 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs74 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple74[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
+const argDetailsSimple75 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
+const makeArgs75 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple75[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
+const argDetailsSimple76 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
+const makeArgs76 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple76[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
+const argDetailsSimple77 = [];
+const makeArgs77 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
   for (let i = 0; i < 0; i++) {
@@ -8951,7 +9394,99 @@ const makeArgs74 = (args, path = []) => {
       pgCodec,
       required,
       fetcher
-    } = argDetailsSimple74[i];
+    } = argDetailsSimple77[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
+const argDetailsSimple78 = [];
+const makeArgs78 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple78[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
+const argDetailsSimple79 = [];
+const makeArgs79 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple79[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -9446,6 +9981,11 @@ type Person implements Node {
   computedInoutOut(ino: String): PersonComputedInoutOutRecord
   exists(email: Email): Boolean @deprecated(reason: "This is deprecated (comment on function c.person_exists).")
   computedFirstArgInoutOut: PersonComputedFirstArgInoutOutRecord
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, b: Int, arg2: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
   computedComplex(a: Int, b: String): PersonComputedComplexRecord
 
   """The first post by the person."""
@@ -13516,18 +14056,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_outPgResource.isUnique && !resource_person_computed_outPgResource.codec.attributes && typeof resource_person_computed_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_outPgResource.codec)`${resource_person_computed_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_outPgResource.codec)`${resource_person_computed_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_outPgResource.execute(selectArgs);
@@ -13550,18 +14100,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_first_namePgResource.isUnique && !resource_person_first_namePgResource.codec.attributes && typeof resource_person_first_namePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_first_namePgResource.codec)`${resource_person_first_namePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_first_namePgResource.codec)`${resource_person_first_namePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_first_namePgResource.execute(selectArgs);
@@ -13584,18 +14144,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_out_outPgResource.isUnique && !resource_person_computed_out_outPgResource.codec.attributes && typeof resource_person_computed_out_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_out_outPgResource.codec)`${resource_person_computed_out_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_out_outPgResource.codec)`${resource_person_computed_out_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_out_outPgResource.execute(selectArgs);
@@ -13619,18 +14189,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_computed_inoutPgResource.isUnique && !resource_person_computed_inoutPgResource.codec.attributes && typeof resource_person_computed_inoutPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_inoutPgResource.codec)`${resource_person_computed_inoutPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_computed_inoutPgResource.codec)`${resource_person_computed_inoutPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_inoutPgResource.execute(selectArgs);
@@ -13658,18 +14238,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_computed_inout_outPgResource.isUnique && !resource_person_computed_inout_outPgResource.codec.attributes && typeof resource_person_computed_inout_outPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_inout_outPgResource.codec)`${resource_person_computed_inout_outPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_computed_inout_outPgResource.codec)`${resource_person_computed_inout_outPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_inout_outPgResource.execute(selectArgs);
@@ -13697,18 +14287,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_existsPgResource.isUnique && !resource_person_existsPgResource.codec.attributes && typeof resource_person_existsPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_existsPgResource.codec)`${resource_person_existsPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_existsPgResource.codec)`${resource_person_existsPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_existsPgResource.execute(selectArgs);
@@ -13735,23 +14335,33 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_first_arg_inout_outPgResource.isUnique && !resource_person_computed_first_arg_inout_outPgResource.codec.attributes && typeof resource_person_computed_first_arg_inout_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_first_arg_inout_outPgResource.codec)`${resource_person_computed_first_arg_inout_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_first_arg_inout_outPgResource.codec)`${resource_person_computed_first_arg_inout_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_first_arg_inout_outPgResource.execute(selectArgs);
     },
-    computedComplex: {
+    optionalMissingMiddle1: {
       plan($in, args, _info) {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -13768,98 +14378,143 @@ export const plans = {
         const selectArgs = [{
           step: $row.record()
         }, ...extraSelectArgs];
-        if (resource_person_computed_complexPgResource.isUnique && !resource_person_computed_complexPgResource.codec.attributes && typeof resource_person_computed_complexPgResource.from === "function") {
+        if (resource_person_optional_missing_middle_1PgResource.isUnique && !resource_person_optional_missing_middle_1PgResource.codec.attributes && typeof resource_person_optional_missing_middle_1PgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_complexPgResource.codec)`${resource_person_computed_complexPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_optional_missing_middle_1PgResource.codec)`${resource_person_optional_missing_middle_1PgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
-        return resource_person_computed_complexPgResource.execute(selectArgs);
+        return resource_person_optional_missing_middle_1PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle2: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs39(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_2PgResource.isUnique && !resource_person_optional_missing_middle_2PgResource.codec.attributes && typeof resource_person_optional_missing_middle_2PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_2PgResource.codec)`${resource_person_optional_missing_middle_2PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_2PgResource.execute(selectArgs);
       },
       args: {
         a: undefined,
-        b: undefined
+        b: undefined,
+        c: undefined
       }
     },
-    firstPost($in, args, _info) {
-      if (!hasRecord($in)) {
-        throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+    optionalMissingMiddle3: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs40(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_3PgResource.isUnique && !resource_person_optional_missing_middle_3PgResource.codec.attributes && typeof resource_person_optional_missing_middle_3PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_3PgResource.codec)`${resource_person_optional_missing_middle_3PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_3PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        c: undefined
       }
-      const extraSelectArgs = makeArgs39(args);
-      /**
-       * An optimisation - if all our dependencies are
-       * compatible with the expression's class plan then we
-       * can inline ourselves into that, otherwise we must
-       * issue the query separately.
-       */
-      const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-      const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-      const selectArgs = [{
-        step: $row.record()
-      }, ...extraSelectArgs];
-      if (resource_person_first_postPgResource.isUnique && !resource_person_first_postPgResource.codec.attributes && typeof resource_person_first_postPgResource.from === "function") {
-        // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
-          if (i === 0) {
-            return $row.getClassStep().alias;
-          } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
-          } else {
-            return $row.placeholder(arg.step);
-          }
-        });
-        return pgClassExpression($row, resource_person_first_postPgResource.codec)`${resource_person_first_postPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
-      }
-      // PERF: or here, if scalar add select to `$row`?
-      return resource_person_first_postPgResource.execute(selectArgs);
     },
-    computedFirstArgInout($in, args, _info) {
-      if (!hasRecord($in)) {
-        throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-      }
-      const extraSelectArgs = makeArgs40(args);
-      /**
-       * An optimisation - if all our dependencies are
-       * compatible with the expression's class plan then we
-       * can inline ourselves into that, otherwise we must
-       * issue the query separately.
-       */
-      const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-      const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-      const selectArgs = [{
-        step: $row.record()
-      }, ...extraSelectArgs];
-      if (resource_person_computed_first_arg_inoutPgResource.isUnique && !resource_person_computed_first_arg_inoutPgResource.codec.attributes && typeof resource_person_computed_first_arg_inoutPgResource.from === "function") {
-        // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
-          if (i === 0) {
-            return $row.getClassStep().alias;
-          } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
-          } else {
-            return $row.placeholder(arg.step);
-          }
-        });
-        return pgClassExpression($row, resource_person_computed_first_arg_inoutPgResource.codec)`${resource_person_computed_first_arg_inoutPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
-      }
-      // PERF: or here, if scalar add select to `$row`?
-      return resource_person_computed_first_arg_inoutPgResource.execute(selectArgs);
-    },
-    friendsList: {
+    optionalMissingMiddle4: {
       plan($in, args, _info) {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -13876,20 +14531,270 @@ export const plans = {
         const selectArgs = [{
           step: $row.record()
         }, ...extraSelectArgs];
-        if (resource_person_friendsPgResource.isUnique && !resource_person_friendsPgResource.codec.attributes && typeof resource_person_friendsPgResource.from === "function") {
+        if (resource_person_optional_missing_middle_4PgResource.isUnique && !resource_person_optional_missing_middle_4PgResource.codec.attributes && typeof resource_person_optional_missing_middle_4PgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_friendsPgResource.codec)`${resource_person_friendsPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_optional_missing_middle_4PgResource.codec)`${resource_person_optional_missing_middle_4PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_4PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        arg2: undefined
+      }
+    },
+    optionalMissingMiddle5: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs42(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_5PgResource.isUnique && !resource_person_optional_missing_middle_5PgResource.codec.attributes && typeof resource_person_optional_missing_middle_5PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_5PgResource.codec)`${resource_person_optional_missing_middle_5PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_5PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        arg2: undefined
+      }
+    },
+    computedComplex: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs43(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_computed_complexPgResource.isUnique && !resource_person_computed_complexPgResource.codec.attributes && typeof resource_person_computed_complexPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_computed_complexPgResource.codec)`${resource_person_computed_complexPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_computed_complexPgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        b: undefined
+      }
+    },
+    firstPost($in, args, _info) {
+      if (!hasRecord($in)) {
+        throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+      }
+      const extraSelectArgs = makeArgs44(args);
+      /**
+       * An optimisation - if all our dependencies are
+       * compatible with the expression's class plan then we
+       * can inline ourselves into that, otherwise we must
+       * issue the query separately.
+       */
+      const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+      const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+      const selectArgs = [{
+        step: $row.record()
+      }, ...extraSelectArgs];
+      if (resource_person_first_postPgResource.isUnique && !resource_person_first_postPgResource.codec.attributes && typeof resource_person_first_postPgResource.from === "function") {
+        // This is a scalar computed attribute, let's inline the expression
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
+          if (i === 0) {
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
+          } else if ("pgCodec" in arg && arg.pgCodec) {
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
+          } else {
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
+          }
+        });
+        return pgClassExpression($row, resource_person_first_postPgResource.codec)`${resource_person_first_postPgResource.from(...newSelectArgs)}`;
+      }
+      // PERF: or here, if scalar add select to `$row`?
+      return resource_person_first_postPgResource.execute(selectArgs);
+    },
+    computedFirstArgInout($in, args, _info) {
+      if (!hasRecord($in)) {
+        throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+      }
+      const extraSelectArgs = makeArgs45(args);
+      /**
+       * An optimisation - if all our dependencies are
+       * compatible with the expression's class plan then we
+       * can inline ourselves into that, otherwise we must
+       * issue the query separately.
+       */
+      const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+      const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+      const selectArgs = [{
+        step: $row.record()
+      }, ...extraSelectArgs];
+      if (resource_person_computed_first_arg_inoutPgResource.isUnique && !resource_person_computed_first_arg_inoutPgResource.codec.attributes && typeof resource_person_computed_first_arg_inoutPgResource.from === "function") {
+        // This is a scalar computed attribute, let's inline the expression
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
+          if (i === 0) {
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
+          } else if ("pgCodec" in arg && arg.pgCodec) {
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
+          } else {
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
+          }
+        });
+        return pgClassExpression($row, resource_person_computed_first_arg_inoutPgResource.codec)`${resource_person_computed_first_arg_inoutPgResource.from(...newSelectArgs)}`;
+      }
+      // PERF: or here, if scalar add select to `$row`?
+      return resource_person_computed_first_arg_inoutPgResource.execute(selectArgs);
+    },
+    friendsList: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs46(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_friendsPgResource.isUnique && !resource_person_friendsPgResource.codec.attributes && typeof resource_person_friendsPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_friendsPgResource.codec)`${resource_person_friendsPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_friendsPgResource.execute(selectArgs);
@@ -13922,7 +14827,7 @@ export const plans = {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
         }
-        const extraSelectArgs = makeArgs42(args);
+        const extraSelectArgs = makeArgs47(args);
         /**
          * An optimisation - if all our dependencies are
          * compatible with the expression's class plan then we
@@ -13936,18 +14841,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_type_function_connectionPgResource.isUnique && !resource_person_type_function_connectionPgResource.codec.attributes && typeof resource_person_type_function_connectionPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_type_function_connectionPgResource.codec)`${resource_person_type_function_connectionPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_type_function_connectionPgResource.codec)`${resource_person_type_function_connectionPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_type_function_connectionPgResource.execute(selectArgs);
@@ -13972,7 +14887,7 @@ export const plans = {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
         }
-        const extraSelectArgs = makeArgs43(args);
+        const extraSelectArgs = makeArgs48(args);
         /**
          * An optimisation - if all our dependencies are
          * compatible with the expression's class plan then we
@@ -13986,18 +14901,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_type_functionPgResource.isUnique && !resource_person_type_functionPgResource.codec.attributes && typeof resource_person_type_functionPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_type_functionPgResource.codec)`${resource_person_type_functionPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_type_functionPgResource.codec)`${resource_person_type_functionPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_type_functionPgResource.execute(selectArgs);
@@ -14010,7 +14935,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs44(args);
+      const extraSelectArgs = makeArgs49(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -14024,18 +14949,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_type_function_listPgResource.isUnique && !resource_person_type_function_listPgResource.codec.attributes && typeof resource_person_type_function_listPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_type_function_listPgResource.codec)`${resource_person_type_function_listPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_type_function_listPgResource.codec)`${resource_person_type_function_listPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_type_function_listPgResource.execute(selectArgs);
@@ -14228,7 +15163,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs45(args);
+      const extraSelectArgs = makeArgs50(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -14242,18 +15177,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_compound_type_computed_fieldPgResource.isUnique && !resource_compound_type_computed_fieldPgResource.codec.attributes && typeof resource_compound_type_computed_fieldPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_compound_type_computed_fieldPgResource.codec)`${resource_compound_type_computed_fieldPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_compound_type_computed_fieldPgResource.codec)`${resource_compound_type_computed_fieldPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_compound_type_computed_fieldPgResource.execute(selectArgs);
@@ -16622,7 +17567,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs46(args);
+      const extraSelectArgs = makeArgs51(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -16636,18 +17581,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_edge_case_computedPgResource.isUnique && !resource_edge_case_computedPgResource.codec.attributes && typeof resource_edge_case_computedPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_edge_case_computedPgResource.codec)`${resource_edge_case_computedPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_edge_case_computedPgResource.codec)`${resource_edge_case_computedPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_edge_case_computedPgResource.execute(selectArgs);
@@ -17264,7 +18219,7 @@ export const plans = {
     __assertStep: __ValueStep,
     mutationOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs47(args, ["input"]);
+        const selectArgs = makeArgs52(args, ["input"]);
         const $result = resource_mutation_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17281,7 +18236,7 @@ export const plans = {
     },
     mutationOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs48(args, ["input"]);
+        const selectArgs = makeArgs53(args, ["input"]);
         const $result = resource_mutation_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17298,7 +18253,7 @@ export const plans = {
     },
     mutationOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs49(args, ["input"]);
+        const selectArgs = makeArgs54(args, ["input"]);
         const $result = resource_mutation_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17315,7 +18270,7 @@ export const plans = {
     },
     noArgsMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs50(args, ["input"]);
+        const selectArgs = makeArgs55(args, ["input"]);
         const $result = resource_no_args_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17332,7 +18287,7 @@ export const plans = {
     },
     mutationInOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs51(args, ["input"]);
+        const selectArgs = makeArgs56(args, ["input"]);
         const $result = resource_mutation_in_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17349,7 +18304,7 @@ export const plans = {
     },
     mutationReturnsTableOneCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs52(args, ["input"]);
+        const selectArgs = makeArgs57(args, ["input"]);
         const $result = resource_mutation_returns_table_one_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17366,7 +18321,7 @@ export const plans = {
     },
     jsonIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs53(args, ["input"]);
+        const selectArgs = makeArgs58(args, ["input"]);
         const $result = resource_json_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17383,7 +18338,7 @@ export const plans = {
     },
     jsonbIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs54(args, ["input"]);
+        const selectArgs = makeArgs59(args, ["input"]);
         const $result = resource_jsonb_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17400,7 +18355,7 @@ export const plans = {
     },
     jsonbIdentityMutationPlpgsql: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs55(args, ["input"]);
+        const selectArgs = makeArgs60(args, ["input"]);
         const $result = resource_jsonb_identity_mutation_plpgsqlPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17417,7 +18372,7 @@ export const plans = {
     },
     jsonbIdentityMutationPlpgsqlWithDefault: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs56(args, ["input"]);
+        const selectArgs = makeArgs61(args, ["input"]);
         const $result = resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17434,7 +18389,7 @@ export const plans = {
     },
     mutationInInout: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs57(args, ["input"]);
+        const selectArgs = makeArgs62(args, ["input"]);
         const $result = resource_mutation_in_inoutPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17451,7 +18406,7 @@ export const plans = {
     },
     mutationOutOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs58(args, ["input"]);
+        const selectArgs = makeArgs63(args, ["input"]);
         const $result = resource_mutation_out_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17468,7 +18423,7 @@ export const plans = {
     },
     mutationOutOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs59(args, ["input"]);
+        const selectArgs = makeArgs64(args, ["input"]);
         const $result = resource_mutation_out_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17485,7 +18440,7 @@ export const plans = {
     },
     mutationOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs60(args, ["input"]);
+        const selectArgs = makeArgs65(args, ["input"]);
         const $result = resource_mutation_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17502,7 +18457,7 @@ export const plans = {
     },
     intSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs61(args, ["input"]);
+        const selectArgs = makeArgs66(args, ["input"]);
         const $result = resource_int_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17519,7 +18474,7 @@ export const plans = {
     },
     mutationOutUnnamedOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs62(args, ["input"]);
+        const selectArgs = makeArgs67(args, ["input"]);
         const $result = resource_mutation_out_unnamed_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17536,7 +18491,7 @@ export const plans = {
     },
     mutationReturnsTableMultiCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs63(args, ["input"]);
+        const selectArgs = makeArgs68(args, ["input"]);
         const $result = resource_mutation_returns_table_multi_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17553,7 +18508,7 @@ export const plans = {
     },
     leftArmIdentity: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs64(args, ["input"]);
+        const selectArgs = makeArgs69(args, ["input"]);
         const $result = resource_left_arm_identityPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17570,7 +18525,7 @@ export const plans = {
     },
     issue756Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs65(args, ["input"]);
+        const selectArgs = makeArgs70(args, ["input"]);
         const $result = resource_issue756_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17587,7 +18542,7 @@ export const plans = {
     },
     issue756SetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs66(args, ["input"]);
+        const selectArgs = makeArgs71(args, ["input"]);
         const $result = resource_issue756_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17604,7 +18559,7 @@ export const plans = {
     },
     typesMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs67(args, ["input"]);
+        const selectArgs = makeArgs72(args, ["input"]);
         const $result = resource_types_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17621,7 +18576,7 @@ export const plans = {
     },
     mutationOutOutCompoundType: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs68(args, ["input"]);
+        const selectArgs = makeArgs73(args, ["input"]);
         const $result = resource_mutation_out_out_compound_typePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17638,7 +18593,7 @@ export const plans = {
     },
     tableMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs69(args, ["input"]);
+        const selectArgs = makeArgs74(args, ["input"]);
         const $result = resource_table_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17655,7 +18610,7 @@ export const plans = {
     },
     mutationOutComplex: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs70(args, ["input"]);
+        const selectArgs = makeArgs75(args, ["input"]);
         const $result = resource_mutation_out_complexPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17672,7 +18627,7 @@ export const plans = {
     },
     mutationOutComplexSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs71(args, ["input"]);
+        const selectArgs = makeArgs76(args, ["input"]);
         const $result = resource_mutation_out_complex_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17689,7 +18644,7 @@ export const plans = {
     },
     mutationOutTable: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs72(args, ["input"]);
+        const selectArgs = makeArgs77(args, ["input"]);
         const $result = resource_mutation_out_tablePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17706,7 +18661,7 @@ export const plans = {
     },
     mutationOutTableSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs73(args, ["input"]);
+        const selectArgs = makeArgs78(args, ["input"]);
         const $result = resource_mutation_out_table_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -17723,7 +18678,7 @@ export const plans = {
     },
     tableSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs74(args, ["input"]);
+        const selectArgs = makeArgs79(args, ["input"]);
         const $result = resource_table_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only.1.graphql
@@ -2459,6 +2459,11 @@ type Person implements Node {
   A globally unique identifier. Can be used in various places throughout the system to identify this single value.
   """
   nodeId: ID!
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, arg2: Int, b: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
 
   """This `Person`'s `PersonSecret`."""
   personSecretByPersonId: PersonSecret @deprecated(reason: "This is deprecated (comment on table c.person_secret).")

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.pets-simple.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.pets-simple.1.export.mjs
@@ -463,18 +463,28 @@ const getSelectPlanFromParentAndArgs = ($in, args, _info) => {
   }, ...extraSelectArgs];
   if (resource_people_odd_petsPgResource.isUnique && !resource_people_odd_petsPgResource.codec.attributes && typeof resource_people_odd_petsPgResource.from === "function") {
     // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
       if (i === 0) {
-        return $row.getClassStep().alias;
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
       } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
       } else {
-        return $row.placeholder(arg.step);
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
       }
     });
-    return pgClassExpression($row, resource_people_odd_petsPgResource.codec)`${resource_people_odd_petsPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
+    return pgClassExpression($row, resource_people_odd_petsPgResource.codec)`${resource_people_odd_petsPgResource.from(...newSelectArgs)}`;
   }
   // PERF: or here, if scalar add select to `$row`?
   return resource_people_odd_petsPgResource.execute(selectArgs);

--- a/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.export.mjs
@@ -3494,6 +3494,11 @@ const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_compu
 const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
 const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
 const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const person_optional_missing_middle_1FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_1");
+const person_optional_missing_middle_2FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_2");
+const person_optional_missing_middle_3FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_3");
+const person_optional_missing_middle_4FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_4");
+const person_optional_missing_middle_5FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_5");
 const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
 const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
 const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
@@ -7383,6 +7388,216 @@ const registry = makeRegistry({
           serviceName: "main",
           schemaName: "c",
           name: "person_computed_first_arg_inout_out"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_1: {
+      executor,
+      name: "person_optional_missing_middle_1",
+      identifier: "main.c.person_optional_missing_middle_1(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_1"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_2: {
+      executor,
+      name: "person_optional_missing_middle_2",
+      identifier: "main.c.person_optional_missing_middle_2(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_2"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_3: {
+      executor,
+      name: "person_optional_missing_middle_3",
+      identifier: "main.c.person_optional_missing_middle_3(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_3"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_4: {
+      executor,
+      name: "person_optional_missing_middle_4",
+      identifier: "main.c.person_optional_missing_middle_4(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_4"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_5: {
+      executor,
+      name: "person_optional_missing_middle_5",
+      identifier: "main.c.person_optional_missing_middle_5(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_5FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_5"
         },
         tags: {}
       },
@@ -11870,22 +12085,28 @@ const makeArgs56 = (args, path = []) => {
 };
 const resource_person_computed_first_arg_inout_outPgResource = registry.pgResources["person_computed_first_arg_inout_out"];
 const argDetailsSimple57 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
+  graphqlArgName: "arg0",
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
   graphqlArgName: "b",
   postgresArgName: "b",
-  pgCodec: TYPES.text,
-  required: true,
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
   fetcher: null
 }];
 const makeArgs57 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11896,7 +12117,7 @@ const makeArgs57 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 1 - 1) {
         skipped = true;
         continue;
       } else {
@@ -11926,12 +12147,30 @@ const makeArgs57 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
-const argDetailsSimple58 = [];
+const resource_person_optional_missing_middle_1PgResource = registry.pgResources["person_optional_missing_middle_1"];
+const argDetailsSimple58 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs58 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11972,12 +12211,30 @@ const makeArgs58 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
-const argDetailsSimple59 = [];
+const resource_person_optional_missing_middle_2PgResource = registry.pgResources["person_optional_missing_middle_2"];
+const argDetailsSimple59 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs59 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11988,7 +12245,7 @@ const makeArgs59 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 2 - 1) {
         skipped = true;
         continue;
       } else {
@@ -12018,12 +12275,30 @@ const makeArgs59 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
-const argDetailsSimple60 = [];
+const resource_person_optional_missing_middle_3PgResource = registry.pgResources["person_optional_missing_middle_3"];
+const argDetailsSimple60 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs60 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12034,7 +12309,7 @@ const makeArgs60 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -12064,46 +12339,30 @@ const makeArgs60 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_friendsPgResource = registry.pgResources["person_friends"];
-const getSelectPlanFromParentAndArgs15 = ($in, args, _info) => {
-  if (!hasRecord($in)) {
-    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-  }
-  const extraSelectArgs = makeArgs60(args);
-  /**
-   * An optimisation - if all our dependencies are
-   * compatible with the expression's class plan then we
-   * can inline ourselves into that, otherwise we must
-   * issue the query separately.
-   */
-  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-  const selectArgs = [{
-    step: $row.record()
-  }, ...extraSelectArgs];
-  if (resource_person_friendsPgResource.isUnique && !resource_person_friendsPgResource.codec.attributes && typeof resource_person_friendsPgResource.from === "function") {
-    // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
-      if (i === 0) {
-        return $row.getClassStep().alias;
-      } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
-      } else {
-        return $row.placeholder(arg.step);
-      }
-    });
-    return pgClassExpression($row, resource_person_friendsPgResource.codec)`${resource_person_friendsPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
-  }
-  // PERF: or here, if scalar add select to `$row`?
-  return resource_person_friendsPgResource.execute(selectArgs);
-};
-const argDetailsSimple61 = [];
+const resource_person_optional_missing_middle_4PgResource = registry.pgResources["person_optional_missing_middle_4"];
+const argDetailsSimple61 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs61 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12114,7 +12373,7 @@ const makeArgs61 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -12144,52 +12403,24 @@ const makeArgs61 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
-const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
-  if (!hasRecord($in)) {
-    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-  }
-  const extraSelectArgs = makeArgs61(args);
-  /**
-   * An optimisation - if all our dependencies are
-   * compatible with the expression's class plan then we
-   * can inline ourselves into that, otherwise we must
-   * issue the query separately.
-   */
-  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-  const selectArgs = [{
-    step: $row.record()
-  }, ...extraSelectArgs];
-  if (resource_person_type_function_connectionPgResource.isUnique && !resource_person_type_function_connectionPgResource.codec.attributes && typeof resource_person_type_function_connectionPgResource.from === "function") {
-    // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
-      if (i === 0) {
-        return $row.getClassStep().alias;
-      } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
-      } else {
-        return $row.placeholder(arg.step);
-      }
-    });
-    return pgClassExpression($row, resource_person_type_function_connectionPgResource.codec)`${resource_person_type_function_connectionPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
-  }
-  // PERF: or here, if scalar add select to `$row`?
-  return resource_person_type_function_connectionPgResource.execute(selectArgs);
-};
+const resource_person_optional_missing_middle_5PgResource = registry.pgResources["person_optional_missing_middle_5"];
 const argDetailsSimple62 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs62 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12230,7 +12461,7 @@ const makeArgs62 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
+const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
 const argDetailsSimple63 = [];
 const makeArgs63 = (args, path = []) => {
   const selectArgs = [];
@@ -12276,9 +12507,7 @@ const makeArgs63 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
-const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
-const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
+const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
 const argDetailsSimple64 = [];
 const makeArgs64 = (args, path = []) => {
   const selectArgs = [];
@@ -12324,16 +12553,7 @@ const makeArgs64 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
-function UUIDSerialize(value) {
-  return "" + value;
-}
-const coerce = string => {
-  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
-    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
-  }
-  return string;
-};
+const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -12379,8 +12599,8 @@ const makeArgs65 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_interval_setPgResource = registry.pgResources["post_computed_interval_set"];
-const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
+const resource_person_friendsPgResource = registry.pgResources["person_friends"];
+const getSelectPlanFromParentAndArgs15 = ($in, args, _info) => {
   if (!hasRecord($in)) {
     throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
   }
@@ -12396,23 +12616,33 @@ const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
   const selectArgs = [{
     step: $row.record()
   }, ...extraSelectArgs];
-  if (resource_post_computed_interval_setPgResource.isUnique && !resource_post_computed_interval_setPgResource.codec.attributes && typeof resource_post_computed_interval_setPgResource.from === "function") {
+  if (resource_person_friendsPgResource.isUnique && !resource_person_friendsPgResource.codec.attributes && typeof resource_person_friendsPgResource.from === "function") {
     // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
       if (i === 0) {
-        return $row.getClassStep().alias;
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
       } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
       } else {
-        return $row.placeholder(arg.step);
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
       }
     });
-    return pgClassExpression($row, resource_post_computed_interval_setPgResource.codec)`${resource_post_computed_interval_setPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
+    return pgClassExpression($row, resource_person_friendsPgResource.codec)`${resource_person_friendsPgResource.from(...newSelectArgs)}`;
   }
   // PERF: or here, if scalar add select to `$row`?
-  return resource_post_computed_interval_setPgResource.execute(selectArgs);
+  return resource_person_friendsPgResource.execute(selectArgs);
 };
 const argDetailsSimple66 = [];
 const makeArgs66 = (args, path = []) => {
@@ -12459,12 +12689,62 @@ const makeArgs66 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_interval_arrayPgResource = registry.pgResources["post_computed_interval_array"];
-const argDetailsSimple67 = [];
+const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
+const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
+  if (!hasRecord($in)) {
+    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+  }
+  const extraSelectArgs = makeArgs66(args);
+  /**
+   * An optimisation - if all our dependencies are
+   * compatible with the expression's class plan then we
+   * can inline ourselves into that, otherwise we must
+   * issue the query separately.
+   */
+  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+  const selectArgs = [{
+    step: $row.record()
+  }, ...extraSelectArgs];
+  if (resource_person_type_function_connectionPgResource.isUnique && !resource_person_type_function_connectionPgResource.codec.attributes && typeof resource_person_type_function_connectionPgResource.from === "function") {
+    // This is a scalar computed attribute, let's inline the expression
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
+      if (i === 0) {
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
+      } else if ("pgCodec" in arg && arg.pgCodec) {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
+      } else {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
+      }
+    });
+    return pgClassExpression($row, resource_person_type_function_connectionPgResource.codec)`${resource_person_type_function_connectionPgResource.from(...newSelectArgs)}`;
+  }
+  // PERF: or here, if scalar add select to `$row`?
+  return resource_person_type_function_connectionPgResource.execute(selectArgs);
+};
+const argDetailsSimple67 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs67 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12505,18 +12785,12 @@ const makeArgs67 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_text_arrayPgResource = registry.pgResources["post_computed_text_array"];
-const argDetailsSimple68 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: false,
-  fetcher: null
-}];
+const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
+const argDetailsSimple68 = [];
 const makeArgs68 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12557,18 +12831,14 @@ const makeArgs68 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_with_optional_argPgResource = registry.pgResources["post_computed_with_optional_arg"];
-const argDetailsSimple69 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
+const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
+const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
+const argDetailsSimple69 = [];
 const makeArgs69 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12609,24 +12879,21 @@ const makeArgs69 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_with_required_argPgResource = registry.pgResources["post_computed_with_required_arg"];
-const argDetailsSimple70 = [{
-  graphqlArgName: "length",
-  postgresArgName: "length",
-  pgCodec: TYPES.int,
-  required: false,
-  fetcher: null
-}, {
-  graphqlArgName: "omission",
-  postgresArgName: "omission",
-  pgCodec: TYPES.text,
-  required: false,
-  fetcher: null
-}];
+const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
+function UUIDSerialize(value) {
+  return "" + value;
+}
+const coerce = string => {
+  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
+    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
+  }
+  return string;
+};
+const argDetailsSimple70 = [];
 const makeArgs70 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12667,24 +12934,56 @@ const makeArgs70 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmedPgResource = registry.pgResources["post_headline_trimmed"];
-const argDetailsSimple71 = [{
-  graphqlArgName: "length",
-  postgresArgName: "length",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "omission",
-  postgresArgName: "omission",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_post_computed_interval_setPgResource = registry.pgResources["post_computed_interval_set"];
+const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
+  if (!hasRecord($in)) {
+    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+  }
+  const extraSelectArgs = makeArgs70(args);
+  /**
+   * An optimisation - if all our dependencies are
+   * compatible with the expression's class plan then we
+   * can inline ourselves into that, otherwise we must
+   * issue the query separately.
+   */
+  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+  const selectArgs = [{
+    step: $row.record()
+  }, ...extraSelectArgs];
+  if (resource_post_computed_interval_setPgResource.isUnique && !resource_post_computed_interval_setPgResource.codec.attributes && typeof resource_post_computed_interval_setPgResource.from === "function") {
+    // This is a scalar computed attribute, let's inline the expression
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
+      if (i === 0) {
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
+      } else if ("pgCodec" in arg && arg.pgCodec) {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
+      } else {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
+      }
+    });
+    return pgClassExpression($row, resource_post_computed_interval_setPgResource.codec)`${resource_post_computed_interval_setPgResource.from(...newSelectArgs)}`;
+  }
+  // PERF: or here, if scalar add select to `$row`?
+  return resource_post_computed_interval_setPgResource.execute(selectArgs);
+};
+const argDetailsSimple71 = [];
 const makeArgs71 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12725,24 +13024,12 @@ const makeArgs71 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmed_no_defaultsPgResource = registry.pgResources["post_headline_trimmed_no_defaults"];
-const argDetailsSimple72 = [{
-  graphqlArgName: "length",
-  postgresArgName: "length",
-  pgCodec: TYPES.int,
-  required: false,
-  fetcher: null
-}, {
-  graphqlArgName: "omission",
-  postgresArgName: "omission",
-  pgCodec: TYPES.text,
-  required: false,
-  fetcher: null
-}];
+const resource_post_computed_interval_arrayPgResource = registry.pgResources["post_computed_interval_array"];
+const argDetailsSimple72 = [];
 const makeArgs72 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12783,12 +13070,12 @@ const makeArgs72 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmed_strictPgResource = registry.pgResources["post_headline_trimmed_strict"];
+const resource_post_computed_text_arrayPgResource = registry.pgResources["post_computed_text_array"];
 const argDetailsSimple73 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
-  required: true,
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: false,
   fetcher: null
 }];
 const makeArgs73 = (args, path = []) => {
@@ -12802,6 +13089,284 @@ const makeArgs73 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple73[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_computed_with_optional_argPgResource = registry.pgResources["post_computed_with_optional_arg"];
+const argDetailsSimple74 = [{
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs74 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple74[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_computed_with_required_argPgResource = registry.pgResources["post_computed_with_required_arg"];
+const argDetailsSimple75 = [{
+  graphqlArgName: "length",
+  postgresArgName: "length",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "omission",
+  postgresArgName: "omission",
+  pgCodec: TYPES.text,
+  required: false,
+  fetcher: null
+}];
+const makeArgs75 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple75[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_headline_trimmedPgResource = registry.pgResources["post_headline_trimmed"];
+const argDetailsSimple76 = [{
+  graphqlArgName: "length",
+  postgresArgName: "length",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "omission",
+  postgresArgName: "omission",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
+const makeArgs76 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple76[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_headline_trimmed_no_defaultsPgResource = registry.pgResources["post_headline_trimmed_no_defaults"];
+const argDetailsSimple77 = [{
+  graphqlArgName: "length",
+  postgresArgName: "length",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "omission",
+  postgresArgName: "omission",
+  pgCodec: TYPES.text,
+  required: false,
+  fetcher: null
+}];
+const makeArgs77 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple77[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_headline_trimmed_strictPgResource = registry.pgResources["post_headline_trimmed_strict"];
+const argDetailsSimple78 = [{
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
+  required: true,
+  fetcher: null
+}];
+const makeArgs78 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple78[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -12892,236 +13457,6 @@ const parseValueLiteral = (ast, variables) => {
       return undefined;
   }
 };
-const argDetailsSimple74 = [];
-const makeArgs74 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple74[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
-const argDetailsSimple75 = [];
-const makeArgs75 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple75[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
-const argDetailsSimple76 = [];
-const makeArgs76 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple76[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
-const argDetailsSimple77 = [];
-const makeArgs77 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple77[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
-const argDetailsSimple78 = [];
-const makeArgs78 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple78[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
 const argDetailsSimple79 = [];
 const makeArgs79 = (args, path = []) => {
   const selectArgs = [];
@@ -13167,7 +13502,7 @@ const makeArgs79 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
+const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
 const argDetailsSimple80 = [];
 const makeArgs80 = (args, path = []) => {
   const selectArgs = [];
@@ -13213,18 +13548,12 @@ const makeArgs80 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
-const argDetailsSimple81 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
+const argDetailsSimple81 = [];
 const makeArgs81 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13265,18 +13594,12 @@ const makeArgs81 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
-const argDetailsSimple82 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
+const argDetailsSimple82 = [];
 const makeArgs82 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13317,18 +13640,12 @@ const makeArgs82 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
-const argDetailsSimple83 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
+const argDetailsSimple83 = [];
 const makeArgs83 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13369,18 +13686,12 @@ const makeArgs83 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
-const argDetailsSimple84 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
+const argDetailsSimple84 = [];
 const makeArgs84 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13421,18 +13732,12 @@ const makeArgs84 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
-const argDetailsSimple85 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
+const argDetailsSimple85 = [];
 const makeArgs85 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13473,12 +13778,12 @@ const makeArgs85 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
+const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
 const argDetailsSimple86 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: false,
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
   fetcher: null
 }];
 const makeArgs86 = (args, path = []) => {
@@ -13525,16 +13830,10 @@ const makeArgs86 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
+const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
 const argDetailsSimple87 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: null,
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "arg1",
-  postgresArgName: null,
+  graphqlArgName: "i",
+  postgresArgName: "i",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -13542,7 +13841,7 @@ const argDetailsSimple87 = [{
 const makeArgs87 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13553,7 +13852,7 @@ const makeArgs87 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 2 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13583,24 +13882,18 @@ const makeArgs87 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
+const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
 const argDetailsSimple88 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.json,
   required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.int,
-  required: false,
   fetcher: null
 }];
 const makeArgs88 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13641,24 +13934,18 @@ const makeArgs88 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
+const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
 const argDetailsSimple89 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "arg1",
-  postgresArgName: "",
-  pgCodec: TYPES.int,
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.jsonb,
   required: true,
   fetcher: null
 }];
 const makeArgs89 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13669,7 +13956,7 @@ const makeArgs89 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 2 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13699,24 +13986,18 @@ const makeArgs89 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
+const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
 const argDetailsSimple90 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: "",
-  pgCodec: TYPES.int,
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
   required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.int,
-  required: false,
   fetcher: null
 }];
 const makeArgs90 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13727,7 +14008,7 @@ const makeArgs90 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 1 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13757,24 +14038,18 @@ const makeArgs90 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
+const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
 const argDetailsSimple91 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: "",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.int,
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
   required: false,
   fetcher: null
 }];
 const makeArgs91 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13785,7 +14060,7 @@ const makeArgs91 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 1 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13815,7 +14090,7 @@ const makeArgs91 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
+const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
 const argDetailsSimple92 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -13873,18 +14148,18 @@ const makeArgs92 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_1PgResource = registry.pgResources["mult_1"];
+const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
 const argDetailsSimple93 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: null,
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "arg1",
-  postgresArgName: null,
+  graphqlArgName: "b",
+  postgresArgName: "b",
   pgCodec: TYPES.int,
-  required: true,
+  required: false,
   fetcher: null
 }];
 const makeArgs93 = (args, path = []) => {
@@ -13901,7 +14176,7 @@ const makeArgs93 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 2 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13931,16 +14206,16 @@ const makeArgs93 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_2PgResource = registry.pgResources["mult_2"];
+const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
 const argDetailsSimple94 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: null,
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
   graphqlArgName: "arg1",
-  postgresArgName: null,
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -13989,18 +14264,18 @@ const makeArgs94 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_3PgResource = registry.pgResources["mult_3"];
+const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
 const argDetailsSimple95 = [{
   graphqlArgName: "arg0",
-  postgresArgName: null,
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "arg1",
-  postgresArgName: null,
+  graphqlArgName: "b",
+  postgresArgName: "b",
   pgCodec: TYPES.int,
-  required: true,
+  required: false,
   fetcher: null
 }];
 const makeArgs95 = (args, path = []) => {
@@ -14014,6 +14289,296 @@ const makeArgs95 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple95[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 1 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
+const argDetailsSimple96 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
+const makeArgs96 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple96[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 1 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
+const argDetailsSimple97 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs97 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple97[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 2 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mult_1PgResource = registry.pgResources["mult_1"];
+const argDetailsSimple98 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs98 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple98[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 2 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mult_2PgResource = registry.pgResources["mult_2"];
+const argDetailsSimple99 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs99 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple99[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 2 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mult_3PgResource = registry.pgResources["mult_3"];
+const argDetailsSimple100 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs100 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple100[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -14048,7 +14613,7 @@ const makeArgs95 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_4PgResource = registry.pgResources["mult_4"];
-const argDetailsSimple96 = [{
+const argDetailsSimple101 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
   pgCodec: TYPES.int,
@@ -14061,258 +14626,10 @@ const argDetailsSimple96 = [{
   required: true,
   fetcher: null
 }];
-const makeArgs96 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 2; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple96[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
-const argDetailsSimple97 = [];
-const makeArgs97 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple97[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
-const argDetailsSimple98 = [];
-const makeArgs98 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple98[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
-const argDetailsSimple99 = [];
-const makeArgs99 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple99[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
-const argDetailsSimple100 = [{
-  graphqlArgName: "x",
-  postgresArgName: "x",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "y",
-  postgresArgName: "y",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "z",
-  postgresArgName: "z",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
-const makeArgs100 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 3; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple100[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
-const argDetailsSimple101 = [];
 const makeArgs101 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14353,18 +14670,12 @@ const makeArgs101 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
-const argDetailsSimple102 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
+const argDetailsSimple102 = [];
 const makeArgs102 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14405,18 +14716,12 @@ const makeArgs102 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
-const argDetailsSimple103 = [{
-  graphqlArgName: "g",
-  postgresArgName: "g",
-  pgCodec: guidCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
+const argDetailsSimple103 = [];
 const makeArgs103 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14457,7 +14762,7 @@ const makeArgs103 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_guid_fnPgResource = registry.pgResources["guid_fn"];
+const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
 const argDetailsSimple104 = [];
 const makeArgs104 = (args, path = []) => {
   const selectArgs = [];
@@ -14503,12 +14808,30 @@ const makeArgs104 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
-const argDetailsSimple105 = [];
+const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
+const argDetailsSimple105 = [{
+  graphqlArgName: "x",
+  postgresArgName: "x",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "y",
+  postgresArgName: "y",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "z",
+  postgresArgName: "z",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs105 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14549,30 +14872,12 @@ const makeArgs105 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
-const argDetailsSimple106 = [{
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: textArrayCodec,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "d",
-  postgresArgName: "d",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "e",
-  postgresArgName: "e",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
+const argDetailsSimple106 = [];
 const makeArgs106 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14613,12 +14918,18 @@ const makeArgs106 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_list_bde_mutationPgResource = registry.pgResources["list_bde_mutation"];
-const argDetailsSimple107 = [];
+const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
+const argDetailsSimple107 = [{
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs107 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14659,30 +14970,18 @@ const makeArgs107 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_failPgResource = registry.pgResources["authenticate_fail"];
+const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
 const argDetailsSimple108 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.numeric,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.bigint,
+  graphqlArgName: "g",
+  postgresArgName: "g",
+  pgCodec: guidCodec,
   required: true,
   fetcher: null
 }];
 const makeArgs108 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14723,18 +15022,12 @@ const makeArgs108 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticatePgResource = registry.pgResources["authenticate"];
-const argDetailsSimple109 = [{
-  graphqlArgName: "leftArm",
-  postgresArgName: "left_arm",
-  pgCodec: leftArmCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_guid_fnPgResource = registry.pgResources["guid_fn"];
+const argDetailsSimple109 = [];
 const makeArgs109 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14775,7 +15068,7 @@ const makeArgs109 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
+const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
 const argDetailsSimple110 = [];
 const makeArgs110 = (args, path = []) => {
   const selectArgs = [];
@@ -14821,12 +15114,30 @@ const makeArgs110 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
-const argDetailsSimple111 = [];
+const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
+const argDetailsSimple111 = [{
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: textArrayCodec,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "d",
+  postgresArgName: "d",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "e",
+  postgresArgName: "e",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
 const makeArgs111 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14867,30 +15178,12 @@ const makeArgs111 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
-const argDetailsSimple112 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.numeric,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.bigint,
-  required: true,
-  fetcher: null
-}];
+const resource_list_bde_mutationPgResource = registry.pgResources["list_bde_mutation"];
+const argDetailsSimple112 = [];
 const makeArgs112 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14931,7 +15224,7 @@ const makeArgs112 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_manyPgResource = registry.pgResources["authenticate_many"];
+const resource_authenticate_failPgResource = registry.pgResources["authenticate_fail"];
 const argDetailsSimple113 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -14995,48 +15288,18 @@ const makeArgs113 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_payloadPgResource = registry.pgResources["authenticate_payload"];
+const resource_authenticatePgResource = registry.pgResources["authenticate"];
 const argDetailsSimple114 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.bigint,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.boolean,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.varchar,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "d",
-  postgresArgName: "d",
-  pgCodec: int4ArrayCodec,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "e",
-  postgresArgName: "e",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "f",
-  postgresArgName: "f",
-  pgCodec: floatrangeCodec,
+  graphqlArgName: "leftArm",
+  postgresArgName: "left_arm",
+  pgCodec: leftArmCodec,
   required: true,
   fetcher: null
 }];
 const makeArgs114 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 6; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15077,18 +15340,12 @@ const makeArgs114 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
-const argDetailsSimple115 = [{
-  graphqlArgName: "i1",
-  postgresArgName: "i1",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
+const argDetailsSimple115 = [];
 const makeArgs115 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15129,18 +15386,12 @@ const makeArgs115 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
-const argDetailsSimple116 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
+const argDetailsSimple116 = [];
 const makeArgs116 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15181,18 +15432,30 @@ const makeArgs116 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_mutationPgResource = registry.pgResources["compound_type_mutation"];
+const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
 const argDetailsSimple117 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.numeric,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.bigint,
   required: true,
   fetcher: null
 }];
 const makeArgs117 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15233,18 +15496,30 @@ const makeArgs117 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
+const resource_authenticate_manyPgResource = registry.pgResources["authenticate_many"];
 const argDetailsSimple118 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.numeric,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.bigint,
   required: true,
   fetcher: null
 }];
 const makeArgs118 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15285,24 +15560,48 @@ const makeArgs118 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
+const resource_authenticate_payloadPgResource = registry.pgResources["authenticate_payload"];
 const argDetailsSimple119 = [{
-  graphqlArgName: "post",
-  postgresArgName: "post",
-  pgCodec: postCodec,
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.bigint,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "suffix",
-  postgresArgName: "suffix",
-  pgCodec: TYPES.text,
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.boolean,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.varchar,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "d",
+  postgresArgName: "d",
+  pgCodec: int4ArrayCodec,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "e",
+  postgresArgName: "e",
+  pgCodec: TYPES.json,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "f",
+  postgresArgName: "f",
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
 const makeArgs119 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 6; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15343,11 +15642,11 @@ const makeArgs119 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_with_suffixPgResource = registry.pgResources["post_with_suffix"];
+const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
 const argDetailsSimple120 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
+  graphqlArgName: "i1",
+  postgresArgName: "i1",
+  pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }];
@@ -15395,7 +15694,7 @@ const makeArgs120 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
+const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
 const argDetailsSimple121 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -15447,11 +15746,11 @@ const makeArgs121 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_array_mutationPgResource = registry.pgResources["compound_type_array_mutation"];
+const resource_compound_type_mutationPgResource = registry.pgResources["compound_type_mutation"];
 const argDetailsSimple122 = [{
-  graphqlArgName: "posts",
-  postgresArgName: "posts",
-  pgCodec: postArrayCodec,
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -15499,24 +15798,18 @@ const makeArgs122 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_manyPgResource = registry.pgResources["post_many"];
+const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
 const argDetailsSimple123 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
+  graphqlArgName: "id",
+  postgresArgName: "id",
   pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs123 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15557,16 +15850,16 @@ const makeArgs123 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
+const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
 const argDetailsSimple124 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
+  graphqlArgName: "post",
+  postgresArgName: "post",
+  pgCodec: postCodec,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
+  graphqlArgName: "suffix",
+  postgresArgName: "suffix",
   pgCodec: TYPES.text,
   required: true,
   fetcher: null
@@ -15615,12 +15908,18 @@ const makeArgs124 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
-const argDetailsSimple125 = [];
+const resource_post_with_suffixPgResource = registry.pgResources["post_with_suffix"];
+const argDetailsSimple125 = [{
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs125 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15661,12 +15960,18 @@ const makeArgs125 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
-const argDetailsSimple126 = [];
+const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
+const argDetailsSimple126 = [{
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs126 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15707,12 +16012,18 @@ const makeArgs126 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
-const argDetailsSimple127 = [];
+const resource_compound_type_array_mutationPgResource = registry.pgResources["compound_type_array_mutation"];
+const argDetailsSimple127 = [{
+  graphqlArgName: "posts",
+  postgresArgName: "posts",
+  pgCodec: postArrayCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs127 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15753,12 +16064,24 @@ const makeArgs127 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
-const argDetailsSimple128 = [];
+const resource_post_manyPgResource = registry.pgResources["post_many"];
+const argDetailsSimple128 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
 const makeArgs128 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15799,18 +16122,24 @@ const makeArgs128 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_type_function_connection_mutationPgResource = registry.pgResources["type_function_connection_mutation"];
+const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
 const argDetailsSimple129 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs129 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15851,7 +16180,7 @@ const makeArgs129 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_type_function_mutationPgResource = registry.pgResources["type_function_mutation"];
+const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
 const argDetailsSimple130 = [];
 const makeArgs130 = (args, path = []) => {
   const selectArgs = [];
@@ -15864,6 +16193,242 @@ const makeArgs130 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple130[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
+const argDetailsSimple131 = [];
+const makeArgs131 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple131[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
+const argDetailsSimple132 = [];
+const makeArgs132 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple132[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
+const argDetailsSimple133 = [];
+const makeArgs133 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple133[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_type_function_connection_mutationPgResource = registry.pgResources["type_function_connection_mutation"];
+const argDetailsSimple134 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs134 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple134[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_type_function_mutationPgResource = registry.pgResources["type_function_mutation"];
+const argDetailsSimple135 = [];
+const makeArgs135 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple135[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -17460,6 +18025,11 @@ type Person implements Node {
   computedInoutOut(ino: String): PersonComputedInoutOutRecord
   exists(email: Email): Boolean @deprecated(reason: "This is deprecated (comment on function c.person_exists).")
   computedFirstArgInoutOut: PersonComputedFirstArgInoutOutRecord
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, b: Int, arg2: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
   computedComplex(a: Int, b: String): PersonComputedComplexRecord
 
   """The first post by the person."""
@@ -28938,18 +29508,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_outPgResource.isUnique && !resource_person_computed_outPgResource.codec.attributes && typeof resource_person_computed_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_outPgResource.codec)`${resource_person_computed_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_outPgResource.codec)`${resource_person_computed_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_outPgResource.execute(selectArgs);
@@ -28972,18 +29552,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_first_namePgResource.isUnique && !resource_person_first_namePgResource.codec.attributes && typeof resource_person_first_namePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_first_namePgResource.codec)`${resource_person_first_namePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_first_namePgResource.codec)`${resource_person_first_namePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_first_namePgResource.execute(selectArgs);
@@ -29006,18 +29596,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_out_outPgResource.isUnique && !resource_person_computed_out_outPgResource.codec.attributes && typeof resource_person_computed_out_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_out_outPgResource.codec)`${resource_person_computed_out_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_out_outPgResource.codec)`${resource_person_computed_out_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_out_outPgResource.execute(selectArgs);
@@ -29041,18 +29641,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_computed_inoutPgResource.isUnique && !resource_person_computed_inoutPgResource.codec.attributes && typeof resource_person_computed_inoutPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_inoutPgResource.codec)`${resource_person_computed_inoutPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_computed_inoutPgResource.codec)`${resource_person_computed_inoutPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_inoutPgResource.execute(selectArgs);
@@ -29080,18 +29690,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_computed_inout_outPgResource.isUnique && !resource_person_computed_inout_outPgResource.codec.attributes && typeof resource_person_computed_inout_outPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_inout_outPgResource.codec)`${resource_person_computed_inout_outPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_computed_inout_outPgResource.codec)`${resource_person_computed_inout_outPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_inout_outPgResource.execute(selectArgs);
@@ -29119,18 +29739,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_existsPgResource.isUnique && !resource_person_existsPgResource.codec.attributes && typeof resource_person_existsPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_existsPgResource.codec)`${resource_person_existsPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_existsPgResource.codec)`${resource_person_existsPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_existsPgResource.execute(selectArgs);
@@ -29157,23 +29787,33 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_first_arg_inout_outPgResource.isUnique && !resource_person_computed_first_arg_inout_outPgResource.codec.attributes && typeof resource_person_computed_first_arg_inout_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_first_arg_inout_outPgResource.codec)`${resource_person_computed_first_arg_inout_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_first_arg_inout_outPgResource.codec)`${resource_person_computed_first_arg_inout_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_first_arg_inout_outPgResource.execute(selectArgs);
     },
-    computedComplex: {
+    optionalMissingMiddle1: {
       plan($in, args, _info) {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -29190,20 +29830,285 @@ export const plans = {
         const selectArgs = [{
           step: $row.record()
         }, ...extraSelectArgs];
-        if (resource_person_computed_complexPgResource.isUnique && !resource_person_computed_complexPgResource.codec.attributes && typeof resource_person_computed_complexPgResource.from === "function") {
+        if (resource_person_optional_missing_middle_1PgResource.isUnique && !resource_person_optional_missing_middle_1PgResource.codec.attributes && typeof resource_person_optional_missing_middle_1PgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_complexPgResource.codec)`${resource_person_computed_complexPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_optional_missing_middle_1PgResource.codec)`${resource_person_optional_missing_middle_1PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_1PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle2: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs58(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_2PgResource.isUnique && !resource_person_optional_missing_middle_2PgResource.codec.attributes && typeof resource_person_optional_missing_middle_2PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_2PgResource.codec)`${resource_person_optional_missing_middle_2PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_2PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        b: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle3: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs59(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_3PgResource.isUnique && !resource_person_optional_missing_middle_3PgResource.codec.attributes && typeof resource_person_optional_missing_middle_3PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_3PgResource.codec)`${resource_person_optional_missing_middle_3PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_3PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle4: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs60(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_4PgResource.isUnique && !resource_person_optional_missing_middle_4PgResource.codec.attributes && typeof resource_person_optional_missing_middle_4PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_4PgResource.codec)`${resource_person_optional_missing_middle_4PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_4PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        arg2: undefined
+      }
+    },
+    optionalMissingMiddle5: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs61(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_5PgResource.isUnique && !resource_person_optional_missing_middle_5PgResource.codec.attributes && typeof resource_person_optional_missing_middle_5PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_5PgResource.codec)`${resource_person_optional_missing_middle_5PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_5PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        arg2: undefined
+      }
+    },
+    computedComplex: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs62(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_computed_complexPgResource.isUnique && !resource_person_computed_complexPgResource.codec.attributes && typeof resource_person_computed_complexPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_computed_complexPgResource.codec)`${resource_person_computed_complexPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_complexPgResource.execute(selectArgs);
@@ -29217,7 +30122,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs58(args);
+      const extraSelectArgs = makeArgs63(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29231,18 +30136,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_first_postPgResource.isUnique && !resource_person_first_postPgResource.codec.attributes && typeof resource_person_first_postPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_first_postPgResource.codec)`${resource_person_first_postPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_first_postPgResource.codec)`${resource_person_first_postPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_first_postPgResource.execute(selectArgs);
@@ -29251,7 +30166,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs59(args);
+      const extraSelectArgs = makeArgs64(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29265,18 +30180,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_first_arg_inoutPgResource.isUnique && !resource_person_computed_first_arg_inoutPgResource.codec.attributes && typeof resource_person_computed_first_arg_inoutPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_first_arg_inoutPgResource.codec)`${resource_person_computed_first_arg_inoutPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_first_arg_inoutPgResource.codec)`${resource_person_computed_first_arg_inoutPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_first_arg_inoutPgResource.execute(selectArgs);
@@ -29381,7 +30306,7 @@ export const plans = {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
         }
-        const extraSelectArgs = makeArgs62(args);
+        const extraSelectArgs = makeArgs67(args);
         /**
          * An optimisation - if all our dependencies are
          * compatible with the expression's class plan then we
@@ -29395,18 +30320,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_type_functionPgResource.isUnique && !resource_person_type_functionPgResource.codec.attributes && typeof resource_person_type_functionPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_type_functionPgResource.codec)`${resource_person_type_functionPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_type_functionPgResource.codec)`${resource_person_type_functionPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_type_functionPgResource.execute(selectArgs);
@@ -29419,7 +30354,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs63(args);
+      const extraSelectArgs = makeArgs68(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29433,18 +30368,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_type_function_listPgResource.isUnique && !resource_person_type_function_listPgResource.codec.attributes && typeof resource_person_type_function_listPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_type_function_listPgResource.codec)`${resource_person_type_function_listPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_type_function_listPgResource.codec)`${resource_person_type_function_listPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_type_function_listPgResource.execute(selectArgs);
@@ -29791,7 +30736,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs64(args);
+      const extraSelectArgs = makeArgs69(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29805,18 +30750,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_compound_type_computed_fieldPgResource.isUnique && !resource_compound_type_computed_fieldPgResource.codec.attributes && typeof resource_compound_type_computed_fieldPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_compound_type_computed_fieldPgResource.codec)`${resource_compound_type_computed_fieldPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_compound_type_computed_fieldPgResource.codec)`${resource_compound_type_computed_fieldPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_compound_type_computed_fieldPgResource.execute(selectArgs);
@@ -29960,7 +30915,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs66(args);
+      const extraSelectArgs = makeArgs71(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -29974,18 +30929,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_post_computed_interval_arrayPgResource.isUnique && !resource_post_computed_interval_arrayPgResource.codec.attributes && typeof resource_post_computed_interval_arrayPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_post_computed_interval_arrayPgResource.codec)`${resource_post_computed_interval_arrayPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_post_computed_interval_arrayPgResource.codec)`${resource_post_computed_interval_arrayPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_post_computed_interval_arrayPgResource.execute(selectArgs);
@@ -29994,7 +30959,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs67(args);
+      const extraSelectArgs = makeArgs72(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -30008,221 +30973,33 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_post_computed_text_arrayPgResource.isUnique && !resource_post_computed_text_arrayPgResource.codec.attributes && typeof resource_post_computed_text_arrayPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_post_computed_text_arrayPgResource.codec)`${resource_post_computed_text_arrayPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_post_computed_text_arrayPgResource.codec)`${resource_post_computed_text_arrayPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_post_computed_text_arrayPgResource.execute(selectArgs);
     },
     computedWithOptionalArg: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs68(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_computed_with_optional_argPgResource.isUnique && !resource_post_computed_with_optional_argPgResource.codec.attributes && typeof resource_post_computed_with_optional_argPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_computed_with_optional_argPgResource.codec)`${resource_post_computed_with_optional_argPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_computed_with_optional_argPgResource.execute(selectArgs);
-      },
-      args: {
-        i: undefined
-      }
-    },
-    computedWithRequiredArg: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs69(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_computed_with_required_argPgResource.isUnique && !resource_post_computed_with_required_argPgResource.codec.attributes && typeof resource_post_computed_with_required_argPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_computed_with_required_argPgResource.codec)`${resource_post_computed_with_required_argPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_computed_with_required_argPgResource.execute(selectArgs);
-      },
-      args: {
-        i: undefined
-      }
-    },
-    headlineTrimmed: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs70(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_headline_trimmedPgResource.isUnique && !resource_post_headline_trimmedPgResource.codec.attributes && typeof resource_post_headline_trimmedPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_headline_trimmedPgResource.codec)`${resource_post_headline_trimmedPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_headline_trimmedPgResource.execute(selectArgs);
-      },
-      args: {
-        length: undefined,
-        omission: undefined
-      }
-    },
-    headlineTrimmedNoDefaults: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs71(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_headline_trimmed_no_defaultsPgResource.isUnique && !resource_post_headline_trimmed_no_defaultsPgResource.codec.attributes && typeof resource_post_headline_trimmed_no_defaultsPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_headline_trimmed_no_defaultsPgResource.codec)`${resource_post_headline_trimmed_no_defaultsPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_headline_trimmed_no_defaultsPgResource.execute(selectArgs);
-      },
-      args: {
-        length: undefined,
-        omission: undefined
-      }
-    },
-    headlineTrimmedStrict: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs72(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_headline_trimmed_strictPgResource.isUnique && !resource_post_headline_trimmed_strictPgResource.codec.attributes && typeof resource_post_headline_trimmed_strictPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_headline_trimmed_strictPgResource.codec)`${resource_post_headline_trimmed_strictPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_headline_trimmed_strictPgResource.execute(selectArgs);
-      },
-      args: {
-        length: undefined,
-        omission: undefined
-      }
-    },
-    computedCompoundTypeArray: {
       plan($in, args, _info) {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -30239,20 +31016,278 @@ export const plans = {
         const selectArgs = [{
           step: $row.record()
         }, ...extraSelectArgs];
-        if (resource_post_computed_compound_type_arrayPgResource.isUnique && !resource_post_computed_compound_type_arrayPgResource.codec.attributes && typeof resource_post_computed_compound_type_arrayPgResource.from === "function") {
+        if (resource_post_computed_with_optional_argPgResource.isUnique && !resource_post_computed_with_optional_argPgResource.codec.attributes && typeof resource_post_computed_with_optional_argPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_post_computed_compound_type_arrayPgResource.codec)`${resource_post_computed_compound_type_arrayPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_post_computed_with_optional_argPgResource.codec)`${resource_post_computed_with_optional_argPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_computed_with_optional_argPgResource.execute(selectArgs);
+      },
+      args: {
+        i: undefined
+      }
+    },
+    computedWithRequiredArg: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs74(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_computed_with_required_argPgResource.isUnique && !resource_post_computed_with_required_argPgResource.codec.attributes && typeof resource_post_computed_with_required_argPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_computed_with_required_argPgResource.codec)`${resource_post_computed_with_required_argPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_computed_with_required_argPgResource.execute(selectArgs);
+      },
+      args: {
+        i: undefined
+      }
+    },
+    headlineTrimmed: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs75(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_headline_trimmedPgResource.isUnique && !resource_post_headline_trimmedPgResource.codec.attributes && typeof resource_post_headline_trimmedPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_headline_trimmedPgResource.codec)`${resource_post_headline_trimmedPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_headline_trimmedPgResource.execute(selectArgs);
+      },
+      args: {
+        length: undefined,
+        omission: undefined
+      }
+    },
+    headlineTrimmedNoDefaults: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs76(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_headline_trimmed_no_defaultsPgResource.isUnique && !resource_post_headline_trimmed_no_defaultsPgResource.codec.attributes && typeof resource_post_headline_trimmed_no_defaultsPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_headline_trimmed_no_defaultsPgResource.codec)`${resource_post_headline_trimmed_no_defaultsPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_headline_trimmed_no_defaultsPgResource.execute(selectArgs);
+      },
+      args: {
+        length: undefined,
+        omission: undefined
+      }
+    },
+    headlineTrimmedStrict: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs77(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_headline_trimmed_strictPgResource.isUnique && !resource_post_headline_trimmed_strictPgResource.codec.attributes && typeof resource_post_headline_trimmed_strictPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_headline_trimmed_strictPgResource.codec)`${resource_post_headline_trimmed_strictPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_headline_trimmed_strictPgResource.execute(selectArgs);
+      },
+      args: {
+        length: undefined,
+        omission: undefined
+      }
+    },
+    computedCompoundTypeArray: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs78(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_computed_compound_type_arrayPgResource.isUnique && !resource_post_computed_compound_type_arrayPgResource.codec.attributes && typeof resource_post_computed_compound_type_arrayPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_computed_compound_type_arrayPgResource.codec)`${resource_post_computed_compound_type_arrayPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_post_computed_compound_type_arrayPgResource.execute(selectArgs);
@@ -38594,7 +39629,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs74(args);
+      const extraSelectArgs = makeArgs79(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -38608,18 +39643,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_edge_case_computedPgResource.isUnique && !resource_edge_case_computedPgResource.codec.attributes && typeof resource_edge_case_computedPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_edge_case_computedPgResource.codec)`${resource_edge_case_computedPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_edge_case_computedPgResource.codec)`${resource_edge_case_computedPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_edge_case_computedPgResource.execute(selectArgs);
@@ -39295,7 +40340,7 @@ export const plans = {
     __assertStep: __ValueStep,
     mutationOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs75(args, ["input"]);
+        const selectArgs = makeArgs80(args, ["input"]);
         const $result = resource_mutation_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39312,7 +40357,7 @@ export const plans = {
     },
     mutationOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs76(args, ["input"]);
+        const selectArgs = makeArgs81(args, ["input"]);
         const $result = resource_mutation_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39329,7 +40374,7 @@ export const plans = {
     },
     mutationOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs77(args, ["input"]);
+        const selectArgs = makeArgs82(args, ["input"]);
         const $result = resource_mutation_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39346,7 +40391,7 @@ export const plans = {
     },
     noArgsMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs78(args, ["input"]);
+        const selectArgs = makeArgs83(args, ["input"]);
         const $result = resource_no_args_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39363,7 +40408,7 @@ export const plans = {
     },
     returnVoidMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs79(args, ["input"]);
+        const selectArgs = makeArgs84(args, ["input"]);
         const $result = resource_return_void_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39380,7 +40425,7 @@ export const plans = {
     },
     mutationIntervalSet: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs80(args, ["input"]);
+        const selectArgs = makeArgs85(args, ["input"]);
         const $result = resource_mutation_interval_setPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39397,7 +40442,7 @@ export const plans = {
     },
     mutationInOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs81(args, ["input"]);
+        const selectArgs = makeArgs86(args, ["input"]);
         const $result = resource_mutation_in_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39414,7 +40459,7 @@ export const plans = {
     },
     mutationReturnsTableOneCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs82(args, ["input"]);
+        const selectArgs = makeArgs87(args, ["input"]);
         const $result = resource_mutation_returns_table_one_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39431,7 +40476,7 @@ export const plans = {
     },
     jsonIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs83(args, ["input"]);
+        const selectArgs = makeArgs88(args, ["input"]);
         const $result = resource_json_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39448,7 +40493,7 @@ export const plans = {
     },
     jsonbIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs84(args, ["input"]);
+        const selectArgs = makeArgs89(args, ["input"]);
         const $result = resource_jsonb_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39465,7 +40510,7 @@ export const plans = {
     },
     jsonbIdentityMutationPlpgsql: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs85(args, ["input"]);
+        const selectArgs = makeArgs90(args, ["input"]);
         const $result = resource_jsonb_identity_mutation_plpgsqlPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39482,7 +40527,7 @@ export const plans = {
     },
     jsonbIdentityMutationPlpgsqlWithDefault: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs86(args, ["input"]);
+        const selectArgs = makeArgs91(args, ["input"]);
         const $result = resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39499,7 +40544,7 @@ export const plans = {
     },
     add1Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs87(args, ["input"]);
+        const selectArgs = makeArgs92(args, ["input"]);
         const $result = resource_add_1_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39516,7 +40561,7 @@ export const plans = {
     },
     add2Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs88(args, ["input"]);
+        const selectArgs = makeArgs93(args, ["input"]);
         const $result = resource_add_2_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39533,7 +40578,7 @@ export const plans = {
     },
     add3Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs89(args, ["input"]);
+        const selectArgs = makeArgs94(args, ["input"]);
         const $result = resource_add_3_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39550,7 +40595,7 @@ export const plans = {
     },
     add4Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs90(args, ["input"]);
+        const selectArgs = makeArgs95(args, ["input"]);
         const $result = resource_add_4_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39567,7 +40612,7 @@ export const plans = {
     },
     add4MutationError: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs91(args, ["input"]);
+        const selectArgs = makeArgs96(args, ["input"]);
         const $result = resource_add_4_mutation_errorPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39584,7 +40629,7 @@ export const plans = {
     },
     mult1: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs92(args, ["input"]);
+        const selectArgs = makeArgs97(args, ["input"]);
         const $result = resource_mult_1PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39601,7 +40646,7 @@ export const plans = {
     },
     mult2: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs93(args, ["input"]);
+        const selectArgs = makeArgs98(args, ["input"]);
         const $result = resource_mult_2PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39618,7 +40663,7 @@ export const plans = {
     },
     mult3: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs94(args, ["input"]);
+        const selectArgs = makeArgs99(args, ["input"]);
         const $result = resource_mult_3PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39635,7 +40680,7 @@ export const plans = {
     },
     mult4: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs95(args, ["input"]);
+        const selectArgs = makeArgs100(args, ["input"]);
         const $result = resource_mult_4PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39652,7 +40697,7 @@ export const plans = {
     },
     mutationInInout: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs96(args, ["input"]);
+        const selectArgs = makeArgs101(args, ["input"]);
         const $result = resource_mutation_in_inoutPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39669,7 +40714,7 @@ export const plans = {
     },
     mutationOutOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs97(args, ["input"]);
+        const selectArgs = makeArgs102(args, ["input"]);
         const $result = resource_mutation_out_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39686,7 +40731,7 @@ export const plans = {
     },
     mutationOutOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs98(args, ["input"]);
+        const selectArgs = makeArgs103(args, ["input"]);
         const $result = resource_mutation_out_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39703,7 +40748,7 @@ export const plans = {
     },
     mutationOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs99(args, ["input"]);
+        const selectArgs = makeArgs104(args, ["input"]);
         const $result = resource_mutation_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39720,7 +40765,7 @@ export const plans = {
     },
     intSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs100(args, ["input"]);
+        const selectArgs = makeArgs105(args, ["input"]);
         const $result = resource_int_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39737,7 +40782,7 @@ export const plans = {
     },
     mutationOutUnnamedOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs101(args, ["input"]);
+        const selectArgs = makeArgs106(args, ["input"]);
         const $result = resource_mutation_out_unnamed_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39754,7 +40799,7 @@ export const plans = {
     },
     mutationReturnsTableMultiCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs102(args, ["input"]);
+        const selectArgs = makeArgs107(args, ["input"]);
         const $result = resource_mutation_returns_table_multi_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39771,7 +40816,7 @@ export const plans = {
     },
     guidFn: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs103(args, ["input"]);
+        const selectArgs = makeArgs108(args, ["input"]);
         const $result = resource_guid_fnPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39788,7 +40833,7 @@ export const plans = {
     },
     mutationIntervalArray: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs104(args, ["input"]);
+        const selectArgs = makeArgs109(args, ["input"]);
         const $result = resource_mutation_interval_arrayPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39805,7 +40850,7 @@ export const plans = {
     },
     mutationTextArray: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs105(args, ["input"]);
+        const selectArgs = makeArgs110(args, ["input"]);
         const $result = resource_mutation_text_arrayPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39822,7 +40867,7 @@ export const plans = {
     },
     listBdeMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs106(args, ["input"]);
+        const selectArgs = makeArgs111(args, ["input"]);
         const $result = resource_list_bde_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39839,7 +40884,7 @@ export const plans = {
     },
     authenticateFail: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs107(args, ["input"]);
+        const selectArgs = makeArgs112(args, ["input"]);
         const $result = resource_authenticate_failPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39856,7 +40901,7 @@ export const plans = {
     },
     authenticate: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs108(args, ["input"]);
+        const selectArgs = makeArgs113(args, ["input"]);
         const $result = resource_authenticatePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39873,7 +40918,7 @@ export const plans = {
     },
     leftArmIdentity: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs109(args, ["input"]);
+        const selectArgs = makeArgs114(args, ["input"]);
         const $result = resource_left_arm_identityPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39890,7 +40935,7 @@ export const plans = {
     },
     issue756Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs110(args, ["input"]);
+        const selectArgs = makeArgs115(args, ["input"]);
         const $result = resource_issue756_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39907,7 +40952,7 @@ export const plans = {
     },
     issue756SetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs111(args, ["input"]);
+        const selectArgs = makeArgs116(args, ["input"]);
         const $result = resource_issue756_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39924,7 +40969,7 @@ export const plans = {
     },
     authenticateMany: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs112(args, ["input"]);
+        const selectArgs = makeArgs117(args, ["input"]);
         const $result = resource_authenticate_manyPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39941,7 +40986,7 @@ export const plans = {
     },
     authenticatePayload: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs113(args, ["input"]);
+        const selectArgs = makeArgs118(args, ["input"]);
         const $result = resource_authenticate_payloadPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39958,7 +41003,7 @@ export const plans = {
     },
     typesMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs114(args, ["input"]);
+        const selectArgs = makeArgs119(args, ["input"]);
         const $result = resource_types_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39975,7 +41020,7 @@ export const plans = {
     },
     mutationOutOutCompoundType: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs115(args, ["input"]);
+        const selectArgs = makeArgs120(args, ["input"]);
         const $result = resource_mutation_out_out_compound_typePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -39992,7 +41037,7 @@ export const plans = {
     },
     compoundTypeMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs116(args, ["input"]);
+        const selectArgs = makeArgs121(args, ["input"]);
         const $result = resource_compound_type_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40009,7 +41054,7 @@ export const plans = {
     },
     compoundTypeSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs117(args, ["input"]);
+        const selectArgs = makeArgs122(args, ["input"]);
         const $result = resource_compound_type_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40026,7 +41071,7 @@ export const plans = {
     },
     tableMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs118(args, ["input"]);
+        const selectArgs = makeArgs123(args, ["input"]);
         const $result = resource_table_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40043,7 +41088,7 @@ export const plans = {
     },
     postWithSuffix: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs119(args, ["input"]);
+        const selectArgs = makeArgs124(args, ["input"]);
         const $result = resource_post_with_suffixPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40060,7 +41105,7 @@ export const plans = {
     },
     mutationCompoundTypeArray: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs120(args, ["input"]);
+        const selectArgs = makeArgs125(args, ["input"]);
         const $result = resource_mutation_compound_type_arrayPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40077,7 +41122,7 @@ export const plans = {
     },
     compoundTypeArrayMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs121(args, ["input"]);
+        const selectArgs = makeArgs126(args, ["input"]);
         const $result = resource_compound_type_array_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40094,7 +41139,7 @@ export const plans = {
     },
     postMany: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs122(args, ["input"]);
+        const selectArgs = makeArgs127(args, ["input"]);
         const $result = resource_post_manyPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40111,7 +41156,7 @@ export const plans = {
     },
     mutationOutComplex: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs123(args, ["input"]);
+        const selectArgs = makeArgs128(args, ["input"]);
         const $result = resource_mutation_out_complexPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40128,7 +41173,7 @@ export const plans = {
     },
     mutationOutComplexSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs124(args, ["input"]);
+        const selectArgs = makeArgs129(args, ["input"]);
         const $result = resource_mutation_out_complex_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40145,7 +41190,7 @@ export const plans = {
     },
     mutationOutTable: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs125(args, ["input"]);
+        const selectArgs = makeArgs130(args, ["input"]);
         const $result = resource_mutation_out_tablePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40162,7 +41207,7 @@ export const plans = {
     },
     mutationOutTableSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs126(args, ["input"]);
+        const selectArgs = makeArgs131(args, ["input"]);
         const $result = resource_mutation_out_table_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40179,7 +41224,7 @@ export const plans = {
     },
     tableSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs127(args, ["input"]);
+        const selectArgs = makeArgs132(args, ["input"]);
         const $result = resource_table_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40196,7 +41241,7 @@ export const plans = {
     },
     typeFunctionConnectionMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs128(args, ["input"]);
+        const selectArgs = makeArgs133(args, ["input"]);
         const $result = resource_type_function_connection_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40213,7 +41258,7 @@ export const plans = {
     },
     typeFunctionMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs129(args, ["input"]);
+        const selectArgs = makeArgs134(args, ["input"]);
         const $result = resource_type_function_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -40230,7 +41275,7 @@ export const plans = {
     },
     typeFunctionListMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs130(args, ["input"]);
+        const selectArgs = makeArgs135(args, ["input"]);
         const $result = resource_type_function_list_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result

--- a/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.graphql
@@ -1415,6 +1415,11 @@ type Person implements Node {
   computedInoutOut(ino: String): PersonComputedInoutOutRecord
   exists(email: Email): Boolean @deprecated(reason: "This is deprecated (comment on function c.person_exists).")
   computedFirstArgInoutOut: PersonComputedFirstArgInoutOutRecord
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, b: Int, arg2: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
   computedComplex(a: Int, b: String): PersonComputedComplexRecord
 
   """The first post by the person."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.1.export.mjs
@@ -3432,6 +3432,11 @@ const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_compu
 const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
 const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
 const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const person_optional_missing_middle_1FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_1");
+const person_optional_missing_middle_2FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_2");
+const person_optional_missing_middle_3FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_3");
+const person_optional_missing_middle_4FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_4");
+const person_optional_missing_middle_5FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_5");
 const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
 const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
 const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
@@ -7321,6 +7326,216 @@ const registry = makeRegistry({
           serviceName: "main",
           schemaName: "c",
           name: "person_computed_first_arg_inout_out"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_1: {
+      executor,
+      name: "person_optional_missing_middle_1",
+      identifier: "main.c.person_optional_missing_middle_1(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_1"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_2: {
+      executor,
+      name: "person_optional_missing_middle_2",
+      identifier: "main.c.person_optional_missing_middle_2(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_2"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_3: {
+      executor,
+      name: "person_optional_missing_middle_3",
+      identifier: "main.c.person_optional_missing_middle_3(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_3"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_4: {
+      executor,
+      name: "person_optional_missing_middle_4",
+      identifier: "main.c.person_optional_missing_middle_4(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_4"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    person_optional_missing_middle_5: {
+      executor,
+      name: "person_optional_missing_middle_5",
+      identifier: "main.c.person_optional_missing_middle_5(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_5FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: personCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_5"
         },
         tags: {}
       },
@@ -11300,22 +11515,28 @@ const makeArgs56 = (args, path = []) => {
 };
 const resource_person_computed_first_arg_inout_outPgResource = registry.pgResources["person_computed_first_arg_inout_out"];
 const argDetailsSimple57 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
+  graphqlArgName: "arg0",
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
   graphqlArgName: "b",
   postgresArgName: "b",
-  pgCodec: TYPES.text,
-  required: true,
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
   fetcher: null
 }];
 const makeArgs57 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11326,7 +11547,7 @@ const makeArgs57 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 1 - 1) {
         skipped = true;
         continue;
       } else {
@@ -11356,12 +11577,30 @@ const makeArgs57 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
-const argDetailsSimple58 = [];
+const resource_person_optional_missing_middle_1PgResource = registry.pgResources["person_optional_missing_middle_1"];
+const argDetailsSimple58 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs58 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11402,12 +11641,30 @@ const makeArgs58 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
-const argDetailsSimple59 = [];
+const resource_person_optional_missing_middle_2PgResource = registry.pgResources["person_optional_missing_middle_2"];
+const argDetailsSimple59 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs59 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11418,7 +11675,7 @@ const makeArgs59 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 2 - 1) {
         skipped = true;
         continue;
       } else {
@@ -11448,12 +11705,30 @@ const makeArgs59 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
-const argDetailsSimple60 = [];
+const resource_person_optional_missing_middle_3PgResource = registry.pgResources["person_optional_missing_middle_3"];
+const argDetailsSimple60 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs60 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11464,7 +11739,7 @@ const makeArgs60 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -11494,46 +11769,30 @@ const makeArgs60 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_friendsPgResource = registry.pgResources["person_friends"];
-const getSelectPlanFromParentAndArgs15 = ($in, args, _info) => {
-  if (!hasRecord($in)) {
-    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-  }
-  const extraSelectArgs = makeArgs60(args);
-  /**
-   * An optimisation - if all our dependencies are
-   * compatible with the expression's class plan then we
-   * can inline ourselves into that, otherwise we must
-   * issue the query separately.
-   */
-  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-  const selectArgs = [{
-    step: $row.record()
-  }, ...extraSelectArgs];
-  if (resource_person_friendsPgResource.isUnique && !resource_person_friendsPgResource.codec.attributes && typeof resource_person_friendsPgResource.from === "function") {
-    // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
-      if (i === 0) {
-        return $row.getClassStep().alias;
-      } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
-      } else {
-        return $row.placeholder(arg.step);
-      }
-    });
-    return pgClassExpression($row, resource_person_friendsPgResource.codec)`${resource_person_friendsPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
-  }
-  // PERF: or here, if scalar add select to `$row`?
-  return resource_person_friendsPgResource.execute(selectArgs);
-};
-const argDetailsSimple61 = [];
+const resource_person_optional_missing_middle_4PgResource = registry.pgResources["person_optional_missing_middle_4"];
+const argDetailsSimple61 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs61 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11544,7 +11803,7 @@ const makeArgs61 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -11574,52 +11833,24 @@ const makeArgs61 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
-const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
-  if (!hasRecord($in)) {
-    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-  }
-  const extraSelectArgs = makeArgs61(args);
-  /**
-   * An optimisation - if all our dependencies are
-   * compatible with the expression's class plan then we
-   * can inline ourselves into that, otherwise we must
-   * issue the query separately.
-   */
-  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-  const selectArgs = [{
-    step: $row.record()
-  }, ...extraSelectArgs];
-  if (resource_person_type_function_connectionPgResource.isUnique && !resource_person_type_function_connectionPgResource.codec.attributes && typeof resource_person_type_function_connectionPgResource.from === "function") {
-    // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
-      if (i === 0) {
-        return $row.getClassStep().alias;
-      } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
-      } else {
-        return $row.placeholder(arg.step);
-      }
-    });
-    return pgClassExpression($row, resource_person_type_function_connectionPgResource.codec)`${resource_person_type_function_connectionPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
-  }
-  // PERF: or here, if scalar add select to `$row`?
-  return resource_person_type_function_connectionPgResource.execute(selectArgs);
-};
+const resource_person_optional_missing_middle_5PgResource = registry.pgResources["person_optional_missing_middle_5"];
 const argDetailsSimple62 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs62 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11660,7 +11891,7 @@ const makeArgs62 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
+const resource_person_computed_complexPgResource = registry.pgResources["person_computed_complex"];
 const argDetailsSimple63 = [];
 const makeArgs63 = (args, path = []) => {
   const selectArgs = [];
@@ -11706,9 +11937,7 @@ const makeArgs63 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
-const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
-const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
+const resource_person_first_postPgResource = registry.pgResources["person_first_post"];
 const argDetailsSimple64 = [];
 const makeArgs64 = (args, path = []) => {
   const selectArgs = [];
@@ -11754,16 +11983,7 @@ const makeArgs64 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
-function UUIDSerialize(value) {
-  return "" + value;
-}
-const coerce = string => {
-  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
-    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
-  }
-  return string;
-};
+const resource_person_computed_first_arg_inoutPgResource = registry.pgResources["person_computed_first_arg_inout"];
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -11809,8 +12029,8 @@ const makeArgs65 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_interval_setPgResource = registry.pgResources["post_computed_interval_set"];
-const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
+const resource_person_friendsPgResource = registry.pgResources["person_friends"];
+const getSelectPlanFromParentAndArgs15 = ($in, args, _info) => {
   if (!hasRecord($in)) {
     throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
   }
@@ -11826,23 +12046,33 @@ const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
   const selectArgs = [{
     step: $row.record()
   }, ...extraSelectArgs];
-  if (resource_post_computed_interval_setPgResource.isUnique && !resource_post_computed_interval_setPgResource.codec.attributes && typeof resource_post_computed_interval_setPgResource.from === "function") {
+  if (resource_person_friendsPgResource.isUnique && !resource_person_friendsPgResource.codec.attributes && typeof resource_person_friendsPgResource.from === "function") {
     // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
       if (i === 0) {
-        return $row.getClassStep().alias;
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
       } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
       } else {
-        return $row.placeholder(arg.step);
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
       }
     });
-    return pgClassExpression($row, resource_post_computed_interval_setPgResource.codec)`${resource_post_computed_interval_setPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
+    return pgClassExpression($row, resource_person_friendsPgResource.codec)`${resource_person_friendsPgResource.from(...newSelectArgs)}`;
   }
   // PERF: or here, if scalar add select to `$row`?
-  return resource_post_computed_interval_setPgResource.execute(selectArgs);
+  return resource_person_friendsPgResource.execute(selectArgs);
 };
 const argDetailsSimple66 = [];
 const makeArgs66 = (args, path = []) => {
@@ -11889,12 +12119,62 @@ const makeArgs66 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_interval_arrayPgResource = registry.pgResources["post_computed_interval_array"];
-const argDetailsSimple67 = [];
+const resource_person_type_function_connectionPgResource = registry.pgResources["person_type_function_connection"];
+const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
+  if (!hasRecord($in)) {
+    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+  }
+  const extraSelectArgs = makeArgs66(args);
+  /**
+   * An optimisation - if all our dependencies are
+   * compatible with the expression's class plan then we
+   * can inline ourselves into that, otherwise we must
+   * issue the query separately.
+   */
+  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+  const selectArgs = [{
+    step: $row.record()
+  }, ...extraSelectArgs];
+  if (resource_person_type_function_connectionPgResource.isUnique && !resource_person_type_function_connectionPgResource.codec.attributes && typeof resource_person_type_function_connectionPgResource.from === "function") {
+    // This is a scalar computed attribute, let's inline the expression
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
+      if (i === 0) {
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
+      } else if ("pgCodec" in arg && arg.pgCodec) {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
+      } else {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
+      }
+    });
+    return pgClassExpression($row, resource_person_type_function_connectionPgResource.codec)`${resource_person_type_function_connectionPgResource.from(...newSelectArgs)}`;
+  }
+  // PERF: or here, if scalar add select to `$row`?
+  return resource_person_type_function_connectionPgResource.execute(selectArgs);
+};
+const argDetailsSimple67 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs67 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11935,18 +12215,12 @@ const makeArgs67 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_text_arrayPgResource = registry.pgResources["post_computed_text_array"];
-const argDetailsSimple68 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: false,
-  fetcher: null
-}];
+const resource_person_type_functionPgResource = registry.pgResources["person_type_function"];
+const argDetailsSimple68 = [];
 const makeArgs68 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11987,18 +12261,14 @@ const makeArgs68 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_with_optional_argPgResource = registry.pgResources["post_computed_with_optional_arg"];
-const argDetailsSimple69 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_person_type_function_listPgResource = registry.pgResources["person_type_function_list"];
+const resource_frmcdc_wrappedUrlPgResource = registry.pgResources["frmcdc_wrappedUrl"];
+const resource_frmcdc_compoundTypePgResource = registry.pgResources["frmcdc_compoundType"];
+const argDetailsSimple69 = [];
 const makeArgs69 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12039,24 +12309,21 @@ const makeArgs69 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_with_required_argPgResource = registry.pgResources["post_computed_with_required_arg"];
-const argDetailsSimple70 = [{
-  graphqlArgName: "length",
-  postgresArgName: "length",
-  pgCodec: TYPES.int,
-  required: false,
-  fetcher: null
-}, {
-  graphqlArgName: "omission",
-  postgresArgName: "omission",
-  pgCodec: TYPES.text,
-  required: false,
-  fetcher: null
-}];
+const resource_compound_type_computed_fieldPgResource = registry.pgResources["compound_type_computed_field"];
+function UUIDSerialize(value) {
+  return "" + value;
+}
+const coerce = string => {
+  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
+    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
+  }
+  return string;
+};
+const argDetailsSimple70 = [];
 const makeArgs70 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12097,24 +12364,56 @@ const makeArgs70 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmedPgResource = registry.pgResources["post_headline_trimmed"];
-const argDetailsSimple71 = [{
-  graphqlArgName: "length",
-  postgresArgName: "length",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "omission",
-  postgresArgName: "omission",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_post_computed_interval_setPgResource = registry.pgResources["post_computed_interval_set"];
+const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
+  if (!hasRecord($in)) {
+    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+  }
+  const extraSelectArgs = makeArgs70(args);
+  /**
+   * An optimisation - if all our dependencies are
+   * compatible with the expression's class plan then we
+   * can inline ourselves into that, otherwise we must
+   * issue the query separately.
+   */
+  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+  const selectArgs = [{
+    step: $row.record()
+  }, ...extraSelectArgs];
+  if (resource_post_computed_interval_setPgResource.isUnique && !resource_post_computed_interval_setPgResource.codec.attributes && typeof resource_post_computed_interval_setPgResource.from === "function") {
+    // This is a scalar computed attribute, let's inline the expression
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
+      if (i === 0) {
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
+      } else if ("pgCodec" in arg && arg.pgCodec) {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
+      } else {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
+      }
+    });
+    return pgClassExpression($row, resource_post_computed_interval_setPgResource.codec)`${resource_post_computed_interval_setPgResource.from(...newSelectArgs)}`;
+  }
+  // PERF: or here, if scalar add select to `$row`?
+  return resource_post_computed_interval_setPgResource.execute(selectArgs);
+};
+const argDetailsSimple71 = [];
 const makeArgs71 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12155,24 +12454,12 @@ const makeArgs71 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmed_no_defaultsPgResource = registry.pgResources["post_headline_trimmed_no_defaults"];
-const argDetailsSimple72 = [{
-  graphqlArgName: "length",
-  postgresArgName: "length",
-  pgCodec: TYPES.int,
-  required: false,
-  fetcher: null
-}, {
-  graphqlArgName: "omission",
-  postgresArgName: "omission",
-  pgCodec: TYPES.text,
-  required: false,
-  fetcher: null
-}];
+const resource_post_computed_interval_arrayPgResource = registry.pgResources["post_computed_interval_array"];
+const argDetailsSimple72 = [];
 const makeArgs72 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12213,12 +12500,12 @@ const makeArgs72 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmed_strictPgResource = registry.pgResources["post_headline_trimmed_strict"];
+const resource_post_computed_text_arrayPgResource = registry.pgResources["post_computed_text_array"];
 const argDetailsSimple73 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
-  required: true,
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: false,
   fetcher: null
 }];
 const makeArgs73 = (args, path = []) => {
@@ -12232,6 +12519,284 @@ const makeArgs73 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple73[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_computed_with_optional_argPgResource = registry.pgResources["post_computed_with_optional_arg"];
+const argDetailsSimple74 = [{
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs74 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple74[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_computed_with_required_argPgResource = registry.pgResources["post_computed_with_required_arg"];
+const argDetailsSimple75 = [{
+  graphqlArgName: "length",
+  postgresArgName: "length",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "omission",
+  postgresArgName: "omission",
+  pgCodec: TYPES.text,
+  required: false,
+  fetcher: null
+}];
+const makeArgs75 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple75[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_headline_trimmedPgResource = registry.pgResources["post_headline_trimmed"];
+const argDetailsSimple76 = [{
+  graphqlArgName: "length",
+  postgresArgName: "length",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "omission",
+  postgresArgName: "omission",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
+const makeArgs76 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple76[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_headline_trimmed_no_defaultsPgResource = registry.pgResources["post_headline_trimmed_no_defaults"];
+const argDetailsSimple77 = [{
+  graphqlArgName: "length",
+  postgresArgName: "length",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "omission",
+  postgresArgName: "omission",
+  pgCodec: TYPES.text,
+  required: false,
+  fetcher: null
+}];
+const makeArgs77 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple77[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_headline_trimmed_strictPgResource = registry.pgResources["post_headline_trimmed_strict"];
+const argDetailsSimple78 = [{
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
+  required: true,
+  fetcher: null
+}];
+const makeArgs78 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple78[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -12322,236 +12887,6 @@ const parseValueLiteral = (ast, variables) => {
       return undefined;
   }
 };
-const argDetailsSimple74 = [];
-const makeArgs74 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple74[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
-const argDetailsSimple75 = [];
-const makeArgs75 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple75[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
-const argDetailsSimple76 = [];
-const makeArgs76 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple76[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
-const argDetailsSimple77 = [];
-const makeArgs77 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple77[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
-const argDetailsSimple78 = [];
-const makeArgs78 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple78[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
 const argDetailsSimple79 = [];
 const makeArgs79 = (args, path = []) => {
   const selectArgs = [];
@@ -12597,7 +12932,7 @@ const makeArgs79 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
+const resource_edge_case_computedPgResource = registry.pgResources["edge_case_computed"];
 const argDetailsSimple80 = [];
 const makeArgs80 = (args, path = []) => {
   const selectArgs = [];
@@ -12643,18 +12978,12 @@ const makeArgs80 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
-const argDetailsSimple81 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_outPgResource = registry.pgResources["mutation_out"];
+const argDetailsSimple81 = [];
 const makeArgs81 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12695,18 +13024,12 @@ const makeArgs81 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
-const argDetailsSimple82 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_setofPgResource = registry.pgResources["mutation_out_setof"];
+const argDetailsSimple82 = [];
 const makeArgs82 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12747,18 +13070,12 @@ const makeArgs82 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
-const argDetailsSimple83 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed"];
+const argDetailsSimple83 = [];
 const makeArgs83 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12799,18 +13116,12 @@ const makeArgs83 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
-const argDetailsSimple84 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_no_args_mutationPgResource = registry.pgResources["no_args_mutation"];
+const argDetailsSimple84 = [];
 const makeArgs84 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12851,18 +13162,12 @@ const makeArgs84 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
-const argDetailsSimple85 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
+const argDetailsSimple85 = [];
 const makeArgs85 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12903,12 +13208,12 @@ const makeArgs85 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
+const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
 const argDetailsSimple86 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: false,
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
   fetcher: null
 }];
 const makeArgs86 = (args, path = []) => {
@@ -12955,16 +13260,10 @@ const makeArgs86 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
+const resource_mutation_in_outPgResource = registry.pgResources["mutation_in_out"];
 const argDetailsSimple87 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: null,
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "arg1",
-  postgresArgName: null,
+  graphqlArgName: "i",
+  postgresArgName: "i",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -12972,7 +13271,7 @@ const argDetailsSimple87 = [{
 const makeArgs87 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12983,7 +13282,7 @@ const makeArgs87 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 2 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13013,24 +13312,18 @@ const makeArgs87 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
+const resource_mutation_returns_table_one_colPgResource = registry.pgResources["mutation_returns_table_one_col"];
 const argDetailsSimple88 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.json,
   required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.int,
-  required: false,
   fetcher: null
 }];
 const makeArgs88 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13071,24 +13364,18 @@ const makeArgs88 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
+const resource_json_identity_mutationPgResource = registry.pgResources["json_identity_mutation"];
 const argDetailsSimple89 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "arg1",
-  postgresArgName: "",
-  pgCodec: TYPES.int,
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.jsonb,
   required: true,
   fetcher: null
 }];
 const makeArgs89 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13099,7 +13386,7 @@ const makeArgs89 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 2 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13129,24 +13416,18 @@ const makeArgs89 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
+const resource_jsonb_identity_mutationPgResource = registry.pgResources["jsonb_identity_mutation"];
 const argDetailsSimple90 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: "",
-  pgCodec: TYPES.int,
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
   required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.int,
-  required: false,
   fetcher: null
 }];
 const makeArgs90 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13157,7 +13438,7 @@ const makeArgs90 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 1 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13187,24 +13468,18 @@ const makeArgs90 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
+const resource_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql"];
 const argDetailsSimple91 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: "",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.int,
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
   required: false,
   fetcher: null
 }];
 const makeArgs91 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13215,7 +13490,7 @@ const makeArgs91 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 1 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13245,7 +13520,7 @@ const makeArgs91 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
+const resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["jsonb_identity_mutation_plpgsql_with_default"];
 const argDetailsSimple92 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -13303,18 +13578,18 @@ const makeArgs92 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_1PgResource = registry.pgResources["mult_1"];
+const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
 const argDetailsSimple93 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: null,
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "arg1",
-  postgresArgName: null,
+  graphqlArgName: "b",
+  postgresArgName: "b",
   pgCodec: TYPES.int,
-  required: true,
+  required: false,
   fetcher: null
 }];
 const makeArgs93 = (args, path = []) => {
@@ -13331,7 +13606,7 @@ const makeArgs93 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 2 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13361,16 +13636,16 @@ const makeArgs93 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_2PgResource = registry.pgResources["mult_2"];
+const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
 const argDetailsSimple94 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: null,
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
   graphqlArgName: "arg1",
-  postgresArgName: null,
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -13419,18 +13694,18 @@ const makeArgs94 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mult_3PgResource = registry.pgResources["mult_3"];
+const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
 const argDetailsSimple95 = [{
   graphqlArgName: "arg0",
-  postgresArgName: null,
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "arg1",
-  postgresArgName: null,
+  graphqlArgName: "b",
+  postgresArgName: "b",
   pgCodec: TYPES.int,
-  required: true,
+  required: false,
   fetcher: null
 }];
 const makeArgs95 = (args, path = []) => {
@@ -13444,6 +13719,296 @@ const makeArgs95 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple95[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 1 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
+const argDetailsSimple96 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
+const makeArgs96 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple96[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 1 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
+const argDetailsSimple97 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs97 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple97[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 2 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mult_1PgResource = registry.pgResources["mult_1"];
+const argDetailsSimple98 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs98 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple98[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 2 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mult_2PgResource = registry.pgResources["mult_2"];
+const argDetailsSimple99 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs99 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple99[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 2 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mult_3PgResource = registry.pgResources["mult_3"];
+const argDetailsSimple100 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs100 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple100[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -13478,7 +14043,7 @@ const makeArgs95 = (args, path = []) => {
   return selectArgs;
 };
 const resource_mult_4PgResource = registry.pgResources["mult_4"];
-const argDetailsSimple96 = [{
+const argDetailsSimple101 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
   pgCodec: TYPES.int,
@@ -13491,258 +14056,10 @@ const argDetailsSimple96 = [{
   required: true,
   fetcher: null
 }];
-const makeArgs96 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 2; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple96[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
-const argDetailsSimple97 = [];
-const makeArgs97 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple97[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
-const argDetailsSimple98 = [];
-const makeArgs98 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple98[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
-const argDetailsSimple99 = [];
-const makeArgs99 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple99[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
-const argDetailsSimple100 = [{
-  graphqlArgName: "x",
-  postgresArgName: "x",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "y",
-  postgresArgName: "y",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "z",
-  postgresArgName: "z",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
-const makeArgs100 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 3; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple100[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
-const argDetailsSimple101 = [];
 const makeArgs101 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13783,18 +14100,12 @@ const makeArgs101 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
-const argDetailsSimple102 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_in_inoutPgResource = registry.pgResources["mutation_in_inout"];
+const argDetailsSimple102 = [];
 const makeArgs102 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13835,18 +14146,12 @@ const makeArgs102 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
-const argDetailsSimple103 = [{
-  graphqlArgName: "g",
-  postgresArgName: "g",
-  pgCodec: guidCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_mutation_out_outPgResource = registry.pgResources["mutation_out_out"];
+const argDetailsSimple103 = [];
 const makeArgs103 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13887,7 +14192,7 @@ const makeArgs103 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_guid_fnPgResource = registry.pgResources["guid_fn"];
+const resource_mutation_out_out_setofPgResource = registry.pgResources["mutation_out_out_setof"];
 const argDetailsSimple104 = [];
 const makeArgs104 = (args, path = []) => {
   const selectArgs = [];
@@ -13933,12 +14238,30 @@ const makeArgs104 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
-const argDetailsSimple105 = [];
+const resource_mutation_out_out_unnamedPgResource = registry.pgResources["mutation_out_out_unnamed"];
+const argDetailsSimple105 = [{
+  graphqlArgName: "x",
+  postgresArgName: "x",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "y",
+  postgresArgName: "y",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "z",
+  postgresArgName: "z",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs105 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13979,30 +14302,12 @@ const makeArgs105 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
-const argDetailsSimple106 = [{
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: textArrayCodec,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "d",
-  postgresArgName: "d",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "e",
-  postgresArgName: "e",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_int_set_mutationPgResource = registry.pgResources["int_set_mutation"];
+const argDetailsSimple106 = [];
 const makeArgs106 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14043,12 +14348,18 @@ const makeArgs106 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_list_bde_mutationPgResource = registry.pgResources["list_bde_mutation"];
-const argDetailsSimple107 = [];
+const resource_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["mutation_out_unnamed_out_out_unnamed"];
+const argDetailsSimple107 = [{
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs107 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14089,30 +14400,18 @@ const makeArgs107 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_failPgResource = registry.pgResources["authenticate_fail"];
+const resource_mutation_returns_table_multi_colPgResource = registry.pgResources["mutation_returns_table_multi_col"];
 const argDetailsSimple108 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.numeric,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.bigint,
+  graphqlArgName: "g",
+  postgresArgName: "g",
+  pgCodec: guidCodec,
   required: true,
   fetcher: null
 }];
 const makeArgs108 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14153,18 +14452,12 @@ const makeArgs108 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticatePgResource = registry.pgResources["authenticate"];
-const argDetailsSimple109 = [{
-  graphqlArgName: "leftArm",
-  postgresArgName: "left_arm",
-  pgCodec: leftArmCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_guid_fnPgResource = registry.pgResources["guid_fn"];
+const argDetailsSimple109 = [];
 const makeArgs109 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14205,7 +14498,7 @@ const makeArgs109 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
+const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
 const argDetailsSimple110 = [];
 const makeArgs110 = (args, path = []) => {
   const selectArgs = [];
@@ -14251,12 +14544,30 @@ const makeArgs110 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
-const argDetailsSimple111 = [];
+const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
+const argDetailsSimple111 = [{
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: textArrayCodec,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "d",
+  postgresArgName: "d",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "e",
+  postgresArgName: "e",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
 const makeArgs111 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14297,30 +14608,12 @@ const makeArgs111 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
-const argDetailsSimple112 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.numeric,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.bigint,
-  required: true,
-  fetcher: null
-}];
+const resource_list_bde_mutationPgResource = registry.pgResources["list_bde_mutation"];
+const argDetailsSimple112 = [];
 const makeArgs112 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14361,7 +14654,7 @@ const makeArgs112 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_manyPgResource = registry.pgResources["authenticate_many"];
+const resource_authenticate_failPgResource = registry.pgResources["authenticate_fail"];
 const argDetailsSimple113 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -14425,48 +14718,18 @@ const makeArgs113 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_authenticate_payloadPgResource = registry.pgResources["authenticate_payload"];
+const resource_authenticatePgResource = registry.pgResources["authenticate"];
 const argDetailsSimple114 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.bigint,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.boolean,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.varchar,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "d",
-  postgresArgName: "d",
-  pgCodec: int4ArrayCodec,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "e",
-  postgresArgName: "e",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "f",
-  postgresArgName: "f",
-  pgCodec: floatrangeCodec,
+  graphqlArgName: "leftArm",
+  postgresArgName: "left_arm",
+  pgCodec: leftArmCodec,
   required: true,
   fetcher: null
 }];
 const makeArgs114 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 6; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14507,18 +14770,12 @@ const makeArgs114 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
-const argDetailsSimple115 = [{
-  graphqlArgName: "i1",
-  postgresArgName: "i1",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_left_arm_identityPgResource = registry.pgResources["left_arm_identity"];
+const argDetailsSimple115 = [];
 const makeArgs115 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14559,18 +14816,12 @@ const makeArgs115 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
-const argDetailsSimple116 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_issue756_mutationPgResource = registry.pgResources["issue756_mutation"];
+const argDetailsSimple116 = [];
 const makeArgs116 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14611,18 +14862,30 @@ const makeArgs116 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_mutationPgResource = registry.pgResources["compound_type_mutation"];
+const resource_issue756_set_mutationPgResource = registry.pgResources["issue756_set_mutation"];
 const argDetailsSimple117 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.numeric,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.bigint,
   required: true,
   fetcher: null
 }];
 const makeArgs117 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14663,18 +14926,30 @@ const makeArgs117 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
+const resource_authenticate_manyPgResource = registry.pgResources["authenticate_many"];
 const argDetailsSimple118 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.numeric,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.bigint,
   required: true,
   fetcher: null
 }];
 const makeArgs118 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14715,24 +14990,48 @@ const makeArgs118 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
+const resource_authenticate_payloadPgResource = registry.pgResources["authenticate_payload"];
 const argDetailsSimple119 = [{
-  graphqlArgName: "post",
-  postgresArgName: "post",
-  pgCodec: postCodec,
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.bigint,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "suffix",
-  postgresArgName: "suffix",
-  pgCodec: TYPES.text,
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.boolean,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.varchar,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "d",
+  postgresArgName: "d",
+  pgCodec: int4ArrayCodec,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "e",
+  postgresArgName: "e",
+  pgCodec: TYPES.json,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "f",
+  postgresArgName: "f",
+  pgCodec: floatrangeCodec,
   required: true,
   fetcher: null
 }];
 const makeArgs119 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 6; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14773,11 +15072,11 @@ const makeArgs119 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_with_suffixPgResource = registry.pgResources["post_with_suffix"];
+const resource_types_mutationPgResource = registry.pgResources["types_mutation"];
 const argDetailsSimple120 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: compoundTypeCodec,
+  graphqlArgName: "i1",
+  postgresArgName: "i1",
+  pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }];
@@ -14825,7 +15124,7 @@ const makeArgs120 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
+const resource_mutation_out_out_compound_typePgResource = registry.pgResources["mutation_out_out_compound_type"];
 const argDetailsSimple121 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -14877,11 +15176,11 @@ const makeArgs121 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_compound_type_array_mutationPgResource = registry.pgResources["compound_type_array_mutation"];
+const resource_compound_type_mutationPgResource = registry.pgResources["compound_type_mutation"];
 const argDetailsSimple122 = [{
-  graphqlArgName: "posts",
-  postgresArgName: "posts",
-  pgCodec: postArrayCodec,
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -14929,24 +15228,18 @@ const makeArgs122 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_manyPgResource = registry.pgResources["post_many"];
+const resource_compound_type_set_mutationPgResource = registry.pgResources["compound_type_set_mutation"];
 const argDetailsSimple123 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
+  graphqlArgName: "id",
+  postgresArgName: "id",
   pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs123 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14987,16 +15280,16 @@ const makeArgs123 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
+const resource_table_mutationPgResource = registry.pgResources["table_mutation"];
 const argDetailsSimple124 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
+  graphqlArgName: "post",
+  postgresArgName: "post",
+  pgCodec: postCodec,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
+  graphqlArgName: "suffix",
+  postgresArgName: "suffix",
   pgCodec: TYPES.text,
   required: true,
   fetcher: null
@@ -15045,12 +15338,18 @@ const makeArgs124 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
-const argDetailsSimple125 = [];
+const resource_post_with_suffixPgResource = registry.pgResources["post_with_suffix"];
+const argDetailsSimple125 = [{
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs125 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15091,12 +15390,18 @@ const makeArgs125 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
-const argDetailsSimple126 = [];
+const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
+const argDetailsSimple126 = [{
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: compoundTypeCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs126 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15137,12 +15442,18 @@ const makeArgs126 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
-const argDetailsSimple127 = [];
+const resource_compound_type_array_mutationPgResource = registry.pgResources["compound_type_array_mutation"];
+const argDetailsSimple127 = [{
+  graphqlArgName: "posts",
+  postgresArgName: "posts",
+  pgCodec: postArrayCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs127 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15183,12 +15494,24 @@ const makeArgs127 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
-const argDetailsSimple128 = [];
+const resource_post_manyPgResource = registry.pgResources["post_many"];
+const argDetailsSimple128 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
 const makeArgs128 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15229,18 +15552,24 @@ const makeArgs128 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_type_function_connection_mutationPgResource = registry.pgResources["type_function_connection_mutation"];
+const resource_mutation_out_complexPgResource = registry.pgResources["mutation_out_complex"];
 const argDetailsSimple129 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs129 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15281,7 +15610,7 @@ const makeArgs129 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_type_function_mutationPgResource = registry.pgResources["type_function_mutation"];
+const resource_mutation_out_complex_setofPgResource = registry.pgResources["mutation_out_complex_setof"];
 const argDetailsSimple130 = [];
 const makeArgs130 = (args, path = []) => {
   const selectArgs = [];
@@ -15294,6 +15623,242 @@ const makeArgs130 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple130[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_tablePgResource = registry.pgResources["mutation_out_table"];
+const argDetailsSimple131 = [];
+const makeArgs131 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple131[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_mutation_out_table_setofPgResource = registry.pgResources["mutation_out_table_setof"];
+const argDetailsSimple132 = [];
+const makeArgs132 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple132[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_table_set_mutationPgResource = registry.pgResources["table_set_mutation"];
+const argDetailsSimple133 = [];
+const makeArgs133 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple133[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_type_function_connection_mutationPgResource = registry.pgResources["type_function_connection_mutation"];
+const argDetailsSimple134 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs134 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple134[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_type_function_mutationPgResource = registry.pgResources["type_function_mutation"];
+const argDetailsSimple135 = [];
+const makeArgs135 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple135[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -16571,6 +17136,11 @@ type Person {
   computedInoutOut(ino: String): PersonComputedInoutOutRecord
   exists(email: Email): Boolean @deprecated(reason: "This is deprecated (comment on function c.person_exists).")
   computedFirstArgInoutOut: PersonComputedFirstArgInoutOutRecord
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, b: Int, arg2: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
   computedComplex(a: Int, b: String): PersonComputedComplexRecord
 
   """The first post by the person."""
@@ -26886,18 +27456,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_outPgResource.isUnique && !resource_person_computed_outPgResource.codec.attributes && typeof resource_person_computed_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_outPgResource.codec)`${resource_person_computed_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_outPgResource.codec)`${resource_person_computed_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_outPgResource.execute(selectArgs);
@@ -26920,18 +27500,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_first_namePgResource.isUnique && !resource_person_first_namePgResource.codec.attributes && typeof resource_person_first_namePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_first_namePgResource.codec)`${resource_person_first_namePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_first_namePgResource.codec)`${resource_person_first_namePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_first_namePgResource.execute(selectArgs);
@@ -26954,18 +27544,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_out_outPgResource.isUnique && !resource_person_computed_out_outPgResource.codec.attributes && typeof resource_person_computed_out_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_out_outPgResource.codec)`${resource_person_computed_out_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_out_outPgResource.codec)`${resource_person_computed_out_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_out_outPgResource.execute(selectArgs);
@@ -26989,18 +27589,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_computed_inoutPgResource.isUnique && !resource_person_computed_inoutPgResource.codec.attributes && typeof resource_person_computed_inoutPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_inoutPgResource.codec)`${resource_person_computed_inoutPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_computed_inoutPgResource.codec)`${resource_person_computed_inoutPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_inoutPgResource.execute(selectArgs);
@@ -27028,18 +27638,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_computed_inout_outPgResource.isUnique && !resource_person_computed_inout_outPgResource.codec.attributes && typeof resource_person_computed_inout_outPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_inout_outPgResource.codec)`${resource_person_computed_inout_outPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_computed_inout_outPgResource.codec)`${resource_person_computed_inout_outPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_inout_outPgResource.execute(selectArgs);
@@ -27067,18 +27687,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_existsPgResource.isUnique && !resource_person_existsPgResource.codec.attributes && typeof resource_person_existsPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_existsPgResource.codec)`${resource_person_existsPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_existsPgResource.codec)`${resource_person_existsPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_existsPgResource.execute(selectArgs);
@@ -27105,23 +27735,33 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_first_arg_inout_outPgResource.isUnique && !resource_person_computed_first_arg_inout_outPgResource.codec.attributes && typeof resource_person_computed_first_arg_inout_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_first_arg_inout_outPgResource.codec)`${resource_person_computed_first_arg_inout_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_first_arg_inout_outPgResource.codec)`${resource_person_computed_first_arg_inout_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_first_arg_inout_outPgResource.execute(selectArgs);
     },
-    computedComplex: {
+    optionalMissingMiddle1: {
       plan($in, args, _info) {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -27138,20 +27778,285 @@ export const plans = {
         const selectArgs = [{
           step: $row.record()
         }, ...extraSelectArgs];
-        if (resource_person_computed_complexPgResource.isUnique && !resource_person_computed_complexPgResource.codec.attributes && typeof resource_person_computed_complexPgResource.from === "function") {
+        if (resource_person_optional_missing_middle_1PgResource.isUnique && !resource_person_optional_missing_middle_1PgResource.codec.attributes && typeof resource_person_optional_missing_middle_1PgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_computed_complexPgResource.codec)`${resource_person_computed_complexPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_optional_missing_middle_1PgResource.codec)`${resource_person_optional_missing_middle_1PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_1PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle2: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs58(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_2PgResource.isUnique && !resource_person_optional_missing_middle_2PgResource.codec.attributes && typeof resource_person_optional_missing_middle_2PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_2PgResource.codec)`${resource_person_optional_missing_middle_2PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_2PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        b: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle3: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs59(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_3PgResource.isUnique && !resource_person_optional_missing_middle_3PgResource.codec.attributes && typeof resource_person_optional_missing_middle_3PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_3PgResource.codec)`${resource_person_optional_missing_middle_3PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_3PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle4: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs60(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_4PgResource.isUnique && !resource_person_optional_missing_middle_4PgResource.codec.attributes && typeof resource_person_optional_missing_middle_4PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_4PgResource.codec)`${resource_person_optional_missing_middle_4PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_4PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        arg2: undefined
+      }
+    },
+    optionalMissingMiddle5: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs61(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_optional_missing_middle_5PgResource.isUnique && !resource_person_optional_missing_middle_5PgResource.codec.attributes && typeof resource_person_optional_missing_middle_5PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_optional_missing_middle_5PgResource.codec)`${resource_person_optional_missing_middle_5PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_person_optional_missing_middle_5PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        arg2: undefined
+      }
+    },
+    computedComplex: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs62(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_person_computed_complexPgResource.isUnique && !resource_person_computed_complexPgResource.codec.attributes && typeof resource_person_computed_complexPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_person_computed_complexPgResource.codec)`${resource_person_computed_complexPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_computed_complexPgResource.execute(selectArgs);
@@ -27165,7 +28070,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs58(args);
+      const extraSelectArgs = makeArgs63(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -27179,18 +28084,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_first_postPgResource.isUnique && !resource_person_first_postPgResource.codec.attributes && typeof resource_person_first_postPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_first_postPgResource.codec)`${resource_person_first_postPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_first_postPgResource.codec)`${resource_person_first_postPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_first_postPgResource.execute(selectArgs);
@@ -27199,7 +28114,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs59(args);
+      const extraSelectArgs = makeArgs64(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -27213,18 +28128,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_computed_first_arg_inoutPgResource.isUnique && !resource_person_computed_first_arg_inoutPgResource.codec.attributes && typeof resource_person_computed_first_arg_inoutPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_computed_first_arg_inoutPgResource.codec)`${resource_person_computed_first_arg_inoutPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_computed_first_arg_inoutPgResource.codec)`${resource_person_computed_first_arg_inoutPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_computed_first_arg_inoutPgResource.execute(selectArgs);
@@ -27329,7 +28254,7 @@ export const plans = {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
         }
-        const extraSelectArgs = makeArgs62(args);
+        const extraSelectArgs = makeArgs67(args);
         /**
          * An optimisation - if all our dependencies are
          * compatible with the expression's class plan then we
@@ -27343,18 +28268,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_person_type_functionPgResource.isUnique && !resource_person_type_functionPgResource.codec.attributes && typeof resource_person_type_functionPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_person_type_functionPgResource.codec)`${resource_person_type_functionPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_person_type_functionPgResource.codec)`${resource_person_type_functionPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_person_type_functionPgResource.execute(selectArgs);
@@ -27367,7 +28302,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs63(args);
+      const extraSelectArgs = makeArgs68(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -27381,18 +28316,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_person_type_function_listPgResource.isUnique && !resource_person_type_function_listPgResource.codec.attributes && typeof resource_person_type_function_listPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_person_type_function_listPgResource.codec)`${resource_person_type_function_listPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_person_type_function_listPgResource.codec)`${resource_person_type_function_listPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_person_type_function_listPgResource.execute(selectArgs);
@@ -27739,7 +28684,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs64(args);
+      const extraSelectArgs = makeArgs69(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -27753,18 +28698,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_compound_type_computed_fieldPgResource.isUnique && !resource_compound_type_computed_fieldPgResource.codec.attributes && typeof resource_compound_type_computed_fieldPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_compound_type_computed_fieldPgResource.codec)`${resource_compound_type_computed_fieldPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_compound_type_computed_fieldPgResource.codec)`${resource_compound_type_computed_fieldPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_compound_type_computed_fieldPgResource.execute(selectArgs);
@@ -27904,7 +28859,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs66(args);
+      const extraSelectArgs = makeArgs71(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -27918,18 +28873,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_post_computed_interval_arrayPgResource.isUnique && !resource_post_computed_interval_arrayPgResource.codec.attributes && typeof resource_post_computed_interval_arrayPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_post_computed_interval_arrayPgResource.codec)`${resource_post_computed_interval_arrayPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_post_computed_interval_arrayPgResource.codec)`${resource_post_computed_interval_arrayPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_post_computed_interval_arrayPgResource.execute(selectArgs);
@@ -27938,7 +28903,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs67(args);
+      const extraSelectArgs = makeArgs72(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -27952,221 +28917,33 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_post_computed_text_arrayPgResource.isUnique && !resource_post_computed_text_arrayPgResource.codec.attributes && typeof resource_post_computed_text_arrayPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_post_computed_text_arrayPgResource.codec)`${resource_post_computed_text_arrayPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_post_computed_text_arrayPgResource.codec)`${resource_post_computed_text_arrayPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_post_computed_text_arrayPgResource.execute(selectArgs);
     },
     computedWithOptionalArg: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs68(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_computed_with_optional_argPgResource.isUnique && !resource_post_computed_with_optional_argPgResource.codec.attributes && typeof resource_post_computed_with_optional_argPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_computed_with_optional_argPgResource.codec)`${resource_post_computed_with_optional_argPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_computed_with_optional_argPgResource.execute(selectArgs);
-      },
-      args: {
-        i: undefined
-      }
-    },
-    computedWithRequiredArg: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs69(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_computed_with_required_argPgResource.isUnique && !resource_post_computed_with_required_argPgResource.codec.attributes && typeof resource_post_computed_with_required_argPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_computed_with_required_argPgResource.codec)`${resource_post_computed_with_required_argPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_computed_with_required_argPgResource.execute(selectArgs);
-      },
-      args: {
-        i: undefined
-      }
-    },
-    headlineTrimmed: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs70(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_headline_trimmedPgResource.isUnique && !resource_post_headline_trimmedPgResource.codec.attributes && typeof resource_post_headline_trimmedPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_headline_trimmedPgResource.codec)`${resource_post_headline_trimmedPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_headline_trimmedPgResource.execute(selectArgs);
-      },
-      args: {
-        length: undefined,
-        omission: undefined
-      }
-    },
-    headlineTrimmedNoDefaults: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs71(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_headline_trimmed_no_defaultsPgResource.isUnique && !resource_post_headline_trimmed_no_defaultsPgResource.codec.attributes && typeof resource_post_headline_trimmed_no_defaultsPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_headline_trimmed_no_defaultsPgResource.codec)`${resource_post_headline_trimmed_no_defaultsPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_headline_trimmed_no_defaultsPgResource.execute(selectArgs);
-      },
-      args: {
-        length: undefined,
-        omission: undefined
-      }
-    },
-    headlineTrimmedStrict: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs72(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_headline_trimmed_strictPgResource.isUnique && !resource_post_headline_trimmed_strictPgResource.codec.attributes && typeof resource_post_headline_trimmed_strictPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_headline_trimmed_strictPgResource.codec)`${resource_post_headline_trimmed_strictPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_headline_trimmed_strictPgResource.execute(selectArgs);
-      },
-      args: {
-        length: undefined,
-        omission: undefined
-      }
-    },
-    computedCompoundTypeArray: {
       plan($in, args, _info) {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -28183,20 +28960,278 @@ export const plans = {
         const selectArgs = [{
           step: $row.record()
         }, ...extraSelectArgs];
-        if (resource_post_computed_compound_type_arrayPgResource.isUnique && !resource_post_computed_compound_type_arrayPgResource.codec.attributes && typeof resource_post_computed_compound_type_arrayPgResource.from === "function") {
+        if (resource_post_computed_with_optional_argPgResource.isUnique && !resource_post_computed_with_optional_argPgResource.codec.attributes && typeof resource_post_computed_with_optional_argPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_post_computed_compound_type_arrayPgResource.codec)`${resource_post_computed_compound_type_arrayPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_post_computed_with_optional_argPgResource.codec)`${resource_post_computed_with_optional_argPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_computed_with_optional_argPgResource.execute(selectArgs);
+      },
+      args: {
+        i: undefined
+      }
+    },
+    computedWithRequiredArg: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs74(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_computed_with_required_argPgResource.isUnique && !resource_post_computed_with_required_argPgResource.codec.attributes && typeof resource_post_computed_with_required_argPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_computed_with_required_argPgResource.codec)`${resource_post_computed_with_required_argPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_computed_with_required_argPgResource.execute(selectArgs);
+      },
+      args: {
+        i: undefined
+      }
+    },
+    headlineTrimmed: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs75(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_headline_trimmedPgResource.isUnique && !resource_post_headline_trimmedPgResource.codec.attributes && typeof resource_post_headline_trimmedPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_headline_trimmedPgResource.codec)`${resource_post_headline_trimmedPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_headline_trimmedPgResource.execute(selectArgs);
+      },
+      args: {
+        length: undefined,
+        omission: undefined
+      }
+    },
+    headlineTrimmedNoDefaults: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs76(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_headline_trimmed_no_defaultsPgResource.isUnique && !resource_post_headline_trimmed_no_defaultsPgResource.codec.attributes && typeof resource_post_headline_trimmed_no_defaultsPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_headline_trimmed_no_defaultsPgResource.codec)`${resource_post_headline_trimmed_no_defaultsPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_headline_trimmed_no_defaultsPgResource.execute(selectArgs);
+      },
+      args: {
+        length: undefined,
+        omission: undefined
+      }
+    },
+    headlineTrimmedStrict: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs77(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_headline_trimmed_strictPgResource.isUnique && !resource_post_headline_trimmed_strictPgResource.codec.attributes && typeof resource_post_headline_trimmed_strictPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_headline_trimmed_strictPgResource.codec)`${resource_post_headline_trimmed_strictPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_headline_trimmed_strictPgResource.execute(selectArgs);
+      },
+      args: {
+        length: undefined,
+        omission: undefined
+      }
+    },
+    computedCompoundTypeArray: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs78(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_computed_compound_type_arrayPgResource.isUnique && !resource_post_computed_compound_type_arrayPgResource.codec.attributes && typeof resource_post_computed_compound_type_arrayPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_computed_compound_type_arrayPgResource.codec)`${resource_post_computed_compound_type_arrayPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_post_computed_compound_type_arrayPgResource.execute(selectArgs);
@@ -36502,7 +37537,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs74(args);
+      const extraSelectArgs = makeArgs79(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -36516,18 +37551,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_edge_case_computedPgResource.isUnique && !resource_edge_case_computedPgResource.codec.attributes && typeof resource_edge_case_computedPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_edge_case_computedPgResource.codec)`${resource_edge_case_computedPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_edge_case_computedPgResource.codec)`${resource_edge_case_computedPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_edge_case_computedPgResource.execute(selectArgs);
@@ -37203,7 +38248,7 @@ export const plans = {
     __assertStep: __ValueStep,
     mutationOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs75(args, ["input"]);
+        const selectArgs = makeArgs80(args, ["input"]);
         const $result = resource_mutation_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37220,7 +38265,7 @@ export const plans = {
     },
     mutationOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs76(args, ["input"]);
+        const selectArgs = makeArgs81(args, ["input"]);
         const $result = resource_mutation_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37237,7 +38282,7 @@ export const plans = {
     },
     mutationOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs77(args, ["input"]);
+        const selectArgs = makeArgs82(args, ["input"]);
         const $result = resource_mutation_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37254,7 +38299,7 @@ export const plans = {
     },
     noArgsMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs78(args, ["input"]);
+        const selectArgs = makeArgs83(args, ["input"]);
         const $result = resource_no_args_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37271,7 +38316,7 @@ export const plans = {
     },
     returnVoidMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs79(args, ["input"]);
+        const selectArgs = makeArgs84(args, ["input"]);
         const $result = resource_return_void_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37288,7 +38333,7 @@ export const plans = {
     },
     mutationIntervalSet: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs80(args, ["input"]);
+        const selectArgs = makeArgs85(args, ["input"]);
         const $result = resource_mutation_interval_setPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37305,7 +38350,7 @@ export const plans = {
     },
     mutationInOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs81(args, ["input"]);
+        const selectArgs = makeArgs86(args, ["input"]);
         const $result = resource_mutation_in_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37322,7 +38367,7 @@ export const plans = {
     },
     mutationReturnsTableOneCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs82(args, ["input"]);
+        const selectArgs = makeArgs87(args, ["input"]);
         const $result = resource_mutation_returns_table_one_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37339,7 +38384,7 @@ export const plans = {
     },
     jsonIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs83(args, ["input"]);
+        const selectArgs = makeArgs88(args, ["input"]);
         const $result = resource_json_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37356,7 +38401,7 @@ export const plans = {
     },
     jsonbIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs84(args, ["input"]);
+        const selectArgs = makeArgs89(args, ["input"]);
         const $result = resource_jsonb_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37373,7 +38418,7 @@ export const plans = {
     },
     jsonbIdentityMutationPlpgsql: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs85(args, ["input"]);
+        const selectArgs = makeArgs90(args, ["input"]);
         const $result = resource_jsonb_identity_mutation_plpgsqlPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37390,7 +38435,7 @@ export const plans = {
     },
     jsonbIdentityMutationPlpgsqlWithDefault: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs86(args, ["input"]);
+        const selectArgs = makeArgs91(args, ["input"]);
         const $result = resource_jsonb_identity_mutation_plpgsql_with_defaultPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37407,7 +38452,7 @@ export const plans = {
     },
     add1Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs87(args, ["input"]);
+        const selectArgs = makeArgs92(args, ["input"]);
         const $result = resource_add_1_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37424,7 +38469,7 @@ export const plans = {
     },
     add2Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs88(args, ["input"]);
+        const selectArgs = makeArgs93(args, ["input"]);
         const $result = resource_add_2_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37441,7 +38486,7 @@ export const plans = {
     },
     add3Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs89(args, ["input"]);
+        const selectArgs = makeArgs94(args, ["input"]);
         const $result = resource_add_3_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37458,7 +38503,7 @@ export const plans = {
     },
     add4Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs90(args, ["input"]);
+        const selectArgs = makeArgs95(args, ["input"]);
         const $result = resource_add_4_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37475,7 +38520,7 @@ export const plans = {
     },
     add4MutationError: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs91(args, ["input"]);
+        const selectArgs = makeArgs96(args, ["input"]);
         const $result = resource_add_4_mutation_errorPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37492,7 +38537,7 @@ export const plans = {
     },
     mult1: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs92(args, ["input"]);
+        const selectArgs = makeArgs97(args, ["input"]);
         const $result = resource_mult_1PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37509,7 +38554,7 @@ export const plans = {
     },
     mult2: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs93(args, ["input"]);
+        const selectArgs = makeArgs98(args, ["input"]);
         const $result = resource_mult_2PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37526,7 +38571,7 @@ export const plans = {
     },
     mult3: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs94(args, ["input"]);
+        const selectArgs = makeArgs99(args, ["input"]);
         const $result = resource_mult_3PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37543,7 +38588,7 @@ export const plans = {
     },
     mult4: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs95(args, ["input"]);
+        const selectArgs = makeArgs100(args, ["input"]);
         const $result = resource_mult_4PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37560,7 +38605,7 @@ export const plans = {
     },
     mutationInInout: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs96(args, ["input"]);
+        const selectArgs = makeArgs101(args, ["input"]);
         const $result = resource_mutation_in_inoutPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37577,7 +38622,7 @@ export const plans = {
     },
     mutationOutOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs97(args, ["input"]);
+        const selectArgs = makeArgs102(args, ["input"]);
         const $result = resource_mutation_out_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37594,7 +38639,7 @@ export const plans = {
     },
     mutationOutOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs98(args, ["input"]);
+        const selectArgs = makeArgs103(args, ["input"]);
         const $result = resource_mutation_out_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37611,7 +38656,7 @@ export const plans = {
     },
     mutationOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs99(args, ["input"]);
+        const selectArgs = makeArgs104(args, ["input"]);
         const $result = resource_mutation_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37628,7 +38673,7 @@ export const plans = {
     },
     intSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs100(args, ["input"]);
+        const selectArgs = makeArgs105(args, ["input"]);
         const $result = resource_int_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37645,7 +38690,7 @@ export const plans = {
     },
     mutationOutUnnamedOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs101(args, ["input"]);
+        const selectArgs = makeArgs106(args, ["input"]);
         const $result = resource_mutation_out_unnamed_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37662,7 +38707,7 @@ export const plans = {
     },
     mutationReturnsTableMultiCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs102(args, ["input"]);
+        const selectArgs = makeArgs107(args, ["input"]);
         const $result = resource_mutation_returns_table_multi_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37679,7 +38724,7 @@ export const plans = {
     },
     guidFn: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs103(args, ["input"]);
+        const selectArgs = makeArgs108(args, ["input"]);
         const $result = resource_guid_fnPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37696,7 +38741,7 @@ export const plans = {
     },
     mutationIntervalArray: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs104(args, ["input"]);
+        const selectArgs = makeArgs109(args, ["input"]);
         const $result = resource_mutation_interval_arrayPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37713,7 +38758,7 @@ export const plans = {
     },
     mutationTextArray: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs105(args, ["input"]);
+        const selectArgs = makeArgs110(args, ["input"]);
         const $result = resource_mutation_text_arrayPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37730,7 +38775,7 @@ export const plans = {
     },
     listBdeMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs106(args, ["input"]);
+        const selectArgs = makeArgs111(args, ["input"]);
         const $result = resource_list_bde_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37747,7 +38792,7 @@ export const plans = {
     },
     authenticateFail: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs107(args, ["input"]);
+        const selectArgs = makeArgs112(args, ["input"]);
         const $result = resource_authenticate_failPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37764,7 +38809,7 @@ export const plans = {
     },
     authenticate: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs108(args, ["input"]);
+        const selectArgs = makeArgs113(args, ["input"]);
         const $result = resource_authenticatePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37781,7 +38826,7 @@ export const plans = {
     },
     leftArmIdentity: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs109(args, ["input"]);
+        const selectArgs = makeArgs114(args, ["input"]);
         const $result = resource_left_arm_identityPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37798,7 +38843,7 @@ export const plans = {
     },
     issue756Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs110(args, ["input"]);
+        const selectArgs = makeArgs115(args, ["input"]);
         const $result = resource_issue756_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37815,7 +38860,7 @@ export const plans = {
     },
     issue756SetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs111(args, ["input"]);
+        const selectArgs = makeArgs116(args, ["input"]);
         const $result = resource_issue756_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37832,7 +38877,7 @@ export const plans = {
     },
     authenticateMany: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs112(args, ["input"]);
+        const selectArgs = makeArgs117(args, ["input"]);
         const $result = resource_authenticate_manyPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37849,7 +38894,7 @@ export const plans = {
     },
     authenticatePayload: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs113(args, ["input"]);
+        const selectArgs = makeArgs118(args, ["input"]);
         const $result = resource_authenticate_payloadPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37866,7 +38911,7 @@ export const plans = {
     },
     typesMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs114(args, ["input"]);
+        const selectArgs = makeArgs119(args, ["input"]);
         const $result = resource_types_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37883,7 +38928,7 @@ export const plans = {
     },
     mutationOutOutCompoundType: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs115(args, ["input"]);
+        const selectArgs = makeArgs120(args, ["input"]);
         const $result = resource_mutation_out_out_compound_typePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37900,7 +38945,7 @@ export const plans = {
     },
     compoundTypeMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs116(args, ["input"]);
+        const selectArgs = makeArgs121(args, ["input"]);
         const $result = resource_compound_type_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37917,7 +38962,7 @@ export const plans = {
     },
     compoundTypeSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs117(args, ["input"]);
+        const selectArgs = makeArgs122(args, ["input"]);
         const $result = resource_compound_type_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37934,7 +38979,7 @@ export const plans = {
     },
     tableMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs118(args, ["input"]);
+        const selectArgs = makeArgs123(args, ["input"]);
         const $result = resource_table_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37951,7 +38996,7 @@ export const plans = {
     },
     postWithSuffix: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs119(args, ["input"]);
+        const selectArgs = makeArgs124(args, ["input"]);
         const $result = resource_post_with_suffixPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37968,7 +39013,7 @@ export const plans = {
     },
     mutationCompoundTypeArray: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs120(args, ["input"]);
+        const selectArgs = makeArgs125(args, ["input"]);
         const $result = resource_mutation_compound_type_arrayPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37985,7 +39030,7 @@ export const plans = {
     },
     compoundTypeArrayMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs121(args, ["input"]);
+        const selectArgs = makeArgs126(args, ["input"]);
         const $result = resource_compound_type_array_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -38002,7 +39047,7 @@ export const plans = {
     },
     postMany: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs122(args, ["input"]);
+        const selectArgs = makeArgs127(args, ["input"]);
         const $result = resource_post_manyPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -38019,7 +39064,7 @@ export const plans = {
     },
     mutationOutComplex: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs123(args, ["input"]);
+        const selectArgs = makeArgs128(args, ["input"]);
         const $result = resource_mutation_out_complexPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -38036,7 +39081,7 @@ export const plans = {
     },
     mutationOutComplexSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs124(args, ["input"]);
+        const selectArgs = makeArgs129(args, ["input"]);
         const $result = resource_mutation_out_complex_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -38053,7 +39098,7 @@ export const plans = {
     },
     mutationOutTable: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs125(args, ["input"]);
+        const selectArgs = makeArgs130(args, ["input"]);
         const $result = resource_mutation_out_tablePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -38070,7 +39115,7 @@ export const plans = {
     },
     mutationOutTableSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs126(args, ["input"]);
+        const selectArgs = makeArgs131(args, ["input"]);
         const $result = resource_mutation_out_table_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -38087,7 +39132,7 @@ export const plans = {
     },
     tableSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs127(args, ["input"]);
+        const selectArgs = makeArgs132(args, ["input"]);
         const $result = resource_table_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -38104,7 +39149,7 @@ export const plans = {
     },
     typeFunctionConnectionMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs128(args, ["input"]);
+        const selectArgs = makeArgs133(args, ["input"]);
         const $result = resource_type_function_connection_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -38121,7 +39166,7 @@ export const plans = {
     },
     typeFunctionMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs129(args, ["input"]);
+        const selectArgs = makeArgs134(args, ["input"]);
         const $result = resource_type_function_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -38138,7 +39183,7 @@ export const plans = {
     },
     typeFunctionListMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs130(args, ["input"]);
+        const selectArgs = makeArgs135(args, ["input"]);
         const $result = resource_type_function_list_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result

--- a/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.1.graphql
@@ -5276,6 +5276,11 @@ type Person {
 
   """The person’s name"""
   name: String!
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, arg2: Int, b: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
 
   """This `Person`'s `PersonSecret`."""
   personSecretByPersonId: PersonSecret @deprecated(reason: "This is deprecated (comment on table c.person_secret).")

--- a/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.polymorphic.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.polymorphic.1.export.mjs
@@ -12514,18 +12514,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_single_table_items_meaning_of_lifePgResource.isUnique && !resource_single_table_items_meaning_of_lifePgResource.codec.attributes && typeof resource_single_table_items_meaning_of_lifePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_single_table_items_meaning_of_lifePgResource.execute(selectArgs);
@@ -17155,18 +17165,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_single_table_items_meaning_of_lifePgResource.isUnique && !resource_single_table_items_meaning_of_lifePgResource.codec.attributes && typeof resource_single_table_items_meaning_of_lifePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_single_table_items_meaning_of_lifePgResource.execute(selectArgs);
@@ -17599,18 +17619,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_single_table_items_meaning_of_lifePgResource.isUnique && !resource_single_table_items_meaning_of_lifePgResource.codec.attributes && typeof resource_single_table_items_meaning_of_lifePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_single_table_items_meaning_of_lifePgResource.execute(selectArgs);
@@ -17967,18 +17997,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_single_table_items_meaning_of_lifePgResource.isUnique && !resource_single_table_items_meaning_of_lifePgResource.codec.attributes && typeof resource_single_table_items_meaning_of_lifePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_single_table_items_meaning_of_lifePgResource.execute(selectArgs);
@@ -18337,18 +18377,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_single_table_items_meaning_of_lifePgResource.isUnique && !resource_single_table_items_meaning_of_lifePgResource.codec.attributes && typeof resource_single_table_items_meaning_of_lifePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_single_table_items_meaning_of_lifePgResource.execute(selectArgs);

--- a/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.1.export.mjs
@@ -3429,6 +3429,11 @@ const person_computed_inoutFunctionIdentifer = sql.identifier("c", "person_compu
 const person_computed_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_inout_out");
 const person_existsFunctionIdentifer = sql.identifier("c", "person_exists");
 const person_computed_first_arg_inout_outFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout_out");
+const person_optional_missing_middle_1FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_1");
+const person_optional_missing_middle_2FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_2");
+const person_optional_missing_middle_3FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_3");
+const person_optional_missing_middle_4FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_4");
+const person_optional_missing_middle_5FunctionIdentifer = sql.identifier("c", "person_optional_missing_middle_5");
 const func_out_complexFunctionIdentifer = sql.identifier("c", "func_out_complex");
 const func_out_complex_setofFunctionIdentifer = sql.identifier("c", "func_out_complex_setof");
 const mutation_out_complexFunctionIdentifer = sql.identifier("c", "mutation_out_complex");
@@ -7302,6 +7307,216 @@ const registry = makeRegistry({
           serviceName: "main",
           schemaName: "c",
           name: "person_computed_first_arg_inout_out"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    c_person_optional_missing_middle_1: {
+      executor,
+      name: "c_person_optional_missing_middle_1",
+      identifier: "main.c.person_optional_missing_middle_1(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_1FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: cPersonCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_1"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    c_person_optional_missing_middle_2: {
+      executor,
+      name: "c_person_optional_missing_middle_2",
+      identifier: "main.c.person_optional_missing_middle_2(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_2FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: cPersonCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_2"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    c_person_optional_missing_middle_3: {
+      executor,
+      name: "c_person_optional_missing_middle_3",
+      identifier: "main.c.person_optional_missing_middle_3(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_3FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: cPersonCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "c",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_3"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    c_person_optional_missing_middle_4: {
+      executor,
+      name: "c_person_optional_missing_middle_4",
+      identifier: "main.c.person_optional_missing_middle_4(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_4FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: cPersonCodec
+      }, {
+        name: "",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "b",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_4"
+        },
+        tags: {}
+      },
+      description: undefined
+    },
+    c_person_optional_missing_middle_5: {
+      executor,
+      name: "c_person_optional_missing_middle_5",
+      identifier: "main.c.person_optional_missing_middle_5(c.person,int4,int4,int4)",
+      from(...args) {
+        return sql`${person_optional_missing_middle_5FunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [{
+        name: "p",
+        required: true,
+        notNull: true,
+        codec: cPersonCodec
+      }, {
+        name: "a",
+        required: true,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }, {
+        name: "",
+        required: false,
+        notNull: true,
+        codec: TYPES.int
+      }],
+      isUnique: !false,
+      codec: TYPES.int,
+      uniques: [],
+      isMutation: false,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "person_optional_missing_middle_5"
         },
         tags: {}
       },
@@ -11335,22 +11550,28 @@ const makeArgs57 = (args, path = []) => {
 };
 const resource_c_person_computed_first_arg_inout_outPgResource = registry.pgResources["c_person_computed_first_arg_inout_out"];
 const argDetailsSimple58 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
+  graphqlArgName: "arg0",
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
   graphqlArgName: "b",
   postgresArgName: "b",
-  pgCodec: TYPES.text,
-  required: true,
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
   fetcher: null
 }];
 const makeArgs58 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11361,7 +11582,7 @@ const makeArgs58 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 1 - 1) {
         skipped = true;
         continue;
       } else {
@@ -11391,12 +11612,30 @@ const makeArgs58 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_c_person_computed_complexPgResource = registry.pgResources["c_person_computed_complex"];
-const argDetailsSimple59 = [];
+const resource_c_person_optional_missing_middle_1PgResource = registry.pgResources["c_person_optional_missing_middle_1"];
+const argDetailsSimple59 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs59 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11437,12 +11676,30 @@ const makeArgs59 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_c_person_first_postPgResource = registry.pgResources["c_person_first_post"];
-const argDetailsSimple60 = [];
+const resource_c_person_optional_missing_middle_2PgResource = registry.pgResources["c_person_optional_missing_middle_2"];
+const argDetailsSimple60 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs60 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11453,7 +11710,7 @@ const makeArgs60 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 2 - 1) {
         skipped = true;
         continue;
       } else {
@@ -11483,12 +11740,30 @@ const makeArgs60 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_c_person_computed_first_arg_inoutPgResource = registry.pgResources["c_person_computed_first_arg_inout"];
-const argDetailsSimple61 = [];
+const resource_c_person_optional_missing_middle_3PgResource = registry.pgResources["c_person_optional_missing_middle_3"];
+const argDetailsSimple61 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs61 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11499,7 +11774,7 @@ const makeArgs61 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -11529,46 +11804,30 @@ const makeArgs61 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_c_person_friendsPgResource = registry.pgResources["c_person_friends"];
-const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
-  if (!hasRecord($in)) {
-    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-  }
-  const extraSelectArgs = makeArgs61(args);
-  /**
-   * An optimisation - if all our dependencies are
-   * compatible with the expression's class plan then we
-   * can inline ourselves into that, otherwise we must
-   * issue the query separately.
-   */
-  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-  const selectArgs = [{
-    step: $row.record()
-  }, ...extraSelectArgs];
-  if (resource_c_person_friendsPgResource.isUnique && !resource_c_person_friendsPgResource.codec.attributes && typeof resource_c_person_friendsPgResource.from === "function") {
-    // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
-      if (i === 0) {
-        return $row.getClassStep().alias;
-      } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
-      } else {
-        return $row.placeholder(arg.step);
-      }
-    });
-    return pgClassExpression($row, resource_c_person_friendsPgResource.codec)`${resource_c_person_friendsPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
-  }
-  // PERF: or here, if scalar add select to `$row`?
-  return resource_c_person_friendsPgResource.execute(selectArgs);
-};
-const argDetailsSimple62 = [];
+const resource_c_person_optional_missing_middle_4PgResource = registry.pgResources["c_person_optional_missing_middle_4"];
+const argDetailsSimple62 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "arg2",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
 const makeArgs62 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11579,7 +11838,7 @@ const makeArgs62 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
+      if (!required && i >= 3 - 1) {
         skipped = true;
         continue;
       } else {
@@ -11609,52 +11868,24 @@ const makeArgs62 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_c_person_type_function_connectionPgResource = registry.pgResources["c_person_type_function_connection"];
-const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
-  if (!hasRecord($in)) {
-    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-  }
-  const extraSelectArgs = makeArgs62(args);
-  /**
-   * An optimisation - if all our dependencies are
-   * compatible with the expression's class plan then we
-   * can inline ourselves into that, otherwise we must
-   * issue the query separately.
-   */
-  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-  const selectArgs = [{
-    step: $row.record()
-  }, ...extraSelectArgs];
-  if (resource_c_person_type_function_connectionPgResource.isUnique && !resource_c_person_type_function_connectionPgResource.codec.attributes && typeof resource_c_person_type_function_connectionPgResource.from === "function") {
-    // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
-      if (i === 0) {
-        return $row.getClassStep().alias;
-      } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
-      } else {
-        return $row.placeholder(arg.step);
-      }
-    });
-    return pgClassExpression($row, resource_c_person_type_function_connectionPgResource.codec)`${resource_c_person_type_function_connectionPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
-  }
-  // PERF: or here, if scalar add select to `$row`?
-  return resource_c_person_type_function_connectionPgResource.execute(selectArgs);
-};
+const resource_c_person_optional_missing_middle_5PgResource = registry.pgResources["c_person_optional_missing_middle_5"];
 const argDetailsSimple63 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs63 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11695,7 +11926,7 @@ const makeArgs63 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_c_person_type_functionPgResource = registry.pgResources["c_person_type_function"];
+const resource_c_person_computed_complexPgResource = registry.pgResources["c_person_computed_complex"];
 const argDetailsSimple64 = [];
 const makeArgs64 = (args, path = []) => {
   const selectArgs = [];
@@ -11741,9 +11972,7 @@ const makeArgs64 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_c_person_type_function_listPgResource = registry.pgResources["c_person_type_function_list"];
-const resource_frmcdc_bWrappedUrlPgResource = registry.pgResources["frmcdc_bWrappedUrl"];
-const resource_frmcdc_cCompoundTypePgResource = registry.pgResources["frmcdc_cCompoundType"];
+const resource_c_person_first_postPgResource = registry.pgResources["c_person_first_post"];
 const argDetailsSimple65 = [];
 const makeArgs65 = (args, path = []) => {
   const selectArgs = [];
@@ -11789,6 +12018,7 @@ const makeArgs65 = (args, path = []) => {
   }
   return selectArgs;
 };
+const resource_c_person_computed_first_arg_inoutPgResource = registry.pgResources["c_person_computed_first_arg_inout"];
 const argDetailsSimple66 = [];
 const makeArgs66 = (args, path = []) => {
   const selectArgs = [];
@@ -11833,6 +12063,51 @@ const makeArgs66 = (args, path = []) => {
     }
   }
   return selectArgs;
+};
+const resource_c_person_friendsPgResource = registry.pgResources["c_person_friends"];
+const getSelectPlanFromParentAndArgs16 = ($in, args, _info) => {
+  if (!hasRecord($in)) {
+    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+  }
+  const extraSelectArgs = makeArgs66(args);
+  /**
+   * An optimisation - if all our dependencies are
+   * compatible with the expression's class plan then we
+   * can inline ourselves into that, otherwise we must
+   * issue the query separately.
+   */
+  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+  const selectArgs = [{
+    step: $row.record()
+  }, ...extraSelectArgs];
+  if (resource_c_person_friendsPgResource.isUnique && !resource_c_person_friendsPgResource.codec.attributes && typeof resource_c_person_friendsPgResource.from === "function") {
+    // This is a scalar computed attribute, let's inline the expression
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
+      if (i === 0) {
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
+      } else if ("pgCodec" in arg && arg.pgCodec) {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
+      } else {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
+      }
+    });
+    return pgClassExpression($row, resource_c_person_friendsPgResource.codec)`${resource_c_person_friendsPgResource.from(...newSelectArgs)}`;
+  }
+  // PERF: or here, if scalar add select to `$row`?
+  return resource_c_person_friendsPgResource.execute(selectArgs);
 };
 const argDetailsSimple67 = [];
 const makeArgs67 = (args, path = []) => {
@@ -11879,11 +12154,62 @@ const makeArgs67 = (args, path = []) => {
   }
   return selectArgs;
 };
-const argDetailsSimple68 = [];
+const resource_c_person_type_function_connectionPgResource = registry.pgResources["c_person_type_function_connection"];
+const getSelectPlanFromParentAndArgs17 = ($in, args, _info) => {
+  if (!hasRecord($in)) {
+    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+  }
+  const extraSelectArgs = makeArgs67(args);
+  /**
+   * An optimisation - if all our dependencies are
+   * compatible with the expression's class plan then we
+   * can inline ourselves into that, otherwise we must
+   * issue the query separately.
+   */
+  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+  const selectArgs = [{
+    step: $row.record()
+  }, ...extraSelectArgs];
+  if (resource_c_person_type_function_connectionPgResource.isUnique && !resource_c_person_type_function_connectionPgResource.codec.attributes && typeof resource_c_person_type_function_connectionPgResource.from === "function") {
+    // This is a scalar computed attribute, let's inline the expression
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
+      if (i === 0) {
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
+      } else if ("pgCodec" in arg && arg.pgCodec) {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
+      } else {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
+      }
+    });
+    return pgClassExpression($row, resource_c_person_type_function_connectionPgResource.codec)`${resource_c_person_type_function_connectionPgResource.from(...newSelectArgs)}`;
+  }
+  // PERF: or here, if scalar add select to `$row`?
+  return resource_c_person_type_function_connectionPgResource.execute(selectArgs);
+};
+const argDetailsSimple68 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs68 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -11924,15 +12250,7 @@ const makeArgs68 = (args, path = []) => {
   }
   return selectArgs;
 };
-function UUIDSerialize(value) {
-  return "" + value;
-}
-const coerce = string => {
-  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
-    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
-  }
-  return string;
-};
+const resource_c_person_type_functionPgResource = registry.pgResources["c_person_type_function"];
 const argDetailsSimple69 = [];
 const makeArgs69 = (args, path = []) => {
   const selectArgs = [];
@@ -11978,41 +12296,9 @@ const makeArgs69 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_interval_setPgResource = registry.pgResources["post_computed_interval_set"];
-const getSelectPlanFromParentAndArgs18 = ($in, args, _info) => {
-  if (!hasRecord($in)) {
-    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-  }
-  const extraSelectArgs = makeArgs69(args);
-  /**
-   * An optimisation - if all our dependencies are
-   * compatible with the expression's class plan then we
-   * can inline ourselves into that, otherwise we must
-   * issue the query separately.
-   */
-  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-  const selectArgs = [{
-    step: $row.record()
-  }, ...extraSelectArgs];
-  if (resource_post_computed_interval_setPgResource.isUnique && !resource_post_computed_interval_setPgResource.codec.attributes && typeof resource_post_computed_interval_setPgResource.from === "function") {
-    // This is a scalar computed attribute, let's inline the expression
-    const placeholders = selectArgs.map((arg, i) => {
-      if (i === 0) {
-        return $row.getClassStep().alias;
-      } else if ("pgCodec" in arg && arg.pgCodec) {
-        return $row.placeholder(arg.step, arg.pgCodec);
-      } else {
-        return $row.placeholder(arg.step);
-      }
-    });
-    return pgClassExpression($row, resource_post_computed_interval_setPgResource.codec)`${resource_post_computed_interval_setPgResource.from(...placeholders.map(placeholder => ({
-      placeholder
-    })))}`;
-  }
-  // PERF: or here, if scalar add select to `$row`?
-  return resource_post_computed_interval_setPgResource.execute(selectArgs);
-};
+const resource_c_person_type_function_listPgResource = registry.pgResources["c_person_type_function_list"];
+const resource_frmcdc_bWrappedUrlPgResource = registry.pgResources["frmcdc_bWrappedUrl"];
+const resource_frmcdc_cCompoundTypePgResource = registry.pgResources["frmcdc_cCompoundType"];
 const argDetailsSimple70 = [];
 const makeArgs70 = (args, path = []) => {
   const selectArgs = [];
@@ -12058,7 +12344,6 @@ const makeArgs70 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_interval_arrayPgResource = registry.pgResources["post_computed_interval_array"];
 const argDetailsSimple71 = [];
 const makeArgs71 = (args, path = []) => {
   const selectArgs = [];
@@ -12104,18 +12389,11 @@ const makeArgs71 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_text_arrayPgResource = registry.pgResources["post_computed_text_array"];
-const argDetailsSimple72 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: false,
-  fetcher: null
-}];
+const argDetailsSimple72 = [];
 const makeArgs72 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12156,18 +12434,11 @@ const makeArgs72 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_with_optional_argPgResource = registry.pgResources["post_computed_with_optional_arg"];
-const argDetailsSimple73 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const argDetailsSimple73 = [];
 const makeArgs73 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12208,24 +12479,20 @@ const makeArgs73 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_computed_with_required_argPgResource = registry.pgResources["post_computed_with_required_arg"];
-const argDetailsSimple74 = [{
-  graphqlArgName: "length",
-  postgresArgName: "length",
-  pgCodec: TYPES.int,
-  required: false,
-  fetcher: null
-}, {
-  graphqlArgName: "omission",
-  postgresArgName: "omission",
-  pgCodec: TYPES.text,
-  required: false,
-  fetcher: null
-}];
+function UUIDSerialize(value) {
+  return "" + value;
+}
+const coerce = string => {
+  if (!/^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i.test(string)) {
+    throw new GraphQLError("Invalid UUID, expected 32 hexadecimal characters, optionally with hypens");
+  }
+  return string;
+};
+const argDetailsSimple74 = [];
 const makeArgs74 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12266,24 +12533,56 @@ const makeArgs74 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmedPgResource = registry.pgResources["post_headline_trimmed"];
-const argDetailsSimple75 = [{
-  graphqlArgName: "length",
-  postgresArgName: "length",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "omission",
-  postgresArgName: "omission",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_post_computed_interval_setPgResource = registry.pgResources["post_computed_interval_set"];
+const getSelectPlanFromParentAndArgs18 = ($in, args, _info) => {
+  if (!hasRecord($in)) {
+    throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+  }
+  const extraSelectArgs = makeArgs74(args);
+  /**
+   * An optimisation - if all our dependencies are
+   * compatible with the expression's class plan then we
+   * can inline ourselves into that, otherwise we must
+   * issue the query separately.
+   */
+  const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+  const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+  const selectArgs = [{
+    step: $row.record()
+  }, ...extraSelectArgs];
+  if (resource_post_computed_interval_setPgResource.isUnique && !resource_post_computed_interval_setPgResource.codec.attributes && typeof resource_post_computed_interval_setPgResource.from === "function") {
+    // This is a scalar computed attribute, let's inline the expression
+    const newSelectArgs = selectArgs.map((arg, i) => {
+      const {
+        name
+      } = arg;
+      if (i === 0) {
+        return {
+          name,
+          placeholder: $row.getClassStep().alias
+        };
+      } else if ("pgCodec" in arg && arg.pgCodec) {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step, arg.pgCodec)
+        };
+      } else {
+        return {
+          name,
+          placeholder: $row.placeholder(arg.step)
+        };
+      }
+    });
+    return pgClassExpression($row, resource_post_computed_interval_setPgResource.codec)`${resource_post_computed_interval_setPgResource.from(...newSelectArgs)}`;
+  }
+  // PERF: or here, if scalar add select to `$row`?
+  return resource_post_computed_interval_setPgResource.execute(selectArgs);
+};
+const argDetailsSimple75 = [];
 const makeArgs75 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12324,24 +12623,12 @@ const makeArgs75 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmed_no_defaultsPgResource = registry.pgResources["post_headline_trimmed_no_defaults"];
-const argDetailsSimple76 = [{
-  graphqlArgName: "length",
-  postgresArgName: "length",
-  pgCodec: TYPES.int,
-  required: false,
-  fetcher: null
-}, {
-  graphqlArgName: "omission",
-  postgresArgName: "omission",
-  pgCodec: TYPES.text,
-  required: false,
-  fetcher: null
-}];
+const resource_post_computed_interval_arrayPgResource = registry.pgResources["post_computed_interval_array"];
+const argDetailsSimple76 = [];
 const makeArgs76 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12382,12 +12669,12 @@ const makeArgs76 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_headline_trimmed_strictPgResource = registry.pgResources["post_headline_trimmed_strict"];
+const resource_post_computed_text_arrayPgResource = registry.pgResources["post_computed_text_array"];
 const argDetailsSimple77 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: cCompoundTypeCodec,
-  required: true,
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: false,
   fetcher: null
 }];
 const makeArgs77 = (args, path = []) => {
@@ -12401,6 +12688,284 @@ const makeArgs77 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple77[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_computed_with_optional_argPgResource = registry.pgResources["post_computed_with_optional_arg"];
+const argDetailsSimple78 = [{
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs78 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple78[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_computed_with_required_argPgResource = registry.pgResources["post_computed_with_required_arg"];
+const argDetailsSimple79 = [{
+  graphqlArgName: "length",
+  postgresArgName: "length",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "omission",
+  postgresArgName: "omission",
+  pgCodec: TYPES.text,
+  required: false,
+  fetcher: null
+}];
+const makeArgs79 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple79[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_headline_trimmedPgResource = registry.pgResources["post_headline_trimmed"];
+const argDetailsSimple80 = [{
+  graphqlArgName: "length",
+  postgresArgName: "length",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "omission",
+  postgresArgName: "omission",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
+const makeArgs80 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple80[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_headline_trimmed_no_defaultsPgResource = registry.pgResources["post_headline_trimmed_no_defaults"];
+const argDetailsSimple81 = [{
+  graphqlArgName: "length",
+  postgresArgName: "length",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}, {
+  graphqlArgName: "omission",
+  postgresArgName: "omission",
+  pgCodec: TYPES.text,
+  required: false,
+  fetcher: null
+}];
+const makeArgs81 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple81[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_post_headline_trimmed_strictPgResource = registry.pgResources["post_headline_trimmed_strict"];
+const argDetailsSimple82 = [{
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: cCompoundTypeCodec,
+  required: true,
+  fetcher: null
+}];
+const makeArgs82 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple82[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -12491,236 +13056,6 @@ const parseValueLiteral = (ast, variables) => {
       return undefined;
   }
 };
-const argDetailsSimple78 = [];
-const makeArgs78 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple78[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_c_edge_case_computedPgResource = registry.pgResources["c_edge_case_computed"];
-const argDetailsSimple79 = [];
-const makeArgs79 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple79[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_c_mutation_outPgResource = registry.pgResources["c_mutation_out"];
-const argDetailsSimple80 = [];
-const makeArgs80 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple80[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_c_mutation_out_setofPgResource = registry.pgResources["c_mutation_out_setof"];
-const argDetailsSimple81 = [];
-const makeArgs81 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple81[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_c_mutation_out_unnamedPgResource = registry.pgResources["c_mutation_out_unnamed"];
-const argDetailsSimple82 = [];
-const makeArgs82 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple82[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_c_no_args_mutationPgResource = registry.pgResources["c_no_args_mutation"];
 const argDetailsSimple83 = [];
 const makeArgs83 = (args, path = []) => {
   const selectArgs = [];
@@ -12766,7 +13101,7 @@ const makeArgs83 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
+const resource_c_edge_case_computedPgResource = registry.pgResources["c_edge_case_computed"];
 const argDetailsSimple84 = [];
 const makeArgs84 = (args, path = []) => {
   const selectArgs = [];
@@ -12812,18 +13147,12 @@ const makeArgs84 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
-const argDetailsSimple85 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_c_mutation_outPgResource = registry.pgResources["c_mutation_out"];
+const argDetailsSimple85 = [];
 const makeArgs85 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12864,18 +13193,12 @@ const makeArgs85 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_c_mutation_in_outPgResource = registry.pgResources["c_mutation_in_out"];
-const argDetailsSimple86 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_c_mutation_out_setofPgResource = registry.pgResources["c_mutation_out_setof"];
+const argDetailsSimple86 = [];
 const makeArgs86 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12916,18 +13239,12 @@ const makeArgs86 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_c_mutation_returns_table_one_colPgResource = registry.pgResources["c_mutation_returns_table_one_col"];
-const argDetailsSimple87 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}];
+const resource_c_mutation_out_unnamedPgResource = registry.pgResources["c_mutation_out_unnamed"];
+const argDetailsSimple87 = [];
 const makeArgs87 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -12968,18 +13285,12 @@ const makeArgs87 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_c_json_identity_mutationPgResource = registry.pgResources["c_json_identity_mutation"];
-const argDetailsSimple88 = [{
-  graphqlArgName: "json",
-  postgresArgName: "json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_c_no_args_mutationPgResource = registry.pgResources["c_no_args_mutation"];
+const argDetailsSimple88 = [];
 const makeArgs88 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13020,18 +13331,12 @@ const makeArgs88 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_c_jsonb_identity_mutationPgResource = registry.pgResources["c_jsonb_identity_mutation"];
-const argDetailsSimple89 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: true,
-  fetcher: null
-}];
+const resource_return_void_mutationPgResource = registry.pgResources["return_void_mutation"];
+const argDetailsSimple89 = [];
 const makeArgs89 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13072,12 +13377,12 @@ const makeArgs89 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_c_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["c_jsonb_identity_mutation_plpgsql"];
+const resource_mutation_interval_setPgResource = registry.pgResources["mutation_interval_set"];
 const argDetailsSimple90 = [{
-  graphqlArgName: "_theJson",
-  postgresArgName: "_the_json",
-  pgCodec: TYPES.jsonb,
-  required: false,
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
   fetcher: null
 }];
 const makeArgs90 = (args, path = []) => {
@@ -13124,16 +13429,10 @@ const makeArgs90 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_c_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["c_jsonb_identity_mutation_plpgsql_with_default"];
+const resource_c_mutation_in_outPgResource = registry.pgResources["c_mutation_in_out"];
 const argDetailsSimple91 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: null,
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "arg1",
-  postgresArgName: null,
+  graphqlArgName: "i",
+  postgresArgName: "i",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -13141,7 +13440,7 @@ const argDetailsSimple91 = [{
 const makeArgs91 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13152,7 +13451,7 @@ const makeArgs91 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 2 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13182,24 +13481,18 @@ const makeArgs91 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
+const resource_c_mutation_returns_table_one_colPgResource = registry.pgResources["c_mutation_returns_table_one_col"];
 const argDetailsSimple92 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.json,
   required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.int,
-  required: false,
   fetcher: null
 }];
 const makeArgs92 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13240,24 +13533,18 @@ const makeArgs92 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
+const resource_c_json_identity_mutationPgResource = registry.pgResources["c_json_identity_mutation"];
 const argDetailsSimple93 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "arg1",
-  postgresArgName: "",
-  pgCodec: TYPES.int,
+  graphqlArgName: "json",
+  postgresArgName: "json",
+  pgCodec: TYPES.jsonb,
   required: true,
   fetcher: null
 }];
 const makeArgs93 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13268,7 +13555,7 @@ const makeArgs93 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 2 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13298,24 +13585,18 @@ const makeArgs93 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
+const resource_c_jsonb_identity_mutationPgResource = registry.pgResources["c_jsonb_identity_mutation"];
 const argDetailsSimple94 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: "",
-  pgCodec: TYPES.int,
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
   required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.int,
-  required: false,
   fetcher: null
 }];
 const makeArgs94 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13326,7 +13607,7 @@ const makeArgs94 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 1 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13356,24 +13637,18 @@ const makeArgs94 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
+const resource_c_jsonb_identity_mutation_plpgsqlPgResource = registry.pgResources["c_jsonb_identity_mutation_plpgsql"];
 const argDetailsSimple95 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: "",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.int,
+  graphqlArgName: "_theJson",
+  postgresArgName: "_the_json",
+  pgCodec: TYPES.jsonb,
   required: false,
   fetcher: null
 }];
 const makeArgs95 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13384,7 +13659,7 @@ const makeArgs95 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 1 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13414,7 +13689,7 @@ const makeArgs95 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
+const resource_c_jsonb_identity_mutation_plpgsql_with_defaultPgResource = registry.pgResources["c_jsonb_identity_mutation_plpgsql_with_default"];
 const argDetailsSimple96 = [{
   graphqlArgName: "arg0",
   postgresArgName: null,
@@ -13472,18 +13747,18 @@ const makeArgs96 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_b_mult_1PgResource = registry.pgResources["b_mult_1"];
+const resource_add_1_mutationPgResource = registry.pgResources["add_1_mutation"];
 const argDetailsSimple97 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: null,
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "arg1",
-  postgresArgName: null,
+  graphqlArgName: "b",
+  postgresArgName: "b",
   pgCodec: TYPES.int,
-  required: true,
+  required: false,
   fetcher: null
 }];
 const makeArgs97 = (args, path = []) => {
@@ -13500,7 +13775,7 @@ const makeArgs97 = (args, path = []) => {
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
-      if (!required && i >= 2 - 1) {
+      if (!required && i >= 0 - 1) {
         skipped = true;
         continue;
       } else {
@@ -13530,16 +13805,16 @@ const makeArgs97 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_b_mult_2PgResource = registry.pgResources["b_mult_2"];
+const resource_add_2_mutationPgResource = registry.pgResources["add_2_mutation"];
 const argDetailsSimple98 = [{
-  graphqlArgName: "arg0",
-  postgresArgName: null,
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
   graphqlArgName: "arg1",
-  postgresArgName: null,
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
@@ -13588,18 +13863,18 @@ const makeArgs98 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_b_mult_3PgResource = registry.pgResources["b_mult_3"];
+const resource_add_3_mutationPgResource = registry.pgResources["add_3_mutation"];
 const argDetailsSimple99 = [{
   graphqlArgName: "arg0",
-  postgresArgName: null,
+  postgresArgName: "",
   pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "arg1",
-  postgresArgName: null,
+  graphqlArgName: "b",
+  postgresArgName: "b",
   pgCodec: TYPES.int,
-  required: true,
+  required: false,
   fetcher: null
 }];
 const makeArgs99 = (args, path = []) => {
@@ -13613,6 +13888,296 @@ const makeArgs99 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple99[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 1 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_add_4_mutationPgResource = registry.pgResources["add_4_mutation"];
+const argDetailsSimple100 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: "",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.int,
+  required: false,
+  fetcher: null
+}];
+const makeArgs100 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple100[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 1 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_add_4_mutation_errorPgResource = registry.pgResources["add_4_mutation_error"];
+const argDetailsSimple101 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs101 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple101[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 2 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_b_mult_1PgResource = registry.pgResources["b_mult_1"];
+const argDetailsSimple102 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs102 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple102[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 2 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_b_mult_2PgResource = registry.pgResources["b_mult_2"];
+const argDetailsSimple103 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs103 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple103[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 2 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_b_mult_3PgResource = registry.pgResources["b_mult_3"];
+const argDetailsSimple104 = [{
+  graphqlArgName: "arg0",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "arg1",
+  postgresArgName: null,
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs104 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 2; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple104[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -13647,7 +14212,7 @@ const makeArgs99 = (args, path = []) => {
   return selectArgs;
 };
 const resource_b_mult_4PgResource = registry.pgResources["b_mult_4"];
-const argDetailsSimple100 = [{
+const argDetailsSimple105 = [{
   graphqlArgName: "i",
   postgresArgName: "i",
   pgCodec: TYPES.int,
@@ -13660,258 +14225,10 @@ const argDetailsSimple100 = [{
   required: true,
   fetcher: null
 }];
-const makeArgs100 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 2; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple100[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_c_mutation_in_inoutPgResource = registry.pgResources["c_mutation_in_inout"];
-const argDetailsSimple101 = [];
-const makeArgs101 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple101[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_c_mutation_out_outPgResource = registry.pgResources["c_mutation_out_out"];
-const argDetailsSimple102 = [];
-const makeArgs102 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple102[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_c_mutation_out_out_setofPgResource = registry.pgResources["c_mutation_out_out_setof"];
-const argDetailsSimple103 = [];
-const makeArgs103 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 0; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple103[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_c_mutation_out_out_unnamedPgResource = registry.pgResources["c_mutation_out_out_unnamed"];
-const argDetailsSimple104 = [{
-  graphqlArgName: "x",
-  postgresArgName: "x",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "y",
-  postgresArgName: "y",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "z",
-  postgresArgName: "z",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
-const makeArgs104 = (args, path = []) => {
-  const selectArgs = [];
-  let skipped = false;
-  for (let i = 0; i < 3; i++) {
-    const {
-      graphqlArgName,
-      postgresArgName,
-      pgCodec,
-      required,
-      fetcher
-    } = argDetailsSimple104[i];
-    const $raw = args.getRaw([...path, graphqlArgName]);
-    let step;
-    if ($raw.evalIs(undefined)) {
-      if (!required && i >= 0 - 1) {
-        skipped = true;
-        continue;
-      } else {
-        step = constant(null);
-      }
-    } else if (fetcher) {
-      step = fetcher(args.get([...path, graphqlArgName])).record();
-    } else {
-      step = args.get([...path, graphqlArgName]);
-    }
-    if (skipped) {
-      const name = postgresArgName;
-      if (!name) {
-        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
-      }
-      selectArgs.push({
-        step,
-        pgCodec,
-        name
-      });
-    } else {
-      selectArgs.push({
-        step,
-        pgCodec
-      });
-    }
-  }
-  return selectArgs;
-};
-const resource_c_int_set_mutationPgResource = registry.pgResources["c_int_set_mutation"];
-const argDetailsSimple105 = [];
 const makeArgs105 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -13952,18 +14269,12 @@ const makeArgs105 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_c_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["c_mutation_out_unnamed_out_out_unnamed"];
-const argDetailsSimple106 = [{
-  graphqlArgName: "i",
-  postgresArgName: "i",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_c_mutation_in_inoutPgResource = registry.pgResources["c_mutation_in_inout"];
+const argDetailsSimple106 = [];
 const makeArgs106 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14004,18 +14315,12 @@ const makeArgs106 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_c_mutation_returns_table_multi_colPgResource = registry.pgResources["c_mutation_returns_table_multi_col"];
-const argDetailsSimple107 = [{
-  graphqlArgName: "g",
-  postgresArgName: "g",
-  pgCodec: bGuidCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_c_mutation_out_outPgResource = registry.pgResources["c_mutation_out_out"];
+const argDetailsSimple107 = [];
 const makeArgs107 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14056,7 +14361,7 @@ const makeArgs107 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_b_guid_fnPgResource = registry.pgResources["b_guid_fn"];
+const resource_c_mutation_out_out_setofPgResource = registry.pgResources["c_mutation_out_out_setof"];
 const argDetailsSimple108 = [];
 const makeArgs108 = (args, path = []) => {
   const selectArgs = [];
@@ -14102,12 +14407,30 @@ const makeArgs108 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
-const argDetailsSimple109 = [];
+const resource_c_mutation_out_out_unnamedPgResource = registry.pgResources["c_mutation_out_out_unnamed"];
+const argDetailsSimple109 = [{
+  graphqlArgName: "x",
+  postgresArgName: "x",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "y",
+  postgresArgName: "y",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "z",
+  postgresArgName: "z",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs109 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14148,30 +14471,12 @@ const makeArgs109 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
-const argDetailsSimple110 = [{
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: pgCatalogTextArrayCodec,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "d",
-  postgresArgName: "d",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "e",
-  postgresArgName: "e",
-  pgCodec: TYPES.text,
-  required: true,
-  fetcher: null
-}];
+const resource_c_int_set_mutationPgResource = registry.pgResources["c_int_set_mutation"];
+const argDetailsSimple110 = [];
 const makeArgs110 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14212,12 +14517,18 @@ const makeArgs110 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_b_list_bde_mutationPgResource = registry.pgResources["b_list_bde_mutation"];
-const argDetailsSimple111 = [];
+const resource_c_mutation_out_unnamed_out_out_unnamedPgResource = registry.pgResources["c_mutation_out_unnamed_out_out_unnamed"];
+const argDetailsSimple111 = [{
+  graphqlArgName: "i",
+  postgresArgName: "i",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
 const makeArgs111 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14258,30 +14569,18 @@ const makeArgs111 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_b_authenticate_failPgResource = registry.pgResources["b_authenticate_fail"];
+const resource_c_mutation_returns_table_multi_colPgResource = registry.pgResources["c_mutation_returns_table_multi_col"];
 const argDetailsSimple112 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.numeric,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.bigint,
+  graphqlArgName: "g",
+  postgresArgName: "g",
+  pgCodec: bGuidCodec,
   required: true,
   fetcher: null
 }];
 const makeArgs112 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14322,18 +14621,12 @@ const makeArgs112 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_b_authenticatePgResource = registry.pgResources["b_authenticate"];
-const argDetailsSimple113 = [{
-  graphqlArgName: "leftArm",
-  postgresArgName: "left_arm",
-  pgCodec: cLeftArmCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_b_guid_fnPgResource = registry.pgResources["b_guid_fn"];
+const argDetailsSimple113 = [];
 const makeArgs113 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14374,7 +14667,7 @@ const makeArgs113 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_c_left_arm_identityPgResource = registry.pgResources["c_left_arm_identity"];
+const resource_mutation_interval_arrayPgResource = registry.pgResources["mutation_interval_array"];
 const argDetailsSimple114 = [];
 const makeArgs114 = (args, path = []) => {
   const selectArgs = [];
@@ -14420,12 +14713,30 @@ const makeArgs114 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_c_issue756_mutationPgResource = registry.pgResources["c_issue756_mutation"];
-const argDetailsSimple115 = [];
+const resource_mutation_text_arrayPgResource = registry.pgResources["mutation_text_array"];
+const argDetailsSimple115 = [{
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: pgCatalogTextArrayCodec,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "d",
+  postgresArgName: "d",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "e",
+  postgresArgName: "e",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
 const makeArgs115 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14466,30 +14777,12 @@ const makeArgs115 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_c_issue756_set_mutationPgResource = registry.pgResources["c_issue756_set_mutation"];
-const argDetailsSimple116 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.numeric,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.bigint,
-  required: true,
-  fetcher: null
-}];
+const resource_b_list_bde_mutationPgResource = registry.pgResources["b_list_bde_mutation"];
+const argDetailsSimple116 = [];
 const makeArgs116 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14530,7 +14823,7 @@ const makeArgs116 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_b_authenticate_manyPgResource = registry.pgResources["b_authenticate_many"];
+const resource_b_authenticate_failPgResource = registry.pgResources["b_authenticate_fail"];
 const argDetailsSimple117 = [{
   graphqlArgName: "a",
   postgresArgName: "a",
@@ -14594,48 +14887,18 @@ const makeArgs117 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_b_authenticate_payloadPgResource = registry.pgResources["b_authenticate_payload"];
+const resource_b_authenticatePgResource = registry.pgResources["b_authenticate"];
 const argDetailsSimple118 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.bigint,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.boolean,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "c",
-  postgresArgName: "c",
-  pgCodec: TYPES.varchar,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "d",
-  postgresArgName: "d",
-  pgCodec: pgCatalogInt4ArrayCodec,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "e",
-  postgresArgName: "e",
-  pgCodec: TYPES.json,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "f",
-  postgresArgName: "f",
-  pgCodec: cFloatrangeCodec,
+  graphqlArgName: "leftArm",
+  postgresArgName: "left_arm",
+  pgCodec: cLeftArmCodec,
   required: true,
   fetcher: null
 }];
 const makeArgs118 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 6; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14676,18 +14939,12 @@ const makeArgs118 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_c_types_mutationPgResource = registry.pgResources["c_types_mutation"];
-const argDetailsSimple119 = [{
-  graphqlArgName: "i1",
-  postgresArgName: "i1",
-  pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}];
+const resource_c_left_arm_identityPgResource = registry.pgResources["c_left_arm_identity"];
+const argDetailsSimple119 = [];
 const makeArgs119 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14728,18 +14985,12 @@ const makeArgs119 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_c_mutation_out_out_compound_typePgResource = registry.pgResources["c_mutation_out_out_compound_type"];
-const argDetailsSimple120 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: cCompoundTypeCodec,
-  required: true,
-  fetcher: null
-}];
+const resource_c_issue756_mutationPgResource = registry.pgResources["c_issue756_mutation"];
+const argDetailsSimple120 = [];
 const makeArgs120 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 0; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14780,18 +15031,30 @@ const makeArgs120 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_b_compound_type_mutationPgResource = registry.pgResources["b_compound_type_mutation"];
+const resource_c_issue756_set_mutationPgResource = registry.pgResources["c_issue756_set_mutation"];
 const argDetailsSimple121 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: cCompoundTypeCodec,
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.numeric,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.bigint,
   required: true,
   fetcher: null
 }];
 const makeArgs121 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14832,18 +15095,30 @@ const makeArgs121 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_b_compound_type_set_mutationPgResource = registry.pgResources["b_compound_type_set_mutation"];
+const resource_b_authenticate_manyPgResource = registry.pgResources["b_authenticate_many"];
 const argDetailsSimple122 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.numeric,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.bigint,
   required: true,
   fetcher: null
 }];
 const makeArgs122 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 3; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14884,24 +15159,48 @@ const makeArgs122 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_c_table_mutationPgResource = registry.pgResources["c_table_mutation"];
+const resource_b_authenticate_payloadPgResource = registry.pgResources["b_authenticate_payload"];
 const argDetailsSimple123 = [{
-  graphqlArgName: "post",
-  postgresArgName: "post",
-  pgCodec: postCodec,
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.bigint,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "suffix",
-  postgresArgName: "suffix",
-  pgCodec: TYPES.text,
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.boolean,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "c",
+  postgresArgName: "c",
+  pgCodec: TYPES.varchar,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "d",
+  postgresArgName: "d",
+  pgCodec: pgCatalogInt4ArrayCodec,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "e",
+  postgresArgName: "e",
+  pgCodec: TYPES.json,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "f",
+  postgresArgName: "f",
+  pgCodec: cFloatrangeCodec,
   required: true,
   fetcher: null
 }];
 const makeArgs123 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 6; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -14942,11 +15241,11 @@ const makeArgs123 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_with_suffixPgResource = registry.pgResources["post_with_suffix"];
+const resource_c_types_mutationPgResource = registry.pgResources["c_types_mutation"];
 const argDetailsSimple124 = [{
-  graphqlArgName: "object",
-  postgresArgName: "object",
-  pgCodec: cCompoundTypeCodec,
+  graphqlArgName: "i1",
+  postgresArgName: "i1",
+  pgCodec: TYPES.int,
   required: true,
   fetcher: null
 }];
@@ -14994,7 +15293,7 @@ const makeArgs124 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
+const resource_c_mutation_out_out_compound_typePgResource = registry.pgResources["c_mutation_out_out_compound_type"];
 const argDetailsSimple125 = [{
   graphqlArgName: "object",
   postgresArgName: "object",
@@ -15046,11 +15345,11 @@ const makeArgs125 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_b_compound_type_array_mutationPgResource = registry.pgResources["b_compound_type_array_mutation"];
+const resource_b_compound_type_mutationPgResource = registry.pgResources["b_compound_type_mutation"];
 const argDetailsSimple126 = [{
-  graphqlArgName: "posts",
-  postgresArgName: "posts",
-  pgCodec: postArrayCodec,
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: cCompoundTypeCodec,
   required: true,
   fetcher: null
 }];
@@ -15098,24 +15397,18 @@ const makeArgs126 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_post_manyPgResource = registry.pgResources["post_many"];
+const resource_b_compound_type_set_mutationPgResource = registry.pgResources["b_compound_type_set_mutation"];
 const argDetailsSimple127 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
+  graphqlArgName: "id",
+  postgresArgName: "id",
   pgCodec: TYPES.int,
-  required: true,
-  fetcher: null
-}, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
-  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs127 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 2; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15156,16 +15449,16 @@ const makeArgs127 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_c_mutation_out_complexPgResource = registry.pgResources["c_mutation_out_complex"];
+const resource_c_table_mutationPgResource = registry.pgResources["c_table_mutation"];
 const argDetailsSimple128 = [{
-  graphqlArgName: "a",
-  postgresArgName: "a",
-  pgCodec: TYPES.int,
+  graphqlArgName: "post",
+  postgresArgName: "post",
+  pgCodec: postCodec,
   required: true,
   fetcher: null
 }, {
-  graphqlArgName: "b",
-  postgresArgName: "b",
+  graphqlArgName: "suffix",
+  postgresArgName: "suffix",
   pgCodec: TYPES.text,
   required: true,
   fetcher: null
@@ -15214,12 +15507,18 @@ const makeArgs128 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_c_mutation_out_complex_setofPgResource = registry.pgResources["c_mutation_out_complex_setof"];
-const argDetailsSimple129 = [];
+const resource_post_with_suffixPgResource = registry.pgResources["post_with_suffix"];
+const argDetailsSimple129 = [{
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: cCompoundTypeCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs129 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15260,12 +15559,18 @@ const makeArgs129 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_c_mutation_out_tablePgResource = registry.pgResources["c_mutation_out_table"];
-const argDetailsSimple130 = [];
+const resource_mutation_compound_type_arrayPgResource = registry.pgResources["mutation_compound_type_array"];
+const argDetailsSimple130 = [{
+  graphqlArgName: "object",
+  postgresArgName: "object",
+  pgCodec: cCompoundTypeCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs130 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15306,12 +15611,18 @@ const makeArgs130 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_c_mutation_out_table_setofPgResource = registry.pgResources["c_mutation_out_table_setof"];
-const argDetailsSimple131 = [];
+const resource_b_compound_type_array_mutationPgResource = registry.pgResources["b_compound_type_array_mutation"];
+const argDetailsSimple131 = [{
+  graphqlArgName: "posts",
+  postgresArgName: "posts",
+  pgCodec: postArrayCodec,
+  required: true,
+  fetcher: null
+}];
 const makeArgs131 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 1; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15352,12 +15663,24 @@ const makeArgs131 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_c_table_set_mutationPgResource = registry.pgResources["c_table_set_mutation"];
-const argDetailsSimple132 = [];
+const resource_post_manyPgResource = registry.pgResources["post_many"];
+const argDetailsSimple132 = [{
+  graphqlArgName: "a",
+  postgresArgName: "a",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
+  required: true,
+  fetcher: null
+}];
 const makeArgs132 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 0; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15398,18 +15721,24 @@ const makeArgs132 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_b_type_function_connection_mutationPgResource = registry.pgResources["b_type_function_connection_mutation"];
+const resource_c_mutation_out_complexPgResource = registry.pgResources["c_mutation_out_complex"];
 const argDetailsSimple133 = [{
-  graphqlArgName: "id",
-  postgresArgName: "id",
+  graphqlArgName: "a",
+  postgresArgName: "a",
   pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}, {
+  graphqlArgName: "b",
+  postgresArgName: "b",
+  pgCodec: TYPES.text,
   required: true,
   fetcher: null
 }];
 const makeArgs133 = (args, path = []) => {
   const selectArgs = [];
   let skipped = false;
-  for (let i = 0; i < 1; i++) {
+  for (let i = 0; i < 2; i++) {
     const {
       graphqlArgName,
       postgresArgName,
@@ -15450,7 +15779,7 @@ const makeArgs133 = (args, path = []) => {
   }
   return selectArgs;
 };
-const resource_b_type_function_mutationPgResource = registry.pgResources["b_type_function_mutation"];
+const resource_c_mutation_out_complex_setofPgResource = registry.pgResources["c_mutation_out_complex_setof"];
 const argDetailsSimple134 = [];
 const makeArgs134 = (args, path = []) => {
   const selectArgs = [];
@@ -15463,6 +15792,242 @@ const makeArgs134 = (args, path = []) => {
       required,
       fetcher
     } = argDetailsSimple134[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_c_mutation_out_tablePgResource = registry.pgResources["c_mutation_out_table"];
+const argDetailsSimple135 = [];
+const makeArgs135 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple135[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_c_mutation_out_table_setofPgResource = registry.pgResources["c_mutation_out_table_setof"];
+const argDetailsSimple136 = [];
+const makeArgs136 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple136[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_c_table_set_mutationPgResource = registry.pgResources["c_table_set_mutation"];
+const argDetailsSimple137 = [];
+const makeArgs137 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple137[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_b_type_function_connection_mutationPgResource = registry.pgResources["b_type_function_connection_mutation"];
+const argDetailsSimple138 = [{
+  graphqlArgName: "id",
+  postgresArgName: "id",
+  pgCodec: TYPES.int,
+  required: true,
+  fetcher: null
+}];
+const makeArgs138 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 1; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple138[i];
+    const $raw = args.getRaw([...path, graphqlArgName]);
+    let step;
+    if ($raw.evalIs(undefined)) {
+      if (!required && i >= 0 - 1) {
+        skipped = true;
+        continue;
+      } else {
+        step = constant(null);
+      }
+    } else if (fetcher) {
+      step = fetcher(args.get([...path, graphqlArgName])).record();
+    } else {
+      step = args.get([...path, graphqlArgName]);
+    }
+    if (skipped) {
+      const name = postgresArgName;
+      if (!name) {
+        throw new Error("GraphileInternalError<6f9e0fbc-6c73-4811-a7cf-c2bc2b3c0946>: This should not be possible since we asserted that allArgsAreNamed");
+      }
+      selectArgs.push({
+        step,
+        pgCodec,
+        name
+      });
+    } else {
+      selectArgs.push({
+        step,
+        pgCodec
+      });
+    }
+  }
+  return selectArgs;
+};
+const resource_b_type_function_mutationPgResource = registry.pgResources["b_type_function_mutation"];
+const argDetailsSimple139 = [];
+const makeArgs139 = (args, path = []) => {
+  const selectArgs = [];
+  let skipped = false;
+  for (let i = 0; i < 0; i++) {
+    const {
+      graphqlArgName,
+      postgresArgName,
+      pgCodec,
+      required,
+      fetcher
+    } = argDetailsSimple139[i];
     const $raw = args.getRaw([...path, graphqlArgName]);
     let step;
     if ($raw.evalIs(undefined)) {
@@ -16690,6 +17255,11 @@ type CPerson {
   computedInoutOut(ino: String): CPersonComputedInoutOutRecord
   exists(email: BEmail): Boolean @deprecated(reason: "This is deprecated (comment on function c.person_exists).")
   computedFirstArgInoutOut: CPersonComputedFirstArgInoutOutRecord
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, b: Int, arg2: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
   computedComplex(a: Int, b: String): CPersonComputedComplexRecord
 
   """The first post by the person."""
@@ -26936,18 +27506,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_c_person_computed_outPgResource.isUnique && !resource_c_person_computed_outPgResource.codec.attributes && typeof resource_c_person_computed_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_c_person_computed_outPgResource.codec)`${resource_c_person_computed_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_c_person_computed_outPgResource.codec)`${resource_c_person_computed_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_c_person_computed_outPgResource.execute(selectArgs);
@@ -26970,18 +27550,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_c_person_first_namePgResource.isUnique && !resource_c_person_first_namePgResource.codec.attributes && typeof resource_c_person_first_namePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_c_person_first_namePgResource.codec)`${resource_c_person_first_namePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_c_person_first_namePgResource.codec)`${resource_c_person_first_namePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_c_person_first_namePgResource.execute(selectArgs);
@@ -27004,18 +27594,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_c_person_computed_out_outPgResource.isUnique && !resource_c_person_computed_out_outPgResource.codec.attributes && typeof resource_c_person_computed_out_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_c_person_computed_out_outPgResource.codec)`${resource_c_person_computed_out_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_c_person_computed_out_outPgResource.codec)`${resource_c_person_computed_out_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_c_person_computed_out_outPgResource.execute(selectArgs);
@@ -27039,18 +27639,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_c_person_computed_inoutPgResource.isUnique && !resource_c_person_computed_inoutPgResource.codec.attributes && typeof resource_c_person_computed_inoutPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_c_person_computed_inoutPgResource.codec)`${resource_c_person_computed_inoutPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_c_person_computed_inoutPgResource.codec)`${resource_c_person_computed_inoutPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_c_person_computed_inoutPgResource.execute(selectArgs);
@@ -27078,18 +27688,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_c_person_computed_inout_outPgResource.isUnique && !resource_c_person_computed_inout_outPgResource.codec.attributes && typeof resource_c_person_computed_inout_outPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_c_person_computed_inout_outPgResource.codec)`${resource_c_person_computed_inout_outPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_c_person_computed_inout_outPgResource.codec)`${resource_c_person_computed_inout_outPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_c_person_computed_inout_outPgResource.execute(selectArgs);
@@ -27117,18 +27737,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_c_person_existsPgResource.isUnique && !resource_c_person_existsPgResource.codec.attributes && typeof resource_c_person_existsPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_c_person_existsPgResource.codec)`${resource_c_person_existsPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_c_person_existsPgResource.codec)`${resource_c_person_existsPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_c_person_existsPgResource.execute(selectArgs);
@@ -27155,23 +27785,33 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_c_person_computed_first_arg_inout_outPgResource.isUnique && !resource_c_person_computed_first_arg_inout_outPgResource.codec.attributes && typeof resource_c_person_computed_first_arg_inout_outPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_c_person_computed_first_arg_inout_outPgResource.codec)`${resource_c_person_computed_first_arg_inout_outPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_c_person_computed_first_arg_inout_outPgResource.codec)`${resource_c_person_computed_first_arg_inout_outPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_c_person_computed_first_arg_inout_outPgResource.execute(selectArgs);
     },
-    computedComplex: {
+    optionalMissingMiddle1: {
       plan($in, args, _info) {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -27188,20 +27828,285 @@ export const plans = {
         const selectArgs = [{
           step: $row.record()
         }, ...extraSelectArgs];
-        if (resource_c_person_computed_complexPgResource.isUnique && !resource_c_person_computed_complexPgResource.codec.attributes && typeof resource_c_person_computed_complexPgResource.from === "function") {
+        if (resource_c_person_optional_missing_middle_1PgResource.isUnique && !resource_c_person_optional_missing_middle_1PgResource.codec.attributes && typeof resource_c_person_optional_missing_middle_1PgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_c_person_computed_complexPgResource.codec)`${resource_c_person_computed_complexPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_c_person_optional_missing_middle_1PgResource.codec)`${resource_c_person_optional_missing_middle_1PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_c_person_optional_missing_middle_1PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle2: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs59(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_c_person_optional_missing_middle_2PgResource.isUnique && !resource_c_person_optional_missing_middle_2PgResource.codec.attributes && typeof resource_c_person_optional_missing_middle_2PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_c_person_optional_missing_middle_2PgResource.codec)`${resource_c_person_optional_missing_middle_2PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_c_person_optional_missing_middle_2PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        b: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle3: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs60(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_c_person_optional_missing_middle_3PgResource.isUnique && !resource_c_person_optional_missing_middle_3PgResource.codec.attributes && typeof resource_c_person_optional_missing_middle_3PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_c_person_optional_missing_middle_3PgResource.codec)`${resource_c_person_optional_missing_middle_3PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_c_person_optional_missing_middle_3PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        c: undefined
+      }
+    },
+    optionalMissingMiddle4: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs61(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_c_person_optional_missing_middle_4PgResource.isUnique && !resource_c_person_optional_missing_middle_4PgResource.codec.attributes && typeof resource_c_person_optional_missing_middle_4PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_c_person_optional_missing_middle_4PgResource.codec)`${resource_c_person_optional_missing_middle_4PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_c_person_optional_missing_middle_4PgResource.execute(selectArgs);
+      },
+      args: {
+        arg0: undefined,
+        b: undefined,
+        arg2: undefined
+      }
+    },
+    optionalMissingMiddle5: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs62(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_c_person_optional_missing_middle_5PgResource.isUnique && !resource_c_person_optional_missing_middle_5PgResource.codec.attributes && typeof resource_c_person_optional_missing_middle_5PgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_c_person_optional_missing_middle_5PgResource.codec)`${resource_c_person_optional_missing_middle_5PgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_c_person_optional_missing_middle_5PgResource.execute(selectArgs);
+      },
+      args: {
+        a: undefined,
+        arg1: undefined,
+        arg2: undefined
+      }
+    },
+    computedComplex: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs63(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_c_person_computed_complexPgResource.isUnique && !resource_c_person_computed_complexPgResource.codec.attributes && typeof resource_c_person_computed_complexPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_c_person_computed_complexPgResource.codec)`${resource_c_person_computed_complexPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_c_person_computed_complexPgResource.execute(selectArgs);
@@ -27215,7 +28120,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs59(args);
+      const extraSelectArgs = makeArgs64(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -27229,18 +28134,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_c_person_first_postPgResource.isUnique && !resource_c_person_first_postPgResource.codec.attributes && typeof resource_c_person_first_postPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_c_person_first_postPgResource.codec)`${resource_c_person_first_postPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_c_person_first_postPgResource.codec)`${resource_c_person_first_postPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_c_person_first_postPgResource.execute(selectArgs);
@@ -27249,7 +28164,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs60(args);
+      const extraSelectArgs = makeArgs65(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -27263,18 +28178,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_c_person_computed_first_arg_inoutPgResource.isUnique && !resource_c_person_computed_first_arg_inoutPgResource.codec.attributes && typeof resource_c_person_computed_first_arg_inoutPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_c_person_computed_first_arg_inoutPgResource.codec)`${resource_c_person_computed_first_arg_inoutPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_c_person_computed_first_arg_inoutPgResource.codec)`${resource_c_person_computed_first_arg_inoutPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_c_person_computed_first_arg_inoutPgResource.execute(selectArgs);
@@ -27346,7 +28271,7 @@ export const plans = {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
         }
-        const extraSelectArgs = makeArgs63(args);
+        const extraSelectArgs = makeArgs68(args);
         /**
          * An optimisation - if all our dependencies are
          * compatible with the expression's class plan then we
@@ -27360,18 +28285,28 @@ export const plans = {
         }, ...extraSelectArgs];
         if (resource_c_person_type_functionPgResource.isUnique && !resource_c_person_type_functionPgResource.codec.attributes && typeof resource_c_person_type_functionPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_c_person_type_functionPgResource.codec)`${resource_c_person_type_functionPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_c_person_type_functionPgResource.codec)`${resource_c_person_type_functionPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_c_person_type_functionPgResource.execute(selectArgs);
@@ -27384,7 +28319,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs64(args);
+      const extraSelectArgs = makeArgs69(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -27398,18 +28333,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_c_person_type_function_listPgResource.isUnique && !resource_c_person_type_function_listPgResource.codec.attributes && typeof resource_c_person_type_function_listPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_c_person_type_function_listPgResource.codec)`${resource_c_person_type_function_listPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_c_person_type_function_listPgResource.codec)`${resource_c_person_type_function_listPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_c_person_type_function_listPgResource.execute(selectArgs);
@@ -27756,7 +28701,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs65(args);
+      const extraSelectArgs = makeArgs70(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -27770,18 +28715,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_c_compound_type_computed_fieldPgResource.isUnique && !resource_c_compound_type_computed_fieldPgResource.codec.attributes && typeof resource_c_compound_type_computed_fieldPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_c_compound_type_computed_fieldPgResource.codec)`${resource_c_compound_type_computed_fieldPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_c_compound_type_computed_fieldPgResource.codec)`${resource_c_compound_type_computed_fieldPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_c_compound_type_computed_fieldPgResource.execute(selectArgs);
@@ -27790,7 +28745,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs66(args);
+      const extraSelectArgs = makeArgs71(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -27804,18 +28759,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_b_compound_type_queryPgResource.isUnique && !resource_b_compound_type_queryPgResource.codec.attributes && typeof resource_b_compound_type_queryPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_b_compound_type_queryPgResource.codec)`${resource_b_compound_type_queryPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_b_compound_type_queryPgResource.codec)`${resource_b_compound_type_queryPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_b_compound_type_queryPgResource.execute(selectArgs);
@@ -27824,7 +28789,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs67(args);
+      const extraSelectArgs = makeArgs72(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -27838,18 +28803,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_query_compound_type_arrayPgResource.isUnique && !resource_query_compound_type_arrayPgResource.codec.attributes && typeof resource_query_compound_type_arrayPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_query_compound_type_arrayPgResource.codec)`${resource_query_compound_type_arrayPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_query_compound_type_arrayPgResource.codec)`${resource_query_compound_type_arrayPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_query_compound_type_arrayPgResource.execute(selectArgs);
@@ -27858,7 +28833,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs68(args);
+      const extraSelectArgs = makeArgs73(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -27872,18 +28847,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_b_compound_type_array_queryPgResource.isUnique && !resource_b_compound_type_array_queryPgResource.codec.attributes && typeof resource_b_compound_type_array_queryPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_b_compound_type_array_queryPgResource.codec)`${resource_b_compound_type_array_queryPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_b_compound_type_array_queryPgResource.codec)`${resource_b_compound_type_array_queryPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_b_compound_type_array_queryPgResource.execute(selectArgs);
@@ -27994,7 +28979,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs70(args);
+      const extraSelectArgs = makeArgs75(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -28008,18 +28993,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_post_computed_interval_arrayPgResource.isUnique && !resource_post_computed_interval_arrayPgResource.codec.attributes && typeof resource_post_computed_interval_arrayPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_post_computed_interval_arrayPgResource.codec)`${resource_post_computed_interval_arrayPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_post_computed_interval_arrayPgResource.codec)`${resource_post_computed_interval_arrayPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_post_computed_interval_arrayPgResource.execute(selectArgs);
@@ -28028,7 +29023,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs71(args);
+      const extraSelectArgs = makeArgs76(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -28042,221 +29037,33 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_post_computed_text_arrayPgResource.isUnique && !resource_post_computed_text_arrayPgResource.codec.attributes && typeof resource_post_computed_text_arrayPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_post_computed_text_arrayPgResource.codec)`${resource_post_computed_text_arrayPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_post_computed_text_arrayPgResource.codec)`${resource_post_computed_text_arrayPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_post_computed_text_arrayPgResource.execute(selectArgs);
     },
     computedWithOptionalArg: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs72(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_computed_with_optional_argPgResource.isUnique && !resource_post_computed_with_optional_argPgResource.codec.attributes && typeof resource_post_computed_with_optional_argPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_computed_with_optional_argPgResource.codec)`${resource_post_computed_with_optional_argPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_computed_with_optional_argPgResource.execute(selectArgs);
-      },
-      args: {
-        i: undefined
-      }
-    },
-    computedWithRequiredArg: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs73(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_computed_with_required_argPgResource.isUnique && !resource_post_computed_with_required_argPgResource.codec.attributes && typeof resource_post_computed_with_required_argPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_computed_with_required_argPgResource.codec)`${resource_post_computed_with_required_argPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_computed_with_required_argPgResource.execute(selectArgs);
-      },
-      args: {
-        i: undefined
-      }
-    },
-    headlineTrimmed: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs74(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_headline_trimmedPgResource.isUnique && !resource_post_headline_trimmedPgResource.codec.attributes && typeof resource_post_headline_trimmedPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_headline_trimmedPgResource.codec)`${resource_post_headline_trimmedPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_headline_trimmedPgResource.execute(selectArgs);
-      },
-      args: {
-        length: undefined,
-        omission: undefined
-      }
-    },
-    headlineTrimmedNoDefaults: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs75(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_headline_trimmed_no_defaultsPgResource.isUnique && !resource_post_headline_trimmed_no_defaultsPgResource.codec.attributes && typeof resource_post_headline_trimmed_no_defaultsPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_headline_trimmed_no_defaultsPgResource.codec)`${resource_post_headline_trimmed_no_defaultsPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_headline_trimmed_no_defaultsPgResource.execute(selectArgs);
-      },
-      args: {
-        length: undefined,
-        omission: undefined
-      }
-    },
-    headlineTrimmedStrict: {
-      plan($in, args, _info) {
-        if (!hasRecord($in)) {
-          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
-        }
-        const extraSelectArgs = makeArgs76(args);
-        /**
-         * An optimisation - if all our dependencies are
-         * compatible with the expression's class plan then we
-         * can inline ourselves into that, otherwise we must
-         * issue the query separately.
-         */
-        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
-        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
-        const selectArgs = [{
-          step: $row.record()
-        }, ...extraSelectArgs];
-        if (resource_post_headline_trimmed_strictPgResource.isUnique && !resource_post_headline_trimmed_strictPgResource.codec.attributes && typeof resource_post_headline_trimmed_strictPgResource.from === "function") {
-          // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
-            if (i === 0) {
-              return $row.getClassStep().alias;
-            } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
-            } else {
-              return $row.placeholder(arg.step);
-            }
-          });
-          return pgClassExpression($row, resource_post_headline_trimmed_strictPgResource.codec)`${resource_post_headline_trimmed_strictPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
-        }
-        // PERF: or here, if scalar add select to `$row`?
-        return resource_post_headline_trimmed_strictPgResource.execute(selectArgs);
-      },
-      args: {
-        length: undefined,
-        omission: undefined
-      }
-    },
-    computedCompoundTypeArray: {
       plan($in, args, _info) {
         if (!hasRecord($in)) {
           throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
@@ -28273,20 +29080,278 @@ export const plans = {
         const selectArgs = [{
           step: $row.record()
         }, ...extraSelectArgs];
-        if (resource_post_computed_compound_type_arrayPgResource.isUnique && !resource_post_computed_compound_type_arrayPgResource.codec.attributes && typeof resource_post_computed_compound_type_arrayPgResource.from === "function") {
+        if (resource_post_computed_with_optional_argPgResource.isUnique && !resource_post_computed_with_optional_argPgResource.codec.attributes && typeof resource_post_computed_with_optional_argPgResource.from === "function") {
           // This is a scalar computed attribute, let's inline the expression
-          const placeholders = selectArgs.map((arg, i) => {
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
             if (i === 0) {
-              return $row.getClassStep().alias;
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
             } else if ("pgCodec" in arg && arg.pgCodec) {
-              return $row.placeholder(arg.step, arg.pgCodec);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
             } else {
-              return $row.placeholder(arg.step);
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
             }
           });
-          return pgClassExpression($row, resource_post_computed_compound_type_arrayPgResource.codec)`${resource_post_computed_compound_type_arrayPgResource.from(...placeholders.map(placeholder => ({
-            placeholder
-          })))}`;
+          return pgClassExpression($row, resource_post_computed_with_optional_argPgResource.codec)`${resource_post_computed_with_optional_argPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_computed_with_optional_argPgResource.execute(selectArgs);
+      },
+      args: {
+        i: undefined
+      }
+    },
+    computedWithRequiredArg: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs78(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_computed_with_required_argPgResource.isUnique && !resource_post_computed_with_required_argPgResource.codec.attributes && typeof resource_post_computed_with_required_argPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_computed_with_required_argPgResource.codec)`${resource_post_computed_with_required_argPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_computed_with_required_argPgResource.execute(selectArgs);
+      },
+      args: {
+        i: undefined
+      }
+    },
+    headlineTrimmed: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs79(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_headline_trimmedPgResource.isUnique && !resource_post_headline_trimmedPgResource.codec.attributes && typeof resource_post_headline_trimmedPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_headline_trimmedPgResource.codec)`${resource_post_headline_trimmedPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_headline_trimmedPgResource.execute(selectArgs);
+      },
+      args: {
+        length: undefined,
+        omission: undefined
+      }
+    },
+    headlineTrimmedNoDefaults: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs80(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_headline_trimmed_no_defaultsPgResource.isUnique && !resource_post_headline_trimmed_no_defaultsPgResource.codec.attributes && typeof resource_post_headline_trimmed_no_defaultsPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_headline_trimmed_no_defaultsPgResource.codec)`${resource_post_headline_trimmed_no_defaultsPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_headline_trimmed_no_defaultsPgResource.execute(selectArgs);
+      },
+      args: {
+        length: undefined,
+        omission: undefined
+      }
+    },
+    headlineTrimmedStrict: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs81(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_headline_trimmed_strictPgResource.isUnique && !resource_post_headline_trimmed_strictPgResource.codec.attributes && typeof resource_post_headline_trimmed_strictPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_headline_trimmed_strictPgResource.codec)`${resource_post_headline_trimmed_strictPgResource.from(...newSelectArgs)}`;
+        }
+        // PERF: or here, if scalar add select to `$row`?
+        return resource_post_headline_trimmed_strictPgResource.execute(selectArgs);
+      },
+      args: {
+        length: undefined,
+        omission: undefined
+      }
+    },
+    computedCompoundTypeArray: {
+      plan($in, args, _info) {
+        if (!hasRecord($in)) {
+          throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
+        }
+        const extraSelectArgs = makeArgs82(args);
+        /**
+         * An optimisation - if all our dependencies are
+         * compatible with the expression's class plan then we
+         * can inline ourselves into that, otherwise we must
+         * issue the query separately.
+         */
+        const canUseExpressionDirectly = $in instanceof PgSelectSingleStep && extraSelectArgs.every(a => stepAMayDependOnStepB($in.getClassStep(), a.step));
+        const $row = canUseExpressionDirectly ? $in : pgSelectSingleFromRecord($in.resource, $in.record());
+        const selectArgs = [{
+          step: $row.record()
+        }, ...extraSelectArgs];
+        if (resource_post_computed_compound_type_arrayPgResource.isUnique && !resource_post_computed_compound_type_arrayPgResource.codec.attributes && typeof resource_post_computed_compound_type_arrayPgResource.from === "function") {
+          // This is a scalar computed attribute, let's inline the expression
+          const newSelectArgs = selectArgs.map((arg, i) => {
+            const {
+              name
+            } = arg;
+            if (i === 0) {
+              return {
+                name,
+                placeholder: $row.getClassStep().alias
+              };
+            } else if ("pgCodec" in arg && arg.pgCodec) {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step, arg.pgCodec)
+              };
+            } else {
+              return {
+                name,
+                placeholder: $row.placeholder(arg.step)
+              };
+            }
+          });
+          return pgClassExpression($row, resource_post_computed_compound_type_arrayPgResource.codec)`${resource_post_computed_compound_type_arrayPgResource.from(...newSelectArgs)}`;
         }
         // PERF: or here, if scalar add select to `$row`?
         return resource_post_computed_compound_type_arrayPgResource.execute(selectArgs);
@@ -35462,7 +36527,7 @@ export const plans = {
       if (!hasRecord($in)) {
         throw new Error(`Invalid plan, exepcted 'PgSelectSingleStep', 'PgInsertSingleStep', 'PgUpdateSingleStep' or 'PgDeleteSingleStep', but found ${$in}`);
       }
-      const extraSelectArgs = makeArgs78(args);
+      const extraSelectArgs = makeArgs83(args);
       /**
        * An optimisation - if all our dependencies are
        * compatible with the expression's class plan then we
@@ -35476,18 +36541,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_c_edge_case_computedPgResource.isUnique && !resource_c_edge_case_computedPgResource.codec.attributes && typeof resource_c_edge_case_computedPgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_c_edge_case_computedPgResource.codec)`${resource_c_edge_case_computedPgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_c_edge_case_computedPgResource.codec)`${resource_c_edge_case_computedPgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_c_edge_case_computedPgResource.execute(selectArgs);
@@ -36715,7 +37790,7 @@ export const plans = {
     __assertStep: __ValueStep,
     cMutationOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs79(args, ["input"]);
+        const selectArgs = makeArgs84(args, ["input"]);
         const $result = resource_c_mutation_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -36732,7 +37807,7 @@ export const plans = {
     },
     cMutationOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs80(args, ["input"]);
+        const selectArgs = makeArgs85(args, ["input"]);
         const $result = resource_c_mutation_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -36749,7 +37824,7 @@ export const plans = {
     },
     cMutationOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs81(args, ["input"]);
+        const selectArgs = makeArgs86(args, ["input"]);
         const $result = resource_c_mutation_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -36766,7 +37841,7 @@ export const plans = {
     },
     cNoArgsMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs82(args, ["input"]);
+        const selectArgs = makeArgs87(args, ["input"]);
         const $result = resource_c_no_args_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -36783,7 +37858,7 @@ export const plans = {
     },
     returnVoidMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs83(args, ["input"]);
+        const selectArgs = makeArgs88(args, ["input"]);
         const $result = resource_return_void_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -36800,7 +37875,7 @@ export const plans = {
     },
     mutationIntervalSet: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs84(args, ["input"]);
+        const selectArgs = makeArgs89(args, ["input"]);
         const $result = resource_mutation_interval_setPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -36817,7 +37892,7 @@ export const plans = {
     },
     cMutationInOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs85(args, ["input"]);
+        const selectArgs = makeArgs90(args, ["input"]);
         const $result = resource_c_mutation_in_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -36834,7 +37909,7 @@ export const plans = {
     },
     cMutationReturnsTableOneCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs86(args, ["input"]);
+        const selectArgs = makeArgs91(args, ["input"]);
         const $result = resource_c_mutation_returns_table_one_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -36851,7 +37926,7 @@ export const plans = {
     },
     cJsonIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs87(args, ["input"]);
+        const selectArgs = makeArgs92(args, ["input"]);
         const $result = resource_c_json_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -36868,7 +37943,7 @@ export const plans = {
     },
     cJsonbIdentityMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs88(args, ["input"]);
+        const selectArgs = makeArgs93(args, ["input"]);
         const $result = resource_c_jsonb_identity_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -36885,7 +37960,7 @@ export const plans = {
     },
     cJsonbIdentityMutationPlpgsql: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs89(args, ["input"]);
+        const selectArgs = makeArgs94(args, ["input"]);
         const $result = resource_c_jsonb_identity_mutation_plpgsqlPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -36902,7 +37977,7 @@ export const plans = {
     },
     cJsonbIdentityMutationPlpgsqlWithDefault: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs90(args, ["input"]);
+        const selectArgs = makeArgs95(args, ["input"]);
         const $result = resource_c_jsonb_identity_mutation_plpgsql_with_defaultPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -36919,7 +37994,7 @@ export const plans = {
     },
     add1Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs91(args, ["input"]);
+        const selectArgs = makeArgs96(args, ["input"]);
         const $result = resource_add_1_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -36936,7 +38011,7 @@ export const plans = {
     },
     add2Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs92(args, ["input"]);
+        const selectArgs = makeArgs97(args, ["input"]);
         const $result = resource_add_2_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -36953,7 +38028,7 @@ export const plans = {
     },
     add3Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs93(args, ["input"]);
+        const selectArgs = makeArgs98(args, ["input"]);
         const $result = resource_add_3_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -36970,7 +38045,7 @@ export const plans = {
     },
     add4Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs94(args, ["input"]);
+        const selectArgs = makeArgs99(args, ["input"]);
         const $result = resource_add_4_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -36987,7 +38062,7 @@ export const plans = {
     },
     add4MutationError: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs95(args, ["input"]);
+        const selectArgs = makeArgs100(args, ["input"]);
         const $result = resource_add_4_mutation_errorPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37004,7 +38079,7 @@ export const plans = {
     },
     bMult1: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs96(args, ["input"]);
+        const selectArgs = makeArgs101(args, ["input"]);
         const $result = resource_b_mult_1PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37021,7 +38096,7 @@ export const plans = {
     },
     bMult2: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs97(args, ["input"]);
+        const selectArgs = makeArgs102(args, ["input"]);
         const $result = resource_b_mult_2PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37038,7 +38113,7 @@ export const plans = {
     },
     bMult3: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs98(args, ["input"]);
+        const selectArgs = makeArgs103(args, ["input"]);
         const $result = resource_b_mult_3PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37055,7 +38130,7 @@ export const plans = {
     },
     bMult4: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs99(args, ["input"]);
+        const selectArgs = makeArgs104(args, ["input"]);
         const $result = resource_b_mult_4PgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37072,7 +38147,7 @@ export const plans = {
     },
     cMutationInInout: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs100(args, ["input"]);
+        const selectArgs = makeArgs105(args, ["input"]);
         const $result = resource_c_mutation_in_inoutPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37089,7 +38164,7 @@ export const plans = {
     },
     cMutationOutOut: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs101(args, ["input"]);
+        const selectArgs = makeArgs106(args, ["input"]);
         const $result = resource_c_mutation_out_outPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37106,7 +38181,7 @@ export const plans = {
     },
     cMutationOutOutSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs102(args, ["input"]);
+        const selectArgs = makeArgs107(args, ["input"]);
         const $result = resource_c_mutation_out_out_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37123,7 +38198,7 @@ export const plans = {
     },
     cMutationOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs103(args, ["input"]);
+        const selectArgs = makeArgs108(args, ["input"]);
         const $result = resource_c_mutation_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37140,7 +38215,7 @@ export const plans = {
     },
     cIntSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs104(args, ["input"]);
+        const selectArgs = makeArgs109(args, ["input"]);
         const $result = resource_c_int_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37157,7 +38232,7 @@ export const plans = {
     },
     cMutationOutUnnamedOutOutUnnamed: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs105(args, ["input"]);
+        const selectArgs = makeArgs110(args, ["input"]);
         const $result = resource_c_mutation_out_unnamed_out_out_unnamedPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37174,7 +38249,7 @@ export const plans = {
     },
     cMutationReturnsTableMultiCol: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs106(args, ["input"]);
+        const selectArgs = makeArgs111(args, ["input"]);
         const $result = resource_c_mutation_returns_table_multi_colPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37191,7 +38266,7 @@ export const plans = {
     },
     bGuidFn: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs107(args, ["input"]);
+        const selectArgs = makeArgs112(args, ["input"]);
         const $result = resource_b_guid_fnPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37208,7 +38283,7 @@ export const plans = {
     },
     mutationIntervalArray: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs108(args, ["input"]);
+        const selectArgs = makeArgs113(args, ["input"]);
         const $result = resource_mutation_interval_arrayPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37225,7 +38300,7 @@ export const plans = {
     },
     mutationTextArray: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs109(args, ["input"]);
+        const selectArgs = makeArgs114(args, ["input"]);
         const $result = resource_mutation_text_arrayPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37242,7 +38317,7 @@ export const plans = {
     },
     bListBdeMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs110(args, ["input"]);
+        const selectArgs = makeArgs115(args, ["input"]);
         const $result = resource_b_list_bde_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37259,7 +38334,7 @@ export const plans = {
     },
     bAuthenticateFail: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs111(args, ["input"]);
+        const selectArgs = makeArgs116(args, ["input"]);
         const $result = resource_b_authenticate_failPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37276,7 +38351,7 @@ export const plans = {
     },
     bAuthenticate: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs112(args, ["input"]);
+        const selectArgs = makeArgs117(args, ["input"]);
         const $result = resource_b_authenticatePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37293,7 +38368,7 @@ export const plans = {
     },
     cLeftArmIdentity: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs113(args, ["input"]);
+        const selectArgs = makeArgs118(args, ["input"]);
         const $result = resource_c_left_arm_identityPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37310,7 +38385,7 @@ export const plans = {
     },
     cIssue756Mutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs114(args, ["input"]);
+        const selectArgs = makeArgs119(args, ["input"]);
         const $result = resource_c_issue756_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37327,7 +38402,7 @@ export const plans = {
     },
     cIssue756SetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs115(args, ["input"]);
+        const selectArgs = makeArgs120(args, ["input"]);
         const $result = resource_c_issue756_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37344,7 +38419,7 @@ export const plans = {
     },
     bAuthenticateMany: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs116(args, ["input"]);
+        const selectArgs = makeArgs121(args, ["input"]);
         const $result = resource_b_authenticate_manyPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37361,7 +38436,7 @@ export const plans = {
     },
     bAuthenticatePayload: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs117(args, ["input"]);
+        const selectArgs = makeArgs122(args, ["input"]);
         const $result = resource_b_authenticate_payloadPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37378,7 +38453,7 @@ export const plans = {
     },
     cTypesMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs118(args, ["input"]);
+        const selectArgs = makeArgs123(args, ["input"]);
         const $result = resource_c_types_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37395,7 +38470,7 @@ export const plans = {
     },
     cMutationOutOutCompoundType: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs119(args, ["input"]);
+        const selectArgs = makeArgs124(args, ["input"]);
         const $result = resource_c_mutation_out_out_compound_typePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37412,7 +38487,7 @@ export const plans = {
     },
     bCompoundTypeMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs120(args, ["input"]);
+        const selectArgs = makeArgs125(args, ["input"]);
         const $result = resource_b_compound_type_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37429,7 +38504,7 @@ export const plans = {
     },
     bCompoundTypeSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs121(args, ["input"]);
+        const selectArgs = makeArgs126(args, ["input"]);
         const $result = resource_b_compound_type_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37446,7 +38521,7 @@ export const plans = {
     },
     cTableMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs122(args, ["input"]);
+        const selectArgs = makeArgs127(args, ["input"]);
         const $result = resource_c_table_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37463,7 +38538,7 @@ export const plans = {
     },
     postWithSuffix: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs123(args, ["input"]);
+        const selectArgs = makeArgs128(args, ["input"]);
         const $result = resource_post_with_suffixPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37480,7 +38555,7 @@ export const plans = {
     },
     mutationCompoundTypeArray: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs124(args, ["input"]);
+        const selectArgs = makeArgs129(args, ["input"]);
         const $result = resource_mutation_compound_type_arrayPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37497,7 +38572,7 @@ export const plans = {
     },
     bCompoundTypeArrayMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs125(args, ["input"]);
+        const selectArgs = makeArgs130(args, ["input"]);
         const $result = resource_b_compound_type_array_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37514,7 +38589,7 @@ export const plans = {
     },
     postMany: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs126(args, ["input"]);
+        const selectArgs = makeArgs131(args, ["input"]);
         const $result = resource_post_manyPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37531,7 +38606,7 @@ export const plans = {
     },
     cMutationOutComplex: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs127(args, ["input"]);
+        const selectArgs = makeArgs132(args, ["input"]);
         const $result = resource_c_mutation_out_complexPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37548,7 +38623,7 @@ export const plans = {
     },
     cMutationOutComplexSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs128(args, ["input"]);
+        const selectArgs = makeArgs133(args, ["input"]);
         const $result = resource_c_mutation_out_complex_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37565,7 +38640,7 @@ export const plans = {
     },
     cMutationOutTable: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs129(args, ["input"]);
+        const selectArgs = makeArgs134(args, ["input"]);
         const $result = resource_c_mutation_out_tablePgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37582,7 +38657,7 @@ export const plans = {
     },
     cMutationOutTableSetof: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs130(args, ["input"]);
+        const selectArgs = makeArgs135(args, ["input"]);
         const $result = resource_c_mutation_out_table_setofPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37599,7 +38674,7 @@ export const plans = {
     },
     cTableSetMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs131(args, ["input"]);
+        const selectArgs = makeArgs136(args, ["input"]);
         const $result = resource_c_table_set_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37616,7 +38691,7 @@ export const plans = {
     },
     bTypeFunctionConnectionMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs132(args, ["input"]);
+        const selectArgs = makeArgs137(args, ["input"]);
         const $result = resource_b_type_function_connection_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37633,7 +38708,7 @@ export const plans = {
     },
     bTypeFunctionMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs133(args, ["input"]);
+        const selectArgs = makeArgs138(args, ["input"]);
         const $result = resource_b_type_function_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result
@@ -37650,7 +38725,7 @@ export const plans = {
     },
     bTypeFunctionListMutation: {
       plan($root, args, _info) {
-        const selectArgs = makeArgs134(args, ["input"]);
+        const selectArgs = makeArgs139(args, ["input"]);
         const $result = resource_b_type_function_list_mutationPgResource.execute(selectArgs, "mutation");
         return object({
           result: $result

--- a/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.1.graphql
@@ -2761,6 +2761,11 @@ type CPerson {
 
   """The person’s name"""
   name: String!
+  optionalMissingMiddle1(arg0: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle2(a: Int!, b: Int, c: Int): Int
+  optionalMissingMiddle3(a: Int!, arg1: Int, c: Int): Int
+  optionalMissingMiddle4(arg0: Int!, arg2: Int, b: Int): Int
+  optionalMissingMiddle5(a: Int!, arg1: Int, arg2: Int): Int
 
   """Reads and enables pagination through a set of `Post`."""
   postsByAuthorId(

--- a/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.polymorphic.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.polymorphic.1.export.mjs
@@ -13916,18 +13916,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_single_table_items_meaning_of_lifePgResource.isUnique && !resource_single_table_items_meaning_of_lifePgResource.codec.attributes && typeof resource_single_table_items_meaning_of_lifePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_single_table_items_meaning_of_lifePgResource.execute(selectArgs);
@@ -20045,18 +20055,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_single_table_items_meaning_of_lifePgResource.isUnique && !resource_single_table_items_meaning_of_lifePgResource.codec.attributes && typeof resource_single_table_items_meaning_of_lifePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_single_table_items_meaning_of_lifePgResource.execute(selectArgs);
@@ -20489,18 +20509,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_single_table_items_meaning_of_lifePgResource.isUnique && !resource_single_table_items_meaning_of_lifePgResource.codec.attributes && typeof resource_single_table_items_meaning_of_lifePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_single_table_items_meaning_of_lifePgResource.execute(selectArgs);
@@ -20857,18 +20887,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_single_table_items_meaning_of_lifePgResource.isUnique && !resource_single_table_items_meaning_of_lifePgResource.codec.attributes && typeof resource_single_table_items_meaning_of_lifePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_single_table_items_meaning_of_lifePgResource.execute(selectArgs);
@@ -21227,18 +21267,28 @@ export const plans = {
       }, ...extraSelectArgs];
       if (resource_single_table_items_meaning_of_lifePgResource.isUnique && !resource_single_table_items_meaning_of_lifePgResource.codec.attributes && typeof resource_single_table_items_meaning_of_lifePgResource.from === "function") {
         // This is a scalar computed attribute, let's inline the expression
-        const placeholders = selectArgs.map((arg, i) => {
+        const newSelectArgs = selectArgs.map((arg, i) => {
+          const {
+            name
+          } = arg;
           if (i === 0) {
-            return $row.getClassStep().alias;
+            return {
+              name,
+              placeholder: $row.getClassStep().alias
+            };
           } else if ("pgCodec" in arg && arg.pgCodec) {
-            return $row.placeholder(arg.step, arg.pgCodec);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step, arg.pgCodec)
+            };
           } else {
-            return $row.placeholder(arg.step);
+            return {
+              name,
+              placeholder: $row.placeholder(arg.step)
+            };
           }
         });
-        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...placeholders.map(placeholder => ({
-          placeholder
-        })))}`;
+        return pgClassExpression($row, resource_single_table_items_meaning_of_lifePgResource.codec)`${resource_single_table_items_meaning_of_lifePgResource.from(...newSelectArgs)}`;
       }
       // PERF: or here, if scalar add select to `$row`?
       return resource_single_table_items_meaning_of_lifePgResource.execute(selectArgs);


### PR DESCRIPTION
## Description

Fixes https://github.com/graphile/crystal/issues/2215

We did an optimization but it had a bug where if an argument needed a name (because we skipped over the previous arg), the name was not passed through and thus we fed the parameters into the wrong positions in the function call.

## Performance impact

Negligible.

## Security impact

Improvement?

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
