### PR TITLE
Simplify `constant()` printing

### DIFF
--- a/.changeset/great-keys-film.md
+++ b/.changeset/great-keys-film.md
@@ -1,0 +1,6 @@
+---
+"grafast": patch
+---
+
+Add more inspect properties to inspect() and have constant() simplify 'Object:
+null prototype'

--- a/grafast/dataplan-pg/__tests__/mutations/withPgClient/multipleActions.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/mutations/withPgClient/multipleActions.deopt.mermaid
@@ -17,7 +17,7 @@ graph TD
     __Value2 --> Access10
     __Value2 --> Access11
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant15{{"Constant[15∈0] ➊<br />ᐸ[Object: null prototype] { a: 3 }ᐳ"}}:::plan
+    Constant15{{"Constant[15∈0] ➊<br />ᐸ§{ a: 3 }ᐳ"}}:::plan
     WithPgClient9[["WithPgClient[9∈1] ➊"]]:::sideeffectplan
     Object12 & Constant15 --> WithPgClient9
     __Item13[/"__Item[13∈3]<br />ᐸ9ᐳ"\]:::itemplan

--- a/grafast/dataplan-pg/__tests__/mutations/withPgClient/multipleActions.mermaid
+++ b/grafast/dataplan-pg/__tests__/mutations/withPgClient/multipleActions.mermaid
@@ -17,7 +17,7 @@ graph TD
     __Value2 --> Access10
     __Value2 --> Access11
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant15{{"Constant[15∈0] ➊<br />ᐸ[Object: null prototype] { a: 3 }ᐳ"}}:::plan
+    Constant15{{"Constant[15∈0] ➊<br />ᐸ§{ a: 3 }ᐳ"}}:::plan
     WithPgClient9[["WithPgClient[9∈1] ➊"]]:::sideeffectplan
     Object12 & Constant15 --> WithPgClient9
     __Item13[/"__Item[13∈3]<br />ᐸ9ᐳ"\]:::itemplan

