### PR TITLE
Don't hydrate introspection results in cache

### DIFF
--- a/.changeset/perfect-elephants-destroy.md
+++ b/.changeset/perfect-elephants-destroy.md
@@ -1,0 +1,6 @@
+---
+"graphile-build-pg": patch
+---
+
+Fix bug causing modifications to introspection results (e.g. fake constraints)
+to be persisted to next watch tick via gather cache.


### PR DESCRIPTION
Fixes #2255

The introspection results were being cached, the cache was being modified, and then later attempts to modify the cache were resulting in errors. Caches should be immutable, so I've moved the parsing of the introspection results out of the cache so that every schema build gets its own tree.