### PR TITLE
Added whatwg-node-server adapter for grafserv

### DIFF
--- a/grafast/grafserv/__tests__/exampleServer.ts
+++ b/grafast/grafserv/__tests__/exampleServer.ts
@@ -4,7 +4,7 @@ import type { AddressInfo } from "node:net";
 import { constant, error, makeGrafastSchema } from "grafast";
 import { resolvePreset } from "graphile-config";
 
-import { grafserv } from "../src/servers/node/index.js";
+import { grafserv } from "../src/servers/whtatwg-node-server";
 
 export async function makeExampleServer(
   preset: GraphileConfig.Preset = {
@@ -36,8 +36,7 @@ export async function makeExampleServer(
   });
 
   const serv = grafserv({ schema, preset });
-  const server = createServer();
-  serv.addTo(server);
+  const server = createServer(serv.createHandler());
   const promise = new Promise<void>((resolve, reject) => {
     server.on("listening", () => {
       server.off("error", reject);

--- a/grafast/grafserv/package.json
+++ b/grafast/grafserv/package.json
@@ -115,6 +115,7 @@
     "@types/koa": "^2.13.8",
     "@types/koa-bodyparser": "^4.3.10",
     "@whatwg-node/fetch": "^0.9.10",
+    "@whatwg-node/server": "^0.9.64",
     "express": "^4.20.0",
     "fastify": "^4.22.1",
     "grafast": "workspace:^",

--- a/grafast/grafserv/src/servers/whtatwg-node-server/index.ts
+++ b/grafast/grafserv/src/servers/whtatwg-node-server/index.ts
@@ -1,0 +1,115 @@
+import { createServerAdapter } from '@whatwg-node/server'
+
+import { GrafservBase } from "../../core/base.js";
+import type {
+  GrafservConfig,
+  RequestDigest,
+  Result,
+} from "../../interfaces.js";
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Grafast {
+    interface RequestContext {
+        whatwg: {
+            request: Request
+        }
+    }
+  }
+}
+
+/** @experimental */
+export class WhatwgGrafserv extends GrafservBase {
+  protected whatwgRequestToGrafserv(
+    request: Request
+  ): RequestDigest {
+    const url = new URL(request.url);
+    return {
+      httpVersionMajor: 1,
+      httpVersionMinor: 0,
+      isSecure: url.protocol === 'https://',
+      method:  request.method,
+      path: url.pathname,
+      headers: this.processHeaders(request.headers),
+      getQueryParams() {
+        return Object.fromEntries(url.searchParams.entries()) as Record<string, string>;
+      },
+      async getBody() {
+        const text = await request.text()
+        return {
+          type: "text",
+          text,
+        };
+      },
+      requestContext: {
+        whatwg: {request}
+      },
+      preferJSON: true,
+    };
+  }
+
+  protected processHeaders(headers: Headers): Record<string, string> {
+    const headerDigest: Record<string, string> = Object.create(null);
+    headers.forEach((v,k)=> {
+      headerDigest[k]= v
+    })
+    return headerDigest
+  }
+
+  protected grafservResponseToWhatwg(response: Result | null): Response {
+    if (response === null) {
+      return new Response("¯\\_(ツ)_/¯", {status: 404, headers: new Headers({"Content-Type": "text/plain"})})
+    }
+
+    switch (response.type) {
+      case "error": {
+        const { statusCode, headers, error } = response;
+        const respHeaders = new Headers(headers)
+        respHeaders.append("Content-Type", "text/plain")
+        return new Response(error.message, {status: statusCode, headers:respHeaders})
+      }
+
+      case "buffer": {
+        const { statusCode, headers, buffer } = response;
+        const respHeaders = new Headers(headers)
+        return new Response(buffer.toString('utf8'), {status: statusCode, headers:respHeaders})
+      }
+
+      case "json": {
+        const { statusCode, headers, json } = response;
+        const respHeaders = new Headers(headers)
+        return new Response(JSON.stringify(json), {status: statusCode, headers:respHeaders})
+      }
+
+      default: {
+        console.log("Unhandled:");
+        console.dir(response);
+        return new Response("Server hasn't implemented this yet", {status: 501, headers: new Headers({"Content-Type": "text/plain"})})
+      }
+    }
+  }
+
+  createHandler() {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    return createServerAdapter(async (request: Request): Promise<Response> => {
+      return this.grafservResponseToWhatwg(
+        await this.processWhatwgRequest(
+          request,
+          this.whatwgRequestToGrafserv(request),
+        ),
+      );
+    })
+  }
+
+  protected processWhatwgRequest(
+    _request: Request,
+    request: RequestDigest,
+  ) {
+    return this.processRequest(request);
+  }
+}
+
+/** @experimental */
+export function grafserv(config: GrafservConfig) {
+  return new WhatwgGrafserv(config);
+}


### PR DESCRIPTION
## Description
@whatwg-node/server is an adapter that helps create generic servers across runtimes (https://www.npmjs.com/package/@whatwg-node/server). It could, at least in theory, replace all of the servers currently implemented, while supporting several more. If this all works out it should help integrations while having to maintain less code. 

Note: This doesn't support web-sockets, I'm still looking for a way to do that in a generic fashion, but I see some of the other adapters don't support web-sockets either so I believe this is good enough for now.

## Performance impact

unknown, but this PR won't affect anything by itself, it's just adding the adapter.

## Security impact

None

## Checklist
- [X] My code matches the project's code style and `yarn lint:fix` passes.
- [X] I've added tests for the new feature, and `yarn test` passes (Well, sort of - I ran the grafserv tests with it and it passed)
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.
