### PR TITLE
Add scopedSQL to various of our classes

### DIFF
--- a/.changeset/dull-moles-exercise.md
+++ b/.changeset/dull-moles-exercise.md
@@ -1,0 +1,11 @@
+---
+"@dataplan/pg": patch
+---
+
+Add `.scopedSQL(sql => ...)` method to PgSelectStep, PgSelectSingleStep,
+PgUnionAllStep, PgUnionAllSingleStep; can be used to allow embedding of other
+_typed_ steps directly into an SQL expression without needing to use
+`$pgSelect.placeholder(...)` wrapper. Only works with steps that have a
+`pgCodec: PgCodec` property (typically those coming from PgSelectSingleStep
+accesses) since otherwise we don't currently know how to cast the value to
+Postgres.

--- a/.changeset/fuzzy-tigers-scream.md
+++ b/.changeset/fuzzy-tigers-scream.md
@@ -1,0 +1,5 @@
+---
+"@dataplan/pg": patch
+---
+
+Internal refactoring around new PgStmtStep abstract class.

--- a/.changeset/serious-sheep-confess.md
+++ b/.changeset/serious-sheep-confess.md
@@ -1,0 +1,6 @@
+---
+"@dataplan/pg": patch
+---
+
+Expand sql scoping to many more PgSelect/PgSelectSingle/PgUnion/PgUnionSingle
+methods, such as .where(), .select(), etc via callback pattern.

--- a/grafast/dataplan-pg/src/interfaces.ts
+++ b/grafast/dataplan-pg/src/interfaces.ts
@@ -1,5 +1,5 @@
 import type { ExecutableStep, ModifierStep } from "grafast";