--- a/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object-errors.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object-errors.deopt.mermaid
@@ -24,7 +24,7 @@ graph TD
     First10 --> PgSelectSingle11
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant45{{"Constant[45∈0] ➊<br />ᐸ[Object: null prototype] {}ᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸ§{}ᐳ"}}:::plan
     GraphQLResolver14[["GraphQLResolver[14∈1] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     PgClassExpression12{{"PgClassExpression[12∈1] ➊<br />ᐸ__random_u...”username”ᐳ"}}:::plan
     PgClassExpression12 & Constant45 & __Value2 & __Value0 & __Value4 --> GraphQLResolver14

--- a/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object-errors.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object-errors.mermaid
@@ -24,7 +24,7 @@ graph TD
     First10 --> PgSelectSingle11
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant45{{"Constant[45∈0] ➊<br />ᐸ[Object: null prototype] {}ᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸ§{}ᐳ"}}:::plan
     GraphQLResolver14[["GraphQLResolver[14∈1] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     PgClassExpression12{{"PgClassExpression[12∈1] ➊<br />ᐸ__random_u...”username”ᐳ"}}:::plan
     PgClassExpression12 & Constant45 & __Value2 & __Value0 & __Value4 --> GraphQLResolver14

--- a/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object-recursive.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object-recursive.deopt.mermaid
@@ -24,7 +24,7 @@ graph TD
     First10 --> PgSelectSingle11
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant33{{"Constant[33∈0] ➊<br />ᐸ[Object: null prototype] {}ᐳ"}}:::plan
+    Constant33{{"Constant[33∈0] ➊<br />ᐸ§{}ᐳ"}}:::plan
     GraphQLResolver14[["GraphQLResolver[14∈1] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     PgClassExpression12{{"PgClassExpression[12∈1] ➊<br />ᐸ__random_u...”username”ᐳ"}}:::plan
     PgClassExpression12 & Constant33 & __Value2 & __Value0 & __Value4 --> GraphQLResolver14

--- a/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object-recursive.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object-recursive.mermaid
@@ -24,7 +24,7 @@ graph TD
     First10 --> PgSelectSingle11
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant33{{"Constant[33∈0] ➊<br />ᐸ[Object: null prototype] {}ᐳ"}}:::plan
+    Constant33{{"Constant[33∈0] ➊<br />ᐸ§{}ᐳ"}}:::plan
     GraphQLResolver14[["GraphQLResolver[14∈1] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     PgClassExpression12{{"PgClassExpression[12∈1] ➊<br />ᐸ__random_u...”username”ᐳ"}}:::plan
     PgClassExpression12 & Constant33 & __Value2 & __Value0 & __Value4 --> GraphQLResolver14

--- a/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object.deopt.mermaid
@@ -24,7 +24,7 @@ graph TD
     First10 --> PgSelectSingle11
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant19{{"Constant[19∈0] ➊<br />ᐸ[Object: null prototype] {}ᐳ"}}:::plan
+    Constant19{{"Constant[19∈0] ➊<br />ᐸ§{}ᐳ"}}:::plan
     GraphQLResolver14[["GraphQLResolver[14∈1] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     PgClassExpression12{{"PgClassExpression[12∈1] ➊<br />ᐸ__random_u...”username”ᐳ"}}:::plan
     PgClassExpression12 & Constant19 & __Value2 & __Value0 & __Value4 --> GraphQLResolver14

--- a/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/resolvers/basics-object.mermaid
@@ -24,7 +24,7 @@ graph TD
     First10 --> PgSelectSingle11
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant19{{"Constant[19∈0] ➊<br />ᐸ[Object: null prototype] {}ᐳ"}}:::plan
+    Constant19{{"Constant[19∈0] ➊<br />ᐸ§{}ᐳ"}}:::plan
     GraphQLResolver14[["GraphQLResolver[14∈1] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     PgClassExpression12{{"PgClassExpression[12∈1] ➊<br />ᐸ__random_u...”username”ᐳ"}}:::plan
     PgClassExpression12 & Constant19 & __Value2 & __Value0 & __Value4 --> GraphQLResolver14

--- a/grafast/dataplan-pg/__tests__/queries/resolvers/basics.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/resolvers/basics.deopt.mermaid
@@ -26,7 +26,7 @@ graph TD
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     GraphQLResolver16[["GraphQLResolver[16∈1] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     Object14{{"Object[14∈1] ➊<br />ᐸ{username}ᐳ"}}:::plan
-    Constant18{{"Constant[18∈1] ➊<br />ᐸ[Object: null prototype] { hashType: 'sha1' }ᐳ"}}:::plan
+    Constant18{{"Constant[18∈1] ➊<br />ᐸ§{ hashType: 'sha1' }ᐳ"}}:::plan
     Object14 & Constant18 & __Value2 & __Value0 & __Value4 --> GraphQLResolver16
     PgClassExpression12{{"PgClassExpression[12∈1] ➊<br />ᐸ__random_u...”username”ᐳ"}}:::plan
     PgSelectSingle11 --> PgClassExpression12

--- a/grafast/dataplan-pg/__tests__/queries/resolvers/basics.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/resolvers/basics.mermaid
@@ -26,7 +26,7 @@ graph TD
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
     GraphQLResolver16[["GraphQLResolver[16∈1] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     Object14{{"Object[14∈1] ➊<br />ᐸ{username}ᐳ"}}:::plan
-    Constant18{{"Constant[18∈1] ➊<br />ᐸ[Object: null prototype] { hashType: 'sha1' }ᐳ"}}:::plan
+    Constant18{{"Constant[18∈1] ➊<br />ᐸ§{ hashType: 'sha1' }ᐳ"}}:::plan
     Object14 & Constant18 & __Value2 & __Value0 & __Value4 --> GraphQLResolver16
     PgClassExpression12{{"PgClassExpression[12∈1] ➊<br />ᐸ__random_u...”username”ᐳ"}}:::plan
     PgSelectSingle11 --> PgClassExpression12

--- a/grafast/dataplan-pg/__tests__/queries/resolvers/objectDefaults.deopt.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/resolvers/objectDefaults.deopt.mermaid
@@ -11,7 +11,7 @@ graph TD
     %% plan dependencies
     GraphQLResolver7[["GraphQLResolver[7∈0] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant15{{"Constant[15∈0] ➊<br />ᐸ[Object: null prototype] {}ᐳ"}}:::plan
+    Constant15{{"Constant[15∈0] ➊<br />ᐸ§{}ᐳ"}}:::plan
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
     __Value4 & Constant15 & __Value2 & __Value0 & __Value4 --> GraphQLResolver7

--- a/grafast/dataplan-pg/__tests__/queries/resolvers/objectDefaults.mermaid
+++ b/grafast/dataplan-pg/__tests__/queries/resolvers/objectDefaults.mermaid
@@ -11,7 +11,7 @@ graph TD
     %% plan dependencies
     GraphQLResolver7[["GraphQLResolver[7∈0] ➊<br />ᐸresolveᐳ"]]:::unbatchedplan
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant15{{"Constant[15∈0] ➊<br />ᐸ[Object: null prototype] {}ᐳ"}}:::plan
+    Constant15{{"Constant[15∈0] ➊<br />ᐸ§{}ᐳ"}}:::plan
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value0["__Value[0∈0] ➊<br />ᐸvariableValuesᐳ"]:::plan
     __Value4 & Constant15 & __Value2 & __Value0 & __Value4 --> GraphQLResolver7

--- a/grafast/grafast/src/inspect.ts
+++ b/grafast/grafast/src/inspect.ts
@@ -1,6 +1,11 @@
 export let inspect: (
   obj: any,
-  options?: { colors?: boolean; depth?: number },
+  options?: {
+    colors?: boolean;
+    depth?: number;
+    compact?: boolean | number;
+    breakLength?: number;
+  },
 ) => string;
 
 try {

--- a/grafast/grafast/src/steps/constant.ts
+++ b/grafast/grafast/src/steps/constant.ts
@@ -32,8 +32,12 @@ export class ConstantStep<TData> extends UnbatchedExecutableStep<TData> {
     // ENHANCE: use nicer simplification
     return this.isSensitive
       ? `[HIDDEN]`
-      : inspect(this.data)
+      : inspect(this.data, {
+          compact: Infinity,
+          breakLength: Infinity,
+        })
           .replace(/[\r\n]/g, " ")
+          .replaceAll("[Object: null prototype] ", "§")
           .slice(0, 60);
   }
 

--- a/postgraphile/postgraphile/__tests__/mutations/v4/enum_tables.mutations.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/enum_tables.mutations.mermaid
@@ -49,7 +49,7 @@ graph TD
     PgInsertSingle24 --> PgClassExpression32
     PgSelect42[["PgSelect[42∈7] ➊<br />ᐸreferencing_table_mutation(mutation)ᐳ"]]:::sideeffectplan
     Object45{{"Object[45∈7] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant58{{"Constant[58∈7] ➊<br />ᐸ[Object: null prototype] {   enum_1: 'a1',   enum_2: 'b2',  ᐳ"}}:::plan
+    Constant58{{"Constant[58∈7] ➊<br />ᐸ§{ enum_1: 'a1', enum_2: 'b2', enum_3: 'c4', simple_enum: 'Qᐳ"}}:::plan
     Object45 & Constant58 --> PgSelect42
     Access43{{"Access[43∈7] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access44{{"Access[44∈7] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan

--- a/postgraphile/postgraphile/__tests__/mutations/v4/geometry.mutations.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/geometry.mutations.mermaid
@@ -17,14 +17,14 @@ graph TD
     __Value2 --> Access84
     __Value2 --> Access85
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant208{{"Constant[208∈0] ➊<br />ᐸ[Object: null prototype] { x: 99, y: 1234 }ᐳ"}}:::plan
-    Constant221{{"Constant[221∈0] ➊<br />ᐸ[Object: null prototype] {   a: [Object: null prototype] { xᐳ"}}:::plan
-    Constant222{{"Constant[222∈0] ➊<br />ᐸ[Object: null prototype] {   a: [Object: null prototype] { xᐳ"}}:::plan
-    Constant223{{"Constant[223∈0] ➊<br />ᐸ[Object: null prototype] {   a: [Object: null prototype] { xᐳ"}}:::plan
-    Constant225{{"Constant[225∈0] ➊<br />ᐸ[Object: null prototype] {   center: [Object: null prototypeᐳ"}}:::plan
-    Constant226{{"Constant[226∈0] ➊<br />ᐸ[Object: null prototype] {   points: [     [Object: null proᐳ"}}:::plan
-    Constant227{{"Constant[227∈0] ➊<br />ᐸ[Object: null prototype] {   points: [     [Object: null proᐳ"}}:::plan
-    Constant228{{"Constant[228∈0] ➊<br />ᐸ[Object: null prototype] {   points: [     [Object: null proᐳ"}}:::plan
+    Constant208{{"Constant[208∈0] ➊<br />ᐸ§{ x: 99, y: 1234 }ᐳ"}}:::plan
+    Constant221{{"Constant[221∈0] ➊<br />ᐸ§{ a: §{ x: 25, y: 200 }, b: §{ x: 0, y: 100 } }ᐳ"}}:::plan
+    Constant222{{"Constant[222∈0] ➊<br />ᐸ§{ a: §{ x: 99, y: 111 }, b: §{ x: 2935, y: 3548 } }ᐳ"}}:::plan
+    Constant223{{"Constant[223∈0] ➊<br />ᐸ§{ a: §{ x: 123, y: 52635 }, b: §{ x: 2342, y: 12445 } }ᐳ"}}:::plan
+    Constant225{{"Constant[225∈0] ➊<br />ᐸ§{ center: §{ x: 7, y: 11 }, radius: 3 }ᐳ"}}:::plan
+    Constant226{{"Constant[226∈0] ➊<br />ᐸ§{ points: [ §{ x: 0, y: 0 }, §{ x: 0, y: 10 }, §{ x: 10, y:ᐳ"}}:::plan
+    Constant227{{"Constant[227∈0] ➊<br />ᐸ§{ points: [ §{ x: 0, y: 0 }, §{ x: 0, y: 10 }, §{ x: 10, y:ᐳ"}}:::plan
+    Constant228{{"Constant[228∈0] ➊<br />ᐸ§{ points: [ §{ x: 0, y: 0 }, §{ x: 0, y: 10 }, §{ x: 10, y:ᐳ"}}:::plan
     PgInsertSingle83[["PgInsertSingle[83∈1] ➊<br />ᐸgeom(point,line,lseg,box,open_path,closed_path,polygon,circle)ᐳ"]]:::sideeffectplan
     Object86 & Constant208 & Constant221 & Constant222 & Constant223 & Constant226 & Constant227 & Constant228 & Constant225 --> PgInsertSingle83
     Object87{{"Object[87∈1] ➊<br />ᐸ{result}ᐳ"}}:::plan

--- a/postgraphile/postgraphile/__tests__/mutations/v4/mutation-create.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/mutation-create.mermaid
@@ -72,16 +72,16 @@ graph TD
     Constant1243{{"Constant[1243∈0] ➊<br />ᐸ'super headline 2'ᐳ"}}:::plan
     Constant1251{{"Constant[1251∈0] ➊<br />ᐸ[ 'red', 'green' ]ᐳ"}}:::plan
     Constant1252{{"Constant[1252∈0] ➊<br />ᐸ[   'have',  'you',   'ever',  'been',   'down',  'the',   'ᐳ"}}:::plan
-    Constant1257{{"Constant[1257∈0] ➊<br />ᐸ[Object: null prototype] {   seconds: 1,   minutes: 2,   houᐳ"}}:::plan
-    Constant1260{{"Constant[1260∈0] ➊<br />ᐸ[Object: null prototype] {   a: 123,   b: 'abc',   c: 'greenᐳ"}}:::plan
-    Constant1263{{"Constant[1263∈0] ➊<br />ᐸ[Object: null prototype] { x: 1, y: 3 }ᐳ"}}:::plan
-    Constant1264{{"Constant[1264∈0] ➊<br />ᐸ[   'TEXT 2098288669218571759',   'TEXT 2098288669218571760'ᐳ"}}:::plan
+    Constant1257{{"Constant[1257∈0] ➊<br />ᐸ§{ seconds: 1, minutes: 2, hours: 3, days: 4, months: 5, yeaᐳ"}}:::plan
+    Constant1260{{"Constant[1260∈0] ➊<br />ᐸ§{ a: 123, b: 'abc', c: 'green', d: 'ec4a9fae-4ec5-4763-98ebᐳ"}}:::plan
+    Constant1263{{"Constant[1263∈0] ➊<br />ᐸ§{ x: 1, y: 3 }ᐳ"}}:::plan
+    Constant1264{{"Constant[1264∈0] ➊<br />ᐸ[ 'TEXT 2098288669218571759', 'TEXT 2098288669218571760', 'Tᐳ"}}:::plan
     Constant1265{{"Constant[1265∈0] ➊<br />ᐸ[ '2098288669218571759', '2098288669218571760', '20982886692ᐳ"}}:::plan
-    Constant1272{{"Constant[1272∈0] ➊<br />ᐸ[Object: null prototype] {   start: [Object: null prototype]ᐳ"}}:::plan
-    Constant1273{{"Constant[1273∈0] ➊<br />ᐸ[Object: null prototype] {   start: [Object: null prototype]ᐳ"}}:::plan
-    Constant1274{{"Constant[1274∈0] ➊<br />ᐸ[Object: null prototype] {   start: [Object: null prototype]ᐳ"}}:::plan
-    Constant1275{{"Constant[1275∈0] ➊<br />ᐸ[   [Object: null prototype] {     seconds: 2,     minutes: ᐳ"}}:::plan
-    Constant1276{{"Constant[1276∈0] ➊<br />ᐸ[Object: null prototype] {   a: [Object: null prototype] {  ᐳ"}}:::plan
+    Constant1272{{"Constant[1272∈0] ➊<br />ᐸ§{ start: §{ value: '50', inclusive: true }, end: §{ value: ᐳ"}}:::plan
+    Constant1273{{"Constant[1273∈0] ➊<br />ᐸ§{ start: §{ value: '1927-11-05', inclusive: false }, end: §ᐳ"}}:::plan
+    Constant1274{{"Constant[1274∈0] ➊<br />ᐸ§{ start: §{ value: undefined, inclusive: undefined }, end: ᐳ"}}:::plan
+    Constant1275{{"Constant[1275∈0] ➊<br />ᐸ[ §{ seconds: 2, minutes: 3, hours: 4, days: 5, months: 6, yᐳ"}}:::plan
+    Constant1276{{"Constant[1276∈0] ➊<br />ᐸ§{ a: §{ a: 456, b: 'def', c: 'blue', d: '79863dcf-0433-4c3dᐳ"}}:::plan
     PgInsertSingle138[["PgInsertSingle[138∈1] ➊<br />ᐸtypes(id,smallint,bigint,numeric,decimal,boolean,varchar,enum,enum_array,domain,domain2,text_array,json,jsonb,numrange,daterange,an_int_range,timestamp,timestamptz,date,time,timetz,interval,interval_array,money,compound_type,nested_compound_type,point,cidr,macaddr,text_array_domain,int8_array_domain)ᐳ"]]:::sideeffectplan
     Object141 & Constant1111 & Constant1112 & Constant1113 & Constant1114 & Constant1114 & Constant1116 & Constant1117 & Constant1118 & Constant1251 & Constant1121 & Constant1122 & Constant1252 & Constant1132 & Constant1133 & Constant1272 & Constant1273 & Constant1274 & Constant1142 & Constant1143 & Constant1144 & Constant1145 & Constant1146 & Constant1257 & Constant1275 & Constant1165 & Constant1260 & Constant1276 & Constant1263 & Constant1190 & Constant1191 & Constant1264 & Constant1265 --> PgInsertSingle138
     Object142{{"Object[142∈1] ➊<br />ᐸ{result}ᐳ"}}:::plan
@@ -996,7 +996,7 @@ graph TD
     PgInsertSingle970 --> PgClassExpression976
     PgInsertSingle995[["PgInsertSingle[995∈102] ➊<br />ᐸpost(headline,comptypes)ᐳ"]]:::sideeffectplan
     Object998{{"Object[998∈102] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant1277{{"Constant[1277∈102] ➊<br />ᐸ[   [Object: null prototype] {     schedule: '2009-10-24 10:ᐳ"}}:::plan
+    Constant1277{{"Constant[1277∈102] ➊<br />ᐸ[ §{ schedule: '2009-10-24 10:23:54+02', is_optimised: true ᐳ"}}:::plan
     Object998 & Constant1236 & Constant1277 --> PgInsertSingle995
     Access996{{"Access[996∈102] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access997{{"Access[997∈102] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -1023,7 +1023,7 @@ graph TD
     PgSelectSingle1012 --> PgClassExpression1014
     PgInsertSingle1033[["PgInsertSingle[1033∈107] ➊<br />ᐸpost(headline,author_id,comptypes)ᐳ"]]:::sideeffectplan
     Object1036{{"Object[1036∈107] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant1278{{"Constant[1278∈107] ➊<br />ᐸ[   [Object: null prototype] {     schedule: '2008-10-24 10:ᐳ"}}:::plan
+    Constant1278{{"Constant[1278∈107] ➊<br />ᐸ[ §{ schedule: '2008-10-24 10:17:54+02', is_optimised: true ᐳ"}}:::plan
     Object1036 & Constant1243 & Constant1147 & Constant1278 --> PgInsertSingle1033
     Access1034{{"Access[1034∈107] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access1035{{"Access[1035∈107] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan

--- a/postgraphile/postgraphile/__tests__/mutations/v4/pg11.types.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/pg11.types.mermaid
@@ -23,7 +23,7 @@ graph TD
     Constant104{{"Constant[104∈0] ➊<br />ᐸ'postgraphile_test_visitor'ᐳ"}}:::plan
     Constant105{{"Constant[105∈0] ➊<br />ᐸ'c'ᐳ"}}:::plan
     Constant110{{"Constant[110∈0] ➊<br />ᐸ[ '2098288669218571759', '2098288669218571760', '20982886692ᐳ"}}:::plan
-    Constant111{{"Constant[111∈0] ➊<br />ᐸ[Object: null prototype] { a: 1 }ᐳ"}}:::plan
+    Constant111{{"Constant[111∈0] ➊<br />ᐸ§{ a: 1 }ᐳ"}}:::plan
     PgUpdateSingle26[["PgUpdateSingle[26∈1] ➊<br />ᐸtypes(id;regrole,regnamespace,bigint_domain_array_domain,domain_constrained_compound_type)ᐳ"]]:::sideeffectplan
     Object29 & Constant97 & Constant98 & Constant99 & Constant110 & Constant111 --> PgUpdateSingle26
     Object30{{"Object[30∈1] ➊<br />ᐸ{result}ᐳ"}}:::plan
@@ -63,7 +63,7 @@ graph TD
     PgInsertSingle71[["PgInsertSingle[71∈6] ➊<br />ᐸtypes(regrole,regnamespace,bigint_domain_array_domain,domain_constrained_compound_type)ᐳ"]]:::sideeffectplan
     Object74{{"Object[74∈6] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Constant112{{"Constant[112∈6] ➊<br />ᐸ[ '2098288669218571759', '2098288669218571760', '20982886692ᐳ"}}:::plan
-    Constant113{{"Constant[113∈6] ➊<br />ᐸ[Object: null prototype] { a: 1 }ᐳ"}}:::plan
+    Constant113{{"Constant[113∈6] ➊<br />ᐸ§{ a: 1 }ᐳ"}}:::plan
     Object74 & Constant104 & Constant105 & Constant112 & Constant113 --> PgInsertSingle71
     Access72{{"Access[72∈6] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access73{{"Access[73∈6] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan

--- a/postgraphile/postgraphile/__tests__/mutations/v4/procedure-mutation.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/procedure-mutation.mermaid
@@ -295,7 +295,7 @@ graph TD
     PgSelect214[["PgSelect[214∈33] ➊<br />ᐸtypes_mutation(mutation)ᐳ"]]:::sideeffectplan
     Object217{{"Object[217∈33] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Constant767{{"Constant[767∈33] ➊<br />ᐸ[ 1, 2, 3 ]ᐳ"}}:::plan
-    Constant775{{"Constant[775∈33] ➊<br />ᐸ[Object: null prototype] {   start: [Object: null prototype]ᐳ"}}:::plan
+    Constant775{{"Constant[775∈33] ➊<br />ᐸ§{ start: §{ value: 1, inclusive: false }, end: §{ value: 5,ᐳ"}}:::plan
     Object217 & Constant692 & Constant693 & Constant694 & Constant767 & Constant698 & Constant775 --> PgSelect214
     Access215{{"Access[215∈33] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access216{{"Access[216∈33] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -312,7 +312,7 @@ graph TD
     PgClassExpression220 --> Object221
     PgSelect241[["PgSelect[241∈35] ➊<br />ᐸcompound_type_mutation(mutation)ᐳ"]]:::sideeffectplan
     Object244{{"Object[244∈35] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant776{{"Constant[776∈35] ➊<br />ᐸ[Object: null prototype] {   a: 419,   b: 'easy cheesy bakedᐳ"}}:::plan
+    Constant776{{"Constant[776∈35] ➊<br />ᐸ§{ a: 419, b: 'easy cheesy baked potatoes', c: 'red', e: 'FOᐳ"}}:::plan
     Object244 & Constant776 --> PgSelect241
     Access242{{"Access[242∈35] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access243{{"Access[243∈35] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -343,7 +343,7 @@ graph TD
     PgSelectSingle246 --> PgClassExpression258
     PgSelect278[["PgSelect[278∈39] ➊<br />ᐸcompound_type_set_mutation(mutation)ᐳ"]]:::sideeffectplan
     Object281{{"Object[281∈39] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant777{{"Constant[777∈39] ➊<br />ᐸ[Object: null prototype] {   a: 419,   b: 'easy cheesy bakedᐳ"}}:::plan
+    Constant777{{"Constant[777∈39] ➊<br />ᐸ§{ a: 419, b: 'easy cheesy baked potatoes', c: 'red', e: 'FOᐳ"}}:::plan
     Object281 & Constant777 --> PgSelect278
     Access279{{"Access[279∈39] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access280{{"Access[280∈39] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -374,7 +374,7 @@ graph TD
     PgSelectSingle284 --> PgClassExpression295
     PgSelect315[["PgSelect[315∈44] ➊<br />ᐸcompound_type_array_mutation(mutation)ᐳ"]]:::sideeffectplan
     Object318{{"Object[318∈44] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant778{{"Constant[778∈44] ➊<br />ᐸ[Object: null prototype] {   a: 419,   b: 'easy cheesy bakedᐳ"}}:::plan
+    Constant778{{"Constant[778∈44] ➊<br />ᐸ§{ a: 419, b: 'easy cheesy baked potatoes', c: 'red', e: 'FOᐳ"}}:::plan
     Object318 & Constant778 --> PgSelect315
     Access316{{"Access[316∈44] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access317{{"Access[317∈44] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -606,7 +606,7 @@ graph TD
     PgClassExpression475 --> Object476
     PgSelect526[["PgSelect[526∈76] ➊<br />ᐸpost_many(mutation)ᐳ"]]:::sideeffectplan
     Object529{{"Object[529∈76] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant786{{"Constant[786∈76] ➊<br />ᐸ[   [Object: null prototype] {     id: 7,     headline: 'heaᐳ"}}:::plan
+    Constant786{{"Constant[786∈76] ➊<br />ᐸ[ §{ id: 7, headline: 'headline', body: 'body', author_id: 9ᐳ"}}:::plan
     Object529 & Constant786 --> PgSelect526
     Access527{{"Access[527∈76] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access528{{"Access[528∈76] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -637,7 +637,7 @@ graph TD
     PgSelectSingle541 --> PgClassExpression543
     PgSelect555[["PgSelect[555∈82] ➊<br />ᐸpost_with_suffix(mutation)ᐳ"]]:::sideeffectplan
     Object558{{"Object[558∈82] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant774{{"Constant[774∈82] ➊<br />ᐸ[Object: null prototype] {   id: 15,   headline: 'headline_'ᐳ"}}:::plan
+    Constant774{{"Constant[774∈82] ➊<br />ᐸ§{ id: 15, headline: 'headline_', body: 'body' }ᐳ"}}:::plan
     Object558 & Constant774 & Constant755 --> PgSelect555
     Access556{{"Access[556∈82] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access557{{"Access[557∈82] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
@@ -692,7 +692,7 @@ graph TD
     PgSelectSingle583 --> PgClassExpression585
     PgSelect605[["PgSelect[605∈92] ➊<br />ᐸmutation_compound_type_array(mutation)ᐳ"]]:::sideeffectplan
     Object608{{"Object[608∈92] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant782{{"Constant[782∈92] ➊<br />ᐸ[Object: null prototype] {   a: 419,   b: 'easy cheesy bakedᐳ"}}:::plan
+    Constant782{{"Constant[782∈92] ➊<br />ᐸ§{ a: 419, b: 'easy cheesy baked potatoes', c: 'red', e: 'BAᐳ"}}:::plan
     Object608 & Constant782 --> PgSelect605
     Access606{{"Access[606∈92] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access607{{"Access[607∈92] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan

--- a/postgraphile/postgraphile/__tests__/mutations/v4/rbac.createPerson.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/rbac.createPerson.mermaid
@@ -21,7 +21,7 @@ graph TD
     Constant41{{"Constant[41∈0] ➊<br />ᐸ'Unknown'ᐳ"}}:::plan
     Constant42{{"Constant[42∈0] ➊<br />ᐸ'jane.doe@example.com'ᐳ"}}:::plan
     Constant44{{"Constant[44∈0] ➊<br />ᐸ[ 'Jay Doe', 'JD' ]ᐳ"}}:::plan
-    Constant45{{"Constant[45∈0] ➊<br />ᐸ[Object: null prototype] { url: 'http://example.com' }ᐳ"}}:::plan
+    Constant45{{"Constant[45∈0] ➊<br />ᐸ§{ url: 'http://example.com' }ᐳ"}}:::plan
     PgInsertSingle17[["PgInsertSingle[17∈1] ➊<br />ᐸperson(person_full_name,aliases,about,email,site)ᐳ"]]:::sideeffectplan
     Object20 & Constant38 & Constant44 & Constant41 & Constant42 & Constant45 --> PgInsertSingle17
     Object21{{"Object[21∈1] ➊<br />ᐸ{result}ᐳ"}}:::plan

--- a/postgraphile/postgraphile/__tests__/mutations/v4/rbac.leftArmIdentity.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/rbac.leftArmIdentity.mermaid
@@ -17,7 +17,7 @@ graph TD
     __Value2 --> Access15
     __Value2 --> Access16
     __Value4["__Value[4∈0] ➊<br />ᐸrootValueᐳ"]:::plan
-    Constant32{{"Constant[32∈0] ➊<br />ᐸ[Object: null prototype] {   id: 9001,   person_id: 99,   leᐳ"}}:::plan
+    Constant32{{"Constant[32∈0] ➊<br />ᐸ§{ id: 9001, person_id: 99, length_in_metres: 77, mood: 'jubᐳ"}}:::plan
     PgSelect14[["PgSelect[14∈1] ➊<br />ᐸleft_arm_identity(mutation)ᐳ"]]:::sideeffectplan
     Object17 & Constant32 --> PgSelect14
     First18{{"First[18∈1] ➊"}}:::plan

--- a/postgraphile/postgraphile/__tests__/mutations/v4/rbac.updatePerson.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/rbac.updatePerson.mermaid
@@ -22,7 +22,7 @@ graph TD
     Constant43{{"Constant[43∈0] ➊<br />ᐸnullᐳ"}}:::plan
     Constant44{{"Constant[44∈0] ➊<br />ᐸ'buddy@example.com'ᐳ"}}:::plan
     Constant46{{"Constant[46∈0] ➊<br />ᐸ[ 'BD', 'Buddy' ]ᐳ"}}:::plan
-    Constant47{{"Constant[47∈0] ➊<br />ᐸ[Object: null prototype] { url: 'http://buddy.com' }ᐳ"}}:::plan
+    Constant47{{"Constant[47∈0] ➊<br />ᐸ§{ url: 'http://buddy.com' }ᐳ"}}:::plan
     PgUpdateSingle18[["PgUpdateSingle[18∈1] ➊<br />ᐸperson(id;person_full_name,aliases,about,email,site)ᐳ"]]:::sideeffectplan
     Object21 & Constant39 & Constant40 & Constant46 & Constant43 & Constant44 & Constant47 --> PgUpdateSingle18
     Object22{{"Object[22∈1] ➊<br />ᐸ{result}ᐳ"}}:::plan

--- a/postgraphile/postgraphile/__tests__/mutations/v4/types.mermaid
+++ b/postgraphile/postgraphile/__tests__/mutations/v4/types.mermaid
@@ -900,15 +900,15 @@ graph TD
     Object734{{"Object[734∈90] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Constant1439{{"Constant[1439∈90] ➊<br />ᐸ[ 'red', 'green', 'blue' ]ᐳ"}}:::plan
     Constant1440{{"Constant[1440∈90] ➊<br />ᐸ[ 'Hi' ]ᐳ"}}:::plan
-    Constant1469{{"Constant[1469∈90] ➊<br />ᐸ[Object: null prototype] {   start: [Object: null prototype]ᐳ"}}:::plan
-    Constant1470{{"Constant[1470∈90] ➊<br />ᐸ[Object: null prototype] {   start: [Object: null prototype]ᐳ"}}:::plan
-    Constant1471{{"Constant[1471∈90] ➊<br />ᐸ[Object: null prototype] {   start: [Object: null prototype]ᐳ"}}:::plan
-    Constant1437{{"Constant[1437∈90] ➊<br />ᐸ[Object: null prototype] {   seconds: undefined,   minutes: ᐳ"}}:::plan
-    Constant1447{{"Constant[1447∈90] ➊<br />ᐸ[   [Object: null prototype] {     seconds: undefined,     mᐳ"}}:::plan
-    Constant1448{{"Constant[1448∈90] ➊<br />ᐸ[Object: null prototype] { a: 1 }ᐳ"}}:::plan
-    Constant1449{{"Constant[1449∈90] ➊<br />ᐸ[Object: null prototype] { a: [Object: null prototype] { a: ᐳ"}}:::plan
-    Constant1450{{"Constant[1450∈90] ➊<br />ᐸ[Object: null prototype] { x: 99, y: 77 }ᐳ"}}:::plan
-    Constant1451{{"Constant[1451∈90] ➊<br />ᐸ[Object: null prototype] { x: 0, y: 42 }ᐳ"}}:::plan
+    Constant1469{{"Constant[1469∈90] ➊<br />ᐸ§{ start: §{ value: '1', inclusive: true }, end: §{ value: 'ᐳ"}}:::plan
+    Constant1470{{"Constant[1470∈90] ➊<br />ᐸ§{ start: §{ value: '1985-01-01', inclusive: true }, end: §{ᐳ"}}:::plan
+    Constant1471{{"Constant[1471∈90] ➊<br />ᐸ§{ start: §{ value: 1, inclusive: true }, end: §{ value: 2, ᐳ"}}:::plan
+    Constant1437{{"Constant[1437∈90] ➊<br />ᐸ§{ seconds: undefined, minutes: 27, hours: undefined, days: ᐳ"}}:::plan
+    Constant1447{{"Constant[1447∈90] ➊<br />ᐸ[ §{ seconds: undefined, minutes: 27, hours: undefined, daysᐳ"}}:::plan
+    Constant1448{{"Constant[1448∈90] ➊<br />ᐸ§{ a: 1 }ᐳ"}}:::plan
+    Constant1449{{"Constant[1449∈90] ➊<br />ᐸ§{ a: §{ a: 1 } }ᐳ"}}:::plan
+    Constant1450{{"Constant[1450∈90] ➊<br />ᐸ§{ x: 99, y: 77 }ᐳ"}}:::plan
+    Constant1451{{"Constant[1451∈90] ➊<br />ᐸ§{ x: 0, y: 42 }ᐳ"}}:::plan
     Constant1452{{"Constant[1452∈90] ➊<br />ᐸ[ 'T1', 'T2', 'T3' ]ᐳ"}}:::plan
     Constant1453{{"Constant[1453∈90] ➊<br />ᐸ[ '2098288669218571759', '2098288669218571760', '20982886692ᐳ"}}:::plan
     Constant1454{{"Constant[1454∈90] ➊<br />ᐸ[ ᐸBuffer 01 a0 5b 09 c0 ddᐳ, ᐸBuffer 01 a0 5bᐳ ]ᐳ"}}:::plan
@@ -1197,14 +1197,14 @@ graph TD
     Object1066{{"Object[1066∈119] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Constant1456{{"Constant[1456∈119] ➊<br />ᐸ[ 'red', 'green', 'blue' ]ᐳ"}}:::plan
     Constant1457{{"Constant[1457∈119] ➊<br />ᐸ[ 'Hi' ]ᐳ"}}:::plan
-    Constant1472{{"Constant[1472∈119] ➊<br />ᐸ[Object: null prototype] {   start: [Object: null prototype]ᐳ"}}:::plan
-    Constant1473{{"Constant[1473∈119] ➊<br />ᐸ[Object: null prototype] {   start: [Object: null prototype]ᐳ"}}:::plan
-    Constant1474{{"Constant[1474∈119] ➊<br />ᐸ[Object: null prototype] {   start: [Object: null prototype]ᐳ"}}:::plan
-    Constant1438{{"Constant[1438∈119] ➊<br />ᐸ[Object: null prototype] {   seconds: undefined,   minutes: ᐳ"}}:::plan
-    Constant1464{{"Constant[1464∈119] ➊<br />ᐸ[   [Object: null prototype] {     seconds: undefined,     mᐳ"}}:::plan
-    Constant1465{{"Constant[1465∈119] ➊<br />ᐸ[Object: null prototype] { a: 1 }ᐳ"}}:::plan
-    Constant1466{{"Constant[1466∈119] ➊<br />ᐸ[Object: null prototype] { a: [Object: null prototype] { a: ᐳ"}}:::plan
-    Constant1467{{"Constant[1467∈119] ➊<br />ᐸ[Object: null prototype] { x: 99, y: 77 }ᐳ"}}:::plan
+    Constant1472{{"Constant[1472∈119] ➊<br />ᐸ§{ start: §{ value: '1', inclusive: true }, end: §{ value: 'ᐳ"}}:::plan
+    Constant1473{{"Constant[1473∈119] ➊<br />ᐸ§{ start: §{ value: '1985-01-01', inclusive: true }, end: §{ᐳ"}}:::plan
+    Constant1474{{"Constant[1474∈119] ➊<br />ᐸ§{ start: §{ value: 1, inclusive: true }, end: §{ value: 2, ᐳ"}}:::plan
+    Constant1438{{"Constant[1438∈119] ➊<br />ᐸ§{ seconds: undefined, minutes: 27, hours: undefined, days: ᐳ"}}:::plan
+    Constant1464{{"Constant[1464∈119] ➊<br />ᐸ[ §{ seconds: undefined, minutes: 27, hours: undefined, daysᐳ"}}:::plan
+    Constant1465{{"Constant[1465∈119] ➊<br />ᐸ§{ a: 1 }ᐳ"}}:::plan
+    Constant1466{{"Constant[1466∈119] ➊<br />ᐸ§{ a: §{ a: 1 } }ᐳ"}}:::plan
+    Constant1467{{"Constant[1467∈119] ➊<br />ᐸ§{ x: 99, y: 77 }ᐳ"}}:::plan
     Constant1468{{"Constant[1468∈119] ➊<br />ᐸ[ 'Bar.Baz.Qux', 'Bar.Foo.Fah' ]ᐳ"}}:::plan
     Object1066 & Constant1323 & Constant1324 & Constant1324 & Constant1324 & Constant1327 & Constant1324 & Constant1329 & Constant1456 & Constant1323 & Constant1323 & Constant1457 & Constant1400 & Constant1401 & Constant1472 & Constant1473 & Constant1474 & Constant1350 & Constant1351 & Constant1352 & Constant1353 & Constant1353 & Constant1438 & Constant1464 & Constant1355 & Constant1465 & Constant1466 & Constant1467 & Constant1367 & Constant1368 & Constant1369 & Constant1370 & Constant1371 & Constant1372 & Constant1373 & Constant1374 & Constant1384 & Constant1468 --> PgInsertSingle1063
     Access1064{{"Access[1064∈119] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan

--- a/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields-cut-down-for-export.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields-cut-down-for-export.mermaid
@@ -12,7 +12,7 @@ graph TD
     PgSelect7[["PgSelect[7∈0] ➊<br />ᐸpostᐳ"]]:::plan
     Object10{{"Object[10∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
     Constant39{{"Constant[39∈0] ➊<br />ᐸ1ᐳ"}}:::plan
-    Constant40{{"Constant[40∈0] ➊<br />ᐸ[Object: null prototype] {}ᐳ"}}:::plan
+    Constant40{{"Constant[40∈0] ➊<br />ᐸ§{}ᐳ"}}:::plan
     Object10 & Constant39 & Constant40 --> PgSelect7
     Access8{{"Access[8∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access9{{"Access[9∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan

--- a/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/procedure-computed-fields.mermaid
@@ -104,7 +104,7 @@ graph TD
     Constant386{{"Constant[386∈10] ➊<br />ᐸ15ᐳ"}}:::plan
     Constant387{{"Constant[387∈10] ➊<br />ᐸ20ᐳ"}}:::plan
     Constant388{{"Constant[388∈10] ➊<br />ᐸ'[...]'ᐳ"}}:::plan
-    Constant418{{"Constant[418∈10] ➊<br />ᐸ[Object: null prototype] {   a: 419,   b: 'easy cheesy bakedᐳ"}}:::plan
+    Constant418{{"Constant[418∈10] ➊<br />ᐸ§{ a: 419, b: 'easy cheesy baked potatoes', c: 'red', e: 'BAᐳ"}}:::plan
     Object17 & Connection100 & Constant386 & Constant387 & Constant388 & Constant386 & Constant387 & Constant388 & Constant387 & Constant388 & Constant386 & Constant131 & Constant418 --> PgSelect101
     __Item102[/"__Item[102∈11]<br />ᐸ101ᐳ"\]:::itemplan
     PgSelect101 ==> __Item102

--- a/postgraphile/postgraphile/__tests__/queries/v4/procedure-query.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/procedure-query.mermaid
@@ -32,13 +32,13 @@ graph TD
     Constant1165{{"Constant[1165∈0] ➊<br />ᐸ'xyz'ᐳ"}}:::plan
     Constant1237{{"Constant[1237∈0] ➊<br />ᐸ[ 1, 2, 3 ]ᐳ"}}:::plan
     Constant1169{{"Constant[1169∈0] ➊<br />ᐸ{ a: 1, b: 2, c: 3 }ᐳ"}}:::plan
-    Constant1242{{"Constant[1242∈0] ➊<br />ᐸ[Object: null prototype] {   start: [Object: null prototype]ᐳ"}}:::plan
+    Constant1242{{"Constant[1242∈0] ➊<br />ᐸ§{ start: §{ value: 1, inclusive: false }, end: §{ value: 5,ᐳ"}}:::plan
     Object10 & Constant1163 & Constant233 & Constant1165 & Constant1237 & Constant1169 & Constant1242 --> PgSelect130
     PgSelect151[["PgSelect[151∈0] ➊<br />ᐸtypes_queryᐳ"]]:::plan
     Constant1176{{"Constant[1176∈0] ➊<br />ᐸ''ᐳ"}}:::plan
     Constant1178{{"Constant[1178∈0] ➊<br />ᐸ[]ᐳ"}}:::plan
     Constant1177{{"Constant[1177∈0] ➊<br />ᐸ{}ᐳ"}}:::plan
-    Constant1240{{"Constant[1240∈0] ➊<br />ᐸ[Object: null prototype] {   start: [Object: null prototype]ᐳ"}}:::plan
+    Constant1240{{"Constant[1240∈0] ➊<br />ᐸ§{ start: §{ value: undefined, inclusive: undefined }, end: ᐳ"}}:::plan
     Object10 & Constant1163 & Constant233 & Constant1176 & Constant1178 & Constant1177 & Constant1240 --> PgSelect151
     Connection508{{"Connection[508∈0] ➊<br />ᐸ506ᐳ"}}:::plan
     PgValidateParsedCursor514["PgValidateParsedCursor[514∈0] ➊"]:::plan
@@ -97,7 +97,7 @@ graph TD
     Constant1141{{"Constant[1141∈0] ➊<br />ᐸ[ { amount: '44' }, { amount: null } ]ᐳ"}}:::plan
     Object10 & Constant1141 --> PgSelect27
     PgSelect173[["PgSelect[173∈0] ➊<br />ᐸcompound_type_queryᐳ"]]:::plan
-    Constant1241{{"Constant[1241∈0] ➊<br />ᐸ[Object: null prototype] {   a: 419,   b: 'easy cheesy bakedᐳ"}}:::plan
+    Constant1241{{"Constant[1241∈0] ➊<br />ᐸ§{ a: 419, b: 'easy cheesy baked potatoes', c: 'red', e: 'BAᐳ"}}:::plan
     Object10 & Constant1241 --> PgSelect173
     PgSelect251[["PgSelect[251∈0] ➊<br />ᐸcompound_type_array_queryᐳ"]]:::plan
     Object10 & Constant1241 --> PgSelect251
@@ -115,7 +115,7 @@ graph TD
     Constant1216{{"Constant[1216∈0] ➊<br />ᐸ6ᐳ"}}:::plan
     Constant1216 & Constant1215 --> Connection757
     PgSelect1029[["PgSelect[1029∈0] ➊<br />ᐸquery_compound_type_arrayᐳ"]]:::plan
-    Constant1244{{"Constant[1244∈0] ➊<br />ᐸ[Object: null prototype] {   a: 419,   b: 'easy cheesy bakedᐳ"}}:::plan
+    Constant1244{{"Constant[1244∈0] ➊<br />ᐸ§{ a: 419, b: 'easy cheesy baked potatoes', c: 'red', e: 'BAᐳ"}}:::plan
     Object10 & Constant1244 --> PgSelect1029
     __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
     __Value2 --> Access8

--- a/postgraphile/postgraphile/__tests__/queries/v4/space.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/space.mermaid
@@ -14,7 +14,7 @@ graph TD
     Connection18{{"Connection[18∈0] ➊<br />ᐸ14ᐳ"}}:::plan
     PgSelect19[["PgSelect[19∈1] ➊<br />ᐸspacecraftᐳ"]]:::plan
     Object17{{"Object[17∈1] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
-    Constant47{{"Constant[47∈1] ➊<br />ᐸ[Object: null prototype] { id: '1', type: 'MOBILE' }ᐳ"}}:::plan
+    Constant47{{"Constant[47∈1] ➊<br />ᐸ§{ id: '1', type: 'MOBILE' }ᐳ"}}:::plan
     Object17 & Connection18 & Constant47 --> PgSelect19
     Access15{{"Access[15∈1] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
     Access16{{"Access[16∈1] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan


### PR DESCRIPTION
Enables more `inspect()` properties and replaces `[Object: null prototype]` in output with `§` to simplify plan diagrams.