### PR TITLE
Add `.unaryValue` to ExecutionValue

### DIFF
--- a/.changeset/fast-phones-change.md
+++ b/.changeset/fast-phones-change.md
@@ -1,0 +1,8 @@
+---
+"grafast": patch
+---
+
+🚨 ExecutionValue no longer exposes .value and .entries (you need to narrow to
+access these). Added new `.unaryValue()` that can be used to assert the value is
+unary and retrieve its value - this should be used instead of `.at(0)` in
+general.

--- a/grafast/grafast/__tests__/unaryDeps-test.ts
+++ b/grafast/grafast/__tests__/unaryDeps-test.ts
@@ -86,8 +86,9 @@ class GetRecordsStep<T extends Record<string, any>> extends ExecutableStep {
     indexMap,
     values,
   }: ExecutionDetails): Promise<GrafastResultsList<any>> {
-    const db = values[this.dbDepId].value as sqlite3.Database;
-    const first = this.firstUDI != null ? values[this.firstUDI].value : null;
+    const db = values[this.dbDepId].unaryValue() as sqlite3.Database;
+    const first =
+      this.firstUDI != null ? values[this.firstUDI].unaryValue() : null;
 
     const identifierCols = Object.keys(this.depIdByIdentifier);
 

--- a/grafast/grafast/src/engine/executeBucket.ts
+++ b/grafast/grafast/src/engine/executeBucket.ts
@@ -1246,6 +1246,12 @@ export function bucketToString(this: Bucket) {
   return `Bucket<${this.layerPlan}>`;
 }
 
+function throwNotUnary(): never {
+  throw new Error(
+    `This is not a unary value so we cannot get the single value - there may be more than one!`,
+  );
+}
+
 // TODO: memoize?
 export function batchExecutionValue<TData>(
   entries: TData[],
@@ -1256,6 +1262,7 @@ export function batchExecutionValue<TData>(
     at: batchEntriesAt,
     isBatch: true,
     entries,
+    unaryValue: throwNotUnary,
     _flags,
     _flagsAt: batchFlagsAt,
     _getStateUnion() {
@@ -1313,6 +1320,7 @@ export function unaryExecutionValue<TData>(
     at: unaryAt,
     isBatch: false,
     value,
+    unaryValue: () => value,
     _entryFlags,
     _flagsAt: unaryFlagsAt,
     _getStateUnion: unaryGetStateUnion,

--- a/grafast/grafast/src/interfaces.ts
+++ b/grafast/grafast/src/interfaces.ts
@@ -849,6 +849,8 @@ export type ExecutionValue<TData = any> =
 interface ExecutionValueBase<TData = any> {
   at(i: number): TData;
   isBatch: boolean;
+  /** Returns this.value for a unary execution value; throws if non-unary */
+  unaryValue(): TData;
   /** @internal */
   _flagsAt(i: number): ExecutionEntryFlags;
   /** bitwise OR of all the entry states @internal */
@@ -866,6 +868,8 @@ export interface BatchExecutionValue<TData = any>
   extends ExecutionValueBase<TData> {
   isBatch: true;
   entries: ReadonlyArray<TData>;
+  /** Always throws, since this should only be called on unary execution values */
+  unaryValue(): never;
   /** @internal */
   readonly _flags: Array<ExecutionEntryFlags>;
 }
@@ -873,6 +877,8 @@ export interface UnaryExecutionValue<TData = any>
   extends ExecutionValueBase<TData> {
   isBatch: false;
   value: TData;
+  /** Same as getting .value */
+  unaryValue(): TData;
   /** @internal */
   _entryFlags: ExecutionEntryFlags;
 }

--- a/grafast/grafast/src/interfaces.ts
+++ b/grafast/grafast/src/interfaces.ts
@@ -866,7 +866,6 @@ export interface BatchExecutionValue<TData = any>
   extends ExecutionValueBase<TData> {
   isBatch: true;
   entries: ReadonlyArray<TData>;
-  value?: never;
   /** @internal */
   readonly _flags: Array<ExecutionEntryFlags>;
 }
@@ -874,7 +873,6 @@ export interface UnaryExecutionValue<TData = any>
   extends ExecutionValueBase<TData> {
   isBatch: false;
   value: TData;
-  entries?: never;
   /** @internal */
   _entryFlags: ExecutionEntryFlags;
 }

--- a/grafast/grafast/src/steps/applyTransforms.ts
+++ b/grafast/grafast/src/steps/applyTransforms.ts
@@ -105,7 +105,7 @@ export class ApplyTransformsStep extends ExecutableStep {
       );
     }
     if (itemStep._isUnary) {
-      store.set(itemStepId, unaryExecutionValue(values0.at(0)));
+      store.set(itemStepId, unaryExecutionValue(values0.unaryValue()));
     } else {
       store.set(itemStepId, batchExecutionValue([]));
     }

--- a/grafast/grafast/src/steps/listTransform.ts
+++ b/grafast/grafast/src/steps/listTransform.ts
@@ -231,7 +231,7 @@ export class __ListTransformStep<
     const listStepValue = values[this.listStepDepId];
 
     if (itemStep._isUnary) {
-      const list = listStepValue.at(0);
+      const list = listStepValue.unaryValue();
       store.set(
         itemStepId,
         unaryExecutionValue(Array.isArray(list) ? list[0] : list),


### PR DESCRIPTION
## Description

ExecutionValue comes in two flavours: batch and unary. Unary has a `.value` and batch has a `.entries`. Previously we included `: never` versions of each of these to make access easier, but this could lead to mistakes. This interface has been removed (:rotating_light: breaking! but only the types) so you'll need to narrow via .isBatch before you can use the relevant property.

When you knew an execution value was unary, you could use `.at(0)` to access its value; however this was risky because there was no assertion that the value is unary. To help mitigate this, I've added the new `.unaryValue()` method which asserts that the value is unary and then accesses the singular value from it; this should make code safer when you know a `$step` should be unary due to calling `this.addUnaryDependency($step)`.

## Performance impact

Negligible.

## Security impact

Improvement: increased safety. Risk: assertions.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