-import type { SQL, SQLRawValue } from "pg-sql2";
+import type { PgSQL, SQL, SQLRawValue } from "pg-sql2";
 
 import type { PgCodecAttributes } from "./codecs.js";
 import type {
@@ -728,3 +728,8 @@ export type GetPgResourceRelations<
 export type GetPgResourceUniques<
   TResource extends PgResource<any, any, any, any, any>,
 > = TResource["uniques"];
+
+export type PgSQLCallback<TResult> = (
+  sql: PgSQL<PgTypedExecutableStep<PgCodec>>,
+) => TResult;
+export type PgSQLCallbackOrDirect<TResult> = PgSQLCallback<TResult> | TResult;

--- a/grafast/dataplan-pg/src/pgLocker.ts
+++ b/grafast/dataplan-pg/src/pgLocker.ts
@@ -1,6 +1,6 @@
 import { isDev } from "grafast";
 
-import type { PgSelectStep, PgUnionAllStep } from "./index";
+import type { PgStmtBaseStep } from "./steps/pgStmt";
 
 export type PgLockableParameter =
   | "orderBy"
@@ -8,13 +8,11 @@ export type PgLockableParameter =
   | "last"
   | "offset"
   | "groupBy";
-export type PgLockCallback<
-  TStep extends PgSelectStep<any> | PgUnionAllStep<any, any>,
-> = (step: TStep) => void;
+export type PgLockCallback<TStep extends PgStmtBaseStep<any>> = (
+  step: TStep,
+) => void;
 
-export class PgLocker<
-  TStep extends PgSelectStep<any> | PgUnionAllStep<any, any>,
-> {
+export class PgLocker<TStep extends PgStmtBaseStep<any>> {
   /**
    * Determines if the PgSelectStep is "locked" - i.e. its
    * FROM,JOINs,WHERE,ORDER BY,LIMIT,OFFSET cannot be changed. Note this does

--- a/grafast/dataplan-pg/src/steps/pgSelect.ts
+++ b/grafast/dataplan-pg/src/steps/pgSelect.ts
@@ -56,6 +56,7 @@ import type {
   PgTypedExecutableStep,
 } from "../interfaces.js";
 import { PgLocker } from "../pgLocker.js";
+import { makeScopedSQL } from "../utils.js";
 import { PgClassExpressionStep } from "./pgClassExpression.js";
 import type {
   PgHavingConditionSpec,
@@ -762,6 +763,8 @@ export class PgSelectStep<
   public unique(): boolean {
     return this.isUnique;
   }
+
+  public scopedSQL = makeScopedSQL(this);
 
   public placeholder($step: PgTypedExecutableStep<PgCodec>): SQL;
   public placeholder($step: ExecutableStep, codec: PgCodec): SQL;

--- a/grafast/dataplan-pg/src/steps/pgSelectSingle.ts
+++ b/grafast/dataplan-pg/src/steps/pgSelectSingle.ts
@@ -28,6 +28,7 @@ import type {
   PgRegistry,
   PgTypedExecutableStep,
 } from "../interfaces.js";
+import { makeScopedSQL } from "../utils.js";
 import type { PgClassExpressionStep } from "./pgClassExpression.js";
 import { pgClassExpression } from "./pgClassExpression.js";
 import { PgCursorStep } from "./pgCursor.js";
@@ -310,6 +311,8 @@ export class PgSelectSingleStep<
   public selectAndReturnIndex(fragment: SQL): number {
     return this.getClassStep().selectAndReturnIndex(fragment);
   }
+
+  public scopedSQL = makeScopedSQL(this);
 
   public placeholder($step: PgTypedExecutableStep<any>): SQL;
   public placeholder($step: ExecutableStep, codec: PgCodec): SQL;

--- a/grafast/dataplan-pg/src/steps/pgSelectSingle.ts
+++ b/grafast/dataplan-pg/src/steps/pgSelectSingle.ts
@@ -26,6 +26,7 @@ import type {
   PgCodec,
   PgCodecRelation,
   PgRegistry,
+  PgSQLCallbackOrDirect,
   PgTypedExecutableStep,
 } from "../interfaces.js";
 import { makeScopedSQL } from "../utils.js";
@@ -290,7 +291,7 @@ export class PgSelectSingleStep<
    * Returns a plan representing the result of an expression.
    */
   public select<TExpressionCodec extends PgCodec>(
-    fragment: SQL,
+    fragment: PgSQLCallbackOrDirect<SQL>,
     codec: TExpressionCodec,
     guaranteedNotNull?: boolean,
   ): PgClassExpressionStep<TExpressionCodec, TResource> {
@@ -299,7 +300,7 @@ export class PgSelectSingleStep<
       codec,
       guaranteedNotNull,
     );
-    return sqlExpr`${fragment}`;
+    return sqlExpr`${this.scopedSQL(fragment)}`;
   }
 
   /**
@@ -308,8 +309,8 @@ export class PgSelectSingleStep<
    *
    * @internal
    */
-  public selectAndReturnIndex(fragment: SQL): number {
-    return this.getClassStep().selectAndReturnIndex(fragment);
+  public selectAndReturnIndex(fragment: PgSQLCallbackOrDirect<SQL>): number {
+    return this.getClassStep().selectAndReturnIndex(this.scopedSQL(fragment));
   }
 
   public scopedSQL = makeScopedSQL(this);

--- a/grafast/dataplan-pg/src/steps/pgStmt.ts
+++ b/grafast/dataplan-pg/src/steps/pgStmt.ts
@@ -3,7 +3,7 @@ import { type SQL, sql } from "pg-sql2";
 
 import type { PgCodec, PgTypedExecutableStep } from "..";
 import type { PgLocker } from "../pgLocker";
-import { makeScopedSQL } from "../utils";
+import { makeScopedSQL } from "../utils.js";
 
 /**
  * Sometimes we want to refer to something that might change later - e.g. we

--- a/grafast/dataplan-pg/src/steps/pgStmt.ts
+++ b/grafast/dataplan-pg/src/steps/pgStmt.ts
@@ -1,0 +1,96 @@
+import { applyTransforms, ExecutableStep } from "grafast";
+import { type SQL, sql } from "pg-sql2";
+
+import type { PgCodec, PgTypedExecutableStep } from "..";
+import { PgLocker } from "../pgLocker";
+import { makeScopedSQL } from "../utils";
+
+/**
+ * Sometimes we want to refer to something that might change later - e.g. we
+ * might have SQL that specifies a list of explicit values, or it might later
+ * want to be replaced with a reference to an existing table value (e.g. when a
+ * query is being inlined). PgStmtDeferred allows for this kind of
+ * flexibility. It's really important to keep in mind that the same placeholder
+ * might be used in multiple different SQL queries, and in the different
+ * queries it might end up with different values - this is particularly
+ * relevant when using `@stream`/`@defer`, for example.
+ */
+type PgStmtDeferredPlaceholder = {
+  symbol: symbol;
+  dependencyIndex: number;
+  codec: PgCodec;
+  alreadyEncoded: boolean;
+};
+
+type PgStmtDeferredSQL = {
+  symbol: symbol;
+  dependencyIndex: number;
+};
+
+const UNHANDLED_PLACEHOLDER = sql`(1/0) /* ERROR! Unhandled pgSelect placeholder! */`;
+
+export abstract class PgStmtBaseStep<T> extends ExecutableStep<T> {
+  static $$export = {
+    moduleName: "@dataplan/pg",
+    exportName: "PgStmtBaseStep",
+  };
+
+  protected locker: PgLocker<this> = new PgLocker(this);
+
+  /**
+   * Values used in this plan.
+   */
+  protected placeholders: Array<PgStmtDeferredPlaceholder> = [];
+  protected deferreds: Array<PgStmtDeferredSQL> = [];
+
+  public scopedSQL = makeScopedSQL(this);
+
+  public placeholder($step: PgTypedExecutableStep<PgCodec>): SQL;
+  public placeholder(
+    $step: ExecutableStep,
+    codec: PgCodec,
+    alreadyEncoded?: boolean,
+  ): SQL;
+  public placeholder(
+    $step: ExecutableStep | PgTypedExecutableStep<PgCodec>,
+    overrideCodec?: PgCodec,
+    alreadyEncoded = false,
+  ): SQL {
+    if (this.locker.locked) {
+      throw new Error(`${this}: cannot add placeholders once plan is locked`);
+    }
+    if (this.placeholders.length >= 100000) {
+      throw new Error(
+        `There's already ${this.placeholders.length} placeholders; wanting more suggests there's a bug somewhere`,
+      );
+    }
+
+    const codec = overrideCodec ?? ("pgCodec" in $step ? $step.pgCodec : null);
+    if (!codec) {
+      console.trace(`${this}.placeholder(${$step}) call, no codec`);
+      throw new Error(
+        `Step ${$step} does not contain pgCodec information, please pass the codec explicitly to the 'placeholder' method.`,
+      );
+      // throw new Error(
+      //   `Step ${$step} does not contain pgCodec information, please wrap ` +
+      //     `it in \`pgCast\`. E.g. \`pgCast($step, TYPES.boolean)\``,
+      // );
+    }
+
+    const $evalledStep = applyTransforms($step);
+
+    const dependencyIndex = this.addDependency($evalledStep);
+    const symbol = Symbol(`step-${$step.id}`);
+    const sqlPlaceholder = sql.placeholder(symbol, UNHANDLED_PLACEHOLDER);
+    const p: PgStmtDeferredPlaceholder = {
+      symbol,
+      dependencyIndex,
+      codec,
+      alreadyEncoded,
+    };
+    this.placeholders.push(p);
+    // This allows us to replace the SQL that will be compiled, for example
+    // when we're inlining this into a parent query.
+    return sqlPlaceholder;
+  }
+}

--- a/grafast/dataplan-pg/src/steps/pgStmt.ts
+++ b/grafast/dataplan-pg/src/steps/pgStmt.ts
@@ -2,7 +2,7 @@ import { applyTransforms, ExecutableStep } from "grafast";
 import { type SQL, sql } from "pg-sql2";
 
 import type { PgCodec, PgTypedExecutableStep } from "..";
-import { PgLocker } from "../pgLocker";
+import type { PgLocker } from "../pgLocker";
 import { makeScopedSQL } from "../utils";
 
 /**
@@ -15,14 +15,14 @@ import { makeScopedSQL } from "../utils";
  * queries it might end up with different values - this is particularly
  * relevant when using `@stream`/`@defer`, for example.
  */
-type PgStmtDeferredPlaceholder = {
+export type PgStmtDeferredPlaceholder = {
   symbol: symbol;
   dependencyIndex: number;
   codec: PgCodec;
   alreadyEncoded: boolean;
 };
 
-type PgStmtDeferredSQL = {
+export type PgStmtDeferredSQL = {
   symbol: symbol;
   dependencyIndex: number;
 };
@@ -35,13 +35,13 @@ export abstract class PgStmtBaseStep<T> extends ExecutableStep<T> {
     exportName: "PgStmtBaseStep",
   };
 
-  protected locker: PgLocker<this> = new PgLocker(this);
+  protected abstract locker: PgLocker<any>;
 
   /**
    * Values used in this plan.
    */
-  protected placeholders: Array<PgStmtDeferredPlaceholder> = [];
-  protected deferreds: Array<PgStmtDeferredSQL> = [];
+  protected abstract placeholders: Array<PgStmtDeferredPlaceholder>;
+  protected abstract deferreds: Array<PgStmtDeferredSQL>;
 
   public scopedSQL = makeScopedSQL(this);
 

--- a/grafast/dataplan-pg/src/steps/pgUnionAll.ts
+++ b/grafast/dataplan-pg/src/steps/pgUnionAll.ts
@@ -44,6 +44,7 @@ import type {
   PgTypedExecutableStep,
 } from "../interfaces.js";
 import { PgLocker } from "../pgLocker.js";
+import { makeScopedSQL } from "../utils.js";
 import type { PgClassExpressionStep } from "./pgClassExpression.js";
 import { pgClassExpression } from "./pgClassExpression.js";
 import type {
@@ -296,6 +297,19 @@ export class PgUnionAllSingleStep
 
   public node() {
     return this;
+  }
+
+  public scopedSQL = makeScopedSQL(this);
+
+  public placeholder($step: PgTypedExecutableStep<any>): SQL;
+  public placeholder($step: ExecutableStep, codec: PgCodec): SQL;
+  public placeholder(
+    $step: ExecutableStep | PgTypedExecutableStep<any>,
+    overrideCodec?: PgCodec,
+  ): SQL {
+    return overrideCodec
+      ? this.getClassStep().placeholder($step, overrideCodec)
+      : this.getClassStep().placeholder($step as PgTypedExecutableStep<any>);
   }
 
   /**
@@ -1032,6 +1046,8 @@ on (${sql.indent(
     this.fetchOneExtra = true;
     return access(this, "hasMore", false);
   }
+
+  public scopedSQL = makeScopedSQL(this);
 
   public placeholder($step: PgTypedExecutableStep<any>): SQL;
   public placeholder(

--- a/grafast/dataplan-pg/src/utils.ts
+++ b/grafast/dataplan-pg/src/utils.ts
@@ -1,5 +1,5 @@
 import { ExecutableStep } from "grafast";
-import type { PgSQL, SQL, Transformer } from "pg-sql2";
+import type { SQL, Transformer } from "pg-sql2";
 import sql from "pg-sql2";
 
 import type { PgResource } from "./datasource.js";


### PR DESCRIPTION
## Description

Using the new `sql.withTransformer` feature introduced in #2320, we can make it so that references to postgres typed steps can be made directly in scoped `sql` fragments rather than having to use `$pgSelect.placeholder()`:

```diff
   User: {
     posts($user, { $forumId }) {
       const $id = $user.get('id');
       const $posts = posts.find();
-      $posts.where(sql`author_id = ${$posts.placeholder($id)} and forum_id = ${$posts.placeholder($forumId)}`);
+      $posts.where(sql => sql`author_id = ${$id} and forum_id = ${$forumId}`);
       return $posts;
     },
   },
```

The code under the hood is equivalent, a transformer will detect `$id` and `$forumId` are typed PG steps and will replace them with `$posts.placeholder($id)` or `$posts.placeholder($forumId)` automatically.

## Performance impact

Negligible.

## Security impact

None known.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
