### PR TITLE
Added checks for "from" field in pgSelect dedup function

### DIFF
--- a/.changeset/yellow-students-glow.md
+++ b/.changeset/yellow-students-glow.md
@@ -1,7 +1,5 @@
 ---
 "@dataplan/pg": patch
-"ruru-components": patch
-"graphile-utils": patch
 ---
 
 Fixes incorrect deduplication in pgSelect resulting from lack of `from`

--- a/.changeset/yellow-students-glow.md
+++ b/.changeset/yellow-students-glow.md
@@ -1,0 +1,8 @@
+---
+"@dataplan/pg": patch
+"ruru-components": patch
+"graphile-utils": patch
+---
+
+Fixes incorrect deduplication in pgSelect resulting from lack of `from`
+comparison when passing custom `from` to custom `pgSelect()` calls.

--- a/grafast/dataplan-pg/src/steps/pgSelect.ts
+++ b/grafast/dataplan-pg/src/steps/pgSelect.ts
@@ -2195,6 +2195,9 @@ ${lateralText};`;
       if (p.resource !== this.resource) {
         return false;
       }
+      if (p.from !== this.from) {
+        return false;
+      }
 
       // Check mode matches
       if (p.mode !== this.mode) {

--- a/grafast/dataplan-pg/src/steps/pgSelectSingle.ts
+++ b/grafast/dataplan-pg/src/steps/pgSelectSingle.ts
@@ -31,7 +31,7 @@ import type {
 import type { PgClassExpressionStep } from "./pgClassExpression.js";
 import { pgClassExpression } from "./pgClassExpression.js";
 import { PgCursorStep } from "./pgCursor.js";
-import type { PgSelectMode } from "./pgSelect.js";
+import type { PgSelectArgumentDigest, PgSelectMode } from "./pgSelect.js";
 import { getFragmentAndCodecFromOrder, PgSelectStep } from "./pgSelect.js";
 // import debugFactory from "debug";
 
@@ -611,6 +611,10 @@ export class PgSelectSingleStep<
   }
 }
 
+function fromRecord(record: PgSelectArgumentDigest) {
+  return sql`(select (${record.placeholder}).*)`;
+}
+
 /**
  * Given a plan that represents a single record (via
  * PgSelectSingleStep.record()) this turns it back into a PgSelectSingleStep
@@ -634,7 +638,7 @@ export function pgSelectFromRecord<
   return new PgSelectStep<TResource>({
     resource: resource,
     identifiers: [],
-    from: (record) => sql`(select (${record.placeholder}).*)`,
+    from: fromRecord,
     args: [{ step: $record, pgCodec: resource.codec }],
     joinAsLateral: true,
   });

--- a/grafast/ruru-components/tsconfig.json
+++ b/grafast/ruru-components/tsconfig.json
@@ -13,5 +13,5 @@
     "module": "NodeNext"
   },
   "include": ["src"],
-  "references": []
+  "references": [{ "path": "../grafast" }]
 }

--- a/graphile-build/graphile-utils/__tests__/makeExtendSchemaPlugin.test.ts
+++ b/graphile-build/graphile-utils/__tests__/makeExtendSchemaPlugin.test.ts
@@ -1,3 +1,4 @@
+import { pgSelect, TYPES } from "@dataplan/pg";
 import { makePgService } from "@dataplan/pg/adaptors/pg";
 import { connection, constant, grafast } from "grafast";
 import type { GraphQLObjectType } from "grafast/graphql";
@@ -12,7 +13,6 @@ import {
   dropTestDatabase,
 } from "../../../grafast/dataplan-pg/__tests__/sharedHelpers.js";
 import { EXPORTABLE, gql, makeExtendSchemaPlugin } from "../src/index.js";
-import { pgSelect, TYPES } from "@dataplan/pg";
 
 let pgPool: Pool | null = null;
 let connectionString = "";
@@ -284,8 +284,8 @@ it("supports arbitrary sql queries, does not dedup unrelated queries", async () 
     extends: [PostGraphileAmberPreset],
     plugins: [
       makeExtendSchemaPlugin((build) => {
-        const {users} = build.input.pgRegistry.pgResources
-        const { sql } = build
+        const { users } = build.input.pgRegistry.pgResources;
+        const { sql } = build;
         return {
           typeDefs: gql`
             extend type User {
@@ -298,34 +298,50 @@ it("supports arbitrary sql queries, does not dedup unrelated queries", async () 
               one($user) {
                 const $one = pgSelect({
                   identifiers: [],
-                  name: 'one',
+                  name: "one",
                   resource: users,
                   args: [
-                    { step: $user.get('id'), pgCodec: TYPES.text, name: 'user_id' },
+                    {
+                      step: $user.get("id"),
+                      pgCodec: TYPES.text,
+                      name: "user_id",
+                    },
                   ],
                   from: ($userId) => {
-                    const usersTblId = sql.identifier(Symbol())
-                    return sql`(select * from ${users!.codec.sqlType} as ${usersTblId} where id != ${$userId.placeholder} order by ${usersTblId}.id limit 1)`
-                  }
-                })
-                $one.setOrderIsUnique()
-                return connection($one)
+                    const usersTblId = sql.identifier(Symbol());
+                    return sql`(select * from ${
+                      users!.codec.sqlType
+                    } as ${usersTblId} where id != ${
+                      $userId.placeholder
+                    } order by ${usersTblId}.id limit 1)`;
+                  },
+                });
+                $one.setOrderIsUnique();
+                return connection($one);
               },
               two($user) {
                 const $two = pgSelect({
                   identifiers: [],
-                  name: 'two',
+                  name: "two",
                   resource: users,
                   args: [
-                    { step: $user.get('id'), pgCodec: TYPES.text, name: 'user_id' },
+                    {
+                      step: $user.get("id"),
+                      pgCodec: TYPES.text,
+                      name: "user_id",
+                    },
                   ],
                   from: ($userId) => {
-                    const usersTblId = sql.identifier(Symbol())
-                    return sql`(select * from ${users!.codec.sqlType} as ${usersTblId} where id != ${$userId.placeholder} order by ${usersTblId}.id limit 1 offset 1)`
-                  }
-                })
-                $two.setOrderIsUnique()
-                return connection($two)
+                    const usersTblId = sql.identifier(Symbol());
+                    return sql`(select * from ${
+                      users!.codec.sqlType
+                    } as ${usersTblId} where id != ${
+                      $userId.placeholder
+                    } order by ${usersTblId}.id limit 1 offset 1)`;
+                  },
+                });
+                $two.setOrderIsUnique();
+                return connection($two);
               },
             },
           },
