### PR TITLE
Add support for introspecting RLS policies

### DIFF
--- a/.changeset/poor-countries-argue.md
+++ b/.changeset/poor-countries-argue.md
@@ -1,0 +1,5 @@
+---
+"pg-introspection": patch
+---
+
+Add support for introspecting RLS policies.

--- a/utils/pg-introspection/src/acl.ts
+++ b/utils/pg-introspection/src/acl.ts
@@ -316,23 +316,15 @@ const ACL_USAGE = "U";
 const ACL_NO_RIGHTS = "";
 
 /** @see {@link https://github.com/postgres/postgres/blob/4908c5872059c409aa647bcde758dfeffe07996e/src/include/utils/acl.h#L159} */
-const ACL_ALL_RIGHTS_RELATION =
-  ACL_INSERT +
-  ACL_SELECT +
-  ACL_UPDATE +
-  ACL_DELETE +
-  ACL_TRUNCATE +
-  ACL_REFERENCES +
-  ACL_TRIGGER +
-  ACL_MAINTAIN;
-const ACL_ALL_RIGHTS_SEQUENCE = ACL_USAGE + ACL_SELECT + ACL_UPDATE;
-const ACL_ALL_RIGHTS_DATABASE = ACL_CREATE + ACL_CREATE_TEMP + ACL_CONNECT;
+const ACL_ALL_RIGHTS_RELATION = `${ACL_INSERT}${ACL_SELECT}${ACL_UPDATE}${ACL_DELETE}${ACL_TRUNCATE}${ACL_REFERENCES}${ACL_TRIGGER}${ACL_MAINTAIN}`;
+const ACL_ALL_RIGHTS_SEQUENCE = `${ACL_USAGE}${ACL_SELECT}${ACL_UPDATE}`;
+const ACL_ALL_RIGHTS_DATABASE = `${ACL_CREATE}${ACL_CREATE_TEMP}${ACL_CONNECT}`;
 const ACL_ALL_RIGHTS_FDW = ACL_USAGE;
 const ACL_ALL_RIGHTS_FOREIGN_SERVER = ACL_USAGE;
 const ACL_ALL_RIGHTS_FUNCTION = ACL_EXECUTE;
 const ACL_ALL_RIGHTS_LANGUAGE = ACL_USAGE;
-const ACL_ALL_RIGHTS_LARGEOBJECT = ACL_SELECT + ACL_UPDATE;
-const ACL_ALL_RIGHTS_SCHEMA = ACL_USAGE + ACL_CREATE;
+const ACL_ALL_RIGHTS_LARGEOBJECT = `${ACL_SELECT}${ACL_UPDATE}`;
+const ACL_ALL_RIGHTS_SCHEMA = `${ACL_USAGE}${ACL_CREATE}`;
 const ACL_ALL_RIGHTS_TABLESPACE = ACL_CREATE;
 const ACL_ALL_RIGHTS_TYPE = ACL_USAGE;
 
@@ -375,7 +367,7 @@ export function parseAcls(
           ownerDefault = ACL_ALL_RIGHTS_SEQUENCE;
           break;
         case OBJECT_DATABASE:
-          worldDefault = ACL_CREATE_TEMP + ACL_CONNECT;
+          worldDefault = `${ACL_CREATE_TEMP}${ACL_CONNECT}`;
           ownerDefault = ACL_ALL_RIGHTS_DATABASE;
           break;
         case OBJECT_FUNCTION:
@@ -609,6 +601,7 @@ export function resolvePermissions(
 
   return permissions;
 }
+
 export function entityPermissions(
   introspection: Introspection,
   entity: Extract<PgEntity, { getACL(): readonly AclObject[] }>,


### PR DESCRIPTION
## Description

Also refactors some constants for better TypeScript hover info.

## Performance impact

Introspection query results in more data being pulled, slowing initial startup.

## Security impact

Introspection query now include RLS policies, which are sensitive. However, it already included grants so I don't think this is a big deal.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
