### PR TITLE
Tweak the way _attributeName works again

### DIFF
--- a/.changeset/five-dogs-rest.md
+++ b/.changeset/five-dogs-rest.md
@@ -1,0 +1,8 @@
+---
+"graphile-build-pg": patch
+"postgraphile": patch
+---
+
+Hotfix to inflection changes in beta.34 - fixes behavior of
+`orderByAttributeEnum` and removes V4 override of `_joinAttributeNames` which
+shouldn't be necessary (and seems to do more harm than good).

--- a/graphile-build/graphile-build-pg/src/plugins/PgAttributesPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgAttributesPlugin.ts
@@ -275,11 +275,8 @@ export const PgAttributesPlugin: GraphileConfig.Plugin = {
         const attribute = codec.attributes[attributeName];
         const name = attribute.extensions?.tags?.name || attributeName;
         // Avoid conflict with 'id' field used for Relay.
-        const nonconflictName = skipRowId
-          ? name
-          : name === "id" && !codec.isAnonymous
-          ? "row_id"
-          : name;
+        const nonconflictName =
+          !skipRowId && name === "id" && !codec.isAnonymous ? "row_id" : name;
         return this.coerceToGraphQLName(nonconflictName);
       },
 

--- a/graphile-build/graphile-build-pg/src/plugins/PgAttributesPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgAttributesPlugin.ts
@@ -271,12 +271,15 @@ export const PgAttributesPlugin: GraphileConfig.Plugin = {
 
   inflection: {
     add: {
-      _attributeName(options, { attributeName, codec }) {
+      _attributeName(options, { attributeName, codec, skipRowId }) {
         const attribute = codec.attributes[attributeName];
         const name = attribute.extensions?.tags?.name || attributeName;
         // Avoid conflict with 'id' field used for Relay.
-        const nonconflictName =
-          name === "id" && !codec.isAnonymous ? "row_id" : name;
+        const nonconflictName = skipRowId
+          ? name
+          : name === "id" && !codec.isAnonymous
+          ? "row_id"
+          : name;
         return this.coerceToGraphQLName(nonconflictName);
       },
 

--- a/postgraphile/postgraphile/src/plugins/PgV4InflectionPlugin.ts
+++ b/postgraphile/postgraphile/src/plugins/PgV4InflectionPlugin.ts
@@ -128,6 +128,9 @@ export const PgV4InflectionPlugin: GraphileConfig.Plugin = {
         }
       },
 
+      // V4 had a bug where even though `id` was renamed to `rowId`, we'd still
+      // use `ID_ASC`/`ID_DESC` when generating ordering - so we have to enable
+      // skipRowId.
       orderByAttributeEnum(
         _previous,
         options,
@@ -136,8 +139,6 @@ export const PgV4InflectionPlugin: GraphileConfig.Plugin = {
         const fieldName = this._attributeName({
           attributeName,
           codec,
-          // V4 had a bug where even though `id` was renamed to `rowId`, we'd
-          // still use `ID_ASC`/`ID_DESC` when generating ordering.
           skipRowId: true,
         });
         return this.constantCase(`${fieldName}-${variant}`);

--- a/postgraphile/postgraphile/src/plugins/PgV4InflectionPlugin.ts
+++ b/postgraphile/postgraphile/src/plugins/PgV4InflectionPlugin.ts
@@ -137,18 +137,18 @@ export const PgV4InflectionPlugin: GraphileConfig.Plugin = {
         );
       },
 
-      // V4 had a bug where even though `id` was renamed to `rowId`, we'd
-      // still use `ID_ASC`/`ID_DESC` when generating ordering.
       orderByAttributeEnum(
         _previous,
         options,
         { codec, attributeName, variant },
       ) {
-        // const fieldName = this._attributeName({ attributeName, codec });
-        const attribute = codec.attributes[attributeName];
-        const name = attribute.extensions?.tags?.name || attributeName;
-        const fieldName = this.coerceToGraphQLName(name);
-
+        const fieldName = this._attributeName({
+          attributeName,
+          codec,
+          // V4 had a bug where even though `id` was renamed to `rowId`, we'd
+          // still use `ID_ASC`/`ID_DESC` when generating ordering.
+          skipRowId: true,
+        });
         return this.constantCase(`${fieldName}-${variant}`);
       },
     },

--- a/postgraphile/postgraphile/src/plugins/PgV4InflectionPlugin.ts
+++ b/postgraphile/postgraphile/src/plugins/PgV4InflectionPlugin.ts
@@ -136,6 +136,21 @@ export const PgV4InflectionPlugin: GraphileConfig.Plugin = {
             .join("-and-")
         );
       },
+
+      // V4 had a bug where even though `id` was renamed to `rowId`, we'd
+      // still use `ID_ASC`/`ID_DESC` when generating ordering.
+      orderByAttributeEnum(
+        _previous,
+        options,
+        { codec, attributeName, variant },
+      ) {
+        // const fieldName = this._attributeName({ attributeName, codec });
+        const attribute = codec.attributes[attributeName];
+        const name = attribute.extensions?.tags?.name || attributeName;
+        const fieldName = this.coerceToGraphQLName(name);
+
+        return this.constantCase(`${fieldName}-${variant}`);
+      },
     },
   },
 };