@@ -373,17 +389,17 @@ it("supports arbitrary sql queries, does not dedup unrelated queries", async () 
             one: {
               nodes: [
                 {
-                  name: "Bob"
-                }
-              ]
+                  name: "Bob",
+                },
+              ],
             },
             two: {
               nodes: [
                 {
-                  name: "Caroline"
-                }
-              ]
-            }
+                  name: "Caroline",
+                },
+              ],
+            },
           },
         ],
       },

--- a/graphile-build/graphile-utils/__tests__/makeExtendSchemaPlugin.test.ts
+++ b/graphile-build/graphile-utils/__tests__/makeExtendSchemaPlugin.test.ts
@@ -1,5 +1,5 @@
 import { makePgService } from "@dataplan/pg/adaptors/pg";
-import { constant, grafast } from "grafast";
+import { connection, constant, grafast } from "grafast";
 import type { GraphQLObjectType } from "grafast/graphql";
 import { GraphQLScalarType, printSchema } from "grafast/graphql";
 import { buildSchema, QueryPlugin } from "graphile-build";
@@ -12,6 +12,7 @@ import {
   dropTestDatabase,
 } from "../../../grafast/dataplan-pg/__tests__/sharedHelpers.js";
 import { EXPORTABLE, gql, makeExtendSchemaPlugin } from "../src/index.js";
