### PR TITLE
Grafast: simplify dep-fetching code with generics and helpers

### DIFF
--- a/.changeset/blue-pumpkins-smile.md
+++ b/.changeset/blue-pumpkins-smile.md
@@ -1,0 +1,6 @@
+---
+"grafast": patch
+---
+
+Make `ExecutableStep::getDep` generic and add helpers: `maybeGetDep` and
+`getDepOrConstant`.

--- a/.changeset/violet-months-suffer.md
+++ b/.changeset/violet-months-suffer.md
@@ -1,0 +1,6 @@
+---
+"@dataplan/pg": patch
+---
+
+Incorporate new getDepOrConstant/maybeGetDep features for better code
+ergonomics.

--- a/grafast/dataplan-pg/src/steps/pgPolymorphic.ts
+++ b/grafast/dataplan-pg/src/steps/pgPolymorphic.ts
@@ -83,13 +83,11 @@ export class PgPolymorphicStep<
   }
 
   itemPlan(): TItemStep {
-    const plan = this.getDep(this.itemStepId);
-    return plan as any;
+    return this.getDep<any>(this.itemStepId);
   }
 
   typeSpecifierPlan(): TTypeSpecifierStep {
-    const plan = this.getDep(this.typeSpecifierStepId) as TTypeSpecifierStep;
-    return plan;
+    return this.getDep<TTypeSpecifierStep>(this.typeSpecifierStepId);
   }
 
   planForType(type: GraphQLObjectType): ExecutableStep {

--- a/grafast/dataplan-pg/src/steps/pgSelect.ts
+++ b/grafast/dataplan-pg/src/steps/pgSelect.ts
@@ -23,7 +23,6 @@ import {
   access,
   applyTransforms,
   arrayOfLength,
-  constant,
   ExecutableStep,
   exportAs,
   first,

--- a/grafast/dataplan-pg/src/steps/pgSelect.ts
+++ b/grafast/dataplan-pg/src/steps/pgSelect.ts
@@ -9,6 +9,7 @@ import type {
   GrafastResultStreamList,
   InputStep,
   LambdaStep,
+  Maybe,
   PromiseOrDirect,
   StepOptimizeOptions,
   StepStreamOptions,
@@ -649,13 +650,13 @@ export class PgSelectStep<
       if (this.beforeStepId != null) {
         this.applyConditionFromCursor(
           "before",
-          this.getDep(this.beforeStepId) as any,
+          this.getDep<any>(this.beforeStepId),
         );
       }
       if (this.afterStepId != null) {
         this.applyConditionFromCursor(
           "after",
-          this.getDep(this.afterStepId) as any,
+          this.getDep<any>(this.afterStepId),
         );
       }
     });
@@ -1059,11 +1060,9 @@ export class PgSelectStep<
       this.addDependency($validate);
     } else {
       // To make the error be thrown in the right place, we should also add this error to our parent connection
-      const $connection = this.getDep(this.connectionDepId) as ConnectionStep<
-        any,
-        any,
-        any
-      >;
+      const $connection = this.getDep<ConnectionStep<any, any, any>>(
+        this.connectionDepId,
+      );
       $connection.addValidation(() => {
         return pgValidateParsedCursor(
           $parsedCursorPlan,
@@ -1690,18 +1689,14 @@ and ${sql.indent(sql.parens(condition(i + 1)))}`}
        * With `fetchOneExtra` it'd be `limit 3 offset 2` still.
        */
 
-      const $lower =
-        this.lowerIndexStepId != null
-          ? (this.getDep(this.lowerIndexStepId) as ExecutableStep<
-              number | null | undefined
-            >)
-          : constant(null);
-      const $upper =
-        this.upperIndexStepId != null
-          ? (this.getDep(this.upperIndexStepId) as ExecutableStep<
-              number | null | undefined
-            >)
-          : constant(null);
+      const $lower = this.getDepOrConstant<Maybe<number>>(
+        this.lowerIndexStepId,
+        null,
+      );
+      const $upper = this.getDepOrConstant<Maybe<number>>(
+        this.upperIndexStepId,
+        null,
+      );
 
       const limitAndOffsetLambda = lambda(
         [$lower, $upper],

--- a/grafast/dataplan-pg/src/steps/pgUnionAll.ts
+++ b/grafast/dataplan-pg/src/steps/pgUnionAll.ts
@@ -10,6 +10,7 @@ import type {
   GrafastValuesList,
   InputStep,
   LambdaStep,
+  Maybe,
   PolymorphicStep,
 } from "grafast";
 import {
@@ -290,7 +291,7 @@ export class PgUnionAllSingleStep
   }
 
   public getClassStep(): PgUnionAllStep<string, string> {
-    return (this.getDep(0) as any).getDep(0);
+    return this.getDep<any>(0).getDep(0);
   }
 
   public node() {
@@ -775,13 +776,13 @@ on (${sql.indent(
         if (this.beforeStepId != null) {
           this.applyConditionFromCursor(
             "before",
-            this.getDep(this.beforeStepId) as any,
+            this.getDep<any>(this.beforeStepId),
           );
         }
         if (this.afterStepId != null) {
           this.applyConditionFromCursor(
             "after",
-            this.getDep(this.afterStepId) as any,
+            this.getDep<any>(this.afterStepId),
           );
         }
       });
@@ -1096,11 +1097,9 @@ on (${sql.indent(
       );
     } else {
       // To make the error be thrown in the right place, we should also add this error to our parent connection
-      const $connection = this.getDep(this.connectionDepId) as ConnectionStep<
-        any,
-        any,
-        any
-      >;
+      const $connection = this.getDep<ConnectionStep<any, any, any>>(
+        this.connectionDepId,
+      );
       $connection.addValidation(() => {
         return pgValidateParsedCursor(
           $parsedCursorPlan,
@@ -1384,18 +1383,14 @@ and ${condition(i + 1)}`}
        * With `fetchOneExtra` it'd be `limit 3 offset 2` still.
        */
 
-      const $lower =
-        this.lowerIndexStepId != null
-          ? (this.getDep(this.lowerIndexStepId) as ExecutableStep<
-              number | null | undefined
-            >)
-          : constant(null);
-      const $upper =
-        this.upperIndexStepId != null
-          ? (this.getDep(this.upperIndexStepId) as ExecutableStep<
-              number | null | undefined
-            >)
-          : constant(null);
+      const $lower = this.getDepOrConstant<Maybe<number>>(
+        this.lowerIndexStepId,
+        null,
+      );
+      const $upper = this.getDepOrConstant<Maybe<number>>(
+        this.upperIndexStepId,
+        null,
+      );
 
       const limitAndOffsetLambda = lambda(
         [$lower, $upper],

--- a/grafast/grafast/src/step.ts
+++ b/grafast/grafast/src/step.ts
@@ -37,7 +37,6 @@ import {
   ALL_FLAGS,
   DEFAULT_FORBIDDEN_FLAGS,
 } from "./interfaces.js";
-import { constant } from "./steps/constant.js";
 import type { __ItemStep } from "./steps/index.js";
 import { stepADependsOnStepB, stepAMayDependOnStepB } from "./utils.js";
 
@@ -412,11 +411,15 @@ export /* abstract */ class ExecutableStep<TData = any> extends BaseStep {
   ): T | null {
     return depId == null ? null : this.getDep<T>(depId);
   }
+
   protected getDepOrConstant<TData = any>(
-    depId: number | null,
-    fallback: TData,
+    _depId: number | null,
+    _fallback: TData,
   ): ExecutableStep<TData> {
-    return this.maybeGetDep(depId) ?? constant(fallback);
+    // This gets replaced when `constant` is loaded. Were we on ESM we could
+    // just put the code here, but since we're not we have to avoid the
+    // circular dependency.
+    throw new Error(`Grafast failed to load correctly`);
   }
 
   /**

--- a/grafast/grafast/src/step.ts
+++ b/grafast/grafast/src/step.ts
@@ -37,6 +37,7 @@ import {
   ALL_FLAGS,
   DEFAULT_FORBIDDEN_FLAGS,
 } from "./interfaces.js";
+import { constant } from "./steps/constant.js";
 import type { __ItemStep } from "./steps/index.js";
 import { stepADependsOnStepB, stepAMayDependOnStepB } from "./utils.js";
 
@@ -397,11 +398,25 @@ export /* abstract */ class ExecutableStep<TData = any> extends BaseStep {
     return { step, acceptFlags, onReject };
   }
 
-  protected getDep(_depId: number): ExecutableStep {
+  protected getDep<T extends ExecutableStep = ExecutableStep>(
+    _depId: number,
+  ): T {
     // This gets replaced when `__FlagStep` is loaded. Were we on ESM we could
     // just put the code here, but since we're not we have to avoid the
     // circular dependency.
     throw new Error(`Grafast failed to load correctly`);
+  }
+
+  protected maybeGetDep<T extends ExecutableStep = ExecutableStep>(
+    depId: number | null | undefined,
+  ): T | null {
+    return depId == null ? null : this.getDep<T>(depId);
+  }
+  protected getDepOrConstant<TData = any>(
+    depId: number | null,
+    fallback: TData,
+  ): ExecutableStep<TData> {
+    return this.maybeGetDep(depId) ?? constant(fallback);
   }
 
   /**

--- a/grafast/grafast/src/steps/__inputDynamicScalar.ts
+++ b/grafast/grafast/src/steps/__inputDynamicScalar.ts
@@ -131,7 +131,7 @@ export class __InputDynamicScalarStep<
 
   eval(): TLeaf {
     const variableValues = this.variableNames.map((variableName, i) =>
-      (this.getDep(i) as __TrackedValueStep).eval(),
+      this.getDep<__TrackedValueStep>(i).eval(),
     );
     return this.valueFromValues(variableValues);
   }

--- a/grafast/grafast/src/steps/__trackedValue.ts
+++ b/grafast/grafast/src/steps/__trackedValue.ts
@@ -166,7 +166,7 @@ export class __TrackedValueStep<
   }
 
   private getValuePlan() {
-    return this.getDep(0) as __ValueStep<TData> | AccessStep<TData>;
+    return this.getDep<__ValueStep<TData> | AccessStep<TData>>(0);
   }
 
   /**

--- a/grafast/grafast/src/steps/connection.ts
+++ b/grafast/grafast/src/steps/connection.ts
@@ -143,9 +143,7 @@ export class ConnectionStep<
   }
 
   public getFirst(): InputStep | null {
-    return this._firstDepId != null
-      ? (this.getDep(this._firstDepId) as InputStep)
-      : null;
+    return this.maybeGetDep<InputStep>(this._firstDepId);
   }
   public setFirst($firstPlan: InputStep) {
     if (this._firstDepId != null) {
@@ -154,9 +152,7 @@ export class ConnectionStep<
     this._firstDepId = this.addDependency($firstPlan);
   }
   public getLast(): InputStep | null {
-    return this._lastDepId != null
-      ? (this.getDep(this._lastDepId) as InputStep)
-      : null;
+    return this.maybeGetDep<InputStep>(this._lastDepId);
   }
   public setLast($lastPlan: InputStep) {
     if (this._lastDepId != null) {
@@ -165,9 +161,7 @@ export class ConnectionStep<
     this._lastDepId = this.addDependency($lastPlan);
   }
   public getOffset(): InputStep | null {
-    return this._offsetDepId != null
-      ? (this.getDep(this._offsetDepId) as InputStep)
-      : null;
+    return this.maybeGetDep<InputStep>(this._offsetDepId);
   }
   public setOffset($offsetPlan: InputStep) {
     if (this._offsetDepId != null) {
@@ -176,9 +170,7 @@ export class ConnectionStep<
     this._offsetDepId = this.addDependency($offsetPlan);
   }
   public getBefore(): TCursorStep | null {
-    return this._beforeDepId != null
-      ? (this.getDep(this._beforeDepId) as TCursorStep)
-      : null;
+    return this.maybeGetDep<TCursorStep>(this._beforeDepId);
   }
   public setBefore($beforePlan: InputStep) {
     if (this._beforeDepId !== undefined) {
@@ -190,9 +182,7 @@ export class ConnectionStep<
       : null;
   }
   public getAfter(): TCursorStep | null {
-    return this._afterDepId != null
-      ? (this.getDep(this._afterDepId) as TCursorStep)
-      : null;
+    return this.maybeGetDep<TCursorStep>(this._afterDepId);
   }
   public setAfter($afterPlan: InputStep) {
     if (this._afterDepId !== undefined) {
@@ -458,11 +448,11 @@ export class EdgeStep<
     TStep,
     TNodeStep
   > {
-    return this.getDep(this.connectionDepId) as any;
+    return this.getDep<any>(this.connectionDepId);
   }
 
   private getItemStep(): TItemStep {
-    return this.getDep(0) as any;
+    return this.getDep<any>(0);
   }
 
   public data(): TEdgeDataStep {

--- a/grafast/grafast/src/steps/constant.ts
+++ b/grafast/grafast/src/steps/constant.ts
@@ -1,6 +1,6 @@
 import { inspect } from "../inspect.js";
 import type { ExecutionDetails, GrafastResultsList } from "../interfaces.js";
-import { UnbatchedExecutableStep } from "../step.js";
+import { ExecutableStep, UnbatchedExecutableStep } from "../step.js";
 import { arrayOfLength } from "../utils.js";
 
 /**
@@ -136,3 +136,12 @@ export function constant<TData>(
   }
   return new ConstantStep<TData>(data, isSecret);
 }
+
+// Have to overwrite the getDepOrConstant method due to circular dependency
+(ExecutableStep.prototype as any).getDepOrConstant = function <TData>(
+  this: ExecutableStep,
+  depId: number | null,
+  fallback: TData,
+): ExecutableStep<TData> {
+  return this.maybeGetDep(depId) ?? constant(fallback);
+};

--- a/grafast/grafast/src/steps/list.ts
+++ b/grafast/grafast/src/steps/list.ts
@@ -137,18 +137,18 @@ export class ListStep<
   /**
    * Get the original plan at the given index back again.
    */
-  public at<TIndex extends keyof TPlanTuple>(
+  public at<TIndex extends keyof TPlanTuple & number>(
     index: TIndex,
   ): TPlanTuple[TIndex] {
-    return this.getDep(index as number) as TPlanTuple[TIndex];
+    return this.getDep<TPlanTuple[TIndex]>(index as number);
   }
 
   public first() {
-    return this.getDep(0) as TPlanTuple[0];
+    return this.getDep<TPlanTuple[0]>(0);
   }
 
   public last() {
-    return this.getDep(this.dependencies.length - 1) as TPlanTuple[number];
+    return this.getDep<TPlanTuple[number]>(this.dependencies.length - 1);
   }
 }
 

--- a/grafast/grafast/src/steps/listTransform.ts
+++ b/grafast/grafast/src/steps/listTransform.ts
@@ -167,7 +167,7 @@ export class __ListTransformStep<
   }
 
   getListStep(): TListStep {
-    return this.getDep(this.listStepDepId) as TListStep;
+    return this.getDep<TListStep>(this.listStepDepId);
   }
 
   [$$deepDepSkip]() {

--- a/grafast/grafast/src/steps/object.ts
+++ b/grafast/grafast/src/steps/object.ts
@@ -324,7 +324,7 @@ ${inner}
         )}'; supported keys: '${this.keys.join("', '")}'`,
       );
     }
-    return this.getDep(index) as TPlans[TKey];
+    return this.getDep<TPlans[TKey]>(index);
   }
 }
 

--- a/grafast/grafast/src/steps/polymorphicBranch.ts
+++ b/grafast/grafast/src/steps/polymorphicBranch.ts
@@ -58,7 +58,7 @@ export class PolymorphicBranchStep<TStep extends ExecutableStep>
 
   planForType(objectType: GraphQLObjectType): ExecutableStep {
     const matcher = this.matchers[objectType.name];
-    const $step = this.getDep(0) as TStep;
+    const $step = this.getDep<TStep>(0);
     if (matcher) {
       if (typeof matcher.plan === "function") {
         return matcher.plan($step);


### PR DESCRIPTION
## Description

Grafast changes:

- update: `ExecutableStep::getDep` is now generic so you don't need to `this.getDep(n) as ExpectedThing` and can instead `this.getDep<ExpectedThing>(n)`
- added: `ExecutableStep::maybeGetDep<TStep>(n)` for when `n` may not be set - returns `null` if `n == null`
- added: `ExecutableStep::getDepOrConstant(n, fallback)`: returns `this.maybeGetDep(n) ?? constant(fallback)`

Then refactored the code to use these helpers.

## Performance impact

Negligible.

## Security impact

Seems unlikely. If anything an improvement because less code is written and thus less risk of copy/paste errors.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
