### PR TITLE
Fix bug in pg-sql2 optimization causing $$type access to throw on null/undefined

### DIFF
--- a/.changeset/dirty-dancers-eat.md
+++ b/.changeset/dirty-dancers-eat.md
@@ -1,0 +1,6 @@
+---
+"pg-sql2": patch
+---
+
+Fix bug causing unhelpful throw on $$type optimization on null - instead pass
+through to more helpful throw.

--- a/grafast/dataplan-pg/__tests__/helpers.ts
+++ b/grafast/dataplan-pg/__tests__/helpers.ts
@@ -360,7 +360,8 @@ export async function runTestQuery(
             stringifyPayload(result as any, outputDataAsString),
           );
           if (!checkErrorSnapshots && errors) {
-            console.error(errors[0].originalError || errors[0]);
+            const originalError = result.errors?.[0]?.originalError;
+            console.error(originalError || errors[0]);
           }
           if (options.callback) {
             throw new Error(

--- a/utils/pg-sql2/src/index.ts
+++ b/utils/pg-sql2/src/index.ts
@@ -460,7 +460,7 @@ export function compile(
     const sqlFragments: string[] = [];
 
     const trustedInput =
-      untrustedInput[$$type] !== undefined
+      untrustedInput?.[$$type] !== undefined
         ? untrustedInput
         : enforceValidNode(untrustedInput, ``);
     const items: ReadonlyArray<SQLNode> =
@@ -472,7 +472,7 @@ export function compile(
     for (let itemIndex = 0; itemIndex < itemCount; itemIndex++) {
       const itemAtIndex = items[itemIndex];
       const item =
-        itemAtIndex[$$type] !== undefined
+        itemAtIndex?.[$$type] !== undefined
           ? itemAtIndex
           : enforceValidNode(itemAtIndex as SQLNode, `item ${itemIndex}`);
       switch (item[$$type]) {
@@ -640,7 +640,7 @@ const sqlBase = function sql(
     if (i < l - 1) {
       const rawVal = values[i];
       const valid: SQL =
-        rawVal[$$type] !== undefined
+        rawVal?.[$$type] !== undefined
           ? (rawVal as SQL)
           : enforceValidNode(rawVal, `template literal placeholder ${i}`);
       if (valid[$$type] === "RAW") {
@@ -828,7 +828,7 @@ export function join(items: Array<SQL>, separator = ""): SQL {
   } else if (items.length === 1) {
     const rawNode = items[0];
     const node: SQL =
-      rawNode[$$type] !== undefined
+      rawNode?.[$$type] !== undefined
         ? rawNode
         : enforceValidNode(rawNode, `join item ${0}`);
     return node;
@@ -841,7 +841,7 @@ export function join(items: Array<SQL>, separator = ""): SQL {
     const rawNode = items[i];
     const addSeparator = i > 0 && hasSeparator;
     const node: SQL =
-      rawNode[$$type] !== undefined
+      rawNode?.[$$type] !== undefined
         ? rawNode
         : enforceValidNode(rawNode, `join item ${i}`);
     if (addSeparator) {


### PR DESCRIPTION
## Performance impact

Marginal decrease in pg-sql2 performance, not sure if it is likely to be measurable but I know from past experience that this isn't quite as fast.

## Security impact

Negligible.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
