### PR TITLE
Update grafast plan diagram doc to include explain option

### DIFF
--- a/grafast/website/grafast/plan-diagrams.mdx
+++ b/grafast/website/grafast/plan-diagrams.mdx
@@ -263,8 +263,8 @@ export default {
     explain: ["plan"],
     // Setting explain: true will expose all explain types
     // explain: true,
-  }
-}
+  },
+};
 ```
 
 [ruru]: /ruru

--- a/grafast/website/grafast/plan-diagrams.mdx
+++ b/grafast/website/grafast/plan-diagrams.mdx
@@ -254,5 +254,18 @@ or you can render it directly from the JSON response. You can convert the plan
 JSON into mermaid format via the `planToMermaid` function so you can load them
 into the [mermaid live editor][].
 
+Use the `grafast.explain` option in your preset to expose plans from your
+server:
+
+```ts title="graphile.config.mjs"
+export default {
+  grafast: {
+    explain: ["plan"],
+    // Setting explain: true will expose all explain types
+    // explain: true,
+  }
+}
+```
+
 [ruru]: /ruru
 [mermaid live editor]: https://mermaid-js.github.io/mermaid-live-editor/edit


### PR DESCRIPTION
Explain how to enable plans in grafast

As discussed here.

https://discord.com/channels/489127045289476126/1325736426587033652/1325875935060299876