### PR TITLE
Relations have no basic `select` behavior

### DIFF
--- a/graphile-build/graphile-build-pg/src/plugins/PgIndexBehaviorsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgIndexBehaviorsPlugin.ts
@@ -117,24 +117,34 @@ export const PgIndexBehaviorsPlugin: GraphileConfig.Plugin = {
         },
       },
       pgCodecRelation: {
-        inferred: {
-          after: ["inferred"],
-          provides: ["postInferred"],
-          callback(behavior, relation) {
-            const newBehavior = [behavior];
-            if (relation.extensions?.isIndexed === false) {
-              newBehavior.push(
-                "-list",
-                "-connection",
-                "-single",
-
-                // HACK: this impacts a community plugin and isn't part of core.
-                "-manyToMany",
-              );
-            }
-            return newBehavior;
+        inferred: [
+          {
+            provides: ["inferred"],
+            callback(behavior) {
+              return [`select`, behavior];
+            },
           },
-        },
+          {
+            after: ["inferred"],
+            provides: ["postInferred"],
+            callback(behavior, relation) {
+              const newBehavior = [behavior];
+              if (relation.extensions?.isIndexed === false) {
+                newBehavior.push(
+                  "-select", // <<<<<
+
+                  "-list",
+                  "-connection",
+                  "-single",
+
+                  // HACK: this impacts a community plugin and isn't part of core.
+                  "-manyToMany",
+                );
+              }
+              return newBehavior;
+            },
+          },
+        ],
       },
     },
   },

--- a/graphile-build/graphile-build-pg/src/plugins/PgIndexBehaviorsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgIndexBehaviorsPlugin.ts
@@ -117,34 +117,25 @@ export const PgIndexBehaviorsPlugin: GraphileConfig.Plugin = {
         },
       },
       pgCodecRelation: {
-        inferred: [
-          {
-            provides: ["inferred"],
-            callback(behavior) {
-              return [`select`, behavior];
-            },
-          },
-          {
-            after: ["inferred"],
-            provides: ["postInferred"],
-            callback(behavior, relation) {
-              const newBehavior = [behavior];
-              if (relation.extensions?.isIndexed === false) {
-                newBehavior.push(
-                  "-select", // <<<<<
+        inferred: {
+          after: ["inferred"],
+          provides: ["postInferred"],
+          callback(behavior, relation) {
+            const newBehavior = [behavior];
+            if (relation.extensions?.isIndexed === false) {
+              newBehavior.push(
+                "-select",
+                "-list",
+                "-connection",
+                "-single",
 
-                  "-list",
-                  "-connection",
-                  "-single",
-
-                  // HACK: this impacts a community plugin and isn't part of core.
-                  "-manyToMany",
-                );
-              }
-              return newBehavior;
-            },
+                // HACK: this impacts a community plugin and isn't part of core.
+                "-manyToMany",
+              );
+            }
+            return newBehavior;
           },
-        ],
+        },
       },
     },
   },

--- a/graphile-build/graphile-build-pg/src/plugins/PgRelationsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgRelationsPlugin.ts
@@ -512,6 +512,10 @@ export const PgRelationsPlugin: GraphileConfig.Plugin = {
   schema: {
     behaviorRegistry: {
       add: {
+        "resource:select": {
+          description: "can we select records via this relationship/ref?",
+          entities: ["pgCodecRelation", "pgCodecRef"],
+        },
         "singularRelation:resource:single": {
           description:
             "can we get a single one of these (resource) from a type?",
@@ -544,13 +548,14 @@ export const PgRelationsPlugin: GraphileConfig.Plugin = {
         inferred(behavior, entity): GraphileBuild.BehaviorString[] {
           if (entity.isUnique) {
             return [
+              "resource:select",
               behavior,
               "single",
               "-singularRelation:resource:list",
               "-singularRelation:resource:connection",
             ];
           } else {
-            return [behavior];
+            return ["resource:select", behavior];
           }
         },
       },
@@ -559,6 +564,7 @@ export const PgRelationsPlugin: GraphileConfig.Plugin = {
           const ref = codec.refs?.[refName];
           if (ref?.definition.singular) {
             return [
+              "resource:select",
               behavior,
               "single",
               "-singularRelation:resource:list",
@@ -566,6 +572,7 @@ export const PgRelationsPlugin: GraphileConfig.Plugin = {
             ];
           } else {
             return [
+              "resource:select",
               behavior,
               "-single",
               "manyRelation:resource:connection",
@@ -578,13 +585,14 @@ export const PgRelationsPlugin: GraphileConfig.Plugin = {
         inferred(behavior, entity) {
           if (entity.singular) {
             return [
+              "resource:select",
               behavior,
               "single",
               "-singularRelation:resource:list",
               "-singularRelation:resource:connection",
             ];
           } else {
-            return behavior;
+            return ["resource:select", behavior];
           }
         },
       },


### PR DESCRIPTION
DON'T MERGE THIS.

Relations have `connection`, `list` and `single` behaviors, but if you just want to turn off using the relation really you just want to do `-select`. Similarly, if you're querying a relation via filter or similar you don't necessarily care whether it's presented as a list or a connection, you just want to know if it's allowed or not. This should be `select`, probably? And as mentioned elsewhere, the behavior system should have implications, like `-select` should imply `-connection -list -single`.