+import { pgSelect, TYPES } from "@dataplan/pg";
 
 let pgPool: Pool | null = null;
 let connectionString = "";
@@ -271,6 +272,118 @@ it("supports unary steps in loadOne", async () => {
           {
             name: "Caroline",
             uppercaseName: "CAROLINE",
+          },
+        ],
+      },
+    },
+  });
+});
+
+it("supports arbitrary sql queries, does not dedup unrelated queries", async () => {
+  const preset: GraphileConfig.Preset = {
+    extends: [PostGraphileAmberPreset],
+    plugins: [
+      makeExtendSchemaPlugin((build) => {
+        const {users} = build.input.pgRegistry.pgResources
+        const { sql } = build
+        return {
+          typeDefs: gql`
+            extend type User {
+              one: UserConnection
+              two: UserConnection
+            }
+          `,
+          plans: {
+            User: {
+              one($user) {
+                const $one = pgSelect({
+                  identifiers: [],
+                  name: 'one',
+                  resource: users,
+                  args: [
+                    { step: $user.get('id'), pgCodec: TYPES.text, name: 'user_id' },
+                  ],
+                  from: ($userId) => {
+                    const usersTblId = sql.identifier(Symbol())
+                    return sql`(select * from ${users!.codec.sqlType} as ${usersTblId} where id != ${$userId.placeholder} order by ${usersTblId}.id limit 1)`
+                  }
+                })
+                $one.setOrderIsUnique()
+                return connection($one)
+              },
+              two($user) {
+                const $two = pgSelect({
+                  identifiers: [],
+                  name: 'two',
+                  resource: users,
+                  args: [
+                    { step: $user.get('id'), pgCodec: TYPES.text, name: 'user_id' },
+                  ],
+                  from: ($userId) => {
+                    const usersTblId = sql.identifier(Symbol())
+                    return sql`(select * from ${users!.codec.sqlType} as ${usersTblId} where id != ${$userId.placeholder} order by ${usersTblId}.id limit 1 offset 1)`
+                  }
+                })
+                $two.setOrderIsUnique()
+                return connection($two)
+              },
+            },
+          },
+        };
+      }),
+    ],
+    pgServices: [
+      makePgService({
+        pool: pgPool!,
+        schemas: ["graphile_utils"],
+      }),
+    ],
+  };
+  const { schema, resolvedPreset } = await makeSchema(preset);
+  const result = await grafast({
+    schema,
+    resolvedPreset,
+    requestContext: {},
+    source: /* GraphQL */ `
+      {
+        allUsers(first: 1) {
+          nodes {
+            name
+            one(orderBy: NATURAL) {
+              nodes {
+                name
+              }
+            }
+            two(orderBy: NATURAL) {
+              nodes {
+                name
+              }
+            }
+          }
+        }
+      }
+    `,
+  });
+  expect(result).toEqual({
+    data: {
+      allUsers: {
+        nodes: [
+          {
+            name: "Alice",
+            one: {
+              nodes: [
+                {
+                  name: "Bob"
+                }
+              ]
+            },
+            two: {
+              nodes: [
+                {
+                  name: "Caroline"
+                }
+              ]
+            }
           },
         ],
       },


### PR DESCRIPTION
## Description

https://discord.com/channels/489127045289476126/498852330754801666/1312193983308365865
I think I found a potential edge case, wondering your thoughts on it. I have two plans implemented in  makeExtendedScemaPlugin, both are implemented manually with calling pgSelect with a custom from function. I'm calling both of them in a query and I think they're getting deduplicated, even though from implementation is different.

## Performance impact

unknown. Theoretically it would deduplicate _less_ than before, but I think that any such deduplications would have been erroneous.

## Security impact

unknown, but don't expect it to change anything.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.