--- a/postgraphile/postgraphile/src/plugins/PgV4InflectionPlugin.ts
+++ b/postgraphile/postgraphile/src/plugins/PgV4InflectionPlugin.ts
@@ -128,15 +128,6 @@ export const PgV4InflectionPlugin: GraphileConfig.Plugin = {
         }
       },
 
-      _joinAttributeNames(_previous, options, codec, names) {
-        return (
-          names
-            // V5 uses this._attributeName here; V4 needs the old style .attribute
-            .map((attributeName) => this.attribute({ attributeName, codec }))
-            .join("-and-")
-        );
-      },
-
       orderByAttributeEnum(
         _previous,
         options,

--- a/postgraphile/postgraphile/src/presets/relay.ts
+++ b/postgraphile/postgraphile/src/presets/relay.ts
@@ -37,7 +37,7 @@ export const PgRelayPlugin: GraphileConfig.Plugin = {
       },
       _attributeName(previous, options, details) {
         const name = previous!(details);
-        if (name === "id") return "row_id";
+        if (!details.skipRowId && name === "id") return "row_id";
         return name;
       },
     },

--- a/postgraphile/postgraphile/src/presets/v4.ts
+++ b/postgraphile/postgraphile/src/presets/v4.ts
@@ -150,7 +150,7 @@ const makeV4Plugin = (options: V4Options): GraphileConfig.Plugin => {
               // Undo rename of 'id' to 'rowId'
               _attributeName(previous, options, details) {
                 const name = previous!(details);
-                if (name === "row_id") {
+                if (!details.skipRowId && name === "row_id") {
                   const { codec, attributeName } = details;
                   const attribute = codec.attributes[attributeName];
                   const baseName =

--- a/postgraphile/postgraphile/src/presets/v4.ts
+++ b/postgraphile/postgraphile/src/presets/v4.ts
@@ -144,17 +144,24 @@ const makeV4Plugin = (options: V4Options): GraphileConfig.Plugin => {
     inflection: {
       ignoreReplaceIfNotExists: ["nodeIdFieldName"],
       replace: {
-        // Don't rename 'id' to 'rowId' (we might undo this in `attribute()` later)
-        _attributeName(previous, options, details) {
-          const { codec, attributeName } = details;
-          const attribute = codec.attributes[attributeName];
-          const baseName = attribute.extensions?.tags?.name || attributeName;
-          const name = previous!(details);
-          if (baseName === "id" && name === "row_id" && !codec.isAnonymous) {
-            return "id";
-          }
-          return name;
-        },
+        ...(classicIds
+          ? null
+          : {
+              // Undo rename of 'id' to 'rowId'
+              _attributeName(previous, options, details) {
+                const name = previous!(details);
+                if (name === "row_id") {
+                  const { codec, attributeName } = details;
+                  const attribute = codec.attributes[attributeName];
+                  const baseName =
+                    attribute.extensions?.tags?.name || attributeName;
+                  if (baseName === "id" && !codec.isAnonymous) {
+                    return "id";
+                  }
+                }
+                return name;
+              },
+            }),
         ...(classicIds ||
         options.skipPlugins?.some((p) => p.name === "NodePlugin")
           ? null
@@ -164,24 +171,6 @@ const makeV4Plugin = (options: V4Options): GraphileConfig.Plugin => {
               nodeIdFieldName() {
                 return "nodeId";
               },
-            }),
-        ...(classicIds
-          ? {
-              // Do rename 'id' to 'rowId', but do it in `attribute()` not `_attributeName`
-              attribute(previous, options, details) {
-                const { codec, attributeName } = details;
-                const attribute = codec.attributes[attributeName];
-                const baseName =
-                  attribute.extensions?.tags?.name || attributeName;
-                const name = previous!(details);
-                if (baseName === "id" && name === "id" && !codec.isAnonymous) {
-                  return "rowId";
-                }
-                return name;
-              },
-            }
-          : {
-              // No action required
             }),
       },
     },


### PR DESCRIPTION
## Description

V4 explicitly does `skipRowId` to force reproduction of a bug in the inflection:

https://github.com/graphile/graphile-engine/blob/e2a8a7cae58ff26947c050505c76c4a30cfe21c6/packages/graphile-build-pg/src/plugins/PgBasicsPlugin.js#L466-L471

This PR better reflects this same change correctly.

It also removes the `_joinAttributeNames` override - it doesn't seem to actually be required, and in fact causes issues in third party plugins compatibility.

See previous PR:

- https://github.com/graphile/crystal/pull/2251 

## Performance impact

Negligible.

## Security impact

None known.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